### PR TITLE
Update classifier for azure-ai-generative

### DIFF
--- a/sdk/ai/azure-ai-generative/setup.py
+++ b/sdk/ai/azure-ai-generative/setup.py
@@ -42,7 +42,7 @@ setup(
     url="https://github.com/Azure/azure-sdk-for-python",
     keywords="azure, azuresdk, azure sdk",
     classifiers=[
-        "Development Status :: 7 - Inactive",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
- We don't run tests against `Inactive` packages, but we still build them
- This is so that we can do the final release of packages that are no longer under active development
- azure-ai-generative has been running [without tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4148706&view=logs&j=f8949c67-9d21-53bc-b8db-079dc324f468&t=0929d268-7fa3-5845-a7aa-34bddb8b1716) because it's disabled

This brings the package back to active