### PR TITLE
[ServiceBus/EventHub] move async ssl opts to transport constructor

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where creating the SSL context in the async clients was making a blocking call outside of the constructor.([#37246](https://github.com/Azure/azure-sdk-for-python/issues/37246))
+
 ### Other Changes
 
 ## 5.12.1 (2024-06-11)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -262,23 +262,21 @@ class AsyncTransport(
         self.sslopts = ssl_opts
         self.network_trace_params = kwargs.get('network_trace_params')
         self._use_tls = use_tls
+        try:
+            self.sslopts = self._build_ssl_opts(self.sslopts)
+        except FileNotFoundError as exc:
+        # FileNotFoundError does not have missing filename info, so adding it below.
+        # Assuming that this must be ca_certs, since this is the only file path that
+        # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
+        # For uamqp exception parity.
+            exc.filename = self.sslopts
+            raise exc
 
     async def connect(self):
         try:
             # are we already connected?
             if self.connected:
                 return
-            try:
-            # Building ssl opts here instead of constructor, so that invalid cert error is raised
-            # when client is connecting, rather then during creation. For uamqp exception parity.
-                self.sslopts = self._build_ssl_opts(self.sslopts)
-            except FileNotFoundError as exc:
-            # FileNotFoundError does not have missing filename info, so adding it below.
-            # Assuming that this must be ca_certs, since this is the only file path that
-            # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
-            # For uamqp exception parity. Remove later when resolving issue #27128.
-                exc.filename = self.sslopts
-                raise exc
             self.reader, self.writer = await asyncio.open_connection(
                 host=self.host,
                 port=self.port,

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
@@ -503,11 +503,10 @@ async def test_client_invalid_credential_async(live_eventhub, get_credential_asy
         fully_qualified_namespace=live_eventhub["hostname"],
         eventhub_name=live_eventhub["event_hub"],
         credential=azure_credential,
-        connection_verify="cacert.pem",
+        connection_verify="fakecert.pem",
         uamqp_transport=uamqp_transport,
     )
 
-    # TODO: this seems like a bug from uamqp, should be ConnectError?
     async with producer_client:
         with pytest.raises(EventHubError):
             await producer_client.create_batch(partition_id="0")

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -444,11 +444,10 @@ def test_client_invalid_credential(live_eventhub, get_credential, uamqp_transpor
         fully_qualified_namespace=live_eventhub["hostname"],
         eventhub_name=live_eventhub["event_hub"],
         credential=azure_credential,
-        connection_verify="cacert.pem",
+        connection_verify="fakecert.pem",
         uamqp_transport=uamqp_transport,
     )
 
-    # TODO: this seems like a bug from uamqp, should be ConnectError?
     with producer_client:
         with pytest.raises(EventHubError):
             producer_client.create_batch(partition_id="0")

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where creating the SSL context in the async clients was making a blocking call outside of the constructor.([#37246](https://github.com/Azure/azure-sdk-for-python/issues/37246))
+
 ### Other Changes
 
 ## 7.12.3 (2024-09-19)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -262,23 +262,21 @@ class AsyncTransport(
         self.sslopts = ssl_opts
         self.network_trace_params = kwargs.get('network_trace_params')
         self._use_tls = use_tls
+        try:
+            self.sslopts = self._build_ssl_opts(self.sslopts)
+        except FileNotFoundError as exc:
+        # FileNotFoundError does not have missing filename info, so adding it below.
+        # Assuming that this must be ca_certs, since this is the only file path that
+        # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
+        # For uamqp exception parity.
+            exc.filename = self.sslopts
+            raise exc
 
     async def connect(self):
         try:
             # are we already connected?
             if self.connected:
                 return
-            try:
-            # Building ssl opts here instead of constructor, so that invalid cert error is raised
-            # when client is connecting, rather then during creation. For uamqp exception parity.
-                self.sslopts = self._build_ssl_opts(self.sslopts)
-            except FileNotFoundError as exc:
-            # FileNotFoundError does not have missing filename info, so adding it below.
-            # Assuming that this must be ca_certs, since this is the only file path that
-            # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
-            # For uamqp exception parity. Remove later when resolving issue #27128.
-                exc.filename = self.sslopts
-                raise exc
             self.reader, self.writer = await asyncio.open_connection(
                 host=self.host,
                 port=self.port,

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -672,8 +672,9 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         # invalid cert file to connection_verify should fail
         client = ServiceBusClient(hostname, credential, connection_verify="fakecertfile.pem", uamqp_transport=uamqp_transport)
         async with client:
+            sender = client.get_queue_sender(servicebus_queue.name)
             with pytest.raises(ServiceBusError):
-                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                async with sender:
                     await sender.send_messages(ServiceBusMessage("foo"))
 
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -700,8 +700,9 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
         # invalid cert file to connection_verify should fail
         client = ServiceBusClient(hostname, credential, connection_verify="fakecertfile.pem", uamqp_transport=uamqp_transport)
         with client:
+            sender = client.get_queue_sender(servicebus_queue.name)
             with pytest.raises(ServiceBusError):
-                with client.get_queue_sender(servicebus_queue.name) as sender:
+                with sender:
                     sender.send_messages(ServiceBusMessage("foo"))
 
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError


### PR DESCRIPTION
addresses: #37246

Creating the SSLContext and loading verify locations [can be done in the constructor.](https://github.com/python/cpython/blob/7e7223e18f58ec48fb36a68fb75b5c5b7a45042a/Lib/asyncio/sslproto.py#L55) Moving the check to the constructor so it doesn't need to be run in a ThreadPoolExecutor.

TODO:
- [x] test/confirm
   - [x] test_sb_client_async.py:test_custom_endpoint_connection_verify_exception_async
   - [x] test_negative_async.py:test_client_invalid_credential_async
