### PR TITLE
[Identity] Fix WorkloadIdentityCredential parameter

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -153,7 +153,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
                     WorkloadIdentityCredential(
                         client_id=cast(str, client_id),
                         tenant_id=workload_identity_tenant_id,
-                        file=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
+                        token_file_path=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
                         **kwargs
                     )
                 )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -108,7 +108,7 @@ class ManagedIdentityCredential:
             self._credential = WorkloadIdentityCredential(
                 tenant_id=os.environ[EnvironmentVariables.AZURE_TENANT_ID],
                 client_id=workload_client_id,
-                file=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
+                token_file_path=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
                 **kwargs,
             )
         else:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -145,7 +145,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
                     WorkloadIdentityCredential(
                         client_id=cast(str, client_id),
                         tenant_id=workload_identity_tenant_id,
-                        file=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
+                        token_file_path=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
                         **kwargs
                     )
                 )

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -96,7 +96,7 @@ class ManagedIdentityCredential(AsyncContextManager):
             self._credential = WorkloadIdentityCredential(
                 tenant_id=os.environ[EnvironmentVariables.AZURE_TENANT_ID],
                 client_id=workload_client_id,
-                file=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
+                token_file_path=os.environ[EnvironmentVariables.AZURE_FEDERATED_TOKEN_FILE],
                 **kwargs
             )
         else:


### PR DESCRIPTION
Small fix to a parameter name to be the actual parameter used. No behavior is changed as the credential constructor would read the same thing from the environment as what we intended to pass in.