### PR TITLE
Provider Revert Init Change

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/_azureappconfigurationprovider.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/_azureappconfigurationprovider.py
@@ -78,30 +78,28 @@ def load(  # pylint: disable=docstring-keyword-should-match-keyword-only
     refresh_interval: int = 30,
     on_refresh_success: Optional[Callable] = None,
     on_refresh_error: Optional[Callable[[Exception], None]] = None,
+    feature_flag_enabled: bool = False,
+    feature_flag_selectors: Optional[List[SettingSelector]] = None,
+    feature_flag_refresh_enabled: bool = False,
     **kwargs
 ) -> "AzureAppConfigurationProvider":
     """
     Loads configuration settings from Azure App Configuration into a Python application.
 
     :param str endpoint: Endpoint for App Configuration resource.
-    :param credential: Credential for App Configuration resource.
-    :type credential: ~azure.core.credentials.TokenCredential
-    :keyword selects: List of setting selectors to filter configuration settings
-    :paramtype selects: Optional[List[~azure.appconfiguration.provider.SettingSelector]]
-    :keyword trim_prefixes: List of prefixes to trim from configuration keys
-    :paramtype trim_prefixes: Optional[List[str]]
-    :keyword keyvault_credential: A credential for authenticating with the key vault. This is optional if
-     keyvault_client_configs is provided.
-    :paramtype keyvault_credential: ~azure.core.credentials.TokenCredential
-    :keyword keyvault_client_configs: A Mapping of SecretClient endpoints to client configurations from
-     azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential isn't provided a
-     credential will need to be in each set for each.
-    :paramtype keyvault_client_configs: Mapping[str, Mapping]
-    :keyword secret_resolver: A function that takes a URI and returns a value.
-    :paramtype secret_resolver: Callable[[str], str]
-    :keyword refresh_on: One or more settings whose modification will trigger a full refresh after a fixed interval.
-    This should be a list of Key-Label pairs for specific settings (filters and wildcards are not supported).
-    :paramtype refresh_on: List[Tuple[str, str]]
+    :param  ~azure.core.credentials.TokenCredential credential: Credential for App Configuration resource.
+    :keyword Optional[List[~azure.appconfiguration.provider.SettingSelector]] selects: List of setting selectors to
+    filter configuration settings
+    :keyword Optional[List[str]] trim_prefixes: List of prefixes to trim from configuration keys
+    :keyword  ~azure.core.credentials.TokenCredential keyvault_credential: A credential for authenticating with the key
+    vault. This is optional if keyvault_client_configs is provided.
+    :keyword Mapping[str, Mapping] keyvault_client_configs: A Mapping of SecretClient endpoints to client
+    configurations from azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential
+    isn't provided a credential will need to be in each set for each.
+    :keyword Callable[[str], str] secret_resolver: A function that takes a URI and returns a value.
+    :keyword List[Tuple[str, str]] refresh_on: One or more settings whose modification will trigger a full refresh
+    after a fixed interval. This should be a list of Key-Label pairs for specific settings (filters and wildcards are
+    not supported).
     :keyword int refresh_interval: The minimum time in seconds between when a call to `refresh` will actually trigger a
      service call to update the settings. Default value is 30 seconds.
     :keyword on_refresh_success: Optional callback to be invoked when a change is found and a successful refresh has
@@ -138,25 +136,27 @@ def load(  # pylint: disable=docstring-keyword-should-match-keyword-only
     refresh_interval: int = 30,
     on_refresh_success: Optional[Callable] = None,
     on_refresh_error: Optional[Callable[[Exception], None]] = None,
+    feature_flag_enabled: bool = False,
+    feature_flag_selectors: Optional[List[SettingSelector]] = None,
+    feature_flag_refresh_enabled: bool = False,
     **kwargs
 ) -> "AzureAppConfigurationProvider":
     """
     Loads configuration settings from Azure App Configuration into a Python application.
 
     :keyword str connection_string: Connection string for App Configuration resource.
