### PR TITLE
[Cosmos] update vector policy and vector query tests

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/test_query_vector_similarity.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_vector_similarity.py
@@ -137,7 +137,7 @@ class TestVectorSimilarityQuery(unittest.TestCase):
                           "SimilarityScore FROM c ORDER BY VectorDistance(c.embedding, [{}], false, {{'distanceFunction': 'euclidean'}})" \
                 .format(str(i), vector_string, vector_string)
 
-            flat_list = list(self.created_flat_euclidean_container.query_items(query=specs_query,
+            flat_list = list(self.created_flat_euclidean_container.query_items(query=vanilla_query,
                                                                                enable_cross_partition_query=True))
             verify_ordering(flat_list, "euclidean")
 

--- a/sdk/cosmos/azure-cosmos/test/test_query_vector_similarity_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_vector_similarity_async.py
@@ -137,7 +137,7 @@ class TestVectorSimilarityQueryAsync(unittest.TestCase):
                           "SimilarityScore FROM c ORDER BY VectorDistance(c.embedding, [{}], false, {{'distanceFunction': 'euclidean'}})" \
                 .format(str(i), vector_string, vector_string)
 
-            flat_list = [item async for item in self.created_flat_euclidean_container.query_items(query=specs_query)]
+            flat_list = [item async for item in self.created_flat_euclidean_container.query_items(query=vanilla_query)]
             verify_ordering(flat_list, "euclidean")
 
             quantized_list = [item async for item in self.created_quantized_cosine_container.query_items(query=specs_query)]

--- a/sdk/cosmos/azure-cosmos/test/test_vector_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_vector_policy.py
@@ -163,7 +163,8 @@ class TestVectorPolicy(unittest.TestCase):
             pytest.fail("Container replace should have failed for indexing policy.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Vector Indexing Policy cannot be changed in Collection Replace" in e.http_error_message
+            assert "Paths in existing vector indexing policy cannot be modified in Collection Replace." \
+                   " They can only be added or removed." in e.http_error_message
         self.test_db.delete_container(container_id)
 
     def test_fail_create_vector_embedding_policy(self):

--- a/sdk/cosmos/azure-cosmos/test/test_vector_policy_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_vector_policy_async.py
@@ -173,7 +173,8 @@ class TestVectorPolicyAsync(unittest.IsolatedAsyncioTestCase):
             pytest.fail("Container replace should have failed for indexing policy.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Vector Indexing Policy cannot be changed in Collection Replace" in e.http_error_message
+            assert "Paths in existing vector indexing policy cannot be modified in Collection Replace." \
+                   " They can only be added or removed." in e.http_error_message
         await self.test_db.delete_container(container_id)
 
     async def test_fail_create_vector_embedding_policy_async(self):


### PR DESCRIPTION
For a while now our tests pipeline has been failing on the vector policy tests due to an update in the error message we are looking for from the service. This PR updates the assertion to look for the new message.

This PR also takes care of a separate update, where we had previously not ran euclidean distance directly due to a separate bug on the service. This PR updates that test to use the default euclidean distance from the policy rather than from the query spec since this bug has been fixed for a while now.