### PR TITLE
[SchemaRegistry] remove pinned azure-schemaregistry in dev reqs

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -11,9 +11,10 @@ Example to show sending, receiving and parsing amqp annotated message(s) to Even
 
 import os
 import asyncio
+from azure.eventhub import TransportType
 from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient
 from azure.eventhub.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
-from azure.identity.aio import DefaultAzureCredential
+from azure.identity.aio import AzureCliCredential
 
 FULLY_QUALIFIED_NAMESPACE = os.environ["EVENT_HUB_HOSTNAME"]
 EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
@@ -97,7 +98,8 @@ async def main():
     producer = EventHubProducerClient(
         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
         eventhub_name=EVENTHUB_NAME,
-        credential=DefaultAzureCredential(),
+        credential=AzureCliCredential(),
+        transport_type=TransportType.AmqpOverWebsocket
     )
     async with producer:
         await send_data_message(producer)
@@ -107,9 +109,10 @@ async def main():
     # Receive
     consumer = EventHubConsumerClient(
         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-        credential=DefaultAzureCredential(),
+        credential=AzureCliCredential(),
         consumer_group='$Default',
         eventhub_name=EVENTHUB_NAME,
+        transport_type=TransportType.AmqpOverWebsocket
     )
     await receive_and_parse_message(consumer)
 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_50158ba496"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_156221620f"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_156221620f"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_0971c24bdc"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
@@ -9,6 +9,7 @@ from devtools_testutils import (
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
+    add_general_regex_sanitizer(regex="(?<=api-version=)[0-9]{4}-[0-9]{2}", value="xxxx-xx")
     add_general_regex_sanitizer(regex="(?<=\\/\\/)[a-z-]+(?=\\.servicebus\\.windows\\.net)", value="fake_resource_avro")
     add_oauth_response_sanitizer()
 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from devtools_testutils import (
     test_proxy,
     add_general_regex_sanitizer,
+    add_remove_header_sanitizer,
     add_oauth_response_sanitizer,
     remove_batch_sanitizers,
 )
@@ -9,8 +10,11 @@ from devtools_testutils import (
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
+    # Scrubbing api-version since latest and mindependency versions of azure-schemaregistry will not be the same.
     add_general_regex_sanitizer(regex="(?<=api-version=)[0-9]{4}-[0-9]{2}", value="xxxx-xx")
     add_general_regex_sanitizer(regex="(?<=\\/\\/)[a-z-]+(?=\\.servicebus\\.windows\\.net)", value="fake_resource_avro")
+    # Accept is not used by the service. Removing from request headers so changes to Accept are not flagged as diffs.
+    add_remove_header_sanitizer(headers="Accept")
     add_oauth_response_sanitizer()
 
     # Remove the following sanitizers since certain fields are needed in tests and are non-sensitive:

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/dev_requirements.txt
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../identity/azure-identity
 aiohttp>=3.0
-azure-schemaregistry<=1.2.0
+azure-schemaregistry

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
@@ -275,9 +275,9 @@ class TestAvroEncoder(AzureRecordedTestCase):
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"favorite_number","type":["int","null"]},{"name":"favorite_color","type":["string","null"]}]}"""
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
+        # if fake kwargs/incorrectly formatted request keyword passed in, should raise TypeError
         with pytest.raises(TypeError) as e:
             encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True, "files": frozenset({'a': False})})
-        assert 'request() got' in str(e.value)
         encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
         encoded_content = encoded_message_content["content"]
@@ -285,7 +285,6 @@ class TestAvroEncoder(AzureRecordedTestCase):
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
             decoded_content = sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True, "files": (False)})
-        assert 'request() got' in str(e.value)
 
 
     ################################################################# 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
@@ -276,16 +276,16 @@ class TestAvroEncoder(AzureRecordedTestCase):
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
         with pytest.raises(TypeError) as e:
-            encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True})
-        assert 'request() got an unexpected keyword' in str(e.value)
+            encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"files": True})
+        assert 'request() got multiple values for keyword' in str(e.value)
         encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
         encoded_content = encoded_message_content["content"]
 
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
-            decoded_content = sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True})
-        assert 'request() got an unexpected keyword' in str(e.value)
+            decoded_content = sr_avro_encoder.decode(encoded_content_dict, request_options={"files": True})
+        assert 'request() got multiple values for keyword' in str(e.value)
 
 
     ################################################################# 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
@@ -276,16 +276,16 @@ class TestAvroEncoder(AzureRecordedTestCase):
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
         with pytest.raises(TypeError) as e:
-            encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"files": True})
-        assert 'request() got multiple values for keyword' in str(e.value)
+            encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True, "files": frozenset({'a': False})})
+        assert 'request() got' in str(e.value)
         encoded_message_content = sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
         encoded_content = encoded_message_content["content"]
 
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
-            decoded_content = sr_avro_encoder.decode(encoded_content_dict, request_options={"files": True})
-        assert 'request() got multiple values for keyword' in str(e.value)
+            decoded_content = sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True, "files": (False)})
+        assert 'request() got' in str(e.value)
 
 
     ################################################################# 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
@@ -240,10 +240,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"favorite_number","type":["int","null"]},{"name":"favorite_color","type":["string","null"]}]}"""
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
+        # if fake kwargs/incorrectly formatted request keyword passed in, should raise TypeError
         with pytest.raises(TypeError) as e:
             encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True, "files": (False)})
