### PR TITLE
Handle CG Failures

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -124,6 +124,15 @@ jobs:
       - 'Build_Windows'
       - 'Build_MacOS'
 
+    # Component governance collates discovered dependencies from a combination of
+    # manifest files, splatted json output from CG detections, setup.py files, and other sources.
+    # At this point in the job, we have downloadeded package artifacts from 3 previous platform-specific build jobs,
+    # so the directory that will be published as packages_extended _already contains_ a collated set of dependencies by
+    # json file. When we attempt to publish the packages_extended artifact, CG re-collates data from the current job, but ALSO
+    # includes all the data from json files left behind by the previous jobs. While this doesn't result in double counting,
+    # we've been running into some nasty timeout issues of the CG running on this job specifically.
+    #
+    # Given that we've ALREADY RUN CG on the previous jobs, we can safely disable it here.
     templateContext:
       sdl:
         componentgovernance:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - 'Build_MacOS'
 
     templateContext:
-      sdk:
+      sdl:
         componentgovernance:
           enabled: false
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -137,6 +137,7 @@ jobs:
       sdl:
         componentgovernance:
           enabled: false
+          justificationForDisabling: "We've already run CG on the previous jobs, and we're running into timeout issues due to previous outputs."
 
     timeoutInMinutes: 90
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -124,6 +124,11 @@ jobs:
       - 'Build_Windows'
       - 'Build_MacOS'
 
+    templateContext:
+      sdk:
+        componentgovernance:
+          enabled: false
+
     timeoutInMinutes: 90
 
     pool:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -124,21 +124,6 @@ jobs:
       - 'Build_Windows'
       - 'Build_MacOS'
 
-    # Component governance collates discovered dependencies from a combination of
-    # manifest files, splatted json output from CG detections, setup.py files, and other sources.
-    # At this point in the job, we have downloadeded package artifacts from 3 previous platform-specific build jobs,
-    # so the directory that will be published as packages_extended _already contains_ a collated set of dependencies by
-    # json file. When we attempt to publish the packages_extended artifact, CG re-collates data from the current job, but ALSO
-    # includes all the data from json files left behind by the previous jobs. While this doesn't result in double counting,
-    # we've been running into some nasty timeout issues of the CG running on this job specifically.
-    #
-    # Given that we've ALREADY RUN CG on the previous jobs, we can safely disable it here.
-    templateContext:
-      sdl:
-        componentgovernance:
-          enabled: false
-          justificationForDisabling: "We've already run CG on the previous jobs, and we're running into timeout issues due to previous outputs."
-
     timeoutInMinutes: 90
 
     pool:

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -99,12 +99,10 @@ steps:
     # Given that we've ALREADY RUN CG on the previous jobs, we can clean up these artifacts to avoid
     # incurring an increased CG runtime. What's present within IS accurate.
   - pwsh: |
-      Get-ChildItem -R -Path "$(Build.ArtifactStagingDirectory)" | % { Write-Host $_.FullName }
       Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter GovCompDisc* | % { Write-Host "Removing $($_.FullName)"; Remove-Item $_ }
       Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter ScanTelemetry* | % { Write-Host "Removing $($_.FullName)"; Remove-Item $_ }
       Remove-Item -Recurse -Force -Path "$(Build.ArtifactStagingDirectory)/bcde-output"
       Remove-Item -Recurse -Force -Path "$(Build.ArtifactStagingDirectory)/_manifest"
-      Get-ChildItem -R -Path "$(Build.ArtifactStagingDirectory)" | % { Write-Host $_.FullName }
     displayName: Clean up Artifact Directory
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -88,6 +88,16 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces
 
+    # Component governance collates discovered dependencies from a combination of
+    # manifest files, splatted json output from CG detections, setup.py files, and other sources.
+    # At this point in the job, we have downloadeded package artifacts from 3 previous platform-specific build jobs,
+    # so the directory that will be published as packages_extended _already contains_ a collated set of dependencies by
+    # json file. When we attempt to publish the packages_extended artifact, CG re-collates data from the current job, but ALSO
+    # includes all the data from json files left behind by the previous jobs. While this doesn't result in double counting,
+    # we've been running into some nasty timeout issues of the CG running on this job specifically.
+    #
+    # Given that we've ALREADY RUN CG on the previous jobs, we can clean up these artifacts to avoid
+    # incurring an increased CG runtime. What's present within IS accurate.
   - pwsh: |
       Get-ChildItem -R -Path "$(Build.ArtifactStagingDirectory)" | % { Write-Host $_.FullName }
       Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter GovCompDisc* | % { Write-Host "Removing $($_.FullName)"; Remove-Item $_ }

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -88,6 +88,12 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces
 
+  - pwsh: |
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter GovCompDisc* | % { Remove-Item $_ }
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter ScanTelemetry* | % { Remove-Item $_ }
+      Remove-Item -Recurse -Force -Path "$(Build.ArtifactStagingDirectory)/bcde-output"
+    displayName: Clean up Artifact Directory
+
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)'

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -89,9 +89,12 @@ steps:
     displayName: Update package properties with namespaces
 
   - pwsh: |
-      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter GovCompDisc* | % { Remove-Item $_ }
-      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter ScanTelemetry* | % { Remove-Item $_ }
+      Get-ChildItem -R -Path "$(Build.ArtifactStagingDirectory)" | % { Write-Host $_.FullName }
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter GovCompDisc* | % { Write-Host "Removing $($_.FullName)"; Remove-Item $_ }
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter ScanTelemetry* | % { Write-Host "Removing $($_.FullName)"; Remove-Item $_ }
       Remove-Item -Recurse -Force -Path "$(Build.ArtifactStagingDirectory)/bcde-output"
+      Remove-Item -Recurse -Force -Path "$(Build.ArtifactStagingDirectory)/_manifest"
+      Get-ChildItem -R -Path "$(Build.ArtifactStagingDirectory)" | % { Write-Host $_.FullName }
     displayName: Clean up Artifact Directory
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml


### PR DESCRIPTION
The issue is that `packages_extended` is being published, and includes all the artifacts from each _individual_ package publishing job.

This causes a number of manifest jsons to be present. That _is_ still accurate metadata for the platform specific artifacts, so I don't want to remove them. However, their presence is causing the [component governance](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4107957&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=3a70d42c-4cbe-5d44-55a0-70dc5de3988f) job to do a BUNCH more work than it really should. `packages_extended` is simply the coalesced result of combined `packages_linux`, `packages_mac`, and `packages_windows`. No reason to run CG AGAIN on top of it.