-    :keyword selects: List of setting selectors to filter configuration settings
-    :paramtype selects: Optional[List[~azure.appconfiguration.provider.SettingSelector]]
-    :keyword trim_prefixes: List of prefixes to trim from configuration keys
-    :paramtype trim_prefixes: Optional[List[str]]
-    :keyword keyvault_credential: A credential for authenticating with the key vault. This is optional if
-     keyvault_client_configs is provided.
-    :paramtype keyvault_credential: ~azure.core.credentials.TokenCredential
-    :keyword keyvault_client_configs: A Mapping of SecretClient endpoints to client configurations from
-     azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential isn't provided a
-     credential will need to be in each set for each.
-    :paramtype keyvault_client_configs: Mapping[str, Mapping]
-    :keyword secret_resolver: A function that takes a URI and returns a value.
-    :paramtype secret_resolver: Callable[[str], str]
+    :keyword Optional[List[~azure.appconfiguration.provider.SettingSelector]] selects: List of setting selectors to
+    filter configuration settings
+    :keyword trim_prefixes: Optional[List[str]] trim_prefixes: List of prefixes to trim from configuration keys
+    :keyword  ~azure.core.credentials.TokenCredential keyvault_credential: A credential for authenticating with the key
+    vault. This is optional if keyvault_client_configs is provided.
+    :keyword Mapping[str, Mapping] keyvault_client_configs: A Mapping of SecretClient endpoints to client
+    configurations from azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential
+    isn't provided a credential will need to be in each set for each.
+    :keyword Callable[[str], str] secret_resolver: A function that takes a URI and returns a value.
+    :keyword List[Tuple[str, str]] refresh_on: One or more settings whose modification will trigger a full refresh
+    after a fixed interval. This should be a list of Key-Label pairs for specific settings (filters and wildcards are
+    not supported).
     :keyword refresh_on: One or more settings whose modification will trigger a full refresh after a fixed interval.
     This should be a list of Key-Label pairs for specific settings (filters and wildcards are not supported).
     :paramtype refresh_on: List[Tuple[str, str]]
