### PR TITLE
Remove unnecessary variable defaults

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -470,7 +470,8 @@
     "dicom",
     "WINDOWSVMIMAGE",
     "LINUXVMIMAGE",
-    "MACVMIMAGE"
+    "MACVMIMAGE",
+    "myuseragent"
   ],
   "overrides": [
     {

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -11,3 +11,4 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   WINDOWS_OUTPUTROOT: $(REPOROOT)\out
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  GDN_SUPPRESS_FORKED_BUILD_WARNING: true

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -11,4 +11,3 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   WINDOWS_OUTPUTROOT: $(REPOROOT)\out
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
-  GDN_SUPPRESS_FORKED_BUILD_WARNING: true

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -391,11 +391,8 @@ function Get-python-DocsMsMetadataForPackage($PackageInfo) {
 
 function Import-Dev-Cert-python
 {
-  Write-Host "Python Trust Methodology"
-
-  $pathToScript = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../scripts/devops_tasks/trust_proxy_cert.py")
-  python -m pip install requests
-  python $pathToScript
+  Write-Host "Python no longer requires an out of proc trust methodology." `
+    "The variables SSL_CERT_DIR, SSL_CERT_FILE, and REQUESTS_CA_BUNDLE are now dynamically set in proxy_startup.py"
 }
 
 # Defined in common.ps1 as:

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -20,7 +20,7 @@ from ci_tools.environment_exclusions import filter_tox_environment_string
 from ci_tools.ci_interactions import output_ci_warning
 from ci_tools.scenario.generation import replace_dev_reqs
 from ci_tools.functions import cleanup_directory
-from ci_tools.parsing import ParsedSetup, get_ci_config
+from ci_tools.parsing import ParsedSetup
 from pkg_resources import parse_requirements, RequirementParseError
 import logging
 
@@ -193,16 +193,6 @@ def cleanup_tox_environments(tox_dir: str, command_array: str) -> None:
                 pass
     else:
         cleanup_directory(tox_dir)
-
-
-def handle_proxy_presence(package_path: str) -> None:
-    ci_config = get_ci_config(package_path)
-
-    if ci_config:
-        proxy_enabled = ci_config.get("extends", {}).get("parameters", {}).get("TestProxy", True)
-        if not proxy_enabled:
-            os.environ.pop("SSL_CER_DIR", None)
-            os.environ.pop("REQUESTS_CA_BUNDLE", None)
 
 
 def execute_tox_serial(tox_command_tuples):

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -9,6 +9,7 @@ from ci_tools.variables import DEFAULT_BUILD_ID, str_to_bool, discover_repo_root
 from ci_tools.versioning.version_shared import set_version_py, set_dev_classifier
 from ci_tools.versioning.version_set_dev import get_dev_version, format_build_id
 
+
 def build() -> None:
     parser = argparse.ArgumentParser(
         description="""This is the primary entrypoint for the "build" action. This command is used to build any package within the azure-sdk-for-python repository.""",
@@ -102,7 +103,9 @@ def build() -> None:
     else:
         target_dir = repo_root
 
-    logging.debug(f"Searching for packages starting from {target_dir} with glob string {args.glob_string} and package filter {args.package_filter_string}")
+    logging.debug(
+        f"Searching for packages starting from {target_dir} with glob string {args.glob_string} and package filter {args.package_filter_string}"
+    )
 
     targeted_packages = discover_targeted_packages(
         args.glob_string,

--- a/tools/azure-sdk-tools/ci_tools/conda/conda_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/conda/conda_functions.py
@@ -239,9 +239,11 @@ def create_setup_files(
     with open(cfg_location, "w") as f:
         f.write(SETUP_CFG)
 
+
 def tolerant_match(pkg_name, input_string):
-    pattern = pkg_name.replace('-', '[-_]')
+    pattern = pkg_name.replace("-", "[-_]")
     return fnmatch.fnmatch(input_string, f"*{pattern}*")
+
 
 def create_combined_sdist(
     conda_build: CondaConfiguration, config_assembly_folder: str, config_assembled_folder: str
@@ -276,7 +278,8 @@ def create_combined_sdist(
                     [
                         os.path.join(config_assembled_folder, a)
                         for a in os.listdir(config_assembled_folder)
-                        if os.path.isfile(os.path.join(config_assembled_folder, a)) and tolerant_match(conda_build.name, a)
+                        if os.path.isfile(os.path.join(config_assembled_folder, a))
+                        and tolerant_match(conda_build.name, a)
                     ]
                 )
             )
@@ -526,15 +529,22 @@ def prep_and_create_environment(environment_dir: str) -> None:
 
     subprocess.run(["conda", "env", "create", "--prefix", environment_dir], cwd=environment_dir, check=True)
     subprocess.run(
-        ["conda", "install", "--yes", "--quiet", "--prefix", environment_dir, "conda-build", "conda-verify", "typing-extensions", "conda-index"],
+        [
+            "conda",
+            "install",
+            "--yes",
+            "--quiet",
+            "--prefix",
+            environment_dir,
+            "conda-build",
+            "conda-verify",
+            "typing-extensions",
+            "conda-index",
+        ],
         cwd=environment_dir,
-        check=True
+        check=True,
     )
-    subprocess.run(
-        ["conda", "run", "--prefix", environment_dir, "conda", "list"],
-        cwd=environment_dir,
-        check=True
-    )
+    subprocess.run(["conda", "run", "--prefix", environment_dir, "conda", "list"], cwd=environment_dir, check=True)
 
 
 def copy_channel_files(coalescing_channel_dir: str, additional_channel_dir: str) -> None:
@@ -573,9 +583,17 @@ def build_conda_packages(
     if additional_channel_folders:
         for channel in additional_channel_folders:
             copy_channel_files(conda_output_dir, channel)
-            subprocess.run(["conda", "run", "--prefix", conda_env_dir, "python", "-m", "conda_index", conda_output_dir], cwd=repo_root, check=True)
+            subprocess.run(
+                ["conda", "run", "--prefix", conda_env_dir, "python", "-m", "conda_index", conda_output_dir],
+                cwd=repo_root,
+                check=True,
+            )
     else:
-        subprocess.run(["conda", "run", "--prefix", conda_env_dir, "python", "-m", "conda_index", conda_output_dir], cwd=repo_root, check=True)
+        subprocess.run(
+            ["conda", "run", "--prefix", conda_env_dir, "python", "-m", "conda_index", conda_output_dir],
+            cwd=repo_root,
+            check=True,
+        )
 
     for conda_build in conda_configurations:
         conda_build_folder = os.path.join(conda_sdist_dir, conda_build.name).replace("\\", "/")
@@ -595,7 +613,18 @@ def invoke_conda_build(
     channels: List[str] = [],
 ) -> None:
 
-    command = ["conda", "run", "--prefix", conda_env_dir, "conda-build", ".", "--output-folder", conda_output_dir, "-c", conda_output_dir]
+    command = [
+        "conda",
+        "run",
+        "--prefix",
+        conda_env_dir,
+        "conda-build",
+        ".",
+        "--output-folder",
+        conda_output_dir,
+        "-c",
+        conda_output_dir,
+    ]
     for channel in channels:
         command.extend(["-c", channel])
 
@@ -641,8 +670,10 @@ def entrypoint():
 
     args = parser.parse_args()
 
-    if (not args.config and not args.config_file):
-        raise argparse.ArgumentError("config arg", "One of either -c (--config) or -f (--file) argument must be provided.")
+    if not args.config and not args.config_file:
+        raise argparse.ArgumentError(
+            "config arg", "One of either -c (--config) or -f (--file) argument must be provided."
+        )
 
     if args.config_file:
         with open(args.config_file, "r") as f:

--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -11,6 +11,7 @@ import re
 import sys
 import textwrap
 from typing import List, Set, Dict, Tuple, Any
+
 try:
     from collections import Sized
 except:

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -42,10 +42,7 @@ MANAGEMENT_PACKAGES_FILTER_EXCLUSIONS = [
 ]
 
 TEST_COMPATIBILITY_MAP = {}
-TEST_PYTHON_DISTRO_INCOMPATIBILITY_MAP = {
-    "azure-storage-blob": "pypy",
-    "azure-eventhub": "pypy"
-}
+TEST_PYTHON_DISTRO_INCOMPATIBILITY_MAP = {"azure-storage-blob": "pypy", "azure-eventhub": "pypy"}
 
 omit_regression = (
     lambda x: "nspkg" not in x
@@ -196,11 +193,13 @@ def discover_targeted_packages(
 
     # glob the starting package set
     collected_packages = glob_packages(glob_string, target_root_dir)
-    logging.info(f"Results for glob_string \"{glob_string}\" and root directory \"{target_root_dir}\" are: {collected_packages}")
+    logging.info(
+        f'Results for glob_string "{glob_string}" and root directory "{target_root_dir}" are: {collected_packages}'
+    )
 
     # apply the additional contains filter
     collected_packages = [pkg for pkg in collected_packages if additional_contains_filter in pkg]
-    logging.info(f"Results after additional contains filter: \"{additional_contains_filter}\" {collected_packages}")
+    logging.info(f'Results after additional contains filter: "{additional_contains_filter}" {collected_packages}')
 
     # filter for compatibility, this means excluding a package that doesn't support py36 when we are running a py36 executable
     if compatibility_filter:
@@ -406,9 +405,7 @@ def find_sdist(dist_dir: str, pkg_name: str, pkg_version: str) -> str:
     packages = [os.path.relpath(w, dist_dir) for w in packages]
 
     if not packages:
-        logging.error(
-            f"No sdist is found in directory {dist_dir} with package name format {pkg_format}."
-        )
+        logging.error(f"No sdist is found in directory {dist_dir} with package name format {pkg_format}.")
         return
     return packages[0]
 

--- a/tools/azure-sdk-tools/ci_tools/git_tools.py
+++ b/tools/azure-sdk-tools/ci_tools/git_tools.py
@@ -1,5 +1,6 @@
 """Pure git tools for managing local folder Git.
 """
+
 import logging
 
 from git import Repo, GitCommandError

--- a/tools/azure-sdk-tools/ci_tools/github_tools.py
+++ b/tools/azure-sdk-tools/ci_tools/github_tools.py
@@ -1,5 +1,6 @@
 """Github tools.
 """
+
 from contextlib import contextmanager
 import logging
 import os

--- a/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
@@ -3,12 +3,11 @@ from .parse_functions import (
     parse_require,
     get_name_from_specifier,
     ParsedSetup,
-    parse_freeze_output,
     read_setup_py_content,
     get_build_config,
     get_config_setting,
     update_build_config,
-    compare_string_to_glob_array
+    compare_string_to_glob_array,
 )
 
 __all__ = [
@@ -16,10 +15,9 @@ __all__ = [
     "parse_require",
     "get_name_from_specifier",
     "ParsedSetup",
-    "parse_freeze_output",
     "read_setup_py_content",
     "get_build_config",
     "get_config_setting",
     "update_build_config",
-    "compare_string_to_glob_array"
+    "compare_string_to_glob_array",
 ]

--- a/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
@@ -8,6 +8,7 @@ from .parse_functions import (
     get_config_setting,
     update_build_config,
     compare_string_to_glob_array,
+    get_ci_config,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "get_config_setting",
     "update_build_config",
     "compare_string_to_glob_array",
+    "get_ci_config",
 ]

--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -11,7 +11,7 @@ except:
     # otherwise fall back to pypi package tomli
     import tomli as toml
 
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
 
 # Assumes the presence of setuptools
 from pkg_resources import (
@@ -102,7 +102,7 @@ class ParsedSetup:
             ext_modules,
         )
 
-    def get_build_config(self) -> Dict[str, Any]:
+    def get_build_config(self) -> Optional[Dict[str, Any]]:
         return get_build_config(self.folder)
 
     def get_config_setting(self, setting: str, default: Any = True) -> Any:
@@ -162,7 +162,7 @@ def get_config_setting(package_path: str, setting: str, default: Any = True) -> 
     return default
 
 
-def get_build_config(package_path: str) -> Dict[str, Any]:
+def get_build_config(package_path: str) -> Optional[Dict[str, Any]]:
     """
     Attempts to retrieve all values within [tools.azure-sdk-build] section of a pyproject.toml.
 
@@ -193,10 +193,24 @@ def read_setup_py_content(setup_filename: str) -> str:
         content = setup_file.read()
         return content
 
+        # name,                 # str
+        # version,              # str
+        # python_requires,      # str
+        # requires,             # List[str]
+        # is_new_sdk,           # bool
+        # setup_filename,       # str
+        # name_space,           # str,
+        # package_data,         # Dict[str, Any],
+        # include_package_data, # bool,
+        # classifiers,          # List[str],
+        # keywords,             # List[str] ADJUSTED
+        # ext_package,          # str
+        # ext_modules           # List[Extension]
+
 
 def parse_setup(
     setup_filename: str,
-) -> Tuple[str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], str, List[Extension]]:
+) -> Tuple[str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], List[str], str, List[Extension]]:
     """
     Used to evaluate a setup.py (or a directory containing a setup.py) and return a tuple containing:
     (
@@ -234,7 +248,7 @@ def parse_setup(
             not isinstance(node, ast.Expr)
             or not isinstance(node.value, ast.Call)
             or not hasattr(node.value.func, "id")
-            or node.value.func.id != "setup"
+            or node.value.func.id != "setup"  # type: ignore
         ):
             continue
         parsed.body[index:index] = parsed_mock_setup.body
@@ -280,19 +294,19 @@ def parse_setup(
     ext_modules = kwargs.get("ext_modules", [])
 
     return (
-        name,
-        version,
-        python_requires,
-        requires,
-        is_new_sdk,
-        setup_filename,
-        name_space,
-        package_data,
-        include_package_data,
-        classifiers,
-        keywords,
-        ext_package,
-        ext_modules,
+        name,  # str
+        version,  # str
+        python_requires,  # str
+        requires,  # List[str]
+        is_new_sdk,  # bool
+        setup_filename,  # str
+        name_space,  # str,
+        package_data,  # Dict[str, Any],
+        include_package_data,  # bool,
+        classifiers,  # List[str],
+        keywords,  # List[str] ADJUSTED
+        ext_package,  # str
+        ext_modules,  # List[Extension]
     )
 
 
@@ -310,16 +324,6 @@ def parse_require(req: str) -> Requirement:
     "azure-core<2.0.0,>=1.11.0" -> [azure-core, <2.0.0,>=1.11.0]
     """
     return Requirement.parse(req)
-
-
-def parse_freeze_output(file_location: str) -> Dict[str, str]:
-    """
-    Takes a python requirements file and returns a dictionary representing the contents.
-    """
-    with open(file_location, "r") as f:
-        reqs = f.read()
-
-    return dict((req.name, req) for req in parse_requirements(reqs))
 
 
 def get_name_from_specifier(version: str) -> str:

--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -12,8 +12,6 @@ except:
     # otherwise fall back to pypi package tomli
     import tomli as toml
 
-import yaml
-
 from typing import Dict, List, Tuple, Any, Optional
 
 # Assumes the presence of setuptools
@@ -201,6 +199,7 @@ def get_ci_config(package_path: str) -> Optional[Dict[str, Any]]:
     ci_file = os.path.join(os.path.dirname(package_path), "ci.yml")
 
     if os.path.exists(ci_file):
+        import yaml
         try:
             with open(ci_file, "r") as f:
                 return yaml.safe_load(f)

--- a/tools/azure-sdk-tools/ci_tools/variables.py
+++ b/tools/azure-sdk-tools/ci_tools/variables.py
@@ -1,5 +1,6 @@
 import os
 
+
 def str_to_bool(input_string: str) -> bool:
     """
     Takes a boolean string representation and returns a bool type value.
@@ -80,10 +81,14 @@ def in_public() -> int:
 
     return 0
 
+
 def in_analyze_weekly() -> int:
     # Returns 4 if the build originates from the tests-weekly analyze job
     # 0 otherwise
-    if "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "") and os.getenv("SYSTEM_STAGEDISPLAYNAME", "") == "Analyze_Test":
+    if (
+        "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "")
+        and os.getenv("SYSTEM_STAGEDISPLAYNAME", "") == "Analyze_Test"
+    ):
         return 4
     return 0
 

--- a/tools/azure-sdk-tools/devtools_testutils/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/__init__.py
@@ -116,5 +116,5 @@ __all__ = [
     "RetryCounter",
     "FakeTokenCredential",
     "create_combined_bundle",
-    "is_live_and_not_recording"
+    "is_live_and_not_recording",
 ]

--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -88,7 +88,7 @@ class AzureRecordedTestCase(object):
         secret = os.environ.get("AZURE_CLIENT_SECRET", getattr(os.environ, "CLIENT_SECRET", None))
 
         # Return live credentials only in live mode
-        if self.is_live: 
+        if self.is_live:
             # Service principal authentication
             if tenant_id and client_id and secret:
                 # Create msrestazure class
@@ -190,6 +190,7 @@ class AzureRecordedTestCase(object):
         token = sas_func(*sas_func_pos_args, **kwargs)
         return token
 
+
 def get_credential(**kwargs):
     tenant_id = os.environ.get("AZURE_TENANT_ID", getattr(os.environ, "TENANT_ID", None))
     client_id = os.environ.get("AZURE_CLIENT_ID", getattr(os.environ, "CLIENT_ID", None))
@@ -261,6 +262,7 @@ def get_credential(**kwargs):
         system_access_token = os.environ.get("SYSTEM_ACCESSTOKEN")
         if service_connection_id and client_id and tenant_id and system_access_token:
             from azure.identity import AzurePipelinesCredential
+
             if is_async:
                 from azure.identity.aio import AzurePipelinesCredential
             return AzurePipelinesCredential(
@@ -268,12 +270,12 @@ def get_credential(**kwargs):
                 client_id=client_id,
                 service_connection_id=service_connection_id,
                 system_access_token=system_access_token,
-                **kwargs
+                **kwargs,
             )
         # This is for testing purposes only, to ensure that the AzurePipelinesCredential is used when available
         else:
             force_fallback_dac = os.environ.get("AZURE_TEST_FORCE_FALLBACK_DAC", "false")
-            if service_connection_id and not(force_fallback_dac):
+            if service_connection_id and not (force_fallback_dac):
                 # if service_connection_id is set, we believe it is running in CI
                 system_access_token = SANITIZED if system_access_token else None
                 raise ValueError(
@@ -282,6 +284,7 @@ def get_credential(**kwargs):
                 )
         # Fall back to DefaultAzureCredential
         from azure.identity import DefaultAzureCredential
+
         if is_async:
             from azure.identity.aio import DefaultAzureCredential
         return DefaultAzureCredential(exclude_managed_identity_credential=True, **kwargs)

--- a/tools/azure-sdk-tools/devtools_testutils/cert.py
+++ b/tools/azure-sdk-tools/devtools_testutils/cert.py
@@ -1,14 +1,15 @@
 from typing import List
 
+
 def create_combined_bundle(cert_files: List[str], output_location: str) -> None:
-   """
-   Combines a list of ascii-encoded PEM certificates into one bundle.
-   """
-   combined_cert_strings: List[str] = []
-   
-   for cert_path in cert_files:
-      with open(cert_path, 'r') as f:
-         combined_cert_strings.extend(f.readlines())
-      
-   with open(output_location, 'w') as f:
-      f.writelines(combined_cert_strings)
+    """
+    Combines a list of ascii-encoded PEM certificates into one bundle.
+    """
+    combined_cert_strings: List[str] = []
+
+    for cert_path in cert_files:
+        with open(cert_path, "r") as f:
+            combined_cert_strings.extend(f.readlines())
+
+    with open(output_location, "w") as f:
+        f.writelines(combined_cert_strings)

--- a/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
+++ b/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
@@ -26,7 +26,7 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
         random_name_enabled=False,
         use_cache=True,
         preparers=None,
-        **kwargs
+        **kwargs,
     ):
         super(EnvironmentVariableLoader, self).__init__(
             name_prefix,
@@ -128,8 +128,8 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
                                 )
                     else:
                         raise AzureTestError(
-                            'To pass a live ID you must provide the scrubbed value for recordings to prevent secrets '
-                            f'from being written to files. {key} was not given. For example: '
+                            "To pass a live ID you must provide the scrubbed value for recordings to prevent secrets "
+                            f"from being written to files. {key} was not given. For example: "
                             '@EnvironmentVariableLoader("schemaregistry", '
                             'schemaregistry_endpoint="fake_endpoint.servicebus.windows.net")'
                         )

--- a/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
+++ b/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
@@ -4,17 +4,20 @@ from azure.core.credentials import AccessToken
 SANITIZED = "Sanitized"
 
 # General-use fake credentials
-FAKE_ACCESS_TOKEN = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2I" \
-    "iLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYwNz" \
+FAKE_ACCESS_TOKEN = (
+    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2I"
+    "iLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYwNz"
     "k3ODY4MyIsIm5iZiI6IjE2MDc5Nzg2ODMiLCJleHAiOiIxNjA3OTc4OTgzIn0."
+)
 FAKE_ID = "00000000-0000-0000-0000-000000000000"
 FAKE_LOGIN_PASSWORD = "F4ke_L0gin_P4ss"
 
 # Service-specific fake credentials
 BATCH_TEST_PASSWORD = "kt#_gahr!@aGERDXA"
 MGMT_HDINSIGHT_FAKE_KEY = "qFmud5LfxcCxWUvWcGMhKDp0v0KuBRLsO/AIddX734W7lzdInsVMsB5ILVoOrF+0fCfk/IYYy5SJ9Q+2v4aihQ=="
-SERVICEBUS_FAKE_SAS = "SharedAccessSignature sr=https%3A%2F%2Ffoo.servicebus.windows.net&sig=dummyValue%3D&se=168726" \
-    "7490&skn=dummyKey"
+SERVICEBUS_FAKE_SAS = (
+    "SharedAccessSignature sr=https%3A%2F%2Ffoo.servicebus.windows.net&sig=dummyValue%3D&se=168726" "7490&skn=dummyKey"
+)
 STORAGE_ACCOUNT_FAKE_KEY = "NzhL3hKZbJBuJ2484dPTR+xF30kYaWSSCbs2BzLgVVI1woqeST/1IgqaLm6QAOTxtGvxctSNbIR/1hW8yH+bJg=="
 
 

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     "WriteStream",
     "AsyncIteratorRandomStream",
     "AsyncRandomStream",
-    "get_random_bytes"
+    "get_random_bytes",
 ]
 
 

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_async_random_stream.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_async_random_stream.py
@@ -63,8 +63,9 @@ class AsyncRandomStream(BytesIO):
 
 class AsyncIteratorRandomStream(AsyncIterator[bytes]):
     """
-        Async random stream of bytes for methods that accept AsyncIterator as input.
+    Async random stream of bytes for methods that accept AsyncIterator as input.
     """
+
     def __init__(self, length, initial_buffer_length=_DEFAULT_LENGTH):
         self._base_data = get_random_bytes(initial_buffer_length)
         self._data_length = length

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_batch_perf_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_batch_perf_test.py
@@ -26,7 +26,7 @@ class BatchPerfTest(_PerfTestBase):
 
         if self.args.insecure:
             # Disable SSL verification for SDK Client
-            self._client_kwargs['connection_verify'] = False
+            self._client_kwargs["connection_verify"] = False
 
             # Disable SSL verification for test proxy session
             self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))
@@ -34,7 +34,8 @@ class BatchPerfTest(_PerfTestBase):
             # Suppress warnings
             import warnings
             from urllib3.exceptions import InsecureRequestWarning
-            warnings.simplefilter('ignore', InsecureRequestWarning)
+
+            warnings.simplefilter("ignore", InsecureRequestWarning)
         else:
             self._session = aiohttp.ClientSession()
 
@@ -42,7 +43,7 @@ class BatchPerfTest(_PerfTestBase):
             # Add policy to redirect requests to the test proxy
             self._test_proxy = self.args.test_proxies[self._parallel_index % len(self.args.test_proxies)]
             self._test_proxy_policy = PerfTestProxyPolicy(self._test_proxy)
-            self._client_kwargs['per_retry_policies'] = [self._test_proxy_policy]
+            self._client_kwargs["per_retry_policies"] = [self._test_proxy_policy]
 
     async def post_setup(self) -> None:
         """
@@ -78,11 +79,8 @@ class BatchPerfTest(_PerfTestBase):
         """
         # cSpell:ignore inmemory
         # Only stop playback if it was successfully started
-        if self._test_proxy_policy and self._test_proxy_policy.mode == 'playback':
-            headers = {
-                "x-recording-id": self._recording_id,
-                "x-purge-inmemory-recording": "true"
-            }
+        if self._test_proxy_policy and self._test_proxy_policy.mode == "playback":
+            headers = {"x-recording-id": self._recording_id, "x-purge-inmemory-recording": "true"}
             url = urljoin(self._test_proxy, "/playback/stop")
             async with self._session.post(url, headers=headers) as resp:
                 assert resp.status == 200

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_base.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_base.py
@@ -93,7 +93,7 @@ class _PerfTestABC(abc.ABC):
         """
         Run all async tests, including both warmup and duration.
         """
-    
+
     @staticmethod
     @abc.abstractmethod
     def add_arguments(parser: argparse.ArgumentParser) -> None:
@@ -225,20 +225,15 @@ class _PerfTestBase(_PerfTestABC):
         """
         if self._profile:
             profile_name = output_path or "{}/cProfile-{}-{}-{}.pstats".format(
-                os.getcwd(),
-                self.__class__.__name__,
-                self._parallel_index,
-                sync)
+                os.getcwd(), self.__class__.__name__, self._parallel_index, sync
+            )
             print("Dumping profile data to {}".format(profile_name))
             self._profile.dump_stats(profile_name)
         else:
             print("No profile generated.")
 
     def _print_profile_stats(
-        self,
-        *,
-        sort_key: pstats.SortKey = PSTATS_PRINT_DEFAULT_SORT_KEY,
-        count: int = PSTATS_PRINT_DEFAULT_LINE_COUNT
+        self, *, sort_key: pstats.SortKey = PSTATS_PRINT_DEFAULT_SORT_KEY, count: int = PSTATS_PRINT_DEFAULT_LINE_COUNT
     ) -> None:
         """Print the profile stats to stdout.
 

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_proc.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_proc.py
@@ -38,6 +38,7 @@ def _synchronize(stages, ignore_error=False):
         if not ignore_error:
             raise
 
+
 async def _start_tests(index, test_class, num_tests, args, test_stages, results, status):
     """Create test classes, run setup, tests and cleanup."""
     # Create all parallel tests with a global unique index value
@@ -111,10 +112,7 @@ async def _run_tests(duration: int, args, tests, results, status, *, with_profil
     """Run the listed tests either in parallel asynchronously or in a thread pool."""
     # Kick of a status monitoring thread.
     stop_status = threading.Event()
-    status_thread = threading.Thread(
-        target=_report_status,
-        args=(status, tests, stop_status),
-        daemon=True)
+    status_thread = threading.Thread(target=_report_status, args=(status, tests, stop_status), daemon=True)
     status_thread.start()
 
     try:

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_policies.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_policies.py
@@ -18,10 +18,7 @@ class PerfTestProxyPolicy(SansIOHTTPPolicy):
     def redirect_to_test_proxy(self, request):
         if self.recording_id and self.mode:
             live_endpoint = urlparse(request.http_request.url)
-            redirected = live_endpoint._replace(
-                scheme=self._proxy_url.scheme,
-                netloc=self._proxy_url.netloc
-            )
+            redirected = live_endpoint._replace(scheme=self._proxy_url.scheme, netloc=self._proxy_url.netloc)
             request.http_request.url = redirected.geturl()
             request.http_request.headers["x-recording-id"] = self.recording_id
             request.http_request.headers["x-recording-mode"] = self.mode

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_repeated_timer.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_repeated_timer.py
@@ -6,6 +6,7 @@
 import itertools
 from threading import Timer, Lock
 
+
 # Credit to https://stackoverflow.com/questions/3393612/run-certain-code-every-n-seconds
 class RepeatedTimer(object):
     def __init__(self, interval, function, *args, start_now: bool = True, **kwargs):
@@ -46,7 +47,7 @@ class AtomicCounter(object):
 
     def increment(self):
         next(self._counter)
-    
+
     def reset(self):
         with self._read_lock:
             self._number_of_read = 0

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/log_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/log_test.py
@@ -9,6 +9,7 @@ import asyncio
 
 from devtools_testutils.perfstress_tests import PerfStressTest
 
+
 # Used for logging every step and property of the perf test
 class LogTest(PerfStressTest):
     _logged_global_completed_operations = 0
@@ -41,11 +42,13 @@ class LogTest(PerfStressTest):
 
     async def cleanup(self):
         await super().cleanup()
-        self.log(f'cleanup() - Completed Operations: {self._logged_completed_operations}')
+        self.log(f"cleanup() - Completed Operations: {self._logged_completed_operations}")
 
     async def global_cleanup(self):
         await super().global_cleanup()
-        self.log(f'global_cleanup() - Global Completed Operations: {self._logged_global_completed_operations}')
+        self.log(f"global_cleanup() - Global Completed Operations: {self._logged_global_completed_operations}")
 
     def log(self, message):
-        print(f'[{(time.time() - type(self).start_time):.3f}] [PID: {os.getpid()}] [Parallel: {self._parallel_index}] {message}')
+        print(
+            f"[{(time.time() - type(self).start_time):.3f}] [PID: {os.getpid()}] [Parallel: {self._parallel_index}] {message}"
+        )

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/pipeline_client_get_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/pipeline_client_get_test.py
@@ -55,6 +55,11 @@ class PipelineClientGetTest(PerfStressTest):
 
     @staticmethod
     def add_arguments(parser):
-        parser.add_argument("--first-run-extra-requests", type=int, default=0, help='Extra requests to send on first run. ' +
-            'Simulates SDKs which require extra requests (like authentication) on first API call.')
+        parser.add_argument(
+            "--first-run-extra-requests",
+            type=int,
+            default=0,
+            help="Extra requests to send on first run. "
+            + "Simulates SDKs which require extra requests (like authentication) on first API call.",
+        )
         parser.add_argument("-u", "--url", required=True)

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sample_batch_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sample_batch_test.py
@@ -6,12 +6,14 @@
 from devtools_testutils.perfstress_tests import BatchPerfTest
 import random
 
-class MockReceiver():
+
+class MockReceiver:
     def receive(self, min_messages=1, max_messages=5):
         for i in range(random.randint(min_messages, max_messages)):
             yield i
 
-class AsyncMockReceiver():
+
+class AsyncMockReceiver:
     async def receive(self, min_messages=1, max_messages=5):
         for i in range(random.randint(min_messages, max_messages)):
             yield i
@@ -27,20 +29,18 @@ class SampleBatchTest(BatchPerfTest):
 
     def run_batch_sync(self) -> int:
         messages = self.receiver_client.receive(
-            max_messages=self.args.max_message_count,
-            min_messages=self.args.min_message_count
+            max_messages=self.args.max_message_count, min_messages=self.args.min_message_count
         )
         return len(list(messages))
 
     async def run_batch_async(self) -> int:
         messages = self.async_receiver_client.receive(
-            max_messages=self.args.max_message_count,
-            min_messages=self.args.min_message_count
+            max_messages=self.args.max_message_count, min_messages=self.args.min_message_count
         )
         return len([m async for m in messages])
-        
+
     @staticmethod
     def add_arguments(parser):
         super(SampleBatchTest, SampleBatchTest).add_arguments(parser)
-        parser.add_argument('--max-message-count', nargs='?', type=int, default=10)
-        parser.add_argument('--min-message-count', nargs='?', type=int, default=0)
+        parser.add_argument("--max-message-count", nargs="?", type=int, default=10)
+        parser.add_argument("--min-message-count", nargs="?", type=int, default=0)

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sample_event_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sample_event_test.py
@@ -11,7 +11,7 @@ import time
 from devtools_testutils.perfstress_tests import EventPerfTest
 
 
-class MockEventProcessor():
+class MockEventProcessor:
 
     def __init__(self, partitions, process_event, process_error, error_after=None, max_events_per_second=None):
         self.partitions = partitions
@@ -20,13 +20,13 @@ class MockEventProcessor():
         self.shutdown = False
         self._error_raised = False
         self._error_lock = threading.Lock()
-        self._event_args = [{'partition': i, 'data': 'hello'} for i in range(self.partitions)]
+        self._event_args = [{"partition": i, "data": "hello"} for i in range(self.partitions)]
         self._events_raised = [0] * self.partitions
         self._starttime = None
         self._process_event = process_event
         self._process_error = process_error
         self._executor = ThreadPoolExecutor(max_workers=self.partitions)
-    
+
     def _process_error_after(self, partition):
         with self._error_lock:
             if not self._error_raised:
@@ -65,7 +65,7 @@ class MockEventProcessor():
                     self._process_event(**event_args)
 
 
-class AsyncMockEventProcessor():
+class AsyncMockEventProcessor:
 
     def __init__(self, partitions, process_event, process_error, error_after=None, max_events_per_second=None):
         self.partitions = partitions
@@ -77,7 +77,7 @@ class AsyncMockEventProcessor():
         self._starttime = None
         self._process_event = process_event
         self._process_error = process_error
-        self._event_args = [{'partition': i, 'data': 'hello'} for i in range(self.partitions)]
+        self._event_args = [{"partition": i, "data": "hello"} for i in range(self.partitions)]
         self._events_raised = [0] * self.partitions
 
     async def _process_error_after(self, partition):
@@ -131,14 +131,14 @@ class SampleEventTest(EventPerfTest):
             self.process_event_sync,
             self.process_error_sync,
             error_after=self.args.error_after_seconds,
-            max_events_per_second=self.args.max_events_per_second
+            max_events_per_second=self.args.max_events_per_second,
         )
         self.async_event_processor = AsyncMockEventProcessor(
             self.args.partitions,
             self.process_event_async,
             self.process_error_async,
             error_after=self.args.error_after_seconds,
-            max_events_per_second=self.args.max_events_per_second
+            max_events_per_second=self.args.max_events_per_second,
         )
 
     def process_event_sync(self, **kwargs):
@@ -176,10 +176,14 @@ class SampleEventTest(EventPerfTest):
         Stop the process for receiving events.
         """
         self.async_event_processor.shutdown = True
-    
+
     @staticmethod
     def add_arguments(parser):
         super(SampleEventTest, SampleEventTest).add_arguments(parser)
-        parser.add_argument('--error-after-seconds', nargs='?', type=int, help='Raise error after this number of seconds.')
-        parser.add_argument('--max-events-per-second', nargs='?', type=int, help='Maximum events per second across all partitions.')
-        parser.add_argument('--partitions', nargs='?', type=int, help="Number of partitions. Default is 8.", default=8)
+        parser.add_argument(
+            "--error-after-seconds", nargs="?", type=int, help="Raise error after this number of seconds."
+        )
+        parser.add_argument(
+            "--max-events-per-second", nargs="?", type=int, help="Maximum events per second across all partitions."
+        )
+        parser.add_argument("--partitions", nargs="?", type=int, help="Number of partitions. Default is 8.", default=8)

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sleep_test.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/system_perfstress/sleep_test.py
@@ -15,7 +15,9 @@ class SleepTest(PerfStressTest):
 
     def __init__(self, arguments):
         super().__init__(arguments)
-        self.seconds_per_operation = (self.args.initial_delay_ms / 1000) * math.pow(self.args.instance_growth_factor, self._parallel_index)
+        self.seconds_per_operation = (self.args.initial_delay_ms / 1000) * math.pow(
+            self.args.instance_growth_factor, self._parallel_index
+        )
 
     def run_sync(self):
         time.sleep(self.seconds_per_operation)
@@ -28,13 +30,25 @@ class SleepTest(PerfStressTest):
     @staticmethod
     def add_arguments(parser):
         super(SleepTest, SleepTest).add_arguments(parser)
-        parser.add_argument('--initial-delay-ms', nargs='?', type=int, default=1000, help='Initial delay (in milliseconds)')
-        
+        parser.add_argument(
+            "--initial-delay-ms", nargs="?", type=int, default=1000, help="Initial delay (in milliseconds)"
+        )
+
         # Used for verifying the perf framework correctly computes average throughput across parallel tests of different speed.
         # Each instance of this test completes operations at a different rate, to allow for testing scenarios where
         # some instances are still waiting when time expires.
-        parser.add_argument('--instance-growth-factor', nargs='?', type=float, default=1,
-            help='Instance growth factor.  The delay of instance N will be (InitialDelayMS * (InstanceGrowthFactor ^ InstanceCount)).')
-        
-        parser.add_argument('--iteration-growth-factor', nargs='?', type=float, default=1,
-            help='Iteration growth factor.  The delay of iteration N will be (InitialDelayMS * (IterationGrowthFactor ^ IterationCount)).')
+        parser.add_argument(
+            "--instance-growth-factor",
+            nargs="?",
+            type=float,
+            default=1,
+            help="Instance growth factor.  The delay of instance N will be (InitialDelayMS * (InstanceGrowthFactor ^ InstanceCount)).",
+        )
+
+        parser.add_argument(
+            "--iteration-growth-factor",
+            nargs="?",
+            type=float,
+            default=1,
+            help="Iteration growth factor.  The delay of iteration N will be (InitialDelayMS * (IterationGrowthFactor ^ IterationCount)).",
+        )

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -169,9 +169,9 @@ def check_certificate_location(repo_root: str) -> None:
     """
 
     existing_root_pem = certifi.where()
-    local_dev_cert = os.path.abspath(os.path.join(repo_root, 'eng', 'common', 'testproxy', 'dotnet-devcert.crt'))
+    local_dev_cert = os.path.abspath(os.path.join(repo_root, "eng", "common", "testproxy", "dotnet-devcert.crt"))
     combined_filename = os.path.basename(local_dev_cert).split(".")[0] + ".pem"
-    combined_folder = os.path.join(repo_root, '.certificate')
+    combined_folder = os.path.join(repo_root, ".certificate")
     combined_location = os.path.join(combined_folder, combined_filename)
 
     # If no local certificate folder exists, create one
@@ -316,11 +316,7 @@ def set_common_sanitizers() -> None:
 
     # General regex sanitizers for sensitive patterns throughout interactions
     batch_sanitizers[Sanitizer.GENERAL_REGEX] = [
-        {
-            "regex": "(?:[\\?&](sig|se|st|sv)=)(?<secret>[^&\\\"\\s]*)",
-            "group_for_replace": "secret",
-            "value": SANITIZED
-        },
+        {"regex": '(?:[\\?&](sig|se|st|sv)=)(?<secret>[^&\\"\\s]*)', "group_for_replace": "secret", "value": SANITIZED},
     ]
 
     # Header regex sanitizers for sensitive patterns in request/response headers

--- a/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
@@ -98,7 +98,7 @@ class ResourceGroupPreparer(AzureMgmtPreparer):
                 id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + name,
             )
         if name != self.moniker:
-                add_general_string_sanitizer(target=name, value=self.moniker)
+            add_general_string_sanitizer(target=name, value=self.moniker)
         return {
             self.parameter_name: self.resource,
             self.parameter_name_for_location: self.location,
@@ -116,7 +116,9 @@ class ResourceGroupPreparer(AzureMgmtPreparer):
                     raise AzureTestError("Timed out waiting for resource group to be deleted.")
                 else:
                     self.client.resource_groups.begin_delete(name, polling=False).result()
-            except Exception as err:  # NOTE: some track 1 libraries do not have azure-core installed. Cannot use HttpResponseError here
+            except (
+                Exception
+            ) as err:  # NOTE: some track 1 libraries do not have azure-core installed. Cannot use HttpResponseError here
                 logging.info("Failed to delete resource group with name {}".format(name))
                 logging.info("{}".format(err))
                 pass

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -490,7 +490,7 @@ def remove_batch_sanitizers(sanitizers: List[str], headers: Optional[Dict] = Non
     if is_live_and_not_recording():
         return
 
-    data = {"Sanitizers" : sanitizers}
+    data = {"Sanitizers": sanitizers}
 
     headers_to_send = {"Content-Type": "application/json"}
     if headers is not None:

--- a/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
@@ -179,7 +179,6 @@ class StorageRecordedTestCase(AzureRecordedTestCase):
                 assert i[0] % max_chunk_size == 0 or i[0] % max_chunk_size == small_chunk_size
                 assert i[1] == size
 
-
     def get_datetime_variable(self, variables, name, dt):
         dt_string = variables.setdefault(name, dt.isoformat())
         return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S.%f")

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -18,6 +18,7 @@ DEPENDENCIES = [
     "urllib3",
     "tomli-w==1.0.0",
     "azure-core",
+    "pyyaml",
     # Perf/Build
     "ConfigArgParse>=0.12.0",
 ]

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -50,7 +50,7 @@ setup(
             "sdk_analyze_deps=ci_tools.dependency_analysis:analyze_dependencies",
             "sdk_find_invalid_versions=ci_tools.versioning.find_invalid_versions:find_invalid_versions_main",
             "sdk_verify_keywords=ci_tools.keywords_verify:entrypoint",
-            "systemperf=devtools_testutils.perfstress_tests:run_system_perfstress_tests_cmd"
+            "systemperf=devtools_testutils.perfstress_tests:run_system_perfstress_tests_cmd",
         ],
     },
     extras_require={

--- a/tools/azure-sdk-tools/tests/conftest.py
+++ b/tools/azure-sdk-tools/tests/conftest.py
@@ -5,9 +5,11 @@ import os
 from typing import List
 from tempfile import TemporaryDirectory
 
+
 @pytest.fixture()
 def tmp_directory_create():
     with TemporaryDirectory() as tmp_dir:
+
         def create_temp_directory(fake_creation_paths: List[str]) -> TemporaryDirectory:
             for file in fake_creation_paths:
                 target_path = os.path.join(tmp_dir, file)

--- a/tools/azure-sdk-tools/tests/example_async.py
+++ b/tools/azure-sdk-tools/tests/example_async.py
@@ -38,16 +38,14 @@ async def test_example_trio():
 
     async def req():
         request = HttpRequest("GET", "https://bing.com/")
-        policies = [
-            UserAgentPolicy("myuseragent"),
-            AsyncRedirectPolicy()
-        ]
+        policies = [UserAgentPolicy("myuseragent"), AsyncRedirectPolicy()]
         # [START trio]
         from azure.core.pipeline.transport import TrioRequestsTransport
 
         async with AsyncPipeline(TrioRequestsTransport(), policies=policies) as pipeline:
             return await pipeline.run(request)
         # [END trio]
+
     response = trio.run(req)
     assert isinstance(response.http_response.status_code, int)
 
@@ -56,10 +54,7 @@ async def test_example_trio():
 async def test_example_asyncio():
 
     request = HttpRequest("GET", "https://bing.com")
-    policies = [
-        UserAgentPolicy("myuseragent"),
-        AsyncRedirectPolicy()
-    ]
+    policies = [UserAgentPolicy("myuseragent"), AsyncRedirectPolicy()]
     # [START asyncio]
     from azure.core.pipeline.transport import AsyncioRequestsTransport
 
@@ -74,10 +69,7 @@ async def test_example_asyncio():
 async def test_example_aiohttp():
 
     request = HttpRequest("GET", "https://bing.com")
-    policies = [
-        UserAgentPolicy("myuseragent"),
-        AsyncRedirectPolicy()
-    ]
+    policies = [UserAgentPolicy("myuseragent"), AsyncRedirectPolicy()]
     # [START aiohttp]
     from azure.core.pipeline.transport import AioHttpTransport
 
@@ -97,10 +89,7 @@ async def test_example_async_pipeline():
 
     # example: create request and policies
     request = HttpRequest("GET", "https://bing.com")
-    policies = [
-        UserAgentPolicy("myuseragent"),
-        AsyncRedirectPolicy()
-    ]
+    policies = [UserAgentPolicy("myuseragent"), AsyncRedirectPolicy()]
 
     # run the pipeline
     async with AsyncPipeline(transport=AioHttpTransport(), policies=policies) as pipeline:
@@ -221,7 +210,7 @@ async def test_example_async_retry_policy():
             retry_status=5,
             retry_backoff_factor=0.5,
             retry_backoff_max=60,
-            retry_on_methods=['GET']
+            retry_on_methods=["GET"],
         )
     # [END async_retry_policy]
 

--- a/tools/azure-sdk-tools/tests/integration/proxy/conftest.py
+++ b/tools/azure-sdk-tools/tests/integration/proxy/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from devtools_testutils import test_proxy
 
+
 @pytest.fixture(scope="session", autouse=True)
 def start_proxy(test_proxy):
-   return
+    return

--- a/tools/azure-sdk-tools/tests/integration/proxy/test_proxy_startup.py
+++ b/tools/azure-sdk-tools/tests/integration/proxy/test_proxy_startup.py
@@ -23,4 +23,4 @@ class TestProxyIntegration:
     # Therefore we are not using recorded_by_proxy decorator or recorded_test fixture
     def test_tool_spinup_http(self):
         result = http_client.request("GET", PROXY_CHECK_URL)
-        assert(result.status == 200)
+        assert result.status == 200

--- a/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_not_present/service/fake-package/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_not_present/service/fake-package/setup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from setuptools import setup, find_packages
+import os
+from io import open
+import re
+
+# example setup.py Feel free to copy the entire "azure-template" folder into a package folder named
+# with "azure-<yourpackagename>". Ensure that the below arguments to setup() are updated to reflect
+# your package.
+
+# this setup.py is set up in a specific way to keep the azure* and azure-mgmt-* namespaces WORKING all the way
+# up from python 2.7. Reference here: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/packaging.md
+
+PACKAGE_NAME = "ci-yml-nonpresent-test"
+
+# a-b-c => a/b/c
+package_folder_path = PACKAGE_NAME.replace("-", "/")
+# a-b-c => a.b.c
+namespace_name = PACKAGE_NAME.replace("-", ".")
+
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name=PACKAGE_NAME,
+    version="1.0.0",
+    description=PACKAGE_NAME,
+    # ensure that these are updated to reflect the package owners' information
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Azure/azure-sdk-for-python",
+    keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
+    author="Microsoft Corporation",
+    author_email="azuresdkengsysadmins@microsoft.com",
+    license="MIT License",
+    # ensure that the development status reflects the status of your package
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "License :: OSI Approved :: MIT License",
+    ],
+    packages=find_packages(
+        exclude=[
+            "tests",
+            # Exclude packages that will be covered by PEP420 or nspkg
+            # This means any folder structure that only consists of a __init__.py.
+            # For example, for storage, this would mean adding 'azure.storage'
+            # in addition to the default 'azure' that is seen here.
+            "azure",
+        ]
+    ),
+    include_package_data=True,
+    package_data={
+        "azure": ["py.typed"],
+    },
+    install_requires=[
+        "azure-core<2.0.0,>=1.10.0",
+    ],
+    python_requires=">=3.7",
+    project_urls={
+        "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
+    },
+)

--- a/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_present/service/ci.yml
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_present/service/ci.yml
@@ -1,0 +1,57 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+
+trigger:
+  branches:
+    include:
+    - main
+    - hotfix/*
+    - release/*
+    - restapi*
+  paths:
+    include:
+    - sdk/core/
+    - eng/
+    - tools/
+    exclude:
+    - eng/common/
+
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+    - restapi*
+  paths:
+    include:
+    - sdk/core/
+    - eng/
+    - tools/
+    exclude:
+    - eng/common/
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: core
+    BuildTargetingString: "*"
+    ValidateFormatting: true
+    TestProxy: false
+    TestTimeoutInMinutes: 120
+    Artifacts:
+    - name: azure-core
+      safeName: azurecore
+    - name: azure-mgmt-core
+      safeName: azuremgmtcore
+    - name: azure-core-tracing-opencensus
+      safeName: azurecorecoretracingopencensus
+    - name: azure-core-tracing-opentelemetry
+      safeName: azurecorecoretracingtelemetry
+    - name: azure-common
+      safeName: azurecommon
+      skipPublishDocMs: true
+    - name: azure-core-experimental
+      safeName: azurecoreexperimental
+    - name: corehttp
+      safeName: corehttp

--- a/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_present/service/fake-package/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/ci_yml_present/service/fake-package/setup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from setuptools import setup, find_packages
+import os
+from io import open
+import re
+
+# example setup.py Feel free to copy the entire "azure-template" folder into a package folder named
+# with "azure-<yourpackagename>". Ensure that the below arguments to setup() are updated to reflect
+# your package.
+
+# this setup.py is set up in a specific way to keep the azure* and azure-mgmt-* namespaces WORKING all the way
+# up from python 2.7. Reference here: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/packaging.md
+
+PACKAGE_NAME = "ci-yml-present-test"
+
+# a-b-c => a/b/c
+package_folder_path = PACKAGE_NAME.replace("-", "/")
+# a-b-c => a.b.c
+namespace_name = PACKAGE_NAME.replace("-", ".")
+
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name=PACKAGE_NAME,
+    version="1.0.0",
+    description=PACKAGE_NAME,
+    # ensure that these are updated to reflect the package owners' information
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Azure/azure-sdk-for-python",
+    keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
+    author="Microsoft Corporation",
+    author_email="azuresdkengsysadmins@microsoft.com",
+    license="MIT License",
+    # ensure that the development status reflects the status of your package
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "License :: OSI Approved :: MIT License",
+    ],
+    packages=find_packages(
+        exclude=[
+            "tests",
+            # Exclude packages that will be covered by PEP420 or nspkg
+            # This means any folder structure that only consists of a __init__.py.
+            # For example, for storage, this would mean adding 'azure.storage'
+            # in addition to the default 'azure' that is seen here.
+            "azure",
+        ]
+    ),
+    include_package_data=True,
+    package_data={
+        "azure": ["py.typed"],
+    },
+    install_requires=[
+        "azure-core<2.0.0,>=1.10.0",
+    ],
+    python_requires=">=3.7",
+    project_urls={
+        "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
+    },
+)

--- a/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_two_options/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_two_options/setup.py
@@ -30,7 +30,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name=PACKAGE_NAME,
-    version='1.0.0',
+    version="1.0.0",
     description=PACKAGE_NAME,
     # ensure that these are updated to reflect the package owners' information
     long_description=long_description,

--- a/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_zero_options/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_zero_options/setup.py
@@ -30,7 +30,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name=PACKAGE_NAME,
-    version='1.0.0',
+    version="1.0.0",
     description=PACKAGE_NAME,
     # ensure that these are updated to reflect the package owners' information
     long_description=long_description,

--- a/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
+++ b/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
@@ -8,6 +8,7 @@ repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", 
 core_service_root = os.path.join(repo_root, "sdk", "core")
 storage_service_root = os.path.join(repo_root, "sdk", "storage")
 
+
 def test_discovery():
     results = discover_targeted_packages("azure*", core_service_root)
 
@@ -16,6 +17,7 @@ def test_discovery():
 
     assert len(results) > 1
     assert len(non_empty_results) == 1
+
 
 def test_discovery_omit_mgmt():
     results = discover_targeted_packages("azure*", storage_service_root, filter_type="Omit_management")
@@ -26,8 +28,9 @@ def test_discovery_omit_mgmt():
         "azure-storage-extensions",
         "azure-storage-file-datalake",
         "azure-storage-file-share",
-        "azure-storage-queue"
+        "azure-storage-queue",
     ]
+
 
 def test_discovery_omit_build():
     results = discover_targeted_packages("*", core_service_root, filter_type="Build")
@@ -38,8 +41,9 @@ def test_discovery_omit_build():
         "azure-core-tracing-opencensus",
         "azure-core-tracing-opentelemetry",
         "azure-mgmt-core",
-        "corehttp"
+        "corehttp",
     ]
+
 
 def test_discovery_single_package():
     results = discover_targeted_packages("azure-core", core_service_root, filter_type="Build")
@@ -47,6 +51,7 @@ def test_discovery_single_package():
     assert [os.path.basename(result) for result in results] == [
         "azure-core",
     ]
+
 
 def test_discovery_omit_regression():
     results = discover_targeted_packages("*", core_service_root, filter_type="Regression")
@@ -56,7 +61,7 @@ def test_discovery_omit_regression():
         "azure-core-experimental",
         "azure-core-tracing-opencensus",
         "azure-core-tracing-opentelemetry",
-        "corehttp"
+        "corehttp",
     ]
 
     storage_results = discover_targeted_packages("azure*", storage_service_root, filter_type="Regression")
@@ -67,7 +72,7 @@ def test_discovery_omit_regression():
         "azure-storage-extensions",
         "azure-storage-file-datalake",
         "azure-storage-file-share",
-        "azure-storage-queue"
+        "azure-storage-queue",
     ]
 
 
@@ -79,7 +84,6 @@ def test_discovery_honors_contains_filter():
         "azure-storage-file-datalake",
         "azure-storage-file-share",
     ]
-
 
 
 def test_discovery_honors_override():

--- a/tools/azure-sdk-tools/tests/test_ci_metadata.py
+++ b/tools/azure-sdk-tools/tests/test_ci_metadata.py
@@ -1,0 +1,23 @@
+import os, tempfile, shutil
+
+import pytest
+
+from ci_tools.parsing import get_ci_config
+from ci_tools.environment_exclusions import is_check_enabled
+
+integration_folder = os.path.join(os.path.dirname(__file__), "integration")
+scenario_present = os.path.join(integration_folder, "scenarios", "ci_yml_present", "service", "fake-package")
+scenario_not_present = os.path.join(integration_folder, "scenarios", "ci_yml_not_present", "service", "fake-package")
+
+def test_ci_config_present():
+    config = get_ci_config(scenario_present)
+    assert config is not None
+    assert type(config) is dict
+    assert type(config["extends"]) is dict
+
+    should_proxy = config.get("extends", {}).get("parameters", {}).get("TestProxy", True)
+    assert should_proxy == False
+
+def test_ci_config_non_present():
+    config = get_ci_config(scenario_not_present)
+    assert config is None

--- a/tools/azure-sdk-tools/tests/test_individual_functions.py
+++ b/tools/azure-sdk-tools/tests/test_individual_functions.py
@@ -6,6 +6,7 @@ import pytest
 from ci_tools.parsing import ParsedSetup, compare_string_to_glob_array
 from typing import List
 
+
 @pytest.mark.parametrize(
     "input_string, glob_array, expected_result",
     [

--- a/tools/azure-sdk-tools/tests/test_optional_functionality.py
+++ b/tools/azure-sdk-tools/tests/test_optional_functionality.py
@@ -4,63 +4,64 @@ import pytest
 from ci_tools.parsing import ParsedSetup
 from ci_tools.functions import get_config_setting
 
-integration_folder = os.path.join(os.path.dirname(__file__), 'integration')
+integration_folder = os.path.join(os.path.dirname(__file__), "integration")
+
 
 def test_toml_result():
-    package_with_toml = os.path.join(integration_folder, 'scenarios', 'optional_environment_two_options')
+    package_with_toml = os.path.join(integration_folder, "scenarios", "optional_environment_two_options")
     parsed_setup = ParsedSetup.from_path(package_with_toml)
     actual = parsed_setup.get_build_config()
 
     expected = {
-        'mypy': True,
-        'type_check_samples': True,
-        'verifytypes': True,
-        'pyright': True,
-        'pylint': True,
-        'black': True,
-        'optional':[
+        "mypy": True,
+        "type_check_samples": True,
+        "verifytypes": True,
+        "pyright": True,
+        "pylint": True,
+        "black": True,
+        "optional": [
             {
-                'name': 'no_requests',
-                'install': [],
-                'uninstall': ['requests'],
-                'additional_pytest_args': ['-k', '*_async.py']
+                "name": "no_requests",
+                "install": [],
+                "uninstall": ["requests"],
+                "additional_pytest_args": ["-k", "*_async.py"],
             },
             {
-                'name': 'no_aiohttp',
-                'install': [],
-                'uninstall': ['aiohttp'],
-                'additional_pytest_args': ['-k', 'not *_async.py']
-            }
-        ]
+                "name": "no_aiohttp",
+                "install": [],
+                "uninstall": ["aiohttp"],
+                "additional_pytest_args": ["-k", "not *_async.py"],
+            },
+        ],
     }
 
     assert actual == expected
 
 
 def test_optional_specific_get():
-    package_with_toml = os.path.join(integration_folder, 'scenarios', 'optional_environment_two_options')
-    actual = get_config_setting(package_with_toml, 'optional')
+    package_with_toml = os.path.join(integration_folder, "scenarios", "optional_environment_two_options")
+    actual = get_config_setting(package_with_toml, "optional")
     expected = [
         {
-            'name': 'no_requests',
-            'install': [],
-            'uninstall': ['requests'],
-            'additional_pytest_args': ['-k', '*_async.py']
+            "name": "no_requests",
+            "install": [],
+            "uninstall": ["requests"],
+            "additional_pytest_args": ["-k", "*_async.py"],
         },
         {
-            'name': 'no_aiohttp',
-            'install': [],
-            'uninstall': ['aiohttp'],
-            'additional_pytest_args': ['-k', 'not *_async.py']
-        }
+            "name": "no_aiohttp",
+            "install": [],
+            "uninstall": ["aiohttp"],
+            "additional_pytest_args": ["-k", "not *_async.py"],
+        },
     ]
 
     assert expected == actual
 
 
 def test_optional_specific_get_no_result():
-    package_with_toml = os.path.join(integration_folder, 'scenarios', 'optional_environment_zero_options')
-    actual = get_config_setting(package_with_toml, 'optional', None)
+    package_with_toml = os.path.join(integration_folder, "scenarios", "optional_environment_zero_options")
+    actual = get_config_setting(package_with_toml, "optional", None)
     expected = None
 
     assert expected == actual

--- a/tools/azure-sdk-tools/tests/test_parse_functionality.py
+++ b/tools/azure-sdk-tools/tests/test_parse_functionality.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 import pytest
 
 package_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-test_folder = os.path.join(os.path.dirname(__file__), )
+test_folder = os.path.join(
+    os.path.dirname(__file__),
+)
+
 
 def test_parse_require():
     test_scenarios = [
@@ -19,7 +22,7 @@ def test_parse_require():
         ("azure-core<2.0.0,>=1.2.2", "azure-core", "<2.0.0,>=1.2.2"),
         ("azure-core[aio]<2.0.0,>=1.26.0", "azure-core", "<2.0.0,>=1.26.0"),
         ("azure-core[aio,cool_extra]<2.0.0,>=1.26.0", "azure-core", "<2.0.0,>=1.26.0"),
-        ("azure-core[]", "azure-core", None)
+        ("azure-core[]", "azure-core", None),
     ]
 
     for scenario in test_scenarios:
@@ -119,6 +122,7 @@ setup(
     assert result.classifiers[5] == "Programming Language :: Python :: 3.8"
     assert result.keywords[0] == "azure sdk"
     assert len(result.keywords) == 2
+
 
 @patch("ci_tools.parsing.parse_functions.read_setup_py_content")
 def test_parse_recognizes_extensions(test_patch):

--- a/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
+++ b/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
@@ -80,6 +80,7 @@ def test_pyproject_update_check_override():
 
         build_config = get_build_config(temp_dir)
 
+        assert build_config is not None
         build_config["pyright"] = True
 
         update_result = update_build_config(temp_dir, build_config)

--- a/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
+++ b/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
@@ -59,12 +59,10 @@ def test_nonpresent_pyproject_update():
         reloaded_build_config = get_build_config(new_path)
         assert reloaded_build_config == update_result
 
+
 @pytest.mark.parametrize(
     "check_name, environment_value, expected_result",
-    [
-        ("mindependency", "true", True),
-        ("mindependency", "false", False)
-    ]
+    [("mindependency", "true", True), ("mindependency", "false", False)],
 )
 def test_environment_override(check_name, environment_value, expected_result):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tools/azure-sdk-tools/tests/test_python_snippet_updater.py
+++ b/tools/azure-sdk-tools/tests/test_python_snippet_updater.py
@@ -1,6 +1,11 @@
 import os
 import pytest
-from ci_tools.snippet_update.python_snippet_updater import get_snippet, update_snippet, check_snippets, check_not_up_to_date
+from ci_tools.snippet_update.python_snippet_updater import (
+    get_snippet,
+    update_snippet,
+    check_snippets,
+    check_not_up_to_date,
+)
 
 
 def test_get_snippet():
@@ -9,8 +14,9 @@ def test_get_snippet():
     get_snippet(file)
     snippets = check_snippets().keys()
     assert len(snippets) == 7
-    assert 'example_async.trio' in snippets
-    assert 'example_async.async_retry_policy' in snippets
+    assert "example_async.trio" in snippets
+    assert "example_async.async_retry_policy" in snippets
+
 
 def test_update_snippet():
     folder = os.path.dirname(os.path.abspath(__file__))
@@ -19,6 +25,7 @@ def test_update_snippet():
     file_1 = os.path.join(folder, "README.md")
     update_snippet(file_1)
 
+
 def test_missing_snippet():
     folder = os.path.dirname(os.path.abspath(__file__))
     file = os.path.join(folder, "example_async.py")
@@ -26,6 +33,7 @@ def test_missing_snippet():
     file_1 = os.path.join(folder, "README_missing_snippet.md")
     with pytest.raises(SystemExit):
         update_snippet(file_1)
+
 
 def test_out_of_sync():
     folder = os.path.dirname(os.path.abspath(__file__))

--- a/tools/azure-sdk-tools/tests/test_requirements_parse.py
+++ b/tools/azure-sdk-tools/tests/test_requirements_parse.py
@@ -96,4 +96,3 @@ def test_replace_dev_reqs_remote(tmp_directory_create):
     replace_dev_reqs(requirements_file, core_location, None)
     requirements_after = get_requirements_from_file(requirements_file)
     assert requirements_before == requirements_after
-

--- a/tools/azure-sdk-tools/tests/test_whl_discovery.py
+++ b/tools/azure-sdk-tools/tests/test_whl_discovery.py
@@ -1,4 +1,3 @@
-
 import os
 
 from unittest.mock import patch
@@ -92,11 +91,11 @@ def test_find_whl_discovers_specific_wheels(test_patch, tmp_directory_create):
             "azure_storage_extensions-1.0.0b1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
             "azure_storage_extensions-1.0.0b1-cp39-cp39-win_amd64.whl",
             "azure_storage_extensions-1.0.0b1-cp39-cp39-win32.whl",
-            "azure-storage-extensions-1.0.0b1.tar.gz"
+            "azure-storage-extensions-1.0.0b1.tar.gz",
         ]
     )
 
-    with open(os.path.join(tags_folder, 'from_WSL_310.txt'), 'r', encoding='utf-8') as f:
+    with open(os.path.join(tags_folder, "from_WSL_310.txt"), "r", encoding="utf-8") as f:
         compatible_tags = [line.strip() for line in f.readlines()]
 
     test_patch.return_value = compatible_tags
@@ -140,11 +139,11 @@ def test_find_sdist_discovers_specific_sdist(test_patch, tmp_directory_create):
             "azure_storage_extensions-1.0.0b1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
             "azure_storage_extensions-1.0.0b1-cp39-cp39-win_amd64.whl",
             "azure_storage_extensions-1.0.0b1-cp39-cp39-win32.whl",
-            "azure-storage-extensions-1.0.0b1.tar.gz"
+            "azure-storage-extensions-1.0.0b1.tar.gz",
         ]
     )
 
-    with open(os.path.join(tags_folder, 'from_WSL_310.txt'), 'r', encoding='utf-8') as f:
+    with open(os.path.join(tags_folder, "from_WSL_310.txt"), "r", encoding="utf-8") as f:
         compatible_tags = [line.strip() for line in f.readlines()]
 
     test_patch.return_value = compatible_tags

--- a/tools/azure-sdk-tools/testutils/common_recordingtestcase.py
+++ b/tools/azure-sdk-tools/testutils/common_recordingtestcase.py
@@ -10,6 +10,7 @@ import json
 import os
 import os.path
 import time
+
 # We don't vcrpy anymore, if this code is loaded, fail
 # import vcr
 import re


### PR DESCRIPTION
`azure-core` traditionally doesn't use the proxy, so the tests aren't designed to work with the SSL_CERT_DIR override. We have a random nitpicky failure on `windows 38` to do with that, but frankly it's not really intended to be supported, so adding this. EDIT: this is affecting the uamqp packages too (which don't use the test-proxy)

This PR:

- [x] Adds functionality to grab a `ci.yml` configuration given a package path
  - While this functionality is immediately being used, it's also very useful going forward, possibly within `get_package_properties.py` being used by `Save-Package-Properties` to auto-populate arguments based on `ci.yml` settings.
- [x] Adds a couple (literally) tests to exercise the two possibilities with a ci.yml
- [x] ~~Uses the new functionality in `tox_harness` to unset `SSL_CERT_DIR` and `REQUESTS_CA_BUNDLE` if the `TestProxy` is not enabled in their `ci.yml` config.~~
- [x] Applies `black` to a significant portion of the azure-sdk-tools directory. 

Instead of UNSETTING variables, I internalized the fact that we don't NEED them to be set, @mccoyp 's work in the `proxy_startup.py` handles this for us!