### PR TITLE
Remove logger from attr_dict.py

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
@@ -4,7 +4,6 @@
 
 # pylint: disable=protected-access, unnecessary-comprehension
 
-import logging
 from abc import ABC
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
@@ -48,7 +47,6 @@ class _AttrDict(Generic[K, V], Dict, ABC):
             # Otherwise use allowed_keys to restrict keys can be set for _AttrDict
             self._allowed_keys = dict(allowed_keys)
             self._key_restriction = True
-        self._logger = logging.getLogger("attr_dict")
 
     def _initializing(self) -> bool:
         # use this to indicate ongoing init process, sub class need to make sure this return True during init process.
@@ -106,7 +104,6 @@ class _AttrDict(Generic[K, V], Dict, ABC):
     def __getattr__(self, key: Any) -> Any:
         if not self._is_arbitrary_attr(key):
             return super().__getattribute__(key)
-        self._logger.debug("getting %s", key)
         try:
             return super().__getitem__(key)
         except KeyError:
@@ -119,7 +116,6 @@ class _AttrDict(Generic[K, V], Dict, ABC):
         if not self._is_arbitrary_attr(key):
             super().__setattr__(key, value)
         else:
-            self._logger.debug("setting %s to %s", key, value)
             super().__setitem__(key, value)
 
     def __setitem__(self, key: Any, value: V) -> None:


### PR DESCRIPTION

# Description

* logger had wrong name, which would bypass configuration of logging in parent loggers
* trivial code that does not benefit from logging

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