-        # aiohttp error differs from sync requests: unexpected keyword vs. multiple keywords
-        assert 'request() got' in str(e.value)
         encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
         encoded_content = encoded_message_content["content"]
@@ -251,7 +250,6 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
             decoded_content = await sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True, "files": (False)})
-        assert 'request() got' in str(e.value)
 
     ################################################################# 
     ######################### PARSE SCHEMAS #########################

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
@@ -241,17 +241,17 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
         with pytest.raises(TypeError) as e:
-            encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"files": True})
+            encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True, "files": (False)})
         # aiohttp error differs from sync requests: unexpected keyword vs. multiple keywords
-        assert 'request() got an unexpected keyword' in str(e.value)
+        assert 'request() got' in str(e.value)
         encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
         encoded_content = encoded_message_content["content"]
 
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
-            decoded_content = await sr_avro_encoder.decode(encoded_content_dict, request_options={"files": True})
-        assert 'request() got an unexpected keyword' in str(e.value)
+            decoded_content = await sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True, "files": (False)})
+        assert 'request() got' in str(e.value)
 
     ################################################################# 
     ######################### PARSE SCHEMAS #########################

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
@@ -241,7 +241,8 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
         dict_content = {"name": u"Ben", "favorite_number": 7, "favorite_color": u"red"}
         with pytest.raises(TypeError) as e:
-            encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"fake_kwarg": True})
+            encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str, request_options={"files": True})
+        # aiohttp error differs from sync requests: unexpected keyword vs. multiple keywords
         assert 'request() got an unexpected keyword' in str(e.value)
         encoded_message_content = await sr_avro_encoder.encode(dict_content, schema=schema_str)
         content_type = encoded_message_content["content_type"]
@@ -249,7 +250,7 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
         encoded_content_dict = {"content": encoded_content, "content_type": content_type}
         with pytest.raises(TypeError) as e:
-            decoded_content = await sr_avro_encoder.decode(encoded_content_dict, request_options={"fake_kwarg": True})
+            decoded_content = await sr_avro_encoder.decode(encoded_content_dict, request_options={"files": True})
         assert 'request() got an unexpected keyword' in str(e.value)
 
     ################################################################# 


### PR DESCRIPTION
The verifytypes check is failing in the CI currently for azure-schemaregistry-avroencoder, as azure-schemaregistry==1.2.0 is pinned in the dev_requirements.txt. It was originally pinned since Windows was picking up 1.2.0 in the mindependency check and Mac/Linux were picking up 1.3.0bx, so api-version in the recordings did not match.

This can be unpinned now as 1.3.0 has been released, so all platforms should be picking up 1.2.0.
Changes:
- New recordings with azure-schemaregistry 1.3.0
- Unpinned azure-schemaregistry in dev_requirements.txt
- Scrubbed api-version from azure-schemaregistry-avroencoder, since mindependency was installing SR 1.0.0, which was api-version=2021-10, and the recordings use 2022-10. This caused CI to always fail mindependency check. Similar to [KV](https://github.com/Azure/azure-sdk-for-python/pull/34057/commits/cd4e89df6c5d7c9fd6b1e67649a58379d210852b).
- Updated the request_options test for the avroencoder package to pass in one of the set of expected http request kwargs, rather than "fake_kwarg". Since we added a check to filter out non-http request specific kwargs after 1.2.0, the new package will not pass "fake_kwarg" through. Passing through a duplicate/(unexpected for aiohttp) value "files", which will raise an error from the core request() method.

