### PR TITLE
[Storage] Support metadata on `upload_blob_from_url` API

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.24.0b1 (Unreleased)
 
 ### Features Added
-
+- Added new `metadata` keyword to the `put_block_from_url` API to allow metadata to be supplied in the same manner as in the `upload_blob` API and others.
 
 
 ## 12.23.1 (2024-09-25)

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.24.0b1 (Unreleased)
 
 ### Features Added
-- Added new `metadata` keyword to the `put_block_from_url` API to allow metadata to be supplied in the same manner as in the `upload_blob` API and others.
+- Added support for passing metadata to `upload_blob_from_url` via the new metadata keyword.
 
 
 ## 12.23.1 (2024-09-25)

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.24.0b1 (Unreleased)
 
 ### Features Added
-- Added support for passing metadata to `upload_blob_from_url` via the new metadata keyword.
+- Added support for passing metadata to `upload_blob_from_url` via the new `metadata` keyword.
 
 
 ## 12.23.1 (2024-09-25)

--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_fad0e99de3"
+  "Tag": "python/storage/azure-storage-blob_7df5687d1f"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -342,6 +342,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             operation will fail with ResourceExistsError.
         :keyword bool include_source_blob_properties:
             Indicates if properties from the source blob should be copied. Defaults to True.
+        :keyword dict(str, str) metadata:
+            Name-value pairs associated with the blob as metadata.
         :keyword tags:
             Name-value pairs associated with the blob as tag. Tags are case-sensitive.
             The tag set may contain at most 10 tags.  Tag keys must be between 1 and 128 characters,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -320,7 +320,12 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             process_storage_error(error)
 
     @distributed_trace
