### PR TITLE
[Cosmos] HTTP/2 prep work

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -103,10 +103,10 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
             # setting the throttle related response headers before returning the result
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryCount
-            ] = resourceThrottle_retry_policy.current_retry_attempt_count
+            ] = str(resourceThrottle_retry_policy.current_retry_attempt_count)
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryWaitTimeInMs
-            ] = resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds
+            ] = str(resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds)
             # TODO: It is better to raise Exceptions manually in the method related to the request,
             #  a rework of retry would be needed to be able to retry exceptions raised that way.
             #  for now raising a manual exception here should allow it to be retried.
@@ -172,10 +172,10 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
                     client.last_response_headers = {}
                 client.last_response_headers[
                     HttpHeaders.ThrottleRetryCount
-                ] = resourceThrottle_retry_policy.current_retry_attempt_count
+                ] = str(resourceThrottle_retry_policy.current_retry_attempt_count)
                 client.last_response_headers[
                     HttpHeaders.ThrottleRetryWaitTimeInMs
-                ] = resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds
+                ] = str(resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds)
                 if args and args[0].should_clear_session_token_on_session_read_failure:
                     client.session.clear_session_token(client.last_response_headers)
                 raise

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
@@ -141,7 +141,10 @@ def _Request(global_endpoint_manager, request_params, connection_policy, pipelin
     response = response.http_response
     headers = copy.copy(response.headers)
 
-    data = response.body()
+    try:
+        data = response.content
+    except AttributeError:
+        data = response.body()
     if data:
         data = data.decode("utf-8")
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_asynchronous_request.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_asynchronous_request.py
@@ -109,7 +109,10 @@ async def _Request(global_endpoint_manager, request_params, connection_policy, p
     response = response.http_response
     headers = copy.copy(response.headers)
 
-    data = response.body()
+    try:
+        data = response.content
+    except AttributeError:
+        data = response.body()
     if data:
         data = data.decode("utf-8")
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
@@ -102,10 +102,10 @@ async def ExecuteAsync(client, global_endpoint_manager, function, *args, **kwarg
             # setting the throttle related response headers before returning the result
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryCount
-            ] = resourceThrottle_retry_policy.current_retry_attempt_count
+            ] = str(resourceThrottle_retry_policy.current_retry_attempt_count)
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryWaitTimeInMs
-            ] = resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds
+            ] = str(resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds)
             # TODO: It is better to raise Exceptions manually in the method related to the request,
             #  a rework of retry would be needed to be able to retry exceptions raised that way.
             #  for now raising a manual exception here should allow it to be retried.
@@ -173,10 +173,10 @@ async def ExecuteAsync(client, global_endpoint_manager, function, *args, **kwarg
                     client.last_response_headers = {}
                 client.last_response_headers[
                     HttpHeaders.ThrottleRetryCount
-                ] = resourceThrottle_retry_policy.current_retry_attempt_count
+                ] = str(resourceThrottle_retry_policy.current_retry_attempt_count)
                 client.last_response_headers[
                     HttpHeaders.ThrottleRetryWaitTimeInMs
-                ] = resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds
+                ] = str(resourceThrottle_retry_policy.cumulative_wait_time_in_milliseconds)
                 if args and args[0].should_clear_session_token_on_session_read_failure:
                     client.session.clear_session_token(client.last_response_headers)
                 raise

--- a/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
@@ -79,13 +79,13 @@ class TestRetryPolicy(unittest.TestCase):
                 self.created_collection.create_item(body=document_definition)
             except exceptions.CosmosHttpResponseError as e:
                 self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
+                self.assertEqual(str(connection_policy.RetryOptions.MaxRetryAttemptCount),
                                  self.created_collection.client_connection.last_response_headers[
                                      HttpHeaders.ThrottleRetryCount])
                 self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[
                                             HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount *
-                                        self.retry_after_in_milliseconds)
+                                        str(connection_policy.RetryOptions.MaxRetryAttemptCount *
+                                        self.retry_after_in_milliseconds))
         finally:
             _retry_utility.ExecuteFunction = self.original_execute_function
 
@@ -106,12 +106,12 @@ class TestRetryPolicy(unittest.TestCase):
                 self.created_collection.create_item(body=document_definition)
             except exceptions.CosmosHttpResponseError as e:
                 self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
+                self.assertEqual(str(connection_policy.RetryOptions.MaxRetryAttemptCount),
                                  self.created_collection.client_connection.last_response_headers[
                                      HttpHeaders.ThrottleRetryCount])
                 self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[
                                             HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds)
+                                        str(connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds))
 
         finally:
             _retry_utility.ExecuteFunction = self.original_execute_function
@@ -135,7 +135,7 @@ class TestRetryPolicy(unittest.TestCase):
                 self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
                 self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[
                                             HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000)
+                                        str(connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000))
         finally:
             _retry_utility.ExecuteFunction = self.original_execute_function
 
@@ -164,12 +164,12 @@ class TestRetryPolicy(unittest.TestCase):
                     }))
             except exceptions.CosmosHttpResponseError as e:
                 self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
+                self.assertEqual(str(connection_policy.RetryOptions.MaxRetryAttemptCount),
                                  self.created_collection.client_connection.last_response_headers[
                                      HttpHeaders.ThrottleRetryCount])
                 self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[
                                             HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
+                                        str(connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds))
         finally:
             _retry_utility.ExecuteFunction = self.original_execute_function
 


### PR DESCRIPTION
This PR aims at making changes to the SDK that will be required for it to work alongside http/2 protocols. 
Missing:
- moving throughput headers logic to pipeline context and removing from headers altogether since we shouldn't edit response headers (other protocols may not allow for this, including http2)
- finding a way to log relevant throughput headers through the policy (this can be a separate work item)