### PR TITLE
[Core] Extend module search paths in some areas

### DIFF
--- a/sdk/core/azure-core/azure/core/__init__.py
+++ b/sdk/core/azure-core/azure/core/__init__.py
@@ -23,6 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 from ._version import VERSION
 

--- a/sdk/core/azure-core/azure/core/tracing/__init__.py
+++ b/sdk/core/azure-core/azure/core/tracing/__init__.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+
 from azure.core.tracing._abstract_span import (
     AbstractSpan,
     SpanKind,

--- a/sdk/core/azure-core/azure/core/tracing/ext/__init__.py
+++ b/sdk/core/azure-core/azure/core/tracing/ext/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore


### PR DESCRIPTION
## **Scenario**: 

In some cases, `azure-core` might be installed in two places that are in the module search path. For example, in Azure CLI, the base CLI dependencies are installed in a path like `/opt/az/lib/python3.11/site-packages` while extension dependencies are installed in a path like `/home/user/.azure/cliextensions/<extension-name>`.  In this case, the base CLI dependencies take precedence over the extension dependencies (i.e. `/opt/az/lib/python3.11/site-packages` comes before `/home/user/.azure/cliextensions/<extension-name>` in `sys.path`).

If an extension has `azure-core-tracing-opentelemetry` as a dependency, this is installed in the `azure/core/tracing/ext` directory/namespace inside the `cliextensions` directory. However, at runtime, Python will only search the `azure-core` in the first `sys.path` and stop there without moving to the next path in `sys.path` before throwing an `ImportError`.

## **Change**:

In order to allow tracing plugin packages to be discovered if they are installed in a separate location, we add `__path__ = __import__("pkgutil").extend_path(__path__, __name__)` to the `__init__.py` files leading up to the `ext` directory. 

This instructs Python to look for submodules and subpackages in additional directories on `sys.path`. With these, it will find/resolve the plugin.
