### PR TITLE
[Tables] Fix broken link in setup.py

### DIFF
--- a/sdk/tables/azure-data-tables/setup.py
+++ b/sdk/tables/azure-data-tables/setup.py
@@ -42,7 +42,7 @@ setup(
     license="MIT License",
     author="Microsoft Corporation",
     author_email="ascl@microsoft.com",
-    url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/table/azure-table",
+    url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/tables/azure-data-tables",
     keywords="azure, azure sdk",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
# Description

Fixed broken homepage links on pypi's azure-data-tables page.

before: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/table/azure-table
after: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/tables/azure-data-tables

https://pypi.org/project/azure-data-tables/
![image](https://github.com/user-attachments/assets/fafcf72d-c62e-4460-aff6-d68807c1e523)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
