### PR TITLE
[Monitor][CI] Remove BuildTargetingString

### DIFF
--- a/sdk/monitor/ci.yml
+++ b/sdk/monitor/ci.yml
@@ -28,7 +28,6 @@ extends:
   parameters:
     ServiceDirectory: monitor
     TestProxy: true
-    BuildTargetingString: '*'
     Artifacts:
     - name: azure-mgmt-monitor
       safeName: azuremgmtmonitor


### PR DESCRIPTION
This is not necessary to have in this file, and we'll let the templates/build scripts handle build targeting.
