### PR TITLE
[auto release pipeline] Bump version for dependency

### DIFF
--- a/scripts/auto_release/PythonSdkLiveTest.yml
+++ b/scripts/auto_release/PythonSdkLiveTest.yml
@@ -19,8 +19,8 @@ variables:
   - group: Azure SDK Auto Release Pipeline Secrets
 
 jobs:
-- job: LiveTestPython38
-  displayName: Live Test Python 3.8
+- job: LiveTestPython310
+  displayName: Live Test Python 3.10
   timeoutInMinutes: 1500
   strategy:
     maxParallel: 5
@@ -31,7 +31,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.10'
         addToPath: true
         architecture: 'x64'
     - bash: |

--- a/scripts/auto_release/requirement.txt
+++ b/scripts/auto_release/requirement.txt
@@ -2,7 +2,7 @@ azure-identity
 python-dotenv==0.15.0
 ghapi==0.1.19
 PyGithub==1.55
-packaging==23.1
+packaging==24.1
 pytest==6.2.5
 fastcore==1.3.25
 tox==4.15.0

--- a/scripts/auto_release/requirement.txt
+++ b/scripts/auto_release/requirement.txt
@@ -5,4 +5,4 @@ PyGithub==1.55
 packaging==23.1
 pytest==6.2.5
 fastcore==1.3.25
-tox==4.5.0
+tox==4.15.0


### PR DESCRIPTION
bump version for `tox/packaging/python`

test link: https://github.com/Azure/azure-sdk-for-python/pull/37306