### PR TITLE
Handle when no "direct" packages are changed

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -219,6 +219,7 @@ jobs:
       parameters:
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo
+        IncludeIndirect: false
 
     - template: ../steps/analyze.yml
       parameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -219,7 +219,6 @@ jobs:
       parameters:
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo
-        IncludeIndirect: false
 
     - template: ../steps/analyze.yml
       parameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -138,7 +138,7 @@ jobs:
       parameters:
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo
-        IncludeIndirect: true
+        IncludeIndirect: false
 
     - template: /eng/pipelines/templates/steps/build-extended-artifacts.yml
       parameters:
@@ -170,7 +170,7 @@ jobs:
       parameters:
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo
-        IncludeIndirect: true
+        IncludeIndirect: false
 
     - template: ../steps/build-extended-artifacts.yml
       parameters:

--- a/eng/pipelines/templates/steps/resolve-package-targeting.yml
+++ b/eng/pipelines/templates/steps/resolve-package-targeting.yml
@@ -33,6 +33,12 @@ steps:
           }
 
           $setting = $packageProperties -join ","
+
+          # in case we don't expect any packages, we should set the variable to null, which will match NO packages and cause whatever the check
+          # is to skip with exit 0 (which is what we want!)
+          if (-not $setting) {
+            $setting = "null"
+          }
         }
       }
 


### PR DESCRIPTION
Such that the resolve-package-properties doesn't cause us to run the _entire_ repo. This is addressing the issue on "python - pullrequest" that causes the build to run `analyze` to timeout.