### PR TITLE
[Key Vault] Support CAE in challenge auth policy

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
+- Added support for Continuous Access Evaluation (CAE)
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
-- Added support for Continuous Access Evaluation (CAE)
+- Added support for Continuous Access Evaluation (CAE). `enable_cae=True` is passed to all `get_token` requests.
 
 ### Breaking Changes
 
@@ -13,6 +13,7 @@
   ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
+- Updated minimum `azure-core` version to 1.31.0
 - Key Vault API version `7.6-preview.1` is now the default
 
 ## 4.4.0 (2024-02-22)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -16,17 +16,47 @@ protocol again.
 
 from copy import deepcopy
 import time
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@overload
+async def await_result(func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+@overload
+async def await_result(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+async def await_result(func: Callable[P, Union[T, Awaitable[T]]], *args: P.args, **kwargs: P.kwargs) -> T:
+    """If func returns an awaitable, await it.
+
+    :param func: The function to run.
+    :type func: callable
+    :param args: The positional arguments to pass to the function.
+    :type args: list
+    :rtype: any
+    :return: The result of the function
+    """
+    result = func(*args, **kwargs)
+    if isinstance(result, Awaitable):
+        return await result
+    return result
+
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -42,6 +72,77 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    async def send(
+        self, request: PipelineRequest[HttpRequest]
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        await await_result(self.on_request, request)
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse]
+        try:
+            response = await self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            await await_result(self.on_exception, request)
+            raise
+        await await_result(self.on_response, request, response)
+
+        if response.http_response.status_code == 401:
+            return await self.handle_challenge_flow(request, response)
+        return response
+
+    async def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = await self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = await self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    await await_result(self.on_exception, request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return await self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                await await_result(self.on_response, request, response)
+        return response
+
 
     async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -78,6 +179,14 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -87,7 +196,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -104,10 +219,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            await self.authorize_request(request, scope, claims=challenge.claims)
         else:
             await self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+                request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id
             )
 
         return True

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -53,11 +53,9 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = await self._credential.get_token(scope)
                 else:
-                    self._token = await self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -106,9 +104,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims)
+            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            await self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            await self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -68,12 +68,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super().__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     async def send(
         self, request: PipelineRequest[HttpRequest]

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -17,8 +17,9 @@ protocol again.
 from copy import deepcopy
 import time
 from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import ParamSpec
 from urllib.parse import urlparse
+
+from typing_extensions import ParamSpec
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
@@ -199,7 +200,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -189,6 +189,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 old_tenant = cached_challenge.tenant_id
 
             challenge = _update_challenge(request, response)
+            # CAE challenges may not include a scope or tenant; use the previous challenge's values if necessary
+            if challenge.claims and old_scope:
+                challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
+                challenge.tenant_id = old_tenant
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
         except ValueError:
@@ -197,13 +201,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
-                if challenge.claims and old_scope:
-                    resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
-                    challenge.tenant_id = old_tenant
-                else:
-                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -68,7 +68,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -159,9 +159,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope)
+                    self._token = await self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = await self._credential.get_token(
+                        scope, tenant_id=challenge.tenant_id, enable_cae=True
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -232,11 +232,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    async def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    async def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -82,9 +82,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, claims=challenge.claims)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(
+                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -132,9 +134,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -66,12 +66,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
         """Authorize request with a bearer token and send it to the next policy.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -23,7 +23,7 @@ from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import HttpRequest, HttpResponse
 
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as ChallengeCache
@@ -71,6 +71,74 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self.on_request(request)
+        try:
+            response = self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            self.on_exception(request)
+            raise
+
+        self.on_response(request, response)
+        if response.http_response.status_code == 401:
+            return self.handle_challenge_flow(request, response)
+        return response
+
+    def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, HttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    self.on_exception(request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                self.on_response(request, response)
+        return response
 
     def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -106,6 +174,14 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -115,7 +191,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -132,11 +214,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
-            )
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -194,7 +194,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -82,11 +82,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = self._credential.get_token(scope)
                 else:
-                    self._token = self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -134,9 +132,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims)
+            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -80,7 +80,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -168,9 +168,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id, enable_cae=True)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -246,11 +246,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
@@ -37,16 +37,11 @@ class HttpChallenge(object):
         trimmed_challenge = split_challenge[1]
 
         self.claims = None
-        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
-            # special case for claims, which can contain = symbols as padding
+            # Special case for claims, which can contain = symbols as padding. Assume at most one claim per challenge
             if "claims=" in item:
-                if encoded_claims:
-                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
-                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
-                    self.claims = None
                 encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
                 padding_needed = -len(encoded_claims) % 4
                 try:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import base64
 from typing import Dict, MutableMapping, Optional
 from urllib import parse
 
@@ -18,7 +19,13 @@ class HttpChallenge(object):
     def __init__(
         self, request_uri: str, challenge: str, response_headers: "Optional[MutableMapping[str, str]]" = None
     ) -> None:
-        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server.
+
+        Example challenge with claims:
+            Bearer authorization="https://login.windows-ppe.net/", error="invalid_token",
+            error_description="User session has been revoked",
+            claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="
+        """
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
         self._parameters: "Dict[str, str]" = {}
@@ -29,16 +36,32 @@ class HttpChallenge(object):
         self.scheme = split_challenge[0]
         trimmed_challenge = split_challenge[1]
 
+        self.claims = None
+        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
+            # special case for claims, which can contain = symbols as padding
+            if "claims=" in item:
+                if encoded_claims:
+                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
+                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
+                    self.claims = None
+                encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
+                padding_needed = -len(encoded_claims) % 4
+                try:
+                    decoded_claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
+                    self.claims = decoded_claims
+                except Exception:  # pylint:disable=broad-except
+                    continue
             # process name=value pairs
-            comps = item.split("=")
-            if len(comps) == 2:
-                key = comps[0].strip(' "')
-                value = comps[1].strip(' "')
-                if key:
-                    self._parameters[key] = value
+            else:
+                comps = item.split("=")
+                if len(comps) == 2:
+                    key = comps[0].strip(' "')
+                    value = comps[1].strip(' "')
+                    if key:
+                        self._parameters[key] = value
 
         # minimum set of parameters
         if not self._parameters:

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -68,7 +68,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.29.5",
+        "azure-core>=1.31.0",
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",
     ],

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
+- Added support for Continuous Access Evaluation (CAE)
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
-- Added support for Continuous Access Evaluation (CAE)
+- Added support for Continuous Access Evaluation (CAE). `enable_cae=True` is passed to all `get_token` requests.
 
 ### Breaking Changes
 
@@ -13,6 +13,7 @@
   ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
+- Updated minimum `azure-core` version to 1.31.0
 - Key Vault API version `7.6-preview.1` is now the default
 
 ## 4.8.0 (2024-02-22)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -16,17 +16,47 @@ protocol again.
 
 from copy import deepcopy
 import time
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@overload
+async def await_result(func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+@overload
+async def await_result(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+async def await_result(func: Callable[P, Union[T, Awaitable[T]]], *args: P.args, **kwargs: P.kwargs) -> T:
+    """If func returns an awaitable, await it.
+
+    :param func: The function to run.
+    :type func: callable
+    :param args: The positional arguments to pass to the function.
+    :type args: list
+    :rtype: any
+    :return: The result of the function
+    """
+    result = func(*args, **kwargs)
+    if isinstance(result, Awaitable):
+        return await result
+    return result
+
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -42,6 +72,77 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    async def send(
+        self, request: PipelineRequest[HttpRequest]
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        await await_result(self.on_request, request)
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse]
+        try:
+            response = await self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            await await_result(self.on_exception, request)
+            raise
+        await await_result(self.on_response, request, response)
+
+        if response.http_response.status_code == 401:
+            return await self.handle_challenge_flow(request, response)
+        return response
+
+    async def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = await self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = await self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    await await_result(self.on_exception, request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return await self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                await await_result(self.on_response, request, response)
+        return response
+
 
     async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -78,6 +179,14 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -87,7 +196,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -104,10 +219,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            await self.authorize_request(request, scope, claims=challenge.claims)
         else:
             await self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+                request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id
             )
 
         return True

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -53,11 +53,9 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = await self._credential.get_token(scope)
                 else:
-                    self._token = await self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -106,9 +104,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims)
+            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            await self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            await self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -68,12 +68,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super().__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     async def send(
         self, request: PipelineRequest[HttpRequest]

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -17,8 +17,9 @@ protocol again.
 from copy import deepcopy
 import time
 from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import ParamSpec
 from urllib.parse import urlparse
+
+from typing_extensions import ParamSpec
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
@@ -199,7 +200,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -189,6 +189,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 old_tenant = cached_challenge.tenant_id
 
             challenge = _update_challenge(request, response)
+            # CAE challenges may not include a scope or tenant; use the previous challenge's values if necessary
+            if challenge.claims and old_scope:
+                challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
+                challenge.tenant_id = old_tenant
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
         except ValueError:
@@ -197,13 +201,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
-                if challenge.claims and old_scope:
-                    resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
-                    challenge.tenant_id = old_tenant
-                else:
-                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -68,7 +68,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -159,9 +159,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope)
+                    self._token = await self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = await self._credential.get_token(
+                        scope, tenant_id=challenge.tenant_id, enable_cae=True
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -232,11 +232,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    async def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    async def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -82,9 +82,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, claims=challenge.claims)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(
+                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -132,9 +134,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -66,12 +66,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
         """Authorize request with a bearer token and send it to the next policy.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -23,7 +23,7 @@ from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import HttpRequest, HttpResponse
 
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as ChallengeCache
@@ -71,6 +71,74 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self.on_request(request)
+        try:
+            response = self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            self.on_exception(request)
+            raise
+
+        self.on_response(request, response)
+        if response.http_response.status_code == 401:
+            return self.handle_challenge_flow(request, response)
+        return response
+
+    def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, HttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    self.on_exception(request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                self.on_response(request, response)
+        return response
 
     def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -106,6 +174,14 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -115,7 +191,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -132,11 +214,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
-            )
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -194,7 +194,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -82,11 +82,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = self._credential.get_token(scope)
                 else:
-                    self._token = self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -134,9 +132,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims)
+            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -80,7 +80,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -168,9 +168,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id, enable_cae=True)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -246,11 +246,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
@@ -37,16 +37,11 @@ class HttpChallenge(object):
         trimmed_challenge = split_challenge[1]
 
         self.claims = None
-        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
-            # special case for claims, which can contain = symbols as padding
+            # Special case for claims, which can contain = symbols as padding. Assume at most one claim per challenge
             if "claims=" in item:
-                if encoded_claims:
-                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
-                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
-                    self.claims = None
                 encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
                 padding_needed = -len(encoded_claims) % 4
                 try:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import base64
 from typing import Dict, MutableMapping, Optional
 from urllib import parse
 
@@ -18,7 +19,13 @@ class HttpChallenge(object):
     def __init__(
         self, request_uri: str, challenge: str, response_headers: "Optional[MutableMapping[str, str]]" = None
     ) -> None:
-        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server.
+
+        Example challenge with claims:
+            Bearer authorization="https://login.windows-ppe.net/", error="invalid_token",
+            error_description="User session has been revoked",
+            claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="
+        """
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
         self._parameters: "Dict[str, str]" = {}
@@ -29,16 +36,32 @@ class HttpChallenge(object):
         self.scheme = split_challenge[0]
         trimmed_challenge = split_challenge[1]
 
+        self.claims = None
+        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
+            # special case for claims, which can contain = symbols as padding
+            if "claims=" in item:
+                if encoded_claims:
+                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
+                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
+                    self.claims = None
+                encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
+                padding_needed = -len(encoded_claims) % 4
+                try:
+                    decoded_claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
+                    self.claims = decoded_claims
+                except Exception:  # pylint:disable=broad-except
+                    continue
             # process name=value pairs
-            comps = item.split("=")
-            if len(comps) == 2:
-                key = comps[0].strip(' "')
-                value = comps[1].strip(' "')
-                if key:
-                    self._parameters[key] = value
+            else:
+                comps = item.split("=")
+                if len(comps) == 2:
+                    key = comps[0].strip(' "')
+                    value = comps[1].strip(' "')
+                    if key:
+                        self._parameters[key] = value
 
         # minimum set of parameters
         if not self._parameters:

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -68,7 +68,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.29.5",
+        "azure-core>=1.31.0",
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",
     ],

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
+- Added support for Continuous Access Evaluation (CAE)
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
-- Added support for Continuous Access Evaluation (CAE)
+- Added support for Continuous Access Evaluation (CAE). `enable_cae=True` is passed to all `get_token` requests.
 
 ### Breaking Changes
 
@@ -13,6 +13,7 @@
   ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
+- Updated minimum `azure-core` version to 1.31.0
 - Key Vault API version `7.6-preview.1` is now the default
 
 ## 4.9.0 (2024-02-22)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -16,17 +16,47 @@ protocol again.
 
 from copy import deepcopy
 import time
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@overload
+async def await_result(func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+@overload
+async def await_result(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+async def await_result(func: Callable[P, Union[T, Awaitable[T]]], *args: P.args, **kwargs: P.kwargs) -> T:
+    """If func returns an awaitable, await it.
+
+    :param func: The function to run.
+    :type func: callable
+    :param args: The positional arguments to pass to the function.
+    :type args: list
+    :rtype: any
+    :return: The result of the function
+    """
+    result = func(*args, **kwargs)
+    if isinstance(result, Awaitable):
+        return await result
+    return result
+
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -43,6 +73,76 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
         self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    async def send(
+        self, request: PipelineRequest[HttpRequest]
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        await await_result(self.on_request, request)
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse]
+        try:
+            response = await self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            await await_result(self.on_exception, request)
+            raise
+        await await_result(self.on_response, request, response)
+
+        if response.http_response.status_code == 401:
+            return await self.handle_challenge_flow(request, response)
+        return response
+
+    async def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = await self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = await self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    await await_result(self.on_exception, request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return await self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                await await_result(self.on_response, request, response)
+        return response
+
 
     async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -53,11 +53,9 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = await self._credential.get_token(scope)
                 else:
-                    self._token = await self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -106,9 +104,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims)
+            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            await self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            await self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -68,12 +68,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super().__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     async def send(
         self, request: PipelineRequest[HttpRequest]

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -17,8 +17,9 @@ protocol again.
 from copy import deepcopy
 import time
 from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import ParamSpec
 from urllib.parse import urlparse
+
+from typing_extensions import ParamSpec
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
@@ -199,7 +200,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -189,6 +189,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 old_tenant = cached_challenge.tenant_id
 
             challenge = _update_challenge(request, response)
+            # CAE challenges may not include a scope or tenant; use the previous challenge's values if necessary
+            if challenge.claims and old_scope:
+                challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
+                challenge.tenant_id = old_tenant
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
         except ValueError:
@@ -197,13 +201,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
-                if challenge.claims and old_scope:
-                    resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
-                    challenge.tenant_id = old_tenant
-                else:
-                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -68,7 +68,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -159,9 +159,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope)
+                    self._token = await self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = await self._credential.get_token(
+                        scope, tenant_id=challenge.tenant_id, enable_cae=True
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -232,11 +232,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    async def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    async def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -82,9 +82,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, claims=challenge.claims)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(
+                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -132,9 +134,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -71,6 +71,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -106,6 +107,14 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -115,7 +124,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -132,11 +147,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
-            )
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -66,12 +66,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
         """Authorize request with a bearer token and send it to the next policy.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -194,7 +194,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -82,11 +82,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = self._credential.get_token(scope)
                 else:
-                    self._token = self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -134,9 +132,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims)
+            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -80,7 +80,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -168,9 +168,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id, enable_cae=True)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -246,11 +246,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
@@ -37,16 +37,11 @@ class HttpChallenge(object):
         trimmed_challenge = split_challenge[1]
 
         self.claims = None
-        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
-            # special case for claims, which can contain = symbols as padding
+            # Special case for claims, which can contain = symbols as padding. Assume at most one claim per challenge
             if "claims=" in item:
-                if encoded_claims:
-                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
-                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
-                    self.claims = None
                 encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
                 padding_needed = -len(encoded_claims) % 4
                 try:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import base64
 from typing import Dict, MutableMapping, Optional
 from urllib import parse
 
@@ -18,7 +19,13 @@ class HttpChallenge(object):
     def __init__(
         self, request_uri: str, challenge: str, response_headers: "Optional[MutableMapping[str, str]]" = None
     ) -> None:
-        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server.
+
+        Example challenge with claims:
+            Bearer authorization="https://login.windows-ppe.net/", error="invalid_token",
+            error_description="User session has been revoked",
+            claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="
+        """
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
         self._parameters: "Dict[str, str]" = {}
@@ -29,16 +36,32 @@ class HttpChallenge(object):
         self.scheme = split_challenge[0]
         trimmed_challenge = split_challenge[1]
 
+        self.claims = None
+        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
+            # special case for claims, which can contain = symbols as padding
+            if "claims=" in item:
+                if encoded_claims:
+                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
+                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
+                    self.claims = None
+                encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
+                padding_needed = -len(encoded_claims) % 4
+                try:
+                    decoded_claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
+                    self.claims = decoded_claims
+                except Exception:  # pylint:disable=broad-except
+                    continue
             # process name=value pairs
-            comps = item.split("=")
-            if len(comps) == 2:
-                key = comps[0].strip(' "')
-                value = comps[1].strip(' "')
-                if key:
-                    self._parameters[key] = value
+            else:
+                comps = item.split("=")
+                if len(comps) == 2:
+                    key = comps[0].strip(' "')
+                    value = comps[1].strip(' "')
+                    if key:
+                        self._parameters[key] = value
 
         # minimum set of parameters
         if not self._parameters:

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -68,7 +68,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.31.0",
+        "azure-core>=1.29.5",
         "cryptography>=2.1.4",
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -68,7 +68,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.29.5",
+        "azure-core>=1.31.0",
         "cryptography>=2.1.4",
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -540,12 +540,21 @@ def test_verify_challenge_resource_valid(verify_challenge_resource):
 
 @empty_challenge_cache
 def test_cae():
-    """The policy should correctly handle claims in a challenge response"""
+    """The policy should handle claims in a challenge response after having successfully authenticated prior."""
 
     expected_content = b"a duck"
 
     def test_with_challenge(challenge, expected_claim):
+        first_token = "first_token"
         expected_token = "expected_token"
+        tenant = "tenant-id"
+        endpoint = f"https://authority.net/{tenant}"
+        resource = "https://vault.azure.net"
+
+        first_challenge = Mock(
+            status_code=401,
+            headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
+        )
 
         class Requests:
             count = 0
@@ -556,9 +565,21 @@ def test_cae():
                 # first request should be unauthorized and have no content
                 assert not request.body
                 assert request.headers["Content-Length"] == "0"
-                return challenge
+                return first_challenge
             elif Requests.count == 2:
                 # second request should be authorized according to challenge and have the expected content
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert first_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            elif Requests.count == 3:
+                # third request will trigger a CAE challenge response in this test scenario
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert first_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 4:
+                # fourth request should include the required claims and correctly use context from the first challenge
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
                 assert expected_token in request.headers["Authorization"]
@@ -566,8 +587,93 @@ def test_cae():
             raise ValueError("unexpected request")
 
         def get_token(*_, **kwargs):
-            assert kwargs.get("claims") == expected_claim
-            return AccessToken(expected_token, 0)
+            if Requests.count == 1:
+                assert kwargs.get("claims") == None
+                assert kwargs.get("enable_cae") == True
+                assert kwargs.get("tenant_id") == tenant
+                return AccessToken(first_token, time.time() + 3600)
+            elif Requests.count == 3:
+                assert kwargs.get("claims") == expected_claim
+                assert kwargs.get("enable_cae") == True
+                assert kwargs.get("tenant_id") == tenant
+                return AccessToken(expected_token, time.time() + 3600)
+
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+        request = HttpRequest("POST", get_random_url())
+        request.set_bytes_body(expected_content)
+        pipeline.run(request)  # Send the request once to trigger a regular auth challenge
+        pipeline.run(request)  # Send the request again to trigger a CAE challenge
+
+        assert credential.get_token.call_count == 2
+
+    url = f'authorization_uri="{get_random_url()}"'
+    cid = 'client_id="00000003-0000-0000-c000-000000000000"'
+    err = 'error="insufficient_claims"'
+    claim = '{"access_token": {"foo": "bar"}}'
+    # Claim token is a string of the base64 encoding of the claim
+    claim_token = base64.b64encode(claim.encode()).decode()
+    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
+
+    challenge_response = Mock(status_code=401, headers={"WWW-Authenticate": challenge})
+
+    test_with_challenge(challenge_response, claim)
+
+
+@empty_challenge_cache
+def test_cae_consecutive_challenges():
+    """The policy should correctly handle consecutive challenges in cases where the flow is valid or invalid."""
+
+    expected_content = b"a duck"
+
+    def test_with_challenge(challenge, expected_claim):
+        first_token = "first_token"
+        expected_token = "expected_token"
+        tenant = "tenant-id"
+        endpoint = f"https://authority.net/{tenant}"
+        resource = "https://vault.azure.net"
+
+        first_challenge = Mock(
+            status_code=401,
+            headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
+        )
+
+        class Requests:
+            count = 0
+
+        def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request should be unauthorized and have no content
+                assert not request.body
+                assert request.headers["Content-Length"] == "0"
+                return first_challenge
+            elif Requests.count == 2:
+                # second request will trigger a CAE challenge response in this test scenario
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert first_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 3:
+                # third request should include the required claims and correctly use context from the first challenge
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert expected_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            raise ValueError("unexpected request")
+
+        def get_token(*_, **kwargs):
+            if Requests.count == 1:
+                assert kwargs.get("claims") == None
+                assert kwargs.get("enable_cae") == True
+                assert kwargs.get("tenant_id") == tenant
+                return AccessToken(first_token, time.time() + 3600)
+            elif Requests.count == 2:
+                assert kwargs.get("claims") == expected_claim
+                assert kwargs.get("enable_cae") == True
+                assert kwargs.get("tenant_id") == tenant
+                return AccessToken(expected_token, time.time() + 3600)
 
         credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
@@ -575,16 +681,16 @@ def test_cae():
         request.set_bytes_body(expected_content)
         pipeline.run(request)
 
-        assert credential.get_token.call_count == 1
+        assert credential.get_token.call_count == 2
 
     url = f'authorization_uri="{get_random_url()}"'
-    resource = 'resource="https://vault.azure.net"'
     cid = 'client_id="00000003-0000-0000-c000-000000000000"'
     err = 'error="insufficient_claims"'
     claim = '{"access_token": {"foo": "bar"}}'
     # Claim token is a string of the base64 encoding of the claim
     claim_token = base64.b64encode(claim.encode()).decode()
-    challenge = f'Bearer realm="", {url}, {resource}, {cid}, {err}, claims="{claim_token}"'
+    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
     challenge_response = Mock(status_code=401, headers={"WWW-Authenticate": challenge})
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -615,7 +615,7 @@ def test_cae():
     claim = '{"access_token": {"foo": "bar"}}'
     # Claim token is a string of the base64 encoding of the claim
     claim_token = base64.b64encode(claim.encode()).decode()
-    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    # Note that no resource or scope is necessarily provided in a CAE challenge
     challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
     claims_challenge = Mock(status_code=401, headers={"WWW-Authenticate": challenge})
@@ -693,7 +693,7 @@ def test_cae_consecutive_challenges():
     claim = '{"access_token": {"foo": "bar"}}'
     # Claim token is a string of the base64 encoding of the claim
     claim_token = base64.b64encode(claim.encode()).decode()
-    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    # Note that no resource or scope is necessarily provided in a CAE challenge
     challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
     claims_challenge = Mock(status_code=401, headers={"WWW-Authenticate": challenge})

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -704,3 +704,75 @@ def test_cae_consecutive_challenges():
         assert credential.get_token.call_count == 2
 
     test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)
+
+
+@empty_challenge_cache
+def test_cae_token_expiry():
+    """The policy should avoid sending claims more than once when a token expires."""
+
+    expected_content = b"a duck"
+
+    def test_with_challenge(claims_challenge, expected_claim):
+        first_token = "first_token"
+        second_token = "second_token"
+        third_token = "third_token"
+
+        class Requests:
+            count = 0
+
+        def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request should be unauthorized and have no content; triggers a KV challenge response
+                assert not request.body
+                assert "Authorization" not in request.headers
+                assert request.headers["Content-Length"] == "0"
+                return KV_CHALLENGE_RESPONSE
+            elif Requests.count == 2:
+                # second request will trigger a CAE challenge response in this test scenario
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert first_token in request.headers["Authorization"]
+                return claims_challenge
+            elif Requests.count == 3:
+                # third request should include the required claims and correctly use content from the first challenge
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert second_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            elif Requests.count == 4:
+                # fourth request should not include claims, but otherwise use content from the first challenge
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert third_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            raise ValueError("unexpected request")
+
+        def get_token(*scopes, **kwargs):
+            assert kwargs.get("enable_cae") == True
+            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+            assert scopes[0] == RESOURCE + "/.default"
+            # Response to KV challenge
+            if Requests.count == 1:
+                assert kwargs.get("claims") == None
+                return AccessToken(first_token, time.time() + 3600)
+            # Response to first CAE challenge
+            elif Requests.count == 2:
+                assert kwargs.get("claims") == expected_claim
+                return AccessToken(second_token, 0)  # Return a token that expires immediately to trigger a refresh
+            # Token refresh before making the final request
+            elif Requests.count == 3:
+                assert kwargs.get("claims") == None
+                return AccessToken(third_token, time.time() + 3600)
+
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+        request = HttpRequest("POST", get_random_url())
+        request.set_bytes_body(expected_content)
+        pipeline.run(request)
+        pipeline.run(request)  # Send the request again to trigger a token refresh upon expiry
+
+        # get_token is called for the KV and CAE challenges, as well as for the token refresh
+        assert credential.get_token.call_count == 3
+
+    test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -69,31 +69,6 @@ class TestChallengeAuth(KeyVaultTestCase, KeysTestCase):
         else:
             os.environ.pop("AZURE_TENANT_ID")
 
-    @pytest.mark.skip("Manual test for specific, CAE-enabled environments.")
-    @pytest.mark.live_test_only
-    def test_cae_live(self, **kwargs):
-        class CredentialWrapper(TokenCredential):
-            def __init__(self, credential):
-                self._credential = credential
-                self._claims = None
-
-            def get_token(self, *scopes, **kwargs):
-                assert kwargs["enable_cae"] == True
-                if kwargs.get("claims"):
-                    # We should only receive claims once; subsequent challenges should be returned to the caller
-                    assert self._claims is None
-                    self._claims = kwargs["claims"]
-                return self._credential.get_token(*scopes, **kwargs)
-
-        credential = self.get_credential(KeyClient)
-        wrapped = CredentialWrapper(credential)
-        client = KeyClient(vault_url=os.environ["AZURE_KEYVAULT_URL"], credential=wrapped)
-        try:
-            client.create_rsa_key("key-name")  # Basic request meant to just trigger CAE challenges
-        # Test environment may continuously return claims challenges; a second consecutive challenge will raise
-        except ClientAuthenticationError as e:
-            assert "continuous access evaluation" in str(e).lower()
-        assert wrapped._claims is not None  # Ensure we passed a claim to a token request
 
 def empty_challenge_cache(fn):
     @functools.wraps(fn)
@@ -109,6 +84,25 @@ def get_random_url():
     """The challenge cache is keyed on URLs. Random URLs defend against tests interfering with each other."""
 
     return f"https://{uuid4()}.vault.azure.net/{uuid4()}".replace("-", "")
+
+
+URL = f'authorization_uri="{get_random_url()}"'
+CLIENT_ID = 'client_id="00000003-0000-0000-c000-000000000000"'
+CAE_ERROR = 'error="insufficient_claims"'
+CAE_DECODED_CLAIM = '{"access_token": {"foo": "bar"}}'
+# Claim token is a string of the base64 encoding of the claim
+CLAIM_TOKEN = base64.b64encode(CAE_DECODED_CLAIM.encode()).decode()
+# Note that no resource or scope is necessarily provided in a CAE challenge
+CLAIM_CHALLENGE = f'Bearer realm="", {URL}, {CLIENT_ID}, {CAE_ERROR}, claims="{CLAIM_TOKEN}"'
+CAE_CHALLENGE_HEADER = Mock(status_code=401, headers={"WWW-Authenticate": CLAIM_CHALLENGE})
+
+KV_CHALLENGE_TENANT = "tenant-id"
+ENDPOINT = f"https://authority.net/{KV_CHALLENGE_TENANT}"
+RESOURCE = "https://vault.azure.net"
+KV_CHALLENGE_HEADER = Mock(
+    status_code=401,
+    headers={"WWW-Authenticate": f'Bearer authorization="{ENDPOINT}", resource={RESOURCE}'},
+)
 
 
 def add_url_port(url: str):
@@ -573,14 +567,6 @@ def test_cae():
     def test_with_challenge(claims_challenge, expected_claim):
         first_token = "first_token"
         expected_token = "expected_token"
-        tenant = "tenant-id"
-        endpoint = f"https://authority.net/{tenant}"
-        resource = "https://vault.azure.net"
-
-        kv_challenge = Mock(
-            status_code=401,
-            headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
-        )
 
         class Requests:
             count = 0
@@ -592,7 +578,7 @@ def test_cae():
                 assert not request.body
                 assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
-                return kv_challenge
+                return KV_CHALLENGE_HEADER
             elif Requests.count == 2:
                 # second request should be authorized according to challenge and have the expected content
                 assert request.headers["Content-Length"]
@@ -606,18 +592,30 @@ def test_cae():
                 assert first_token in request.headers["Authorization"]
                 return claims_challenge
             elif Requests.count == 4:
-                # fourth request should include the required claims and correctly use context from the first challenge
-                # we return another KV challenge to verify that the policy doesn't try to handle this invalid flow
+                # fourth request should include the required claims and correctly use content from the first challenge
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
                 assert expected_token in request.headers["Authorization"]
-                return kv_challenge
+                return Mock(status_code=200)
+            elif Requests.count == 5:
+                # fifth request should be a regular request with the expected token
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert expected_token in request.headers["Authorization"]
+                return KV_CHALLENGE_HEADER
+            elif Requests.count == 6:
+                # sixth request should respond to the KV challenge WITHOUT including claims
+                # we return another challenge to confirm that the policy will return consecutive 401s to the user
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert first_token in request.headers["Authorization"]
+                return KV_CHALLENGE_HEADER
             raise ValueError("unexpected request")
 
         def get_token(*scopes, **kwargs):
             assert kwargs.get("enable_cae") == True
-            assert kwargs.get("tenant_id") == tenant
-            assert scopes[0] == resource + "/.default"
+            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+            assert scopes[0] == RESOURCE + "/.default"
             # Response to KV challenge
             if Requests.count == 1:
                 assert kwargs.get("claims") == None
@@ -626,6 +624,12 @@ def test_cae():
             elif Requests.count == 3:
                 assert kwargs.get("claims") == expected_claim
                 return AccessToken(expected_token, time.time() + 3600)
+            # Response to second KV challenge
+            elif Requests.count == 5:
+                assert kwargs.get("claims") == None
+                return AccessToken(first_token, time.time() + 3600)
+            elif Requests.count == 6:
+                raise ValueError("unexpected token request")
 
         credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
@@ -633,23 +637,12 @@ def test_cae():
         request.set_bytes_body(expected_content)
         pipeline.run(request)  # Send the request once to trigger a regular auth challenge
         pipeline.run(request)  # Send the request again to trigger a CAE challenge
+        pipeline.run(request)  # Send the request once to trigger another regular auth challenge
 
-        # get_token is called for the first KV challenge and CAE challenge, but not the second KV challenge
-        assert credential.get_token.call_count == 2
+        # get_token is called for the CAE challenge and first two KV challenges, but not the final KV challenge
+        assert credential.get_token.call_count == 3
 
-    url = f'authorization_uri="{get_random_url()}"'
-    cid = 'client_id="00000003-0000-0000-c000-000000000000"'
-    err = 'error="insufficient_claims"'
-    claim = '{"access_token": {"foo": "bar"}}'
-    # Claim token is a string of the base64 encoding of the claim. Trim the padding to ensure the policy can handle it
-    claim_token = base64.b64encode(claim.encode()).decode()
-    claim_token = claim_token.strip("=")
-    # Note that no resource or scope is necessarily provided in a CAE challenge
-    challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
-
-    claims_challenge = Mock(status_code=401, headers={"WWW-Authenticate": challenge})
-
-    test_with_challenge(claims_challenge, claim)
+    test_with_challenge(CAE_CHALLENGE_HEADER, CAE_DECODED_CLAIM)
 
 
 @empty_challenge_cache
@@ -661,14 +654,6 @@ def test_cae_consecutive_challenges():
     def test_with_challenge(claims_challenge, expected_claim):
         first_token = "first_token"
         expected_token = "expected_token"
-        tenant = "tenant-id"
-        endpoint = f"https://authority.net/{tenant}"
-        resource = "https://vault.azure.net"
-
-        kv_challenge = Mock(
-            status_code=401,
-            headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
-        )
 
         class Requests:
             count = 0
@@ -680,7 +665,7 @@ def test_cae_consecutive_challenges():
                 assert not request.body
                 assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
-                return kv_challenge
+                return KV_CHALLENGE_HEADER
             elif Requests.count == 2:
                 # second request will trigger a CAE challenge response in this test scenario
                 assert request.headers["Content-Length"]
@@ -688,7 +673,7 @@ def test_cae_consecutive_challenges():
                 assert first_token in request.headers["Authorization"]
                 return claims_challenge
             elif Requests.count == 3:
-                # third request should include the required claims and correctly use context from the first challenge
+                # third request should include the required claims and correctly use content from the first challenge
                 # we return another CAE challenge to verify that the policy will return consecutive CAE 401s to the user
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
@@ -698,8 +683,8 @@ def test_cae_consecutive_challenges():
 
         def get_token(*scopes, **kwargs):
             assert kwargs.get("enable_cae") == True
-            assert kwargs.get("tenant_id") == tenant
-            assert scopes[0] == resource + "/.default"
+            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+            assert scopes[0] == RESOURCE + "/.default"
             # Response to KV challenge
             if Requests.count == 1:
                 assert kwargs.get("claims") == None
@@ -718,15 +703,4 @@ def test_cae_consecutive_challenges():
         # get_token is called for the KV challenge and first CAE challenge, but not the second CAE challenge
         assert credential.get_token.call_count == 2
 
-    url = f'authorization_uri="{get_random_url()}"'
-    cid = 'client_id="00000003-0000-0000-c000-000000000000"'
-    err = 'error="insufficient_claims"'
-    claim = '{"access_token": {"foo": "bar"}}'
-    # Claim token is a string of the base64 encoding of the claim
-    claim_token = base64.b64encode(claim.encode()).decode()
-    # Note that no resource or scope is necessarily provided in a CAE challenge
-    challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
-
-    claims_challenge = Mock(status_code=401, headers={"WWW-Authenticate": challenge})
-
-    test_with_challenge(claims_challenge, claim)
+    test_with_challenge(CAE_CHALLENGE_HEADER, CAE_DECODED_CLAIM)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -8,6 +8,7 @@ the challenge cache is global to the process.
 """
 import base64
 import functools
+from itertools import product
 import os
 import time
 from unittest.mock import Mock, patch
@@ -17,8 +18,8 @@ from uuid import uuid4
 from devtools_testutils import recorded_by_proxy
 
 import pytest
-from azure.core.credentials import AccessToken, TokenCredential
-from azure.core.exceptions import ClientAuthenticationError, ServiceRequestError
+from azure.core.credentials import AccessToken, AccessTokenInfo
+from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
@@ -32,6 +33,8 @@ from _test_case import KeysClientPreparer, get_decorator
 from _keys_test_case import KeysTestCase
 
 only_default_version = get_decorator(api_versions=[DEFAULT_VERSION])
+
+TOKEN_TYPES = [AccessToken, AccessTokenInfo]
 
 class TestChallengeAuth(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", only_default_version)
@@ -155,7 +158,8 @@ def test_challenge_parsing():
 
 
 @empty_challenge_cache
-def test_scope():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_scope(token_type):
     """The policy's token requests should always be for an AADv2 scope"""
 
     expected_content = b"a duck"
@@ -184,15 +188,21 @@ def test_scope():
         def get_token(*scopes, **_):
             assert len(scopes) == 1
             assert scopes[0] == expected_scope
-            return AccessToken(expected_token, 0)
+            return token_type(expected_token, 0)
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
 
-        assert credential.get_token.call_count == 1
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 1
+        else:
+            assert credential.get_token_info.call_count == 1
 
     endpoint = "https://authority.net/tenant"
 
@@ -214,7 +224,8 @@ def test_scope():
 
 
 @empty_challenge_cache
-def test_tenant():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_tenant(token_type):
     """The policy's token requests should pass the parsed tenant ID from the challenge"""
 
     expected_content = b"a duck"
@@ -240,17 +251,24 @@ def test_tenant():
                 return Mock(status_code=200)
             raise ValueError("unexpected request")
 
-        def get_token(*_, **kwargs):
-            assert kwargs.get("tenant_id") == expected_tenant
-            return AccessToken(expected_token, 0)
+        def get_token(*_, options=None, **kwargs):
+            options_bag = options if options else kwargs
+            assert options_bag.get("tenant_id") == expected_tenant
+            return token_type(expected_token, 0)
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
 
-        assert credential.get_token.call_count == 1
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 1
+        else:
+            assert credential.get_token_info.call_count == 1
 
     tenant = "tenant-id"
     endpoint = f"https://authority.net/{tenant}"
@@ -265,7 +283,8 @@ def test_tenant():
 
 
 @empty_challenge_cache
-def test_adfs():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_adfs(token_type):
     """The policy should handle AD FS challenges as a special case and omit the tenant ID from token requests"""
 
     expected_content = b"a duck"
@@ -294,15 +313,21 @@ def test_adfs():
         def get_token(*_, **kwargs):
             # we shouldn't provide a tenant ID during AD FS authentication
             assert "tenant_id" not in kwargs
-            return AccessToken(expected_token, 0)
+            return token_type(expected_token, 0)
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         policy = ChallengeAuthPolicy(credential=credential)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
-        assert credential.get_token.call_count == 1
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 1
+        else:
+            assert credential.get_token_info.call_count == 1
 
         # Regression test: https://github.com/Azure/azure-sdk-for-python/issues/33621
         policy._token = None
@@ -321,7 +346,8 @@ def test_adfs():
     test_with_challenge(challenge, tenant)
 
 
-def test_policy_updates_cache():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_policy_updates_cache(token_type):
     """
     It's possible for the challenge returned for a request to change, e.g. when a vault is moved to a new tenant.
     When the policy receives a 401, it should update the cached challenge for the requested URL, if one exists.
@@ -360,23 +386,38 @@ def test_policy_updates_cache():
         ),
     )
 
-    credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=AccessToken(first_token, time.time() + 3600)))
+    token = token_type(first_token, time.time() + 3600)
+
+    def get_token(*_, **__):
+        return token
+
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
     pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=transport)
 
     # policy should complete and cache the first challenge and access token
     for _ in range(2):
         pipeline.run(HttpRequest("GET", url))
-        assert credential.get_token.call_count == 1
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 1
+        else:
+            assert credential.get_token_info.call_count == 1
 
     # The next request will receive a new challenge. The policy should handle it and update caches.
-    credential.get_token.return_value = AccessToken(second_token, time.time() + 3600)
+    token = token_type(second_token, time.time() + 3600)
     for _ in range(2):
         pipeline.run(HttpRequest("GET", url))
-        assert credential.get_token.call_count == 2
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 2
+        else:
+            assert credential.get_token_info.call_count == 2
 
 
-
-def test_token_expiration():
+@empty_challenge_cache
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_token_expiration(token_type):
     """policy should not use a cached token which has expired"""
 
     url = get_random_url()
@@ -386,12 +427,15 @@ def test_token_expiration():
     second_token = "**"
     resource = "https://vault.azure.net"
 
-    token = AccessToken(first_token, expires_on)
+    token = token_type(first_token, expires_on)
 
     def get_token(*_, **__):
         return token
 
-    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
     transport = validating_transport(
         requests=[
             Request(),
@@ -410,16 +454,23 @@ def test_token_expiration():
 
     for _ in range(2):
         pipeline.run(HttpRequest("GET", url))
-        assert credential.get_token.call_count == 1
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 1
+        else:
+            assert credential.get_token_info.call_count == 1
 
-    token = AccessToken(second_token, time.time() + 3600)
+    token = token_type(second_token, time.time() + 3600)
     with patch("time.time", lambda: expires_on):
         pipeline.run(HttpRequest("GET", url))
-    assert credential.get_token.call_count == 2
+    if hasattr(credential, "get_token"):
+        assert credential.get_token.call_count == 2
+    else:
+        assert credential.get_token_info.call_count == 2
 
 
 @empty_challenge_cache
-def test_preserves_options_and_headers():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_preserves_options_and_headers(token_type):
     """After a challenge, the policy should send the original request with its options and headers preserved"""
 
     url = get_random_url()
@@ -427,9 +478,12 @@ def test_preserves_options_and_headers():
     resource = "https://vault.azure.net"
 
     def get_token(*_, **__):
-        return AccessToken(token, 0)
+        return token_type(token, 0)
 
-    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request()] * 2 + [Request(required_headers={"Authorization": "Bearer " + token})],
@@ -471,8 +525,8 @@ def test_preserves_options_and_headers():
 
 
 @empty_challenge_cache
-@pytest.mark.parametrize("verify_challenge_resource", [True, False])
-def test_verify_challenge_resource_matches(verify_challenge_resource):
+@pytest.mark.parametrize("verify_challenge_resource,token_type", product([True, False], TOKEN_TYPES))
+def test_verify_challenge_resource_matches(verify_challenge_resource, token_type):
     """The auth policy should raise if the challenge resource doesn't match the request URL unless check is disabled"""
 
     url = get_random_url()
@@ -481,9 +535,12 @@ def test_verify_challenge_resource_matches(verify_challenge_resource):
     resource = "https://myvault.azure.net"  # Doesn't match a "".vault.azure.net" resource because of the "my" prefix
 
     def get_token(*_, **__):
-        return AccessToken(token, 0)
+        return token_type(token, 0)
 
-    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],
@@ -524,8 +581,8 @@ def test_verify_challenge_resource_matches(verify_challenge_resource):
 
 
 @empty_challenge_cache
-@pytest.mark.parametrize("verify_challenge_resource", [True, False])
-def test_verify_challenge_resource_valid(verify_challenge_resource):
+@pytest.mark.parametrize("verify_challenge_resource,token_type", product([True, False], TOKEN_TYPES))
+def test_verify_challenge_resource_valid(verify_challenge_resource, token_type):
     """The auth policy should raise if the challenge resource isn't a valid URL unless check is disabled"""
 
     url = get_random_url()
@@ -533,9 +590,12 @@ def test_verify_challenge_resource_valid(verify_challenge_resource):
     resource = "bad-resource"
 
     def get_token(*_, **__):
-        return AccessToken(token, 0)
+        return token_type(token, 0)
 
-    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],
@@ -559,7 +619,8 @@ def test_verify_challenge_resource_valid(verify_challenge_resource):
 
 
 @empty_challenge_cache
-def test_cae():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_cae(token_type):
     """The policy should handle claims in a challenge response after having successfully authenticated prior."""
 
     expected_content = b"a duck"
@@ -612,26 +673,30 @@ def test_cae():
                 return KV_CHALLENGE_RESPONSE
             raise ValueError("unexpected request")
 
-        def get_token(*scopes, **kwargs):
-            assert kwargs.get("enable_cae") == True
-            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+        def get_token(*scopes, options=None, **kwargs):
+            options_bag = options if options else kwargs
+            assert options_bag.get("enable_cae") == True
+            assert options_bag.get("tenant_id") == KV_CHALLENGE_TENANT
             assert scopes[0] == RESOURCE + "/.default"
             # Response to KV challenge
             if Requests.count == 1:
-                assert kwargs.get("claims") == None
+                assert options_bag.get("claims") == None
                 return AccessToken(first_token, time.time() + 3600)
             # Response to CAE challenge
             elif Requests.count == 3:
-                assert kwargs.get("claims") == expected_claim
+                assert options_bag.get("claims") == expected_claim
                 return AccessToken(expected_token, time.time() + 3600)
             # Response to second KV challenge
             elif Requests.count == 5:
-                assert kwargs.get("claims") == None
+                assert options_bag.get("claims") == None
                 return AccessToken(first_token, time.time() + 3600)
             elif Requests.count == 6:
                 raise ValueError("unexpected token request")
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
@@ -639,14 +704,18 @@ def test_cae():
         pipeline.run(request)  # Send the request again to trigger a CAE challenge
         pipeline.run(request)  # Send the request once to trigger another regular auth challenge
 
-        # get_token is called for the CAE challenge and first two KV challenges, but not the final KV challenge
-        assert credential.get_token.call_count == 3
+        # token requests made for the CAE challenge and first two KV challenges, but not the final KV challenge
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 3
+        else:
+            assert credential.get_token_info.call_count == 3
 
     test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)
 
 
 @empty_challenge_cache
