### PR TITLE
Replace azure-identity in mindependency checks

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -17,12 +17,9 @@ from pkg_resources import parse_version, Requirement
 from pypi_tools.pypi import PyPIClient
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version, parse
-import pkginfo
 
 from ci_tools.parsing import ParsedSetup, parse_require
 from ci_tools.functions import compare_python_version
-from ci_tools.variables import in_ci
-
 
 from typing import List
 
@@ -309,7 +306,7 @@ def replace_identity(dev_requirement_line) -> str:
     regex = r"azure[-_]identity"
 
     if re.search(regex, dev_requirement_line):
-        return "azure-identity==1.17.0"
+        return "azure-identity==1.17.0\n"
     else:
         return dev_requirement_line
 

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -301,7 +301,7 @@ def check_req_against_exclusion(req, req_to_exclude):
 
     return req_id == req_to_exclude
 
-
+# todo: remove when merging #37450
 def replace_identity(dev_requirement_line) -> str:
     regex = r"azure[-_]identity"
 

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -17,10 +17,11 @@ from pkg_resources import parse_version, Requirement
 from pypi_tools.pypi import PyPIClient
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version, parse
-import pdb
+import pkginfo
 
 from ci_tools.parsing import ParsedSetup, parse_require
 from ci_tools.functions import compare_python_version
+from ci_tools.variables import in_ci
 
 
 from typing import List
@@ -104,7 +105,7 @@ def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):
 
     logging.info("%s released packages: %s", dependency_type, released_packages)
     # filter released packages from dev_requirements and create a new file "new_dev_requirements.txt"
-    dev_req_file_path = filter_dev_requirements(setup_py_file_path, released_packages, temp_dir)
+    dev_req_file_path = filter_dev_requirements(setup_py_file_path, released_packages, temp_dir, dependency_type)
 
     if override_added_packages:
         logging.info(f"Expanding the requirement set by the packages {override_added_packages}.")
@@ -304,7 +305,16 @@ def check_req_against_exclusion(req, req_to_exclude):
     return req_id == req_to_exclude
 
 
-def filter_dev_requirements(setup_py_path, released_packages, temp_dir):
+def replace_identity(dev_requirement_line) -> str:
+    regex = r"azure[-_]identity"
+
+    if re.search(regex, dev_requirement_line):
+        return "azure-identity==1.17.0"
+    else:
+        return dev_requirement_line
+
+
+def filter_dev_requirements(setup_py_path, released_packages, temp_dir, dependency_type):
     # This method returns list of requirements from dev_requirements by filtering out packages in given list
     dev_req_path = os.path.join(os.path.dirname(setup_py_path), DEV_REQ_FILE)
     requirements = []
@@ -326,6 +336,10 @@ def filter_dev_requirements(setup_py_path, released_packages, temp_dir):
         if os.path.basename(req.replace("\n", "")) not in req_to_exclude
         and not any([check_req_against_exclusion(req, i) for i in req_to_exclude])
     ]
+
+    if dependency_type == "Minimum":
+        # replace identity with the minimum version of the package
+        filtered_req = [replace_identity(req) for req in filtered_req]
 
     logging.info("Filtered dev requirements: %s", filtered_req)
 


### PR DESCRIPTION
This is a specialcase while I followup on #37450 

It's proving to be difficult and I want to ensure that folks don't have to keep specialcasing their releases.