### PR TITLE
Fix broken links

### DIFF
--- a/sdk/core/azure/CHANGELOG.md
+++ b/sdk/core/azure/CHANGELOG.md
@@ -422,7 +422,8 @@ Our goal is to release a stable version by the end of March 2016.  Please send u
 
 **BREAKING CHANGES**
 
-We made our possible to document the breaking from ARM 1.0.0 version to 2.0.0 [here](https://github.com/Azure/azure-sdk-for-python/wiki/Migrate-from-1.0.0-ARM-preview-to-2.0.0).
+~~We made our possible to document the breaking from ARM 1.0.0 version to 2.0.0 here.~~
+The previously-linked documentation is no longer available.
 
 **Dependencies**
 

--- a/sdk/purview/azure-purview-sharing/README.md
+++ b/sdk/purview/azure-purview-sharing/README.md
@@ -569,7 +569,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 <!-- LINKS -->
 
 [source_code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/purview/azure-purview-sharing/azure/purview/sharing
-[client_pypi_package]: https://aka.ms/azsdk/python/purviewsharing/pypi
+[client_pypi_package]: https://pypi.org/project/azure-purview-sharing/
 [sharing_ref_docs]: https://aka.ms/azsdk/python/purviewcatalog/ref-docs
 [sharing_product_documentation]: https://azure.microsoft.com/services/purview/
 [azure_subscription]: https://azure.microsoft.com/free/

--- a/sdk/purview/azure-purview-sharing/samples/README.md
+++ b/sdk/purview/azure-purview-sharing/samples/README.md
@@ -59,5 +59,5 @@ pip install azure-purview-sharing
 
 ## Next steps
 
-Check out the [API reference documentation](https://aka.ms/azsdk-purview-sharing-ref) to learn more about
+Check out the [API reference documentation](https://aka.ms/azsdk/python/purviewcatalog/ref-docs) to learn more about
 what you can do with the Azure Purview Sharing API client library.


### PR DESCRIPTION
# Description

This fixes two broken links for `azure-purview-sharing` -- a PyPI `aka.ms` link appears to have been removed, and a broken ref docs link is replaced with an `aka.ms` link to the same docs that's used elsewhere.

One broken link came from the long-deprecated `core/azure` package: a migration guide from 2016 that no longer exists in the repo's wiki. Given the fact that the package is no longer used and the guide was almost a decade old, I removed the link and included a note to mention the docs being dropped.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