-def test_cae_consecutive_challenges():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_cae_consecutive_challenges(token_type):
     """The policy should correctly handle consecutive challenges in cases where the flow is valid or invalid."""
 
     expected_content = b"a duck"
@@ -681,33 +750,41 @@ def test_cae_consecutive_challenges():
                 return claims_challenge
             raise ValueError("unexpected request")
 
-        def get_token(*scopes, **kwargs):
-            assert kwargs.get("enable_cae") == True
-            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+        def get_token(*scopes, options=None, **kwargs):
+            options_bag = options if options else kwargs
+            assert options_bag.get("enable_cae") == True
+            assert options_bag.get("tenant_id") == KV_CHALLENGE_TENANT
             assert scopes[0] == RESOURCE + "/.default"
             # Response to KV challenge
             if Requests.count == 1:
-                assert kwargs.get("claims") == None
-                return AccessToken(first_token, time.time() + 3600)
+                assert options_bag.get("claims") == None
+                return token_type(first_token, time.time() + 3600)
             # Response to first CAE challenge
             elif Requests.count == 2:
-                assert kwargs.get("claims") == expected_claim
-                return AccessToken(expected_token, time.time() + 3600)
+                assert options_bag.get("claims") == expected_claim
+                return token_type(expected_token, time.time() + 3600)
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
 
