### PR TITLE
Azure-AI-Evaluator: Pass user simulator kwargs during flow invocation

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
@@ -280,7 +280,9 @@ class Simulator:
 
         while len(current_simulation) < max_conversation_turns:
             user_response_content = user_flow(
-                task="Continue the conversation", conversation_history=current_simulation.to_list()
+                task="Continue the conversation",
+                conversation_history=current_simulation.to_list(),
+                **user_simulator_prompty_kwargs
             )
             user_response = self._parse_prompty_response(response=user_response_content)
             user_turn = Turn(role=ConversationRole.USER, content=user_response["content"])
@@ -612,9 +614,12 @@ class Simulator:
             prompty_model_config=self._build_prompty_model_config(),
             user_simulator_prompty_kwargs=user_simulator_prompty_kwargs,
         )
-
         try:
-            response_content = user_flow(task=task, conversation_history=conversation_history)
+            response_content = user_flow(
+                task=task,
+                conversation_history=conversation_history,
+                **user_simulator_prompty_kwargs
+            )
             user_response = self._parse_prompty_response(response=response_content)
             return user_response["content"]
         except Exception as e:


### PR DESCRIPTION
# Description

Update the simulator.py to pass user_simulator_prompty_kwargs in the flow invocation, not just at flow loading.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
