### PR TITLE
fix: add read-write mount on input type for jobs

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
@@ -43,6 +43,7 @@ INPUT_MOUNT_MAPPING_FROM_REST = {
 
 INPUT_MOUNT_MAPPING_TO_REST = {
     InputOutputModes.MOUNT: InputDeliveryMode.READ_ONLY_MOUNT,
+    InputOutputModes.RW_MOUNT: InputDeliveryMode.READ_WRITE_MOUNT,
     InputOutputModes.RO_MOUNT: InputDeliveryMode.READ_ONLY_MOUNT,
     InputOutputModes.DOWNLOAD: InputDeliveryMode.DOWNLOAD,
     InputOutputModes.EVAL_MOUNT: InputDeliveryMode.EVAL_MOUNT,


### PR DESCRIPTION
# Description

The web azure portal allows to mount input as read write, but the SDK limits to only read only. I've tested this patch locally and it matches azure portal behaviour.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
