### PR TITLE
[pyAMQP] port fix

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue where if a port was specified as a part of the fully qualified namespace, negotation failed ([37547]https://github.com/Azure/azure-sdk-for-python/issues/37547)
 
 ### Other Changes
 
@@ -14,6 +15,7 @@
 
 ### Bugs Fixed
 - Implemented backpressure for  async consumer  to address a memory leak issue. ([#36398](https://github.com/Azure/azure-sdk-for-python/issues/36398))
+
 
 ## 5.12.1 (2024-06-11)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -309,7 +309,8 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
         if not eventhub_name:
             raise ValueError("The eventhub name can not be None or empty.")
         path = "/" + eventhub_name if eventhub_name else ""
-        self._address = _Address(hostname=fully_qualified_namespace, path=path)
+        parsed_url = urlparse(fully_qualified_namespace)
+        self._address = _Address(hostname=parsed_url.scheme, path=path)
         self._container_id = CONTAINER_PREFIX + str(uuid.uuid4())[:8]
         if isinstance(credential, AzureSasCredential):
             self._credential = EventhubAzureSasTokenCredential(credential)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -118,7 +118,8 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port:
+        if parsed_url.port and not kwargs.get("use_tls"):
+            # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":
             self._port = SECURE_PORT

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -118,7 +118,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port and not kwargs.get("use_tls"):
+        if parsed_url.port and not kwargs.get("use_tls", True):
             # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -99,7 +99,8 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port:
+        if parsed_url.port and not kwargs.get("use_tls"):
+            # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":
             self._port = SECURE_PORT

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -99,7 +99,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port and not kwargs.get("use_tls"):
+        if parsed_url.port and not kwargs.get("use_tls", True):
             # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -769,7 +769,7 @@ def test_send_with_port(
         auth_credential_receivers
     )
     client = EventHubProducerClient(
-        fully_qualified_namespace=fully_qualified_namespace+":443/",
+        fully_qualified_namespace=fully_qualified_namespace+":443",
         eventhub_name=eventhub_name,
         credential=credential(),
         uamqp_transport=uamqp_transport,

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -760,3 +760,20 @@ def test_send_long_wait_idle_timeout(auth_credential_receivers, keep_alive, uamq
             else:
                 with pytest.raises(AMQPConnectionError):
                     sender._send_event_data()
+
+@pytest.mark.liveTest
+def test_send_with_port(
+    auth_credential_receivers, live_eventhub, uamqp_transport, timeout_factor
+):
+    fully_qualified_namespace, eventhub_name, credential, receivers = (
+        auth_credential_receivers
+    )
+    client = EventHubProducerClient(
+        fully_qualified_namespace=fully_qualified_namespace+":443/",
+        eventhub_name=eventhub_name,
+        credential=credential(),
+        uamqp_transport=uamqp_transport,
+    )
+
+    with client:
+        client.send_event(EventData("A single event"))

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -769,7 +769,7 @@ def test_send_with_port(
         auth_credential_receivers
     )
     client = EventHubProducerClient(
-        fully_qualified_namespace=fully_qualified_namespace+":443",
+        fully_qualified_namespace=fully_qualified_namespace+":443/",
         eventhub_name=eventhub_name,
         credential=credential(),
         uamqp_transport=uamqp_transport,

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a broken f-string present in a `ValueError` when using the async client ([37695](https://github.com/Azure/azure-sdk-for-python/issues/37695))
+- Fixed an issue where if a port was specified as a part of the fully qualified namespace, negotation failed ([37547]https://github.com/Azure/azure-sdk-for-python/issues/37547)
 
 ### Other Changes
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/receiver_mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/receiver_mixins.py
@@ -6,6 +6,11 @@
 import uuid
 from typing import TYPE_CHECKING, Union
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse  # type: ignore
+
 from ..exceptions import MessageAlreadySettled
 from .constants import (
     NEXT_AVAILABLE_SESSION,
@@ -30,8 +35,9 @@ class ReceiverMixin(object):  # pylint: disable=too-many-instance-attributes
         else:
             self.entity_path = self._entity_name
 
+        parsed_url = urlparse(self.fully_qualified_namespace)
         self._auth_uri = "sb://{}/{}".format(
-            self.fully_qualified_namespace, self.entity_path
+            parsed_url.scheme, self.entity_path
         )
         self._entity_uri = "amqps://{}/{}".format(
             self.fully_qualified_namespace, self.entity_path

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -118,7 +118,8 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port:
+        if parsed_url.port and not kwargs.get("use_tls"):
+            # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":
             self._port = SECURE_PORT

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -118,7 +118,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port and not kwargs.get("use_tls"):
+        if parsed_url.port and not kwargs.get("use_tls", True):
             # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -99,7 +99,8 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port:
+        if parsed_url.port and not kwargs.get("use_tls"):
+            # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":
             self._port = SECURE_PORT

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -99,7 +99,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
         self._hostname = parsed_url.hostname
         kwargs["http_proxy"] = http_proxy
         endpoint = self._hostname
-        if parsed_url.port and not kwargs.get("use_tls"):
+        if parsed_url.port and not kwargs.get("use_tls", True):
             # if we are using an emulator, use the port passed in url
             self._port = parsed_url.port
         elif parsed_url.scheme == "amqps":

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -9,6 +9,11 @@ from weakref import WeakSet
 from typing_extensions import Literal
 import certifi
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse  # type: ignore
+
 from ._base_handler import (
     _parse_conn_str,
     ServiceBusSharedKeyCredential,
@@ -141,7 +146,8 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
         self._connection = None
         # Optional entity name, can be the name of Queue or Topic.  Intentionally not advertised, typically be needed.
         self._entity_name = kwargs.get("entity_name")
-        self._auth_uri = f"sb://{self.fully_qualified_namespace}"
+        parsed_url = urlparse(self.fully_qualified_namespace)
+        self._auth_uri = f"sb://{parsed_url.scheme}"
         if self._entity_name:
             self._auth_uri = f"{self._auth_uri}/{self._entity_name}"
         # Internal flag for switching whether to apply connection sharing, pending fix in uamqp library

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -9,6 +9,11 @@ import datetime
 import warnings
 from typing import Any, TYPE_CHECKING, Union, List, Optional, Mapping, cast, Iterable
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse  # type: ignore
+
 from ._base_handler import BaseHandler
 from ._common import mgmt_handlers
 from ._common.message import (
@@ -74,7 +79,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class SenderMixin:
     def _create_attribute(self, **kwargs):
-        self._auth_uri = f"sb://{self.fully_qualified_namespace}/{self._entity_name}"
+        parsed_url = urlparse(self.fully_qualified_namespace)
+        self._auth_uri = f"sb://{parsed_url.scheme}/{self._entity_name}"
         self._entity_uri = f"amqps://{self.fully_qualified_namespace}/{self._entity_name}"
         # TODO: What's the retry overlap between servicebus and pyamqp?
         self._error_policy = self._amqp_transport.create_retry_policy(self._config)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -9,6 +9,11 @@ from weakref import WeakSet
 from typing_extensions import Literal
 import certifi
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse  # type: ignore
+
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 
 from ._transport._pyamqp_transport_async import PyamqpTransportAsync
@@ -131,7 +136,8 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
         self._connection = None
         # Optional entity name, can be the name of Queue or Topic.  Intentionally not advertised, typically be needed.
         self._entity_name = kwargs.get("entity_name")
-        self._auth_uri = f"sb://{self.fully_qualified_namespace}"
+        parsed_url = urlparse(self.fully_qualified_namespace)
+        self._auth_uri = f"sb://{parsed_url.scheme}"
         if self._entity_name:
             self._auth_uri = f"{self._auth_uri}/{self._entity_name}"
         # Internal flag for switching whether to apply connection sharing, pending fix in uamqp library

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3417,7 +3417,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_fully_qualified_port(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}:443/"
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}:443"
         credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3417,7 +3417,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_fully_qualified_port(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}:443"
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}:443/"
         credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:


### PR DESCRIPTION
the following url: https://accountname.servicebus.windows.net:443/ never worked with the current code.

Because of the following edit for emulator support in connection.py we were passing the parsed_url.port into the code and it was causing a negotation frame error. Fixing that aligns the SDK with the other versions, where given the following url it will raise a CBS auth connection error. 

If we want to fix the CBS auth error we need to figure out how to parse out the url port before it gets used as the auth_uri to the JWTTokenAuth.