### PR TITLE
bump min azure-core that works with 3.13

### DIFF
--- a/sdk/communication/azure-communication-identity/setup.py
+++ b/sdk/communication/azure-communication-identity/setup.py
@@ -69,7 +69,7 @@ setup(
         "pytyped": ["py.typed"],
     },
     python_requires=">=3.8",
-    install_requires=["msrest>=0.7.1", "azure-core>=1.24.0"],
+    install_requires=["msrest>=0.7.1", "azure-core>=1.27.0"],
     extras_require={":python_version<'3.8'": ["typing-extensions"]},
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",

--- a/sdk/communication/azure-communication-sms/setup.py
+++ b/sdk/communication/azure-communication-sms/setup.py
@@ -68,7 +68,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        'azure-core>=1.24.0',
+        'azure-core>=1.27.0',
         'msrest>=0.7.1',
     ],
     extras_require={

--- a/sdk/containerregistry/azure-containerregistry/setup.py
+++ b/sdk/containerregistry/azure-containerregistry/setup.py
@@ -56,7 +56,7 @@ setup(
     ),
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.24.0,<2.0.0",
+        "azure-core>=1.27.0,<2.0.0",
         "isodate>=0.6.0",
     ],
     project_urls={

--- a/sdk/eventhub/azure-eventhub/setup.py
+++ b/sdk/eventhub/azure-eventhub/setup.py
@@ -71,7 +71,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=exclude_packages),
     install_requires=[
-        "azure-core>=1.14.0",
+        "azure-core>=1.27.0",
         "typing-extensions>=4.0.1",
     ]
 )

--- a/sdk/textanalytics/azure-ai-textanalytics/setup.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/setup.py
@@ -69,7 +69,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "azure-core>=1.24.0",
+        "azure-core>=1.27.0",
         'azure-common>=1.1',
         "isodate>=0.6.1",
         "typing-extensions>=4.0.1",


### PR DESCRIPTION
Failures observed in https://github.com/Azure/azure-sdk-for-python/pull/37508

These libraries specify a min azure-core version that imported `cgi`, a std library module that was removed in 3.13.