### PR TITLE
enable bandit

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -470,7 +470,6 @@ setenv =
   PROXY_URL=http://localhost:5015
 deps =
   {[base]deps}
-  importlib-metadata<5.0
 commands =
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir} \

--- a/sdk/ai/azure-ai-generative/pyproject.toml
+++ b/sdk/ai/azure-ai-generative/pyproject.toml
@@ -5,7 +5,6 @@ verifytypes = false
 pyright = false
 pylint = true
 black = false
-bandit = false
 sphinx=true
 breaking = false
 whl_no_aio = false

--- a/sdk/ai/azure-ai-resources/pyproject.toml
+++ b/sdk/ai/azure-ai-resources/pyproject.toml
@@ -5,7 +5,6 @@ verifytypes = false
 pyright = false
 pylint = false
 black = false
-bandit = false
 sphinx = true
 breaking = false
 

--- a/sdk/evaluation/azure-ai-evaluation/pyproject.toml
+++ b/sdk/evaluation/azure-ai-evaluation/pyproject.toml
@@ -3,4 +3,3 @@ mypy = false
 pyright = false
 pylint = false
 black = true
-bandit = false


### PR DESCRIPTION
Re-enables `bandit` for libraries which currently have it disabled. 

@Azure/azure-sdk-write-evaluation can we please fix the code which bandit is flagging below:

```
>> Issue: [B307:blacklist] Use of possibly insecure function - consider using safer ast.literal_eval.
   Severity: Medium   Confidence: High
   Location: /mnt/vss/_work/1/s/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/synthetic/_model_tools/models.py:237
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b307-eval
236	        elif type(stop) is str and stop.startswith("[") and stop.endswith("]"):
237	            stop = eval(stop)
238	        elif type(stop) is str:
```