### PR TITLE
Fix setting custom `TracerProvider` bug with no global `TracerProvider`

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fix setting custom `TracerProvider` bug
-    ([#36363](https://github.com/Azure/azure-sdk-for-python/pull/36363))
+    ([#37469](https://github.com/Azure/azure-sdk-for-python/pull/37469))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fix setting custom `TracerProvider` bug
+    ([#36363](https://github.com/Azure/azure-sdk-for-python/pull/36363))
+
 ### Other Changes
 
 ## 1.0.0b29 (2024-09-10)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -72,7 +72,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
     """Azure Monitor Trace exporter for OpenTelemetry."""
 
     def __init__(self, **kwargs: Any):
-        self._tracer_provider = kwargs.pop("tracer_provider", get_tracer_provider())
+        self._tracer_provider = kwargs.pop("tracer_provider", None)
         super().__init__(**kwargs)
 
     def export(self, spans: Sequence[ReadableSpan], **kwargs: Any) -> SpanExportResult: # pylint: disable=unused-argument
@@ -87,7 +87,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
         if spans and self._should_collect_otel_resource_metric():
             resource = None
             try:
-                tracer_provider = self._tracer_provider
+                tracer_provider = self._tracer_provider or get_tracer_provider()
                 resource = tracer_provider.resource # type: ignore
                 envelopes.append(self._get_otel_resource_envelope(resource))
             except AttributeError as e:


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/pull/36363 introduced a bug that errors out if no global `TracerProvider` is set before creating the `AzureMonitorTraceExporter`. Fixing this so that the `export` calls the global itself if no custom `TracerProvider` was used.

Addresses: https://github.com/Azure/azure-sdk-for-python/issues/37460