-    def upload_blob_from_url(self, source_url: str, **kwargs: Any) -> Dict[str, Any]:
+    def upload_blob_from_url(
+        self, source_url: str,
+        *,
+        metadata: Optional[Dict[str, str]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """
         Creates a new Block Blob where the content of the blob is read from a given URL.
         The content of an existing blob is overwritten with the new blob.
@@ -337,13 +342,13 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
 
             https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+        :keyword dict(str, str) metadata:
+            Name-value pairs associated with the blob as metadata.
         :keyword bool overwrite: Whether the blob to be uploaded should overwrite the current data.
             If True, upload_blob will overwrite the existing data. If set to False, the
             operation will fail with ResourceExistsError.
         :keyword bool include_source_blob_properties:
             Indicates if properties from the source blob should be copied. Defaults to True.
-        :keyword dict(str, str) metadata:
-            Name-value pairs associated with the blob as metadata.
         :keyword tags:
             Name-value pairs associated with the blob as tag. Tags are case-sensitive.
             The tag set may contain at most 10 tags.  Tag keys must be between 1 and 128 characters,
@@ -424,6 +429,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             raise ValueError("Customer provided encryption key must be used over HTTPS.")
         options = _upload_blob_from_url_options(
             source_url=source_url,
+            metadata=metadata,
             **kwargs)
         try:
             return cast(Dict[str, Any], self._client.block_blob.put_blob_from_url(**options))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -188,7 +188,10 @@ def _upload_blob_options(  # pylint:disable=too-many-statements
         raise ValueError(f"Unsupported BlobType: {blob_type}")
     return kwargs
 
-def _upload_blob_from_url_options(source_url: str, **kwargs: Any ) -> Dict[str, Any]:
+def _upload_blob_from_url_options(source_url: str, **kwargs: Any) -> Dict[str, Any]:
+    metadata = kwargs.pop('metadata', None)
+    headers = kwargs.pop('headers', {})
+    headers.update(add_metadata_headers(metadata))
     source_url = _encode_source_url(source_url=source_url)
     tier = kwargs.pop('standard_blob_tier', None)
     overwrite = kwargs.pop('overwrite', False)
@@ -222,7 +225,8 @@ def _upload_blob_from_url_options(source_url: str, **kwargs: Any ) -> Dict[str, 
         'tier': tier.value if tier else None,
         'source_modified_access_conditions': get_source_conditions(kwargs),
         'cpk_info': cpk_info,
-        'cpk_scope_info': get_cpk_scope_info(kwargs)
+        'cpk_scope_info': get_cpk_scope_info(kwargs),
+        'headers': headers,
     }
     options.update(kwargs)
     if not overwrite and not _any_conditions(**options): # pylint: disable=protected-access

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -310,7 +310,12 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             process_storage_error(error)
 
     @distributed_trace_async
-    async def upload_blob_from_url(self, source_url: str, **kwargs: Any) -> Dict[str, Any]:
+    async def upload_blob_from_url(
+        self, source_url: str,
+        *,
+        metadata: Optional[Dict[str, str]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """
         Creates a new Block Blob where the content of the blob is read from a given URL.
         The content of an existing blob is overwritten with the new blob.
@@ -327,13 +332,13 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
 
             https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+        :keyword dict(str, str) metadata:
+            Name-value pairs associated with the blob as metadata.
         :keyword bool overwrite: Whether the blob to be uploaded should overwrite the current data.
             If True, upload_blob will overwrite the existing data. If set to False, the
             operation will fail with ResourceExistsError.
         :keyword bool include_source_blob_properties:
             Indicates if properties from the source blob should be copied. Defaults to True.
-        :keyword dict(str, str) metadata:
-            Name-value pairs associated with the blob as metadata.
         :keyword tags:
             Name-value pairs associated with the blob as tag. Tags are case-sensitive.
             The tag set may contain at most 10 tags.  Tag keys must be between 1 and 128 characters,
@@ -414,6 +419,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             raise ValueError("Customer provided encryption key must be used over HTTPS.")
         options = _upload_blob_from_url_options(
             source_url=source_url,
+            metadata=metadata,
             **kwargs)
         try:
             return cast(Dict[str, Any], await self._client.block_blob.put_blob_from_url(**options))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -332,6 +332,8 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             operation will fail with ResourceExistsError.
         :keyword bool include_source_blob_properties:
             Indicates if properties from the source blob should be copied. Defaults to True.
+        :keyword dict(str, str) metadata:
+            Name-value pairs associated with the blob as metadata.
         :keyword tags:
             Name-value pairs associated with the blob as tag. Tags are case-sensitive.
             The tag set may contain at most 10 tags.  Tag keys must be between 1 and 128 characters,

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -199,6 +199,38 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy
+    def test_upload_blob_from_url_with_metadata(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        self._setup(storage_account_name, storage_account_key, container_name="testcontainer")
+        blob = self._create_blob()
+        self.bsc.get_blob_client(self.container_name, blob.blob_name)
+        sas = self.generate_sas(
+            generate_blob_sas,
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            container_name=self.container_name,
+            blob_name=blob.blob_name,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
+        )
+        # Act
+        source_blob = '{0}/{1}/{2}?{3}'.format(
+            self.account_url(storage_account_name, "blob"), self.container_name, blob.blob_name, sas)
+
+        blob_name = self.get_resource_name("blobcopy")
+        new_blob = self.bsc.get_blob_client(self.container_name, blob_name)
+        new_blob.upload_blob_from_url(source_blob, metadata={'blobdata': 'data1'})
+
+        new_blob_properties = new_blob.get_blob_properties()
+
+        # Assert
+        assert new_blob_properties.metadata == {'blobdata': 'data1'}
+
+    @BlobPreparer()
+    @recorded_by_proxy
     def test_upload_blob_from_url_with_cold_tier_specified(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -222,6 +222,38 @@ class TestStorageBlockBlobAsync(AsyncStorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy_async
+    async def test_upload_blob_from_url_with_metadata(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        await self._setup(storage_account_name, storage_account_key, container_name="testcontainer")
+        blob = await self._create_blob()
+        self.bsc.get_blob_client(self.container_name, blob.blob_name)
+        sas = self.generate_sas(
+            generate_blob_sas,
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            container_name=self.container_name,
+            blob_name=blob.blob_name,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
+        )
+        # Act
+        source_blob = '{0}/{1}/{2}?{3}'.format(
+            self.account_url(storage_account_name, "blob"), self.container_name, blob.blob_name, sas)
+
+        blob_name = self.get_resource_name("blobcopy")
+        new_blob = self.bsc.get_blob_client(self.container_name, blob_name)
+        await new_blob.upload_blob_from_url(source_blob, metadata={'blobdata': 'data1'})
+
+        new_blob_properties = await new_blob.get_blob_properties()
+
+        # Assert
+        assert new_blob_properties.metadata == {'blobdata': 'data1'}
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
     async def test_upload_blob_from_url_with_cold_tier_specified(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")


### PR DESCRIPTION
This PR aims to allow `metadata` to be set more easily on `upload_blob_from_url` rather than having to do the headers workaround. Addresses #37634 