### PR TITLE
Revert "Telemetry migration from opencensus to azure monitor opentelemetry"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -300,9 +300,9 @@
 /sdk/ml/pipeline.tests.yml                                           @wangchao1230 @eniac871 @kingernupur @achauhan-scc
 
 # PRLabel: %ML-Workspace
-/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/                            @seanyao1 @debuggerXi
-/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/                          @seanyao1 @debuggerXi
-/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py           @seanyao1 @debuggerXi
+/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/                            @seanyao1 @debuggerXi @kingernupur @achauhan-scc
+/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/                          @seanyao1 @debuggerXi @kingernupur @achauhan-scc
+/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py           @seanyao1 @debuggerXi @kingernupur @achauhan-scc
 
 # PRLabel: %ML-ImportJob
 /sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/import_job.py                     @xiongrenyi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -300,9 +300,9 @@
 /sdk/ml/pipeline.tests.yml                                           @wangchao1230 @eniac871 @kingernupur @achauhan-scc
 
 # PRLabel: %ML-Workspace
-/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/                            @seanyao1 @debuggerXi @kingernupur @achauhan-scc
-/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/                          @seanyao1 @debuggerXi @kingernupur @achauhan-scc
-/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py           @seanyao1 @debuggerXi @kingernupur @achauhan-scc
+/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/                            @seanyao1 @debuggerXi
+/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/                          @seanyao1 @debuggerXi
+/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py           @seanyao1 @debuggerXi
 
 # PRLabel: %ML-ImportJob
 /sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/import_job.py                     @xiongrenyi

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -8,8 +8,6 @@
 ### Bugs Fixed
   - #35820 - using compute location attribute to fill compute location to align the experience with UI.
 
-### Other Changes
-  - Added dependency on `azure-monitor-opentelemetry`.
   
 ## 1.20.0 (2024-09-10)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -10,7 +10,7 @@ import os
 from functools import singledispatch
 from itertools import product
 from pathlib import Path
-from typing import Any, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 from azure.ai.ml._azure_environments import (
     CloudArgumentKeys,
@@ -43,7 +43,7 @@ from azure.ai.ml._restclient.workspace_dataplane import (
     AzureMachineLearningWorkspaces as ServiceClientWorkspaceDataplane,
 )
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationsContainer, OperationScope
-from azure.ai.ml._telemetry.logging_handler import set_appinsights_distro
+from azure.ai.ml._telemetry.logging_handler import get_appinsights_log_handler
 from azure.ai.ml._user_agent import USER_AGENT
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils._http_utils import HttpPipeline
@@ -278,11 +278,12 @@ class MLClient:
 
         user_agent = kwargs.get("user_agent", None)
 
-        set_appinsights_distro(
+        app_insights_handler: Tuple = get_appinsights_log_handler(
             user_agent,
             **{"properties": properties},
             enable_telemetry=self._operation_config.enable_telemetry,
         )
+        app_insights_handler_kwargs: Dict[str, Tuple] = {"app_insights_handler": app_insights_handler}
 
         base_url = _get_base_url_from_metadata(cloud_name=cloud_name, is_local_mfe=True)
         self._base_url = base_url
@@ -291,7 +292,7 @@ class MLClient:
         self._operation_container = OperationsContainer()
 
         # kwargs related to operations alone not all kwargs passed to MLClient are needed by operations
-        ops_kwargs = {}
+        ops_kwargs = app_insights_handler_kwargs
         if base_url:
             ops_kwargs["enforce_https"] = _is_https_url(base_url)
 
@@ -478,6 +479,7 @@ class MLClient:
             self._credential,
             requests_pipeline=self._requests_pipeline,
             dataplane_client=self._service_client_workspace_dataplane,
+            **app_insights_handler_kwargs,
         )
         self._operation_container.add(AzureMLResourceType.WORKSPACE, self._workspaces)  # type: ignore[arg-type]
 
@@ -495,6 +497,7 @@ class MLClient:
             self._service_client_10_2022_preview,
             self._operation_container,
             self._credential,
+            **app_insights_handler_kwargs,  # type: ignore[arg-type]
         )
         self._operation_container.add(AzureMLResourceType.REGISTRY, self._registries)  # type: ignore[arg-type]
 
@@ -516,6 +519,7 @@ class MLClient:
             self._operation_config,
             self._service_client_08_2023_preview,
             self._service_client_04_2024_preview,
+            **app_insights_handler_kwargs,  # type: ignore[arg-type]
         )
         self._operation_container.add(AzureMLResourceType.COMPUTE, self._compute)
         self._datastores = DatastoreOperations(
@@ -541,6 +545,7 @@ class MLClient:
             workspace_rg=self._ws_rg,
             workspace_sub=self._ws_sub,
             registry_reference=registry_reference,
+            **app_insights_handler_kwargs,  # type: ignore[arg-type]
         )
         # Evaluators
         self._evaluators = EvaluatorOperations(
@@ -558,6 +563,7 @@ class MLClient:
             workspace_rg=self._ws_rg,
             workspace_sub=self._ws_sub,
             registry_reference=registry_reference,
+            **app_insights_handler_kwargs,  # type: ignore[arg-type]
         )
 
         self._operation_container.add(AzureMLResourceType.MODEL, self._models)
