### PR TITLE
[Monitor Distro] Update dev dependency

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/dev_requirements.txt
+++ b/sdk/monitor/azure-monitor-opentelemetry/dev_requirements.txt
@@ -3,6 +3,6 @@ pytest
 django
 fastapi-slim
 flask
-psycopg2
+psycopg2-binary
 requests
 urllib3


### PR DESCRIPTION
There are sometimes issues building psycopg2 on the test agents (currently on Mac). For testing, let's use the psycopg2-binary package instead.

[Sample pipeline failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4200893&view=logs&j=4f43d237-9eb7-56e2-1682-eb02dd3a11cb&t=132b9719-8bdf-53d1-1111-f060409543f5&l=14500).

```sh
Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <[https://www.psycopg.org/docs/install.html>).](https://www.psycopg.org/docs/install.html%3E).)
```