### PR TITLE
Use correct service connection for cosmos sub

### DIFF
--- a/sdk/cosmos/tests.yml
+++ b/sdk/cosmos/tests.yml
@@ -9,7 +9,7 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-cosmos-azure-cloud-test-resources)
-          ServiceConnection: azure-sdk-tests    
+          ServiceConnection: azure-sdk-tests-cosmos
       MaxParallel: 6
       BuildTargetingString: azure-cosmos
       ServiceDirectory: cosmos


### PR DESCRIPTION
Currently the live test clean-up is failing and it is because our service connection wasn't correctly linked to the cosmos test sub. This should fix this.

Example https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4146771&view=logs&j=5ed68bac-6be8-523e-30ff-f394f614dd82&t=6a7ae0a6-d53c-5a44-def4-6df208c89d17