@@ -316,36 +316,11 @@ def _buildprovider(
         endpoint = connection_string.split(";")[0].split("=")[1]
     if not endpoint:
         raise ValueError("No endpoint specified.")
-    retry_total = kwargs.pop("retry_total", 2)
-    retry_backoff_max = kwargs.pop("retry_backoff_max", 60)
-    replica_discovery_enabled = kwargs.pop("replica_discovery_enabled", True)
 
-    if "user_agent" in kwargs:
-        user_agent = kwargs.pop("user_agent") + " " + USER_AGENT
-    else:
-        user_agent = USER_AGENT
+    kwargs["connection_string"] = connection_string
+    kwargs["credential"] = credential
 
-    interval: int = kwargs.get("refresh_interval", 30)
-    if interval < 1:
-        raise ValueError("Refresh interval must be greater than or equal to 1 second.")
-
-    min_backoff: int = min(kwargs.pop("min_backoff", 30), interval)
-    max_backoff: int = min(kwargs.pop("max_backoff", 600), interval)
-
-    replica_client_manager = ConfigurationClientManager(
-        connection_string,
-        endpoint,
-        credential,
-        user_agent,
-        retry_total,
-        retry_backoff_max,
-        replica_discovery_enabled,
-        min_backoff,
-        max_backoff,
-        **kwargs
-    )
-    provider = AzureAppConfigurationProvider(endpoint, replica_client_manager, **kwargs)
-    return provider
+    return AzureAppConfigurationProvider(endpoint, **kwargs)
 
 
 def _resolve_keyvault_reference(
@@ -475,9 +450,33 @@ class AzureAppConfigurationProvider(Mapping[str, Union[str, JSON]]):  # pylint: 
     keys. Enables resolution of Key Vault references in configuration settings.
     """
 
-    def __init__(self, endpoint, replica_client_manager, **kwargs) -> None:
+    def __init__(self, endpoint, **kwargs) -> None:
         self._origin_endpoint = endpoint
-        self._replica_client_manager = replica_client_manager
+
+        if "user_agent" in kwargs:
+            user_agent = kwargs.pop("user_agent") + " " + USER_AGENT
+        else:
+            user_agent = USER_AGENT
+
+        interval: int = kwargs.get("refresh_interval", 30)
+        if interval < 1:
+            raise ValueError("Refresh interval must be greater than or equal to 1 second.")
+
+        min_backoff: int = min(kwargs.pop("min_backoff", 30), interval)
+        max_backoff: int = min(kwargs.pop("max_backoff", 600), interval)
+
+        self._replica_client_manager = ConfigurationClientManager(
+            connection_string=kwargs.pop("connection_string", None),
+            endpoint=endpoint,
+            credential=kwargs.pop("credential", None),
+            user_agent=user_agent,
+            retry_total=kwargs.pop("retry_total", 2),
+            retry_backoff_max=kwargs.pop("retry_backoff_max", 60),
+            replica_discovery_enabled=kwargs.pop("replica_discovery_enabled", True),
+            min_backoff_sec=min_backoff,
+            max_backoff_sec=max_backoff,
+            **kwargs
+        )
         self._dict: Dict[str, Any] = {}
         self._secret_clients: Dict[str, SecretClient] = {}
         self._selects: List[SettingSelector] = kwargs.pop(

--- a/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/aio/_azureappconfigurationproviderasync.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/aio/_azureappconfigurationproviderasync.py
@@ -77,24 +77,19 @@ async def load(  # pylint: disable=docstring-keyword-should-match-keyword-only
     Loads configuration settings from Azure App Configuration into a Python application.
 
     :param str endpoint: Endpoint for App Configuration resource.
-    :param credential: Credential for App Configuration resource.
-    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword selects: List of setting selectors to filter configuration settings
-    :paramtype selects: Optional[List[~azure.appconfiguration.provider.SettingSelector]]
-    :keyword trim_prefixes: List of prefixes to trim from configuration keys
-    :paramtype trim_prefixes: Optional[List[str]]
-    :keyword keyvault_credential: A credential for authenticating with the key vault. This is optional if
-     keyvault_client_configs is provided.
-    :paramtype keyvault_credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword keyvault_client_configs: A Mapping of SecretClient endpoints to client configurations from
-     azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential isn't provided a
-     credential will need to be in each set for each.
-    :paramtype keyvault_client_configs: Mapping[str, Mapping]
-    :keyword secret_resolver: A function that takes a URI and returns a value.
-    :paramtype secret_resolver: Callable[[str], str]
-    :keyword refresh_on: One or more settings whose modification will trigger a full refresh after a fixed interval.
-    This should be a list of Key-Label pairs for specific settings (filters and wildcards are not supported).
-    :paramtype refresh_on: List[Tuple[str, str]]
+    :param ~azure.core.credentials_async.AsyncTokenCredential credential: Credential for App Configuration resource.
+    :keyword Optional[List[~azure.appconfiguration.provider.SettingSelector]] selects: List of setting selectors to
+    filter configuration settings
+    :keyword Optional[List[str]] trim_prefixes: List of prefixes to trim from configuration keys
+    :keyword ~azure.core.credentials_async.AsyncTokenCredential keyvault_credential: A credential for authenticating
+    with the key vault. This is optional if keyvault_client_configs is provided.
+    :keyword Mapping[str, Mapping] keyvault_client_configs: A Mapping of SecretClient endpoints to client
+    configurations from azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential
+    isn't provided a credential will need to be in each set for each.
+    :keyword Callable[[str], str] secret_resolver: A function that takes a URI and returns a value.
+    :keyword List[Tuple[str, str]] refresh_on: One or more settings whose modification will trigger a full refresh
+    after a fixed interval. This should be a list of Key-Label pairs for specific settings (filters and wildcards are
+    not supported).
     :keyword int refresh_interval: The minimum time in seconds between when a call to `refresh` will actually trigger a
      service call to update the settings. Default value is 30 seconds.
     :keyword on_refresh_success: Optional callback to be invoked when a change is found and a successful refresh has
@@ -131,25 +126,27 @@ async def load(  # pylint: disable=docstring-keyword-should-match-keyword-only
     refresh_interval: int = 30,
     on_refresh_success: Optional[Callable] = None,
     on_refresh_error: Optional[Callable[[Exception], Awaitable[None]]] = None,
+    feature_flag_enabled: bool = False,
+    feature_flag_selectors: Optional[List[SettingSelector]] = None,
+    feature_flag_refresh_enabled: bool = False,
     **kwargs
 ) -> "AzureAppConfigurationProvider":
     """
     Loads configuration settings from Azure App Configuration into a Python application.
 
     :keyword str connection_string: Connection string for App Configuration resource.
-    :keyword selects: List of setting selectors to filter configuration settings
-    :paramtype selects: Optional[List[~azure.appconfiguration.provider.SettingSelector]]
-    :keyword trim_prefixes: List of prefixes to trim from configuration keys
-    :paramtype trim_prefixes: Optional[List[str]]
-    :keyword keyvault_credential: A credential for authenticating with the key vault. This is optional if
-     keyvault_client_configs is provided.
-    :paramtype keyvault_credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword keyvault_client_configs: A Mapping of SecretClient endpoints to client configurations from
-     azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential isn't provided a
-     credential will need to be in each set for each.
-    :paramtype keyvault_client_configs: Mapping[str, Mapping]
-    :keyword secret_resolver: A function that takes a URI and returns a value.
-    :paramtype secret_resolver: Callable[[str], str]
+    :keyword Optional[List[~azure.appconfiguration.provider.SettingSelector]] selects: List of setting selectors to
+    filter configuration settings
+    :keyword trim_prefixes: Optional[List[str]] trim_prefixes: List of prefixes to trim from configuration keys
+    :keyword ~azure.core.credentials_async.AsyncTokenCredential keyvault_credential: A credential for authenticating
+    with the key vault. This is optional if keyvault_client_configs is provided.
+    :keyword Mapping[str, Mapping] keyvault_client_configs: A Mapping of SecretClient endpoints to client
+    configurations from azure-keyvault-secrets. This is optional if keyvault_credential is provided. If a credential
+    isn't provided a credential will need to be in each set for each.
+    :keyword Callable[[str], str] secret_resolver: A function that takes a URI and returns a value.
+    :keyword List[Tuple[str, str]] refresh_on: One or more settings whose modification will trigger a full refresh
+    after a fixed interval. This should be a list of Key-Label pairs for specific settings (filters and wildcards are
+    not supported).
     :keyword refresh_on: One or more settings whose modification will trigger a full refresh after a fixed interval.
     This should be a list of Key-Label pairs for specific settings (filters and wildcards are not supported).
     :paramtype refresh_on: List[Tuple[str, str]]
@@ -221,6 +218,8 @@ async def load(*args, **kwargs) -> "AzureAppConfigurationProvider":
     )
 
     provider = await _buildprovider(connection_string, endpoint, credential, uses_key_vault=uses_key_vault, **kwargs)
+    # Discovering replicas outside of init as it's async
+    await provider._replica_client_manager.setup_initial_clients()  # pylint:disable=protected-access
     headers = _get_headers(
         kwargs.pop("headers", {}),
         "Startup",
@@ -246,36 +245,11 @@ async def _buildprovider(
         endpoint = connection_string.split(";")[0].split("=")[1]
     if not endpoint:
         raise ValueError("No endpoint specified.")
-    retry_total = kwargs.pop("retry_total", 2)
-    retry_backoff_max = kwargs.pop("retry_backoff_max", 60)
-    replica_discovery_enabled = kwargs.pop("replica_discovery_enabled", True)
 
-    if "user_agent" in kwargs:
-        user_agent = kwargs.pop("user_agent") + " " + USER_AGENT
-    else:
-        user_agent = USER_AGENT
+    kwargs["connection_string"] = connection_string
+    kwargs["credential"] = credential
 
-    interval: int = kwargs.get("refresh_interval", 30)
-    if interval < 1:
-        raise ValueError("Refresh interval must be greater than or equal to 1 second.")
-
-    min_backoff: int = min(kwargs.pop("min_backoff", 30), interval)
-    max_backoff: int = min(kwargs.pop("max_backoff", 600), interval)
-
-    replica_client_manager = AsyncConfigurationClientManager(
-        connection_string,
-        endpoint,
-        credential,
-        user_agent,
-        retry_total,
-        retry_backoff_max,
-        replica_discovery_enabled,
-        min_backoff,
-        max_backoff,
-        **kwargs
-    )
-    await replica_client_manager.setup_initial_clients()
-    provider = AzureAppConfigurationProvider(endpoint, replica_client_manager, **kwargs)
+    provider = AzureAppConfigurationProvider(endpoint, **kwargs)
     return provider
 
 
@@ -334,9 +308,33 @@ class AzureAppConfigurationProvider(Mapping[str, Union[str, JSON]]):  # pylint: 
     keys. Enables resolution of Key Vault references in configuration settings.
     """
 
-    def __init__(self, endpoint, replica_client_manager, **kwargs) -> None:
+    def __init__(self, endpoint, **kwargs) -> None:
         self._origin_endpoint = endpoint
-        self._replica_client_manager = replica_client_manager
+
+        if "user_agent" in kwargs:
+            user_agent = kwargs.pop("user_agent") + " " + USER_AGENT
+        else:
+            user_agent = USER_AGENT
+
+        interval: int = kwargs.get("refresh_interval", 30)
+        if interval < 1:
+            raise ValueError("Refresh interval must be greater than or equal to 1 second.")
+
+        min_backoff: int = min(kwargs.pop("min_backoff", 30), interval)
+        max_backoff: int = min(kwargs.pop("max_backoff", 600), interval)
+
+        self._replica_client_manager = AsyncConfigurationClientManager(
+            connection_string=kwargs.pop("connection_string", None),
+            endpoint=endpoint,
+            credential=kwargs.pop("credential", None),
+            user_agent=user_agent,
+            retry_total=kwargs.pop("retry_total", 2),
+            retry_backoff_max=kwargs.pop("retry_backoff_max", 60),
+            replica_discovery_enabled=kwargs.pop("replica_discovery_enabled", True),
+            min_backoff_sec=min_backoff,
+            max_backoff_sec=max_backoff,
+            **kwargs
+        )
         self._dict: Dict[str, Any] = {}
         self._secret_clients: Dict[str, SecretClient] = {}
         self._selects: List[SettingSelector] = kwargs.pop(


### PR DESCRIPTION
# Description

Reverts the API change to the init method. The API should match the one here.

https://github.com/Azure/azure-sdk-for-python/blob/azure-appconfiguration-provider_1.2.0/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/_azureappconfigurationprovider.py#L490

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