-        # get_token is called for the KV challenge and first CAE challenge, but not the second CAE challenge
-        assert credential.get_token.call_count == 2
+        # token requests made for the KV challenge and first CAE challenge, but not the second CAE challenge
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 2
+        else:
+            assert credential.get_token_info.call_count == 2
 
     test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)
 
 
 @empty_challenge_cache
-def test_cae_token_expiry():
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_cae_token_expiry(token_type):
     """The policy should avoid sending claims more than once when a token expires."""
 
     expected_content = b"a duck"
@@ -748,31 +825,38 @@ def test_cae_token_expiry():
                 return Mock(status_code=200)
             raise ValueError("unexpected request")
 
-        def get_token(*scopes, **kwargs):
-            assert kwargs.get("enable_cae") == True
-            assert kwargs.get("tenant_id") == KV_CHALLENGE_TENANT
+        def get_token(*scopes, options=None, **kwargs):
+            options_bag = options if options else kwargs
+            assert options_bag.get("enable_cae") == True
+            assert options_bag.get("tenant_id") == KV_CHALLENGE_TENANT
             assert scopes[0] == RESOURCE + "/.default"
             # Response to KV challenge
             if Requests.count == 1:
-                assert kwargs.get("claims") == None
-                return AccessToken(first_token, time.time() + 3600)
+                assert options_bag.get("claims") == None
+                return token_type(first_token, time.time() + 3600)
             # Response to first CAE challenge
             elif Requests.count == 2:
