### PR TITLE
Revert "[ServiceBus/EventHub] move async ssl opts to transport constructor"

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -3,12 +3,7 @@
 ## 5.12.2 (2024-10-02)
 
 ### Bugs Fixed
-
-- Fixed a bug where creating the SSL context in the async clients was making a blocking call outside of the constructor.([#37246](https://github.com/Azure/azure-sdk-for-python/issues/37246))
-
-### Other Changes
-
-- Implemented backpressure for async consumer to address a memory leak issue. ([#36398](https://github.com/Azure/azure-sdk-for-python/issues/36398))
+- Implemented backpressure for  async consumer  to address a memory leak issue. ([#36398](https://github.com/Azure/azure-sdk-for-python/issues/36398))
 
 ## 5.12.1 (2024-06-11)
 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
@@ -503,10 +503,11 @@ async def test_client_invalid_credential_async(live_eventhub, get_credential_asy
         fully_qualified_namespace=live_eventhub["hostname"],
         eventhub_name=live_eventhub["event_hub"],
         credential=azure_credential,
-        connection_verify="fakecert.pem",
+        connection_verify="cacert.pem",
         uamqp_transport=uamqp_transport,
     )
 
+    # TODO: this seems like a bug from uamqp, should be ConnectError?
     async with producer_client:
         with pytest.raises(EventHubError):
             await producer_client.create_batch(partition_id="0")

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -444,10 +444,11 @@ def test_client_invalid_credential(live_eventhub, get_credential, uamqp_transpor
         fully_qualified_namespace=live_eventhub["hostname"],
         eventhub_name=live_eventhub["event_hub"],
         credential=azure_credential,
-        connection_verify="fakecert.pem",
+        connection_verify="cacert.pem",
         uamqp_transport=uamqp_transport,
     )
 
+    # TODO: this seems like a bug from uamqp, should be ConnectError?
     with producer_client:
         with pytest.raises(EventHubError):
             producer_client.create_batch(partition_id="0")

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where creating the SSL context in the async clients was making a blocking call outside of the constructor.([#37246](https://github.com/Azure/azure-sdk-for-python/issues/37246))
-
 ### Other Changes
 
 ## 7.12.3 (2024-09-19)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -672,9 +672,8 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         # invalid cert file to connection_verify should fail
         client = ServiceBusClient(hostname, credential, connection_verify="fakecertfile.pem", uamqp_transport=uamqp_transport)
         async with client:
-            sender = client.get_queue_sender(servicebus_queue.name)
             with pytest.raises(ServiceBusError):
-                async with sender:
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
                     await sender.send_messages(ServiceBusMessage("foo"))
 
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -700,9 +700,8 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
         # invalid cert file to connection_verify should fail
         client = ServiceBusClient(hostname, credential, connection_verify="fakecertfile.pem", uamqp_transport=uamqp_transport)
         with client:
-            sender = client.get_queue_sender(servicebus_queue.name)
             with pytest.raises(ServiceBusError):
-                with sender:
+                with client.get_queue_sender(servicebus_queue.name) as sender:
                     sender.send_messages(ServiceBusMessage("foo"))
 
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#37655

Needs further discussion + need to release other bug fix.