### PR TITLE
Use 1ES pool for all Ubuntu images

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -25,6 +25,7 @@ jobs:
     displayName: 'Run AutoRest'
 
     pool:
+      name: azsdk-pool-mms-ubuntu-2004-general
       vmImage: 'ubuntu-20.04'
 
     steps:

--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -12,6 +12,7 @@ jobs:
     timeoutInMinutes: 120
 
     pool:
+      name: azsdk-pool-mms-ubuntu-2004-general
       vmImage: 'ubuntu-20.04'
 
     steps:

--- a/eng/pipelines/templates/jobs/update_pr.yml
+++ b/eng/pipelines/templates/jobs/update_pr.yml
@@ -10,7 +10,8 @@ variables:
   skipComponentGovernanceDetection: true
 
 pool:
-  vmImage: 'ubuntu-latest'
+  name: azsdk-pool-mms-ubuntu-2004-general
+  vmImage: 'ubuntu-20.04'
 
 steps:
 - task: UsePythonVersion@0

--- a/eng/pipelines/templates/jobs/update_pr.yml
+++ b/eng/pipelines/templates/jobs/update_pr.yml
@@ -10,8 +10,8 @@ variables:
   skipComponentGovernanceDetection: true
 
 pool:
-  name: azsdk-pool-mms-ubuntu-2004-general
-  vmImage: 'ubuntu-20.04'
+  name: azsdk-pool-mms-ubuntu-2204-general
+  vmImage: 'ubuntu-22.04'
 
 steps:
 - task: UsePythonVersion@0

--- a/eng/pipelines/templates/stages/archetype-conda-release.yml
+++ b/eng/pipelines/templates/stages/archetype-conda-release.yml
@@ -18,7 +18,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general
-          vmImage: MMSUbuntu20.04
+          vmImage: 'ubuntu-20.04'
 
         strategy:
           runOnce:

--- a/scripts/auto_release/PythonSdkLiveTest.yml
+++ b/scripts/auto_release/PythonSdkLiveTest.yml
@@ -25,6 +25,7 @@ jobs:
   strategy:
     maxParallel: 5
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: 'ubuntu-20.04'
   variables:
     Codeql.Enabled: false

--- a/scripts/collect_api_version_for_multi_api_sdk/collect_api_version.yml
+++ b/scripts/collect_api_version_for_multi_api_sdk/collect_api_version.yml
@@ -22,6 +22,7 @@ jobs:
   strategy:
     maxParallel: 1
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0

--- a/scripts/issue_helper/issue_helper.yml
+++ b/scripts/issue_helper/issue_helper.yml
@@ -31,6 +31,7 @@ jobs:
   strategy:
     maxParallel: 3
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0

--- a/scripts/release_helper/release_helper.yml
+++ b/scripts/release_helper/release_helper.yml
@@ -35,6 +35,7 @@ jobs:
   strategy:
     maxParallel: 1
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: 'ubuntu-20.04'
   variables:
     Codeql.Enabled: false

--- a/scripts/release_sdk_status/release_sdk_status.yml
+++ b/scripts/release_sdk_status/release_sdk_status.yml
@@ -34,6 +34,7 @@ jobs:
   strategy:
     maxParallel: 1
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0


### PR DESCRIPTION
- Reduces capacity demands on DevOps pool

Example build incorrectly using DevOps pool:

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4189678&view=logs&j=f453a87e-a85c-5f44-a92c-6b85546844d9&t=427c226a-a4f9-4854-aee9-bc537d82ba90