### PR TITLE
[ServiceBus] make async ssl load_verify_locations non-blocking

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -228,8 +228,7 @@ class AsyncTransportMixin:
         if not cafile:
             cafile = certifi.where()
         loop = asyncio.get_event_loop()
-        with ThreadPoolExecutor() as pool:
-            await loop.run_in_executor(pool, ctx.load_verify_locations, cafile=cafile)
+        await loop.run_in_executor(None, ctx.load_verify_locations, cafile=cafile)
 
     async def _build_ssl_context(
         self, check_hostname=None, **ctx_options

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -228,7 +228,7 @@ class AsyncTransportMixin:
         if not cafile:
             cafile = certifi.where()
         loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, ctx.load_verify_locations, cafile=cafile)
+        await loop.run_in_executor(None, ctx.load_verify_locations, cafile)
 
     async def _build_ssl_context(
         self, check_hostname=None, **ctx_options

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -228,8 +228,7 @@ class AsyncTransportMixin:
         if not cafile:
             cafile = certifi.where()
         loop = asyncio.get_event_loop()
-        with ThreadPoolExecutor() as pool:
-            await loop.run_in_executor(pool, ctx.load_verify_locations, cafile=cafile)
+        await loop.run_in_executor(None, ctx.load_verify_locations, cafile=cafile)
 
     async def _build_ssl_context(
         self, check_hostname=None, **ctx_options

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -228,7 +228,7 @@ class AsyncTransportMixin:
         if not cafile:
             cafile = certifi.where()
         loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, ctx.load_verify_locations, cafile=cafile)
+        await loop.run_in_executor(None, ctx.load_verify_locations, cafile)
 
     async def _build_ssl_context(
         self, check_hostname=None, **ctx_options


### PR DESCRIPTION
fixes: #37246

TODO:
- [x] test/confirm
   - [x] test_sb_client_async.py:test_custom_endpoint_connection_verify_exception_async
   - [x] test_negative_async.py:test_client_invalid_credential_async
