### PR TITLE
[auto release pipeline] fix logic to extract swagger file

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -152,7 +152,7 @@ def get_related_swagger(readme_content: List[str], tag: str) -> List[str]:
             while idx < len(readme_content):
                 if "```" in readme_content[idx]:
                     break
-                if ".json" in readme_content[idx]:
+                if ".json" in readme_content[idx] and "Microsoft." in readme_content[idx]:
                     result.append(readme_content[idx].strip("\n -"))
                 idx += 1
             break


### PR DESCRIPTION
- failed logs:
![image](https://github.com/user-attachments/assets/d5147926-0f89-46ac-afce-a576d40882a7)

- root cause: some tags have additional suppressions
![image](https://github.com/user-attachments/assets/57dec202-abc0-466b-8672-035ba915c95a)

