### PR TITLE
Handle changes in `sdk` or `sdk/<service>` that are not actually packages

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -89,7 +89,6 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
   }
 
   foreach ($changedService in $changedServices) {
-    Write-Host "Changed service: $changedService"
     $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
 
     $additionalPackages | % { Write-Host $_.Name }
@@ -98,7 +97,6 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
 
   $uniqueResultSet = @()
   foreach ($pkg in $additionalValidationPackages) {
-    Write-Host "Examining $($pkg.Name)"
     if ($uniqueResultSet -notcontains $pkg -and $LocatedPackages -notcontains $pkg) {
       $pkg.IncludedForValidation = $true
       $uniqueResultSet += $pkg

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -90,8 +90,6 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
 
   foreach ($changedService in $changedServices) {
     $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
-
-    $additionalPackages | % { Write-Host $_.Name }
     $additionalValidationPackages += $additionalPackages
   }
 


### PR DESCRIPTION
@swathipil this will resolve the issue you saw on #37796 

In the above scenario, these changes would result in the packages within `eventhub` and `servicebus` triggering:

- `azure-eventhub-checkpointstoreblob-aio`
- `azure-eventhub-checkpointstoreblob`
- `azure-eventhub-checkpointstoretable`
- `azure-eventhub`
- `azure-mgmt-eventhub`
- `azure-mgmt-servicebus`
- `azure-servicebus`

