### PR TITLE
[Core] Adjust auth tests to avoid false CredScan flags

### DIFF
--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -42,22 +42,27 @@ import pytest
 from unittest.mock import Mock
 
 
+CLAIM_TOKEN = base64.b64encode(b'{"access_token": {"foo": "bar"}}').decode()
+CLAIM_NBF = base64.b64encode(b'{"access_token":{"nbf":{"essential":true, "value":"1603742800"}}}').decode()
+CLAIM_IP = base64.b64encode(b'{"access_token":{"nbf":{"essential":true,"value":"1610563006"},"xms_rp_ipaddr":{"value":"1.2.3.4"}}}').decode()[:-2]  # Trim off padding = characters
+
+
 @pytest.mark.parametrize(
     "challenge,expected_claims",
     (
         # CAE - insufficient claims
         (
-            'Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", client_id="00000003-0000-0000-c000-000000000000", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOiB7ImZvbyI6ICJiYXIifX0="',
+            f'Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", client_id="00000003-0000-0000-c000-000000000000", error="insufficient_claims", claims="{CLAIM_TOKEN}"',
             '{"access_token": {"foo": "bar"}}',
         ),
         # CAE - sessions revoked
         (
-            'Bearer authorization_uri="https://login.windows-ppe.net/", error="invalid_token", error_description="User session has been revoked", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="',
+            f'Bearer authorization_uri="https://login.windows-ppe.net/", error="invalid_token", error_description="User session has been revoked", claims={CLAIM_NBF}',
             '{"access_token":{"nbf":{"essential":true, "value":"1603742800"}}}',
         ),
         # CAE - IP policy
         (
-            'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="Tenant IP Policy validate failed.", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNjEwNTYzMDA2In0sInhtc19ycF9pcGFkZHIiOnsidmFsdWUiOiIxLjIuMy40In19fQ"',
+            f'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="Tenant IP Policy validate failed.", claims={CLAIM_IP}',
             '{"access_token":{"nbf":{"essential":true,"value":"1610563006"},"xms_rp_ipaddr":{"value":"1.2.3.4"}}}',
         ),
         # ARM

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -44,7 +44,8 @@ from unittest.mock import Mock
 
 CLAIM_TOKEN = base64.b64encode(b'{"access_token": {"foo": "bar"}}').decode()
 CLAIM_NBF = base64.b64encode(b'{"access_token":{"nbf":{"essential":true, "value":"1603742800"}}}').decode()
-CLAIM_IP = base64.b64encode(b'{"access_token":{"nbf":{"essential":true,"value":"1610563006"},"xms_rp_ipaddr":{"value":"1.2.3.4"}}}').decode()[:-2]  # Trim off padding = characters
+ip_claim = b'{"access_token":{"nbf":{"essential":true,"value":"1610563006"},"xms_rp_ipaddr":{"value":"1.2.3.4"}}}'
+CLAIM_IP = base64.b64encode(ip_claim).decode()[:-2]  # Trim off padding = characters
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Nightly CredScan runs [are upset](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4116963&view=logs&j=3b141548-98d7-5be1-7ef8-eeb08ca02972&t=41e0d8dc-42df-5fff-2417-80cd016cccdb) by test claims used in `azure-mgmt-core`'s authentication tests. This modifies the tests to use variable references instead of direct strings to avoid the issue; a benefit is more clearly indicating what each claim is supposed to represent.

Validating run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4121434&view=logs&j=3b141548-98d7-5be1-7ef8-eeb08ca02972&t=41e0d8dc-42df-5fff-2417-80cd016cccdb

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