@@ -699,6 +705,7 @@ class MLClient:
             self._service_client_07_2024_preview,
             self._operation_container,
             self._credential,
+            **app_insights_handler_kwargs,  # type: ignore[arg-type]
         )
 
         self._featuresets = FeatureSetOperations(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/__init__.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/__init__.py
@@ -5,13 +5,13 @@
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from .activity import ActivityType, log_activity, monitor_with_activity, monitor_with_telemetry_mixin
-from .logging_handler import AML_INTERNAL_LOGGER_NAMESPACE, set_appinsights_distro
+from .logging_handler import AML_INTERNAL_LOGGER_NAMESPACE, get_appinsights_log_handler
 
 __all__ = [
     "monitor_with_activity",
     "monitor_with_telemetry_mixin",
     "log_activity",
     "ActivityType",
-    "set_appinsights_distro",
+    "get_appinsights_log_handler",
     "AML_INTERNAL_LOGGER_NAMESPACE",
 ]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/activity.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/activity.py
@@ -31,8 +31,6 @@ from azure.core.exceptions import HttpResponseError
 # Get environment variable IS_IN_CI_PIPELINE to decide whether it's in CI test
 IS_IN_CI_PIPELINE = _str_to_bool(os.environ.get("IS_IN_CI_PIPELINE", "False"))
 
-ACTIVITY_SPAN = "activity_span"
-
 
 class ActivityType(object):
     """The type of activity (code) monitored.
@@ -95,7 +93,10 @@ class ActivityLoggerAdapter(logging.LoggerAdapter):
         if "extra" not in kwargs:
             kwargs["extra"] = {}
 
-        kwargs["extra"].update(self._activity_info)
+        if "properties" not in kwargs["extra"]:
+            kwargs["extra"]["properties"] = {}
+
+        kwargs["extra"]["properties"].update(self._activity_info)
 
         return msg, kwargs
 
@@ -281,7 +282,7 @@ def monitor_with_activity(
         def wrapper(*args, **kwargs):
             tracer = logger.package_tracer if isinstance(logger, OpsLogger) else None
             if tracer:
-                with tracer.start_as_current_span(ACTIVITY_SPAN):
+                with tracer.span():
                     with log_activity(
                         logger.package_logger, activity_name or f.__name__, activity_type, custom_dimensions
                     ):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
@@ -8,22 +8,21 @@
 
 import logging
 import platform
-from typing import Any
+import traceback
+from typing import Any, Optional, Tuple, Union
+
+from opencensus.ext.azure.common import utils
+from opencensus.ext.azure.common.protocol import Data, Envelope, ExceptionData, Message
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+from opencensus.ext.azure.trace_exporter import AzureExporter
+from opencensus.trace import config_integration
+from opencensus.trace.samplers import ProbabilitySampler
+from opencensus.trace.tracer import Tracer
 
 from azure.ai.ml._user_agent import USER_AGENT
-from azure.monitor.opentelemetry import configure_azure_monitor
-
-# Disable internal azure monitor openTelemetry logs
-AZURE_MONITOR_OPENTELEMETRY_LOGGER_NAMESPACE = "azure.monitor.opentelemetry"
-logging.getLogger(AZURE_MONITOR_OPENTELEMETRY_LOGGER_NAMESPACE).addHandler(logging.NullHandler())
 
 AML_INTERNAL_LOGGER_NAMESPACE = "azure.ai.ml._telemetry"
-CONNECTION_STRING = (
-    "InstrumentationKey=71b954a8-6b7d-43f5-986c-3d3a6605d803;"
-    "IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;"
-    "LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;"
-    "ApplicationId=82daf08e-6a78-455f-9ce1-9396a8b5128b"
-)
+INSTRUMENTATION_KEY = "71b954a8-6b7d-43f5-986c-3d3a6605d803"
 
 test_subscriptions = [
     "b17253fa-f327-42d6-9686-f3e553e24763",
@@ -36,8 +35,12 @@ test_subscriptions = [
 ]
 
 
+# activate operation id tracking
+config_integration.trace_integrations(["logging"])
+
+
 class CustomDimensionsFilter(logging.Filter):
-    """Add application-wide properties to log record"""
+    """Add application-wide properties to AzureLogHandler records"""
 
     def __init__(self, custom_dimensions=None):  # pylint: disable=super-init-not-called
         self.custom_dimensions = custom_dimensions or {}
@@ -53,8 +56,9 @@ class CustomDimensionsFilter(logging.Filter):
         """
 
         custom_dimensions = self.custom_dimensions.copy()
-        if isinstance(custom_dimensions, dict):
-            record.__dict__.update(custom_dimensions)
+        custom_dimensions.update(getattr(record, "custom_dimensions", {}))
+        record.custom_dimensions = custom_dimensions  # type: ignore[attr-defined]
+
         return True
 
 
@@ -80,60 +84,170 @@ def in_jupyter_notebook() -> bool:
 
 
 # cspell:ignore overriden
-def set_appinsights_distro(
+def get_appinsights_log_handler(
     user_agent,
     *args,  # pylint: disable=unused-argument
-    connection_string=None,
+    instrumentation_key=None,
+    component_name=None,
     enable_telemetry=True,
     **kwargs: Any,
-) -> None:
-    """Set the Opentelemetry logging distro for specified logger and connection string to send info to AppInsights.
+) -> Tuple[Union["AzureMLSDKLogHandler", logging.NullHandler], Optional[Tracer]]:
+    """Enable the OpenCensus logging handler for specified logger and instrumentation key to send info to AppInsights.
 
     :param user_agent: Information about the user's browser.
     :type user_agent: Dict[str, str]
     :param args: Optional arguments for formatting messages.
     :type args: list
-    :keyword connection_string: The Application Insights connection string.
-    :paramtype connection_string: str
+    :keyword instrumentation_key: The Application Insights instrumentation key.
+    :paramtype instrumentation_key: str
+    :keyword component_name: The component name.
+    :paramtype component_name: str
     :keyword enable_telemetry: Whether to enable telemetry. Will be overriden to False if not in a Jupyter Notebook.
     :paramtype enable_telemetry: bool
-    :return: None
+    :return: The logging handler and tracer.
+    :rtype: Tuple[Union[AzureMLSDKLogHandler, logging.NullHandler], Optional[opencensus.trace.tracer.Tracer]]
     """
     try:
-        if connection_string is None:
-            connection_string = CONNECTION_STRING
+        if instrumentation_key is None:
+            instrumentation_key = INSTRUMENTATION_KEY
 
-        logger = logging.getLogger(AML_INTERNAL_LOGGER_NAMESPACE)
-        logger.setLevel(logging.INFO)
-        logger.propagate = False
+        if not in_jupyter_notebook() or not enable_telemetry:
+            return (logging.NullHandler(), None)
 
-        if (
-            not in_jupyter_notebook()
-            or not enable_telemetry
-            or not user_agent
-            or not user_agent.lower() == USER_AGENT.lower()
-        ):
-            # Disable logging for this logger, all the child loggers will inherit this setting
-            logger.addHandler(logging.NullHandler())
-            return
+        if not user_agent or not user_agent.lower() == USER_AGENT.lower():
+            return (logging.NullHandler(), None)
 
         if kwargs:
             if "properties" in kwargs and "subscription_id" in kwargs.get("properties"):  # type: ignore[operator]
                 if kwargs.get("properties")["subscription_id"] in test_subscriptions:  # type: ignore[index]
-                    logger.addHandler(logging.NullHandler())
-                    return
+                    return (logging.NullHandler(), None)
+
+        child_namespace = component_name or __name__
+        current_logger = logging.getLogger(AML_INTERNAL_LOGGER_NAMESPACE).getChild(child_namespace)
+        current_logger.propagate = False
+        current_logger.setLevel(logging.CRITICAL)
 
         custom_properties = {"PythonVersion": platform.python_version()}
         custom_properties.update({"user_agent": user_agent})
         if "properties" in kwargs:
             custom_properties.update(kwargs.pop("properties"))
-
-        logger.addFilter(CustomDimensionsFilter(custom_properties))
-
-        configure_azure_monitor(
-            connection_string=connection_string,
-            logger_name=AML_INTERNAL_LOGGER_NAMESPACE,
+        handler = AzureMLSDKLogHandler(
+            connection_string=f"InstrumentationKey={instrumentation_key}",
+            custom_properties=custom_properties,
+            enable_telemetry=enable_telemetry,
         )
+        current_logger.addHandler(handler)
+
+        tracer = Tracer(
+            exporter=AzureExporter(connection_string=f"InstrumentationKey={instrumentation_key}"),
+            sampler=ProbabilitySampler(1.0),
+        )
+
+        return (handler, tracer)
     except Exception:  # pylint: disable=W0718
         # ignore any exceptions, telemetry collection errors shouldn't block an operation
-        return
+        return (logging.NullHandler(), None)
+
+
+# cspell:ignore AzureMLSDKLogHandler
+class AzureMLSDKLogHandler(AzureLogHandler):
+    """Customized AzureLogHandler for AzureML SDK"""
+
+    def __init__(self, custom_properties, enable_telemetry, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._is_telemetry_collection_disabled = not enable_telemetry
+        self._custom_properties = custom_properties
+        self.addFilter(CustomDimensionsFilter(self._custom_properties))
+
+    def emit(self, record):
+        if self._is_telemetry_collection_disabled:
+            return
+
+        try:
+            self._queue.put(record, block=False)
+
+            # log the record immediately if it is an error
+            if record.exc_info and not all(item is None for item in record.exc_info):
+                self._queue.flush()
+        except Exception:  # pylint: disable=W0718
+            # ignore any exceptions, telemetry collection errors shouldn't block an operation
+            return
+
+    # The code below is vendored from opencensus-ext-azure's AzureLogHandler base class, but the telemetry disabling
+    # logic has been added to the beginning. Without this, the base class would still send telemetry even if
+    # enable_telemetry had been set to true.
+    def log_record_to_envelope(self, record):
+        if self._is_telemetry_collection_disabled:
+            return None
+
+        envelope = Envelope(
+            iKey=self.options.instrumentation_key,
+            tags=dict(utils.azure_monitor_context),
+            time=utils.timestamp_to_iso_str(record.created),
+        )
+
+        properties = {
+            "process": record.processName,
+            "module": record.module,
+            "level": record.levelname,
+            "activity_id": record.properties.get("activity_id", "00000000-0000-0000-0000-000000000000"),
+            "client-request-id": record.properties.get("client_request_id", "00000000-0000-0000-0000-000000000000"),
+            "span_id": record.spanId,
+            "trace_id": record.traceId,
+        }
+
+        if hasattr(record, "custom_dimensions") and isinstance(record.custom_dimensions, dict):
+            properties.update(record.custom_dimensions)
+
+        if record.exc_info:
+            exctype, _value, tb = record.exc_info
+            callstack = []
+            level = 0
+            has_full_stack = False
+            exc_type = "N/A"
+            message = self.format(record)
+            if tb is not None:
+                has_full_stack = True
+                for _, line, method, _text in traceback.extract_tb(tb):
+                    callstack.append(
+                        {
+                            "level": level,
+                            "method": method,
+                            "line": line,
+                        }
+                    )
+                    level += 1
+                callstack.reverse()
+            elif record.message:
+                message = record.message
+
+            if exctype is not None:
+                exc_type = exctype.__name__
+
+            envelope.name = "Microsoft.ApplicationInsights.Exception"
+
+            data = ExceptionData(
+                exceptions=[
+                    {
+                        "id": 1,
+                        "outerId": 0,
+                        "typeName": exc_type,
+                        "message": message,
+                        "hasFullStack": has_full_stack,
+                        "parsedStack": callstack,
+                    }
+                ],
+                severityLevel=max(0, record.levelno - 1) // 10,
+                properties=properties,
+            )
+            envelope.data = Data(baseData=data, baseType="ExceptionData")
+        else:
+            envelope.name = "Microsoft.ApplicationInsights.Message"
+            data = Message(
+                message=self.format(record),
+                severityLevel=max(0, record.levelno - 1) // 10,
+                properties=properties,
+            )
+            envelope.data = Data(baseData=data, baseType="MessageData")
+        return envelope

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_logger_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_logger_utils.py
@@ -4,8 +4,7 @@
 
 import logging
 import sys
-
-from opentelemetry import trace
+from typing import Dict
 
 from azure.ai.ml._telemetry.logging_handler import AML_INTERNAL_LOGGER_NAMESPACE
 
@@ -20,18 +19,16 @@ def initialize_logger_info(module_logger: logging.Logger, terminator="\n") -> No
     module_logger.addHandler(handler)
 
 
-tracer = trace.get_tracer(AML_INTERNAL_LOGGER_NAMESPACE)
-
-
 class OpsLogger:
     def __init__(self, name: str):
-        self.package_logger: logging.Logger = logging.getLogger(AML_INTERNAL_LOGGER_NAMESPACE).getChild(name)
-        self.package_logger.propagate = True
-        self.package_tracer = tracer
+        self.package_logger: logging.Logger = logging.getLogger(AML_INTERNAL_LOGGER_NAMESPACE + name)
+        self.package_logger.propagate = False
+        self.package_tracer = None
         self.module_logger = logging.getLogger(name)
         self.custom_dimensions = {}
 
-    def update_filter(self) -> None:
-        # Attach filter explicitly as parent logger's filter is not propagated to child logger
-        if self.package_logger.parent.filters:
-            self.package_logger.addFilter(self.package_logger.parent.filters[0])
+    def update_info(self, data: Dict) -> None:
+        if "app_insights_handler" in data:
+            logger, tracer = data.pop("app_insights_handler")
+            self.package_logger.addHandler(logger)
+            self.package_tracer = tracer

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -70,7 +70,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super(BatchDeploymentOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._batch_deployment = service_client_01_2024_preview.batch_deployments
         self._batch_job_deployment = kwargs.pop("service_client_09_2020_dataplanepreview").batch_job_deployment
         service_client_02_2023_preview = kwargs.pop("service_client_02_2023_preview")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
@@ -98,7 +98,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super(BatchEndpointOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._batch_operation = service_client_10_2023.batch_endpoints
         self._batch_deployment_operation = service_client_10_2023.batch_deployments
         self._batch_job_endpoint = kwargs.pop("service_client_09_2020_dataplanepreview").batch_job_endpoint

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_code_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_code_operations.py
@@ -82,7 +82,7 @@ class CodeOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(CodeOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._service_client = service_client
         self._version_operation = service_client.code_versions
         self._container_operation = service_client.code_containers

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -97,7 +97,7 @@ class ComponentOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ) -> None:
         super(ComponentOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._version_operation = service_client.component_versions
         self._preflight_operation = preflight_operation
         self._container_operation = service_client.component_containers

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
@@ -46,7 +46,7 @@ class ComputeOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ) -> None:
         super(ComputeOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._operation = service_client.compute
         self._operation2024 = service_client_2024.compute
         self._workspace_operations = service_client.workspaces

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
@@ -118,7 +118,7 @@ class DataOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super(DataOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._operation = service_client.data_versions
         self._container_operation = service_client.data_containers
         self._datastore_operation = datastore_operations

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -56,7 +56,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(DatastoreOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._operation = serviceclient_2024_07_01_preview.datastores
         self._compute_operation = serviceclient_2024_01_01_preview.compute
         self._credential = serviceclient_2024_07_01_preview._config.credential

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
@@ -75,7 +75,7 @@ class EnvironmentOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super(EnvironmentOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._kwargs = kwargs
         self._containers_operations = service_client.environment_containers
         self._version_operations = service_client.environment_versions

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_evaluator_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_evaluator_operations.py
@@ -6,12 +6,15 @@
 
 from os import PathLike
 from typing import Any, Dict, Iterable, Optional, Union, cast
-
 from azure.ai.ml._restclient.v2021_10_01_dataplanepreview import (
     AzureMachineLearningWorkspaces as ServiceClient102021Dataplane,
 )
-from azure.ai.ml._restclient.v2023_08_01_preview import AzureMachineLearningWorkspaces as ServiceClient082023Preview
-from azure.ai.ml._restclient.v2023_08_01_preview.models import ListViewType
+from azure.ai.ml._restclient.v2023_08_01_preview import (
+    AzureMachineLearningWorkspaces as ServiceClient082023Preview,
+)
+from azure.ai.ml._restclient.v2023_08_01_preview.models import (
+    ListViewType,
+)
 from azure.ai.ml._scope_dependent_operations import (
     OperationConfig,
     OperationsContainer,
@@ -20,13 +23,21 @@ from azure.ai.ml._scope_dependent_operations import (
 )
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._logger_utils import OpsLogger
-from azure.ai.ml._utils.utils import _get_evaluator_properties, _is_evaluator
+from azure.ai.ml._utils.utils import (
+    _get_evaluator_properties,
+    _is_evaluator,
+)
 from azure.ai.ml.entities._assets import Model
-from azure.ai.ml.entities._assets.workspace_asset_reference import WorkspaceAssetReference
-from azure.ai.ml.exceptions import UnsupportedOperationError
+from azure.ai.ml.entities._assets.workspace_asset_reference import (
+    WorkspaceAssetReference,
+)
+from azure.ai.ml.exceptions import (
+    UnsupportedOperationError,
+)
 from azure.ai.ml.operations._datastore_operations import DatastoreOperations
-from azure.ai.ml.operations._model_operations import ModelOperations
 from azure.core.exceptions import ResourceNotFoundError
+
+from azure.ai.ml.operations._model_operations import ModelOperations
 
 ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
@@ -68,7 +79,7 @@ class EvaluatorOperations(_ScopeDependentOperations):
     ):
         super(EvaluatorOperations, self).__init__(operation_scope, operation_config)
 
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._model_op = ModelOperations(
             operation_scope=operation_scope,
             operation_config=operation_config,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -68,7 +68,7 @@ class FeatureSetOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(FeatureSetOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._operation = service_client.featureset_versions
         self._container_operation = service_client.featureset_containers
         self._jobs_operation = service_client_for_jobs.jobs

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
@@ -42,7 +42,7 @@ class FeatureStoreEntityOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(FeatureStoreEntityOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._operation = service_client.featurestore_entity_versions
         self._container_operation = service_client.featurestore_entity_containers
         self._service_client = service_client

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -19,10 +19,10 @@ from azure.ai.ml._utils.utils import camel_to_snake
 from azure.ai.ml.constants import ManagedServiceIdentityType
 from azure.ai.ml.constants._common import Scope, WorkspaceKind
 from azure.ai.ml.entities import (
+    WorkspaceConnection,
     IdentityConfiguration,
     ManagedIdentityConfiguration,
     ManagedNetworkProvisionStatus,
-    WorkspaceConnection,
 )
 from azure.ai.ml.entities._feature_store._constants import (
     OFFLINE_MATERIALIZATION_STORE_TYPE,
@@ -63,7 +63,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._provision_network_operation = service_client.managed_network_provisions
         super().__init__(
             operation_scope=operation_scope,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_index_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_index_operations.py
@@ -4,7 +4,7 @@
 
 # pylint: disable=protected-access
 import json
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union, Callable, List
 
 from azure.ai.ml._artifacts._artifact_utilities import _check_and_upload_path
 
@@ -23,27 +23,25 @@ from azure.ai.ml._scope_dependent_operations import (
     _ScopeDependentOperations,
 )
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
-from azure.ai.ml._utils._asset_utils import (
-    _resolve_label_to_asset,
-    _validate_auto_delete_setting_in_data_output,
-    _validate_workspace_managed_datastore,
-)
+from azure.ai.ml._utils._asset_utils import _resolve_label_to_asset
 from azure.ai.ml._utils._http_utils import HttpPipeline
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml._utils.utils import _get_base_urls_from_discovery_service
-from azure.ai.ml.constants._common import AssetTypes, AzureMLResourceType, WorkspaceDiscoveryUrlKey
-from azure.ai.ml.dsl import pipeline
-from azure.ai.ml.entities import PipelineJob, PipelineJobSettings
+from azure.ai.ml.constants._common import AzureMLResourceType, WorkspaceDiscoveryUrlKey, AssetTypes
 from azure.ai.ml.entities._assets import Index
-from azure.ai.ml.entities._credentials import ManagedIdentityConfiguration, UserIdentityConfiguration
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
+from azure.ai.ml.operations._datastore_operations import DatastoreOperations
+from azure.core.credentials import TokenCredential
+
+from azure.ai.ml.entities import PipelineJob, PipelineJobSettings
+from azure.ai.ml.entities._inputs_outputs import Input
 from azure.ai.ml.entities._indexes import (
     AzureAISearchConfig,
-    GitSource,
     IndexDataSource,
     LocalSource,
+    GitSource,
     ModelConfiguration,
 )
-from azure.ai.ml.entities._indexes.data_index_func import index_data as index_data_func
 from azure.ai.ml.entities._indexes.entities.data_index import (
     CitationRegex,
     Data,
@@ -52,11 +50,14 @@ from azure.ai.ml.entities._indexes.entities.data_index import (
     IndexSource,
     IndexStore,
 )
-from azure.ai.ml.entities._indexes.utils._open_ai_utils import build_connection_id, build_open_ai_protocol
-from azure.ai.ml.entities._inputs_outputs import Input
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
-from azure.ai.ml.operations._datastore_operations import DatastoreOperations
-from azure.core.credentials import TokenCredential
+from azure.ai.ml.entities._indexes.utils._open_ai_utils import build_open_ai_protocol, build_connection_id
+from azure.ai.ml.entities._credentials import ManagedIdentityConfiguration, UserIdentityConfiguration
+from azure.ai.ml.dsl import pipeline
+from azure.ai.ml.entities._indexes.data_index_func import index_data as index_data_func
+from azure.ai.ml._utils._asset_utils import (
+    _validate_auto_delete_setting_in_data_output,
+    _validate_workspace_managed_datastore,
+)
 
 ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
@@ -80,7 +81,7 @@ class IndexOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super().__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._credential = credential
         # Dataplane service clients are lazily created as they are needed
         self.__azure_ai_assets_client: Optional[AzureAiAssetsClient042024] = None

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -159,7 +159,7 @@ class JobOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ) -> None:
         super(JobOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
 
         self._operation_2023_02_preview = service_client_02_2023_preview.jobs
         self._service_client = service_client_02_2023_preview

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_marketplace_subscription_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_marketplace_subscription_operations.py
@@ -7,12 +7,17 @@
 from typing import Iterable
 
 from azure.ai.ml._restclient.v2024_01_01_preview import AzureMachineLearningWorkspaces as ServiceClient202401Preview
-from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope, _ScopeDependentOperations
+from azure.ai.ml._scope_dependent_operations import (
+    OperationConfig,
+    OperationScope,
+    _ScopeDependentOperations,
+)
+from azure.core.polling import LROPoller
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml.entities._autogen_entities.models import MarketplaceSubscription
-from azure.core.polling import LROPoller
+
 
 ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
@@ -33,7 +38,6 @@ class MarketplaceSubscriptionOperations(_ScopeDependentOperations):
         service_client: ServiceClient202401Preview,
     ):
         super().__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
         self._service_client = service_client.marketplace_subscriptions
 
     @experimental

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
@@ -50,7 +50,7 @@ from azure.ai.ml._utils._registry_utils import (
     get_storage_details_for_registry_assets,
 )
 from azure.ai.ml._utils._storage_utils import get_ds_name_and_path_prefix, get_storage_client
-from azure.ai.ml._utils.utils import _is_evaluator, resolve_short_datastore_url, validate_ml_flow_folder
+from azure.ai.ml._utils.utils import resolve_short_datastore_url, validate_ml_flow_folder, _is_evaluator
 from azure.ai.ml.constants._common import ARM_ID_PREFIX, ASSET_ID_FORMAT, REGISTRY_URI_FORMAT, AzureMLResourceType
 from azure.ai.ml.entities._assets import Environment, Model, ModelPackage
 from azure.ai.ml.entities._assets._artifacts.code import Code
@@ -108,7 +108,7 @@ class ModelOperations(_ScopeDependentOperations):
         **kwargs,
     ):
         super(ModelOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._model_versions_operation = service_client.model_versions
         self._model_container_operation = service_client.model_containers
         self._service_client = service_client

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -68,7 +68,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(OnlineDeploymentOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._local_deployment_helper = local_deployment_helper
         self._online_deployment = service_client_04_2023_preview.online_deployments
         self._online_endpoint_operations = service_client_04_2023_preview.online_endpoints

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -72,7 +72,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(OnlineEndpointOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._online_operation = service_client_02_2022_preview.online_endpoints
         self._online_deployment_operation = service_client_02_2022_preview.online_deployments
         self._all_operations = all_operations
@@ -288,6 +288,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         if endpoint.properties.auth_mode.lower() == "key":
             return self._regenerate_online_keys(name=name, key_type=key_type)
+
         raise ValidationException(
             message=f"Endpoint '{name}' does not use keys for authentication.",
             target=ErrorTarget.ONLINE_ENDPOINT,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -37,7 +37,7 @@ class RegistryOperations:
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._subscription_id = operation_scope.subscription_id
         self._resource_group_name = operation_scope.resource_group_name
         self._default_registry_name = operation_scope.registry_name

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_schedule_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_schedule_operations.py
@@ -21,10 +21,10 @@ from azure.ai.ml.entities._monitoring.schedule import MonitorSchedule
 from azure.ai.ml.entities._monitoring.signals import (
     BaselineDataRange,
     FADProductionData,
-    GenerationTokenStatisticsSignal,
-    LlmData,
     ProductionData,
     ReferenceData,
+    LlmData,
+    GenerationTokenStatisticsSignal,
 )
 from azure.ai.ml.entities._monitoring.target import MonitoringTarget
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ScheduleException
@@ -83,7 +83,7 @@ class ScheduleOperations(_ScopeDependentOperations):
         **kwargs: Any,
     ):
         super(ScheduleOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self.service_client = service_client_06_2023_preview.schedules
         # Note: Trigger once is supported since 24_01, we don't upgrade other operations' client because there are
         # some breaking changes, for example: AzMonMonitoringAlertNotificationSettings is removed.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_serverless_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_serverless_endpoint_operations.py
@@ -4,26 +4,27 @@
 
 # pylint: disable=protected-access
 
-import re
 from typing import Iterable
+import re
 
+from azure.ai.ml.exceptions import ValidationException, ErrorTarget, ErrorCategory, ValidationErrorType
+from azure.ai.ml.constants._common import AzureMLResourceType, REGISTRY_VERSION_PATTERN
+from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._restclient.v2024_01_01_preview import AzureMachineLearningWorkspaces as ServiceClient202401Preview
-from azure.ai.ml._restclient.v2024_01_01_preview.models import KeyType, RegenerateEndpointKeysRequest
+from azure.ai.ml._restclient.v2024_01_01_preview.models import RegenerateEndpointKeysRequest, KeyType
 from azure.ai.ml._scope_dependent_operations import (
     OperationConfig,
     OperationsContainer,
     OperationScope,
     _ScopeDependentOperations,
 )
-from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
+from azure.core.polling import LROPoller
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils._logger_utils import OpsLogger
-from azure.ai.ml.constants._common import REGISTRY_VERSION_PATTERN, AzureMLResourceType
-from azure.ai.ml.constants._endpoint import EndpointKeyType
 from azure.ai.ml.entities._autogen_entities.models import ServerlessEndpoint
 from azure.ai.ml.entities._endpoint.online_endpoint import EndpointAuthKeys
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
-from azure.core.polling import LROPoller
+from azure.ai.ml.constants._endpoint import EndpointKeyType
+
 
 ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
@@ -45,7 +46,6 @@ class ServerlessEndpointOperations(_ScopeDependentOperations):
         all_operations: OperationsContainer,
     ):
         super().__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
         self._service_client = service_client.serverless_endpoints
         self._marketplace_subscriptions = service_client.marketplace_subscriptions
         self._all_operations = all_operations

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
@@ -47,7 +47,7 @@ class VirtualClusterOperations:
         _service_client_kwargs: Dict,
         **kwargs: Dict,
     ):
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._resource_group_name = operation_scope.resource_group_name
         self._subscription_id = operation_scope.subscription_id
         self._credentials = credentials

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_connections_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_connections_operations.py
@@ -16,10 +16,12 @@ from azure.ai.ml._scope_dependent_operations import (
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml._utils.utils import _snake_to_camel
-from azure.ai.ml.entities._credentials import ApiKeyConfiguration
 from azure.ai.ml.entities._workspace.connections.workspace_connection import WorkspaceConnection
 from azure.core.credentials import TokenCredential
 from azure.core.tracing.decorator import distributed_trace
+from azure.ai.ml.entities._credentials import (
+    ApiKeyConfiguration,
+)
 
 ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
@@ -42,7 +44,7 @@ class WorkspaceConnectionsOperations(_ScopeDependentOperations):
         **kwargs: Dict,
     ):
         super(WorkspaceConnectionsOperations, self).__init__(operation_scope, operation_config)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._all_operations = all_operations
         self._operation = service_client.workspace_connections
         self._credentials = credentials

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -61,7 +61,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
             kwargs.pop("dataplane_client").workspaces if kwargs.get("dataplane_client") else None
         )
         self._requests_pipeline: HttpPipeline = kwargs.pop("requests_pipeline", None)
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._provision_network_operation = service_client.managed_network_provisions
         super().__init__(
             operation_scope=operation_scope,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -65,7 +65,7 @@ class WorkspaceOperationsBase(ABC):
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        ops_logger.update_filter()
+        # ops_logger.update_info(kwargs)
         self._subscription_id = operation_scope.subscription_id
         self._resource_group_name = operation_scope.resource_group_name
         self._default_workspace_name = operation_scope.workspace_name

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_outbound_rule_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_outbound_rule_operations.py
@@ -33,7 +33,7 @@ class WorkspaceOutboundRuleOperations:
         credentials: TokenCredential = None,
         **kwargs: Dict,
     ):
-        ops_logger.update_filter()
+        ops_logger.update_info(kwargs)
         self._subscription_id = operation_scope.subscription_id
         self._resource_group_name = operation_scope.resource_group_name
         self._default_workspace_name = operation_scope.workspace_name

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -88,7 +88,6 @@ setup(
         "typing-extensions",
         "opencensus-ext-azure",
         "opencensus-ext-logging",
-        "azure-monitor-opentelemetry",
     ],
     extras_require={
         # user can run `pip install azure-ai-ml[designer]` to install mldesigner along with this package

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_logger_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_logger_utils.py
@@ -1,9 +1,12 @@
 import logging
 
 import pytest
-from mock import MagicMock, patch
+from mock import patch
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+from opencensus.trace.tracer import Tracer
 
-from azure.ai.ml._telemetry import AML_INTERNAL_LOGGER_NAMESPACE, set_appinsights_distro
+from azure.ai.ml._telemetry import AML_INTERNAL_LOGGER_NAMESPACE, get_appinsights_log_handler
+from azure.ai.ml._telemetry.logging_handler import AzureMLSDKLogHandler
 from azure.ai.ml._user_agent import USER_AGENT
 from azure.ai.ml._utils._logger_utils import OpsLogger, initialize_logger_info
 
@@ -25,22 +28,17 @@ class TestLoggerUtils:
 
 @pytest.mark.unittest
 class TestLoggingHandler:
-    @patch("azure.ai.ml._telemetry.logging_handler.configure_azure_monitor")
-    @patch("azure.ai.ml._telemetry.logging_handler.logging.getLogger")
-    def test_logging_enabled(self, mock_get_logger, mock_configure_azure_monitor) -> None:
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+    def test_logging_enabled(self) -> None:
         with patch("azure.ai.ml._telemetry.logging_handler.in_jupyter_notebook", return_value=False):
-            set_appinsights_distro(user_agent=USER_AGENT)
-            assert len(mock_logger.addHandler.call_args_list) == 1
-            assert isinstance(mock_logger.addHandler.call_args[0][0], logging.NullHandler)
-            mock_configure_azure_monitor.assert_not_called()
-            mock_logger.reset_mock()
+            handler, tracer = get_appinsights_log_handler(user_agent=USER_AGENT)
+            assert isinstance(handler, logging.NullHandler)
+            assert tracer is None
 
         with patch("azure.ai.ml._telemetry.logging_handler.in_jupyter_notebook", return_value=True):
-            set_appinsights_distro(user_agent=USER_AGENT)
-            mock_logger.addHandler.assert_not_called()
-            mock_configure_azure_monitor.assert_called_once()
+            handler, tracer = get_appinsights_log_handler(user_agent=USER_AGENT)
+            assert isinstance(handler, AzureLogHandler)
+            assert isinstance(handler, AzureMLSDKLogHandler)
+            assert isinstance(tracer, Tracer)
 
 
 @pytest.mark.unittest
@@ -50,20 +48,19 @@ class TestOpsLogger:
         test_logger = OpsLogger(name=test_name)
 
         assert test_logger is not None
-        assert test_logger.package_logger.name == AML_INTERNAL_LOGGER_NAMESPACE + "." + test_name
-        assert test_logger.package_logger.propagate
-        assert test_logger.package_tracer is not None
+        assert test_logger.package_logger.name == AML_INTERNAL_LOGGER_NAMESPACE + test_name
+        assert not test_logger.package_logger.propagate
         assert test_logger.module_logger.name == test_name
         assert len(test_logger.custom_dimensions) == 0
 
-    def test_update_filter(self) -> None:
+    def test_update_info(self) -> None:
         test_name = "test"
+        test_handler = (logging.NullHandler(), None)
+        test_data = {"app_insights_handler": test_handler}
 
         test_logger = OpsLogger(name=test_name)
-        assert len(test_logger.package_logger.filters) == 0
+        test_logger.update_info(test_data)
 
-        test_logger.package_logger.parent = logging.getLogger("parent")
-        test_logger.package_logger.parent.addFilter(logging.Filter)
-        test_logger.update_filter()
-
-        assert len(test_logger.package_logger.filters) == 1
+        assert len(test_data) == 0
+        assert test_logger.package_logger.hasHandlers()
+        assert test_logger.package_logger.handlers[0] == test_handler[0]

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -73,4 +73,3 @@ promptflow-devkit
 numpy
 nltk
 rouge-score
-azure-monitor-opentelemetry


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#37392
Reverting due to incompatibility with CLI. Runs into `"No module named azure.core.tracing.ext.opentelemetry_span"` on CLI. Root cause unknown yet.