-                assert kwargs.get("claims") == expected_claim
-                return AccessToken(second_token, 0)  # Return a token that expires immediately to trigger a refresh
+                assert options_bag.get("claims") == expected_claim
+                return token_type(second_token, 0)  # Return a token that expires immediately to trigger a refresh
             # Token refresh before making the final request
             elif Requests.count == 3:
-                assert kwargs.get("claims") == None
-                return AccessToken(third_token, time.time() + 3600)
+                assert options_bag.get("claims") == None
+                return token_type(third_token, time.time() + 3600)
 
-        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        if token_type == AccessToken:
+            credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+        else:
+            credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
         pipeline.run(request)  # Send the request again to trigger a token refresh upon expiry
 
-        # get_token is called for the KV and CAE challenges, as well as for the token refresh
-        assert credential.get_token.call_count == 3
+        # token requests made for the KV and CAE challenges, as well as for the token refresh
+        if hasattr(credential, "get_token"):
+            assert credential.get_token.call_count == 3
+        else:
+            assert credential.get_token_info.call_count == 3
 
     test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -580,7 +580,7 @@ async def test_cae():
     claim = '{"access_token": {"foo": "bar"}}'
     # Claim token is a string of the base64 encoding of the claim
     claim_token = base64.b64encode(claim.encode()).decode()
