### PR TITLE
Address async run upload error during eval batch run

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -625,7 +625,10 @@ def _evaluate(  # pylint: disable=too-many-locals,too-many-statements
     evaluators_info = {}
     use_pf_client = kwargs.get("_use_pf_client", True)
     if use_pf_client:
-        batch_run_client = ProxyClient(pf_client)
+        # Some user occasionally encountered errors when PFClient uploaded evaluation runs to the cloud.
+        # The root cause is unclear yet, but it appears to involve a conflict between the async evaluator and
+        # the async run uploader. As a temporary mitigation, use a PFClient without a trace destination for batch runs.
+        batch_run_client = ProxyClient(PFClient(user_agent=USER_AGENT))
 
         # Ensure the absolute path is passed to pf.run, as relative path doesn't work with
         # multiple evaluators. If the path is already absolute, abspath will return the original path.

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -625,9 +625,9 @@ def _evaluate(  # pylint: disable=too-many-locals,too-many-statements
     evaluators_info = {}
     use_pf_client = kwargs.get("_use_pf_client", True)
     if use_pf_client:
-        # Some user occasionally encountered errors when PFClient uploaded evaluation runs to the cloud.
-        # The root cause is unclear yet, but it appears to involve a conflict between the async evaluator and
-        # the async run uploader. As a temporary mitigation, use a PFClient without a trace destination for batch runs.
+        # A user reported intermittent errors when PFClient uploads evaluation runs to the cloud.
+        # The root cause is still unclear, but it seems related to a conflict between the async run uploader
+        # and the async batch run. As a quick mitigation, use a PFClient without a trace destination for batch runs.
         batch_run_client = ProxyClient(PFClient(user_agent=USER_AGENT))
 
         # Ensure the absolute path is passed to pf.run, as relative path doesn't work with

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
@@ -289,7 +289,7 @@ class Simulator:
             user_response_content = user_flow(
                 task="Continue the conversation",
                 conversation_history=current_simulation.to_list(),
-                **user_simulator_prompty_kwargs
+                **user_simulator_prompty_kwargs,
             )
             user_response = self._parse_prompty_response(response=user_response_content)
             user_turn = Turn(role=ConversationRole.USER, content=user_response["content"])
@@ -622,9 +622,7 @@ class Simulator:
         )
         try:
             response_content = user_flow(
-                task=task,
-                conversation_history=conversation_history,
-                **user_simulator_prompty_kwargs
+                task=task, conversation_history=conversation_history, **user_simulator_prompty_kwargs
             )
             user_response = self._parse_prompty_response(response=response_content)
             return user_response["content"]


### PR DESCRIPTION
# Description

A customer reported encountering an Azure async run uploader error during an evaluation batch run. However, after switching back to multiprocessing, the issue was resolved. It appears there’s a conflict between the async batch run and the async run uploader. As a temporary solution, disable the run uploader for evaluation runs.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
