### PR TITLE
Disable `3.13` tests for `azure-ai-ml`

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -65,7 +65,7 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
       "azure-core-experimental",
       "azure-core-tracing-opentelemetry",
       "azure-core-tracing-opencensus",
-      "azure-cosmos",
+      # "azure-cosmos", leave removed until we resolve what to do with the emulator tests
       "azure-ai-documentintelligence",
       "azure-ai-ml",
       "azure-ai-inference",

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -41,7 +41,9 @@ MANAGEMENT_PACKAGES_FILTER_EXCLUSIONS = [
     "azure-mgmt-core",
 ]
 
-TEST_COMPATIBILITY_MAP = {}
+TEST_COMPATIBILITY_MAP = {
+    "azure-ai-ml": ">=3.7, !=3.13.*"
+}
 TEST_PYTHON_DISTRO_INCOMPATIBILITY_MAP = {
     "azure-storage-blob": "pypy",
     "azure-storage-queue": "pypy",

--- a/tools/azure-sdk-tools/tests/test_conflict_resolution.py
+++ b/tools/azure-sdk-tools/tests/test_conflict_resolution.py
@@ -31,4 +31,4 @@ def test_resolution_no_requirement():
         "azure-identity",
         [Requirement("azure-core")],
     )
-    assert result == "azure-identity==1.18.0"
+    assert result == "azure-identity==1.19.0"

--- a/tools/azure-sdk-tools/tests/test_requirements_parse.py
+++ b/tools/azure-sdk-tools/tests/test_requirements_parse.py
@@ -63,14 +63,14 @@ def test_replace_dev_reqs_relative(tmp_directory_create):
     expected_results = [
         os.path.join(expected_output_folder, "coretestserver-1.0.0b1-py3-none-any.whl"),
         os.path.join(expected_output_folder, "coretestserver-1.0.0b1-py3-none-any.whl"),
-        os.path.join(expected_output_folder, "azure_identity-1.18.1-py3-none-any.whl"),
-        os.path.join(expected_output_folder, "azure_identity-1.18.1-py3-none-any.whl"),
+        os.path.join(expected_output_folder, "azure_identity-1.19.1-py3-none-any.whl"),
+        os.path.join(expected_output_folder, "azure_identity-1.19.1-py3-none-any.whl"),
         os.path.join(expected_output_folder, "azure_mgmt_core-1.4.0-py3-none-any.whl"),
         os.path.join(expected_output_folder, "azure_mgmt_core-1.4.0-py3-none-any.whl"),
         os.path.join(expected_output_folder, "azure_sdk_tools-0.0.0-py3-none-any.whl[build]"),
         os.path.join(expected_output_folder, "azure_sdk_tools-0.0.0-py3-none-any.whl[build]"),
-        os.path.join(expected_output_folder, "azure_core-1.31.1-py3-none-any.whl"),
-        os.path.join(expected_output_folder, "azure_core-1.31.1-py3-none-any.whl"),
+        os.path.join(expected_output_folder, "azure_core-1.32.0-py3-none-any.whl"),
+        os.path.join(expected_output_folder, "azure_core-1.32.0-py3-none-any.whl"),
     ]
 
     requirements_before = get_requirements_from_file(requirements_file)


### PR DESCRIPTION
So that we don't even invoke them. Missing a required package.