### PR TITLE
Skip psycopg2 test for Python 3.13 to fix build

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
@@ -8,7 +8,7 @@ import sys
 import unittest
 
 # Skip for Python v3.13 until https://github.com/psycopg/psycopg2/pull/1729 is resolved
-if sys.implementation.name != "pypy" and sys.version_info <= (3, 13):
+if sys.implementation.name != "pypy" and sys.version_info < (3, 13):
     from opentelemetry.instrumentation.psycopg2 import (
         Psycopg2Instrumentor,
     )
@@ -16,7 +16,7 @@ if sys.implementation.name != "pypy" and sys.version_info <= (3, 13):
 
 class TestPsycopg2Instrumentation(unittest.TestCase):
 
-    @pytest.mark.skipif(sys.implementation.name == "pypy", reason="Psycopg2 not supported for pypy3.9")
+    @pytest.mark.skipif(sys.implementation.name == "pypy" or sys.version_info >= (3, 13), reason="Psycopg2 not supported for pypy3.9 and Py3.13")
     def test_instrument(self):
         try:
             Psycopg2Instrumentor().instrument()

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
@@ -7,7 +7,8 @@ import pytest
 import sys
 import unittest
 
-if sys.implementation.name != "pypy":
+# Skip for Python v3.13 until https://github.com/psycopg/psycopg2/pull/1729 is resolved
+if sys.implementation.name != "pypy" and sys.version_info <= (3, 13):
     from opentelemetry.instrumentation.psycopg2 import (
         Psycopg2Instrumentor,
     )


### PR DESCRIPTION
Builds are using Python 3.13 now.
Skip psycopg2 test import when running on Python 3.13 until psycopg2 builds binaries in 3.13.

Failing build: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4215071&view=logs&j=447d33cb-e696-5bdf-6dab-daffaacae469&t=3a72120e-05b6-5405-ef0a-05b69dbc1d3d