### PR TITLE
`DefaultAzureCredential()` -> `DefaultAzureCredential(exclude_managed_identity=True)`

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -55,8 +55,7 @@ steps:
       }
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
-
-      python "$(Build.SourcesDirectory)/devops_tasks/update_sample_code.py" "${{ parameters.ServiceDirectory }}"
+      python "$(Build.SourcesDirectory)/scripts/devops_tasks/update_sample_code.py" "${{ parameters.ServiceDirectory }}"
     displayName: 'Samples Credential Update'
 
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -45,6 +45,21 @@ steps:
       Write-Host (Get-Command python).Source
     displayName: 'Prep Environment'
 
+
+  - pwsh: |
+      if ($IsWindows) {
+        . $(VENV_LOCATION)/Scripts/Activate.ps1
+      }
+      else {
+        . $(VENV_LOCATION)/bin/activate.ps1
+      }
+      $ErrorActionPreference = 'Stop'
+      $PSNativeCommandUseErrorActionPreference = $true
+
+      python "$(Build.SourcesDirectory)/devops_tasks/update_sample_code.py" "${{ parameters.ServiceDirectory }}"
+    displayName: 'Samples Credential Update'
+
+
   - template: /eng/common/testproxy/test-proxy-tool.yml
     parameters:
       runProxy: false

--- a/scripts/devops_tasks/update_sample_code.py
+++ b/scripts/devops_tasks/update_sample_code.py
@@ -1,0 +1,54 @@
+import os
+import re
+import argparse
+
+from ci_tools.functions import discover_targeted_packages
+from ci_tools.parsing import ParsedSetup
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+def replace_samples_in(directory: str) -> None:
+    # Define the strings to search and replace
+    old_string = "DefaultAzureCredential()"
+    new_string = "DefaultAzureCredential(exclude_managed_identity_credential=True)"
+
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".py"):  # Only process Python files
+                file_path = os.path.join(root, file)
+
+                # Read the file contents
+                with open(file_path, "r", encoding="utf-8") as f:
+                    file_content = f.read()
+
+                # Replace the old string with the new string
+                updated_content = re.sub(re.escape(old_string), new_string, file_content)
+
+                if updated_content != file_content:
+                    print(f"Updating {file_path}")
+
+                    # Write the updated content back to the file
+                    with open(file_path, "w", encoding="utf-8") as f:
+                        f.write(updated_content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="DefaultAzureCredential tries credentials in a specific order. "
+        "This script is intended to walk all the samples of a service and update them to exclude a configuration that is unsupported by Azure Devops."
+        "This is necessary because we do not want customers copying part of a sample that is only the way it is BECAUSE of restrictions of our infrastructure."
+    )
+    parser.add_argument("target_service", help="The target service to process.")
+
+    args = parser.parse_args()
+    target_discovery_directory = os.path.join(root_dir, "sdk", args.target_service)
+
+    discovered_packages = discover_targeted_packages("*", target_discovery_directory)
+
+    for package_directory in discovered_packages:
+        print(f"scanning {package_directory}")
+        if os.path.exists(os.path.join(package_directory, "samples")):
+            replace_samples_in(os.path.join(package_directory, "samples"))
+
+        if os.path.exists(os.path.join(package_directory, "sample")):
+            replace_samples_in(os.path.join(package_directory, "sample"))


### PR DESCRIPTION
This runs find-replace against samples before they are run.  @xiangyan99 for FYI.

@weshaggard , the problem here is that we need to exclude managed identity to get these samples to work properly. That isn't configuarable via environment right now, so the alternative is to do something like this. We do NOT want to have the samples code at rest to contain the replacement string, as we don't want customers to go that route to begin with.