### PR TITLE
Remove `.env` file from azure-sdk-tools

### DIFF
--- a/tools/azure-sdk-tools/.env
+++ b/tools/azure-sdk-tools/.env
@@ -1,1 +1,0 @@
-PROXY_URL=http://localhost:5000


### PR DESCRIPTION
# Description

Reverts part of https://github.com/Azure/azure-sdk-for-python/pull/37580. @YalinLi0312 noticed that tests weren't behaving as expected locally; despite setting `AZURE_TEST_RUN_LIVE` and `AZURE_SKIP_LIVE_RECORDING` to True in her `.env` file, tests still attempted to run in playback.

I tracked this down to the recently-added `.env` file in `azure-sdk-tools`. `find_dotenv()` invocations from the library (which are used by test proxy tooling) now resolved to this new file instead of a user's own `.env` file at the repository root level.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
