### PR TITLE
Update to `Analyze` job condition

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -147,7 +147,7 @@ jobs:
         Artifacts: ${{ parameters.Artifacts }}
 
   - job: 'Analyze'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], 'true'))
+    condition: and(succeeded(), ne(variables['Skip.Analyze'], 'true'))
 
     timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 


### PR DESCRIPTION
@catalinaperalta reported an issue with `Analyze` unexpectedly failing due to inability to find the relevant artifact. The source turned out to be [Build_Extended](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4108793&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=4e79825b-10c2-5c5f-64dd-6a4e872e8af4) failing. 

The reason behind Build_Extended failing doesn't actually matter. What matters is that due to the job condition governing `Analyze`, we would run `Analyze` even if `Build_Extended` (its sole dependency) failed! If `Build_Extended` _fails_, then the artifact `packages_extended`, which `Analyze` REQUIRES to be present, won't exist named as `packages_extended`! If the artifact doesn't exist, it can't be downloaded in `Analyze`, and [we get failures that complain about being unable to locate the wheel.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4108793&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=d32d6c50-584d-5bc8-5a7d-7426470979cb&l=159)

Simply change the condition to `succeeded()`, which will delay the job run until `Build_Extended` passes.