-    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    # Note that no resource or scope is necessarily provided in a CAE challenge
     challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
     # get_token is called for the first KV challenge and CAE challenge, but not the second KV challenge
@@ -660,7 +660,7 @@ async def test_cae_consecutive_challenges():
     claim = '{"access_token": {"foo": "bar"}}'
     # Claim token is a string of the base64 encoding of the claim
     claim_token = base64.b64encode(claim.encode()).decode()
-    # Note that no resource or scope is necessarily proovided in a CAE challenge
+    # Note that no resource or scope is necessarily provided in a CAE challenge
     challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
     claims_challenge = Mock(status_code=401, headers={"WWW-Authenticate": challenge})

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -530,6 +530,7 @@ async def test_cae():
             if Requests.count == 1:
                 # first request should be unauthorized and have no content; triggers a KV challenge response
                 assert not request.body
+                assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
                 return kv_challenge
             elif Requests.count == 2:
@@ -554,15 +555,15 @@ async def test_cae():
             raise ValueError("unexpected request")
 
         async def get_token(*_, **kwargs):
+            assert kwargs.get("enable_cae") == True
+            assert kwargs.get("tenant_id") == tenant
+            # Response to KV challenge
             if Requests.count == 1:
                 assert kwargs.get("claims") == None
-                assert kwargs.get("enable_cae") == True
-                assert kwargs.get("tenant_id") == tenant
                 return AccessToken(first_token, time.time() + 3600)
+            # Response to CAE challenge
             elif Requests.count == 3:
                 assert kwargs.get("claims") == expected_claim
-                assert kwargs.get("enable_cae") == True
-                assert kwargs.get("tenant_id") == tenant
                 return AccessToken(expected_token, time.time() + 3600)
 
         credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
@@ -578,8 +579,9 @@ async def test_cae():
     cid = 'client_id="00000003-0000-0000-c000-000000000000"'
     err = 'error="insufficient_claims"'
     claim = '{"access_token": {"foo": "bar"}}'
-    # Claim token is a string of the base64 encoding of the claim
+    # Claim token is a string of the base64 encoding of the claim. Trim the padding to ensure the policy can handle it
     claim_token = base64.b64encode(claim.encode()).decode()
+    claim_token = claim_token.strip("=")
     # Note that no resource or scope is necessarily provided in a CAE challenge
     challenge = f'Bearer realm="", {url}, {cid}, {err}, claims="{claim_token}"'
 
@@ -616,6 +618,7 @@ async def test_cae_consecutive_challenges():
             if Requests.count == 1:
                 # first request should be unauthorized and have no content; triggers a KV challenge response
                 assert not request.body
+                assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
                 return kv_challenge
             elif Requests.count == 2:
@@ -634,15 +637,15 @@ async def test_cae_consecutive_challenges():
             raise ValueError("unexpected request")
 
         async def get_token(*_, **kwargs):
+            assert kwargs.get("enable_cae") == True
+            assert kwargs.get("tenant_id") == tenant
+            # Response to KV challenge
             if Requests.count == 1:
                 assert kwargs.get("claims") == None
-                assert kwargs.get("enable_cae") == True
-                assert kwargs.get("tenant_id") == tenant
                 return AccessToken(first_token, time.time() + 3600)
+            # Response to first CAE challenge
             elif Requests.count == 2:
                 assert kwargs.get("claims") == expected_claim
-                assert kwargs.get("enable_cae") == True
-                assert kwargs.get("tenant_id") == tenant
                 return AccessToken(expected_token, time.time() + 3600)
 
         credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -33,9 +33,9 @@ from test_challenge_auth import (
     empty_challenge_cache,
     get_random_url,
     add_url_port,
-    CAE_CHALLENGE_HEADER,
+    CAE_CHALLENGE_RESPONSE,
     CAE_DECODED_CLAIM,
-    KV_CHALLENGE_HEADER,
+    KV_CHALLENGE_RESPONSE,
     KV_CHALLENGE_TENANT,
     RESOURCE,
 )
@@ -534,7 +534,7 @@ async def test_cae():
                 assert not request.body
                 assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
-                return KV_CHALLENGE_HEADER
+                return KV_CHALLENGE_RESPONSE
             elif Requests.count == 2:
                 # second request should be authorized according to challenge and have the expected content
                 assert request.headers["Content-Length"]
@@ -558,14 +558,14 @@ async def test_cae():
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
                 assert expected_token in request.headers["Authorization"]
-                return KV_CHALLENGE_HEADER
+                return KV_CHALLENGE_RESPONSE
             elif Requests.count == 6:
                 # sixth request should respond to the KV challenge WITHOUT including claims
                 # we return another challenge to confirm that the policy will return consecutive 401s to the user
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
                 assert first_token in request.headers["Authorization"]
-                return KV_CHALLENGE_HEADER
+                return KV_CHALLENGE_RESPONSE
             raise ValueError("unexpected request")
 
         async def get_token(*scopes, **kwargs):
@@ -598,7 +598,7 @@ async def test_cae():
         # get_token is called for the CAE challenge and first two KV challenges, but not the final KV challenge
         assert credential.get_token.call_count == 3
 
-    await test_with_challenge(CAE_CHALLENGE_HEADER, CAE_DECODED_CLAIM)
+    await test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)
 
 
 @pytest.mark.asyncio
@@ -622,7 +622,7 @@ async def test_cae_consecutive_challenges():
                 assert not request.body
                 assert "Authorization" not in request.headers
                 assert request.headers["Content-Length"] == "0"
-                return KV_CHALLENGE_HEADER
+                return KV_CHALLENGE_RESPONSE
             elif Requests.count == 2:
                 # second request will trigger a CAE challenge response in this test scenario
                 assert request.headers["Content-Length"]
@@ -660,4 +660,4 @@ async def test_cae_consecutive_challenges():
         # get_token is called for the KV challenge and first CAE challenge, but not the second CAE challenge
         assert credential.get_token.call_count == 2
 
-    await test_with_challenge(CAE_CHALLENGE_HEADER, CAE_DECODED_CLAIM)
+    await test_with_challenge(CAE_CHALLENGE_RESPONSE, CAE_DECODED_CLAIM)

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
+- Added support for Continuous Access Evaluation (CAE)
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
-- Added support for Continuous Access Evaluation (CAE)
+- Added support for Continuous Access Evaluation (CAE). `enable_cae=True` is passed to all `get_token` requests.
 
 ### Breaking Changes
 
@@ -13,6 +13,7 @@
   ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
+- Updated minimum `azure-core` version to 1.31.0
 - Key Vault API version `7.6-preview.1` is now the default
 
 ## 4.8.0 (2024-02-22)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -16,17 +16,47 @@ protocol again.
 
 from copy import deepcopy
 import time
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@overload
+async def await_result(func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+@overload
+async def await_result(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+async def await_result(func: Callable[P, Union[T, Awaitable[T]]], *args: P.args, **kwargs: P.kwargs) -> T:
+    """If func returns an awaitable, await it.
+
+    :param func: The function to run.
+    :type func: callable
+    :param args: The positional arguments to pass to the function.
+    :type args: list
+    :rtype: any
+    :return: The result of the function
+    """
+    result = func(*args, **kwargs)
+    if isinstance(result, Awaitable):
+        return await result
+    return result
+
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -42,6 +72,77 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    async def send(
+        self, request: PipelineRequest[HttpRequest]
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        await await_result(self.on_request, request)
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse]
+        try:
+            response = await self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            await await_result(self.on_exception, request)
+            raise
+        await await_result(self.on_response, request, response)
+
+        if response.http_response.status_code == 401:
+            return await self.handle_challenge_flow(request, response)
+        return response
+
+    async def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, AsyncHttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, AsyncHttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = await self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = await self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    await await_result(self.on_exception, request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return await self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                await await_result(self.on_response, request, response)
+        return response
+
 
     async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -78,6 +179,14 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -87,7 +196,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -104,10 +219,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            await self.authorize_request(request, scope, claims=challenge.claims)
         else:
             await self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+                request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id
             )
 
         return True

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -53,11 +53,9 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = await self._credential.get_token(scope)
                 else:
-                    self._token = await self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -106,9 +104,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            await self.authorize_request(request, scope, claims=challenge.claims)
+            await self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            await self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            await self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -68,12 +68,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super().__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     async def send(
         self, request: PipelineRequest[HttpRequest]

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -17,8 +17,9 @@ protocol again.
 from copy import deepcopy
 import time
 from typing import Any, Awaitable, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import ParamSpec
 from urllib.parse import urlparse
+
+from typing_extensions import ParamSpec
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
@@ -199,7 +200,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -189,6 +189,10 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 old_tenant = cached_challenge.tenant_id
 
             challenge = _update_challenge(request, response)
+            # CAE challenges may not include a scope or tenant; use the previous challenge's values if necessary
+            if challenge.claims and old_scope:
+                challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
+                challenge.tenant_id = old_tenant
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
         except ValueError:
@@ -197,13 +201,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
-                if challenge.claims and old_scope:
-                    resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
-                    challenge.tenant_id = old_tenant
-                else:
-                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -68,7 +68,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super().__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: AsyncTokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -159,9 +159,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = await self._credential.get_token(scope)
+                    self._token = await self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = await self._credential.get_token(
+                        scope, tenant_id=challenge.tenant_id, enable_cae=True
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -232,11 +232,12 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    async def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    async def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -82,9 +82,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, claims=challenge.claims)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(
+                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
+                    )
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -132,9 +134,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -66,12 +66,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
+        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
-        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
 
     def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
         """Authorize request with a bearer token and send it to the next policy.

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -23,7 +23,7 @@ from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
-from azure.core.rest import HttpRequest
+from azure.core.rest import HttpRequest, HttpResponse
 
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as ChallengeCache
@@ -71,6 +71,74 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
         self._request_copy: Optional[HttpRequest] = None
+        self._enable_cae = kwargs.pop("enable_cae", True)  # When True, `enable_cae=True` is always passed to get_token
+
+    def send(self, request: PipelineRequest[HttpRequest]) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Authorize request with a bearer token and send it to the next policy.
+
+        We implement this method to account for the valid scenario where a Key Vault authentication challenge is
+        immediately followed by a CAE claims challenge. The base class's implementation would return the second 401 to
+        the caller, but we should handle that second challenge as well (and only return any third 401 response).
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self.on_request(request)
+        try:
+            response = self.next.send(request)
+        except Exception:  # pylint:disable=broad-except
+            self.on_exception(request)
+            raise
+
+        self.on_response(request, response)
+        if response.http_response.status_code == 401:
+            return self.handle_challenge_flow(request, response)
+        return response
+
+    def handle_challenge_flow(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, HttpResponse],
+        consecutive_challenge: bool = False,
+    ) -> PipelineResponse[HttpRequest, HttpResponse]:
+        """Handle the challenge flow of Key Vault and CAE authentication.
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: The pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        :param bool consecutive_challenge: Whether the challenge is arriving immediately after another challenge.
+            Consecutive challenges can only be valid if a Key Vault challenge is followed by a CAE claims challenge.
+            True if the preceding challenge was a Key Vault challenge; False otherwise.
+
+        :return: The pipeline response object
+        :rtype: ~azure.core.pipeline.PipelineResponse
+        """
+        self._token = None  # any cached token is invalid
+        if "WWW-Authenticate" in response.http_response.headers:
+            request_authorized = self.on_challenge(request, response)
+            if request_authorized:
+                # if we receive a challenge response, we retrieve a new token
+                # which matches the new target. In this case, we don't want to remove
+                # token from the request so clear the 'insecure_domain_change' tag
+                request.context.options.pop("insecure_domain_change", False)
+                try:
+                    response = self.next.send(request)
+                except Exception:  # pylint:disable=broad-except
+                    self.on_exception(request)
+                    raise
+
+                # If consecutive_challenge == True, this could be a third consecutive 401
+                if response.http_response.status_code == 401 and not consecutive_challenge:
+                    # If the previous challenge wasn't from CAE, we can try this function one more time
+                    challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+                    if challenge and not challenge.claims:
+                        return self.handle_challenge_flow(request, response, consecutive_challenge=True)
+                self.on_response(request, response)
+        return response
 
     def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
@@ -106,6 +174,14 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
+            # CAE challenges may not include a scope or tenant; cache from the previous challenge to use if necessary
+            old_scope: Optional[str] = None
+            old_tenant: Optional[str] = None
+            cached_challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
+            if cached_challenge:
+                old_scope = cached_challenge.get_scope() or cached_challenge.get_resource() + "/.default"
+                old_tenant = cached_challenge.tenant_id
+
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.get_scope() or challenge.get_resource() + "/.default"
@@ -115,7 +191,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         if self._verify_challenge_resource:
             resource_domain = urlparse(scope).netloc
             if not resource_domain:
-                raise ValueError(f"The challenge contains invalid scope '{scope}'.")
+                # Use the old scope for CAE challenges. The parsing will succeed here since it did before
+                if challenge.claims and old_scope:
+                    resource_domain = urlparse(old_scope).netloc
+                    challenge._parameters["scope"] = old_scope
+                    challenge.tenant_id = old_tenant
+                else:
+                    raise ValueError(f"The challenge contains invalid scope '{scope}'.")
 
             request_domain = urlparse(request.http_request.url).netloc
             if not request_domain.lower().endswith(f".{resource_domain.lower()}"):
@@ -132,11 +214,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
+            self.authorize_request(request, scope, claims=challenge.claims)
         else:
-            self.authorize_request(
-                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
-            )
+            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -194,7 +194,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 # Use the old scope for CAE challenges. The parsing will succeed here since it did before
                 if challenge.claims and old_scope:
                     resource_domain = urlparse(old_scope).netloc
-                    challenge._parameters["scope"] = old_scope
+                    challenge._parameters["scope"] = old_scope  # pylint:disable=protected-access
                     challenge.tenant_id = old_tenant
                 else:
                     raise ValueError(f"The challenge contains invalid scope '{scope}'.")

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -82,11 +82,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope, claims=challenge.claims)
+                    self._token = self._credential.get_token(scope)
                 else:
-                    self._token = self._credential.get_token(
-                        scope, claims=challenge.claims, tenant_id=challenge.tenant_id
-                    )
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
@@ -134,9 +132,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
         if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-            self.authorize_request(request, scope, claims=challenge.claims)
+            self.authorize_request(request, scope, claims=challenge.claims, enable_cae=True)
         else:
-            self.authorize_request(request, scope, claims=challenge.claims, tenant_id=challenge.tenant_id)
+            self.authorize_request(
+                request, scope, claims=challenge.claims, enable_cae=True, tenant_id=challenge.tenant_id
+            )
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -80,7 +80,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """
 
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
-        # Pass `enable_cae` so `enable_cae=True` is always passed to get_token
+        # Pass `enable_cae` so `enable_cae=True` is always passed through self.authorize_request
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, enable_cae=True, **kwargs)
         self._credential: TokenCredential = credential
         self._token: Optional[AccessToken] = None
@@ -168,9 +168,9 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
                 # Exclude tenant for AD FS authentication
                 if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
-                    self._token = self._credential.get_token(scope)
+                    self._token = self._credential.get_token(scope, enable_cae=True)
                 else:
-                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id, enable_cae=True)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -246,11 +246,12 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         refresh_on = getattr(self._token, "refresh_on", None)
         return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
-    def _request_kv_token(self, scope: str, challenge: HttpChallenge, **kwargs: Any) -> None:
+    def _request_kv_token(self, scope: str, challenge: HttpChallenge) -> None:
         """Implementation of BearerTokenCredentialPolicy's _request_token method, but specific to Key Vault.
 
         :param str scope: The scope for which to request a token.
         :param challenge: The challenge for the request being made.
+        :type challenge: HttpChallenge
         """
         # Exclude tenant for AD FS authentication
         exclude_tenant = challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs")

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
@@ -37,16 +37,11 @@ class HttpChallenge(object):
         trimmed_challenge = split_challenge[1]
 
         self.claims = None
-        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
-            # special case for claims, which can contain = symbols as padding
+            # Special case for claims, which can contain = symbols as padding. Assume at most one claim per challenge
             if "claims=" in item:
-                if encoded_claims:
-                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
-                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
-                    self.claims = None
                 encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
                 padding_needed = -len(encoded_claims) % 4
                 try:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import base64
 from typing import Dict, MutableMapping, Optional
 from urllib import parse
 
@@ -18,7 +19,13 @@ class HttpChallenge(object):
     def __init__(
         self, request_uri: str, challenge: str, response_headers: "Optional[MutableMapping[str, str]]" = None
     ) -> None:
-        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server.
+
+        Example challenge with claims:
+            Bearer authorization="https://login.windows-ppe.net/", error="invalid_token",
+            error_description="User session has been revoked",
+            claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="
+        """
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
         self._parameters: "Dict[str, str]" = {}
@@ -29,16 +36,32 @@ class HttpChallenge(object):
         self.scheme = split_challenge[0]
         trimmed_challenge = split_challenge[1]
 
+        self.claims = None
+        encoded_claims = None
         # split trimmed challenge into comma-separated name=value pairs. Values are expected
         # to be surrounded by quotes which are stripped here.
         for item in trimmed_challenge.split(","):
+            # special case for claims, which can contain = symbols as padding
+            if "claims=" in item:
+                if encoded_claims:
+                    # multiple claims challenges, e.g. for cross-tenant auth, would require special handling
+                    # we can't support this scenario for now, so we ignore claims altogether if there are multiple
+                    self.claims = None
+                encoded_claims = item[item.index("=") + 1 :].strip(" \"'")
+                padding_needed = -len(encoded_claims) % 4
+                try:
+                    decoded_claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
+                    self.claims = decoded_claims
+                except Exception:  # pylint:disable=broad-except
+                    continue
             # process name=value pairs
-            comps = item.split("=")
-            if len(comps) == 2:
-                key = comps[0].strip(' "')
-                value = comps[1].strip(' "')
-                if key:
-                    self._parameters[key] = value
+            else:
+                comps = item.split("=")
+                if len(comps) == 2:
+                    key = comps[0].strip(' "')
+                    value = comps[1].strip(' "')
+                    if key:
+                        self._parameters[key] = value
 
         # minimum set of parameters
         if not self._parameters:

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -68,7 +68,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.29.5",
+        "azure-core>=1.31.0",
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",
     ],


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python-pr/issues/919. Based on https://github.com/Azure/azure-sdk-for-java/pull/41814. The `HttpChallenge` model now has a `claims` attribute, which contains the decoded claims from an authentication challenge if one is present. Parsing logic is largely pulled from the [`_parse_claims_challenge`](https://github.com/Azure/azure-sdk-for-python/blob/c79320ce8923b75d065d8d33557ceceed0b6d901/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py#L155) utility in `azure-mgmt-core`.

In order to support the unique challenge flow that KV+CAE enables -- where we handle two consecutive challenges -- we need to implement the `send` method on the KV challenge auth policy. Doing so on the async side requires some awaiting logic that's been lifted from [`azure-core` utilities](https://github.com/Azure/azure-sdk-for-python/blob/79f436baa407b3767d757779526b73662a0b01f7/sdk/core/azure-core/azure/core/pipeline/_tools_async.py#L44).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
