### PR TITLE
`python - pullrequest` fails when running pypy39 on windows

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix-no-313.json
+++ b/eng/pipelines/templates/stages/platform-matrix-no-313.json
@@ -10,11 +10,22 @@
       "ubuntu-20.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" },
       "macos-latest": { "OSVmImage": "env:MACVMIMAGE", "Pool": "env:MACPOOL" }
     },
-    "PythonVersion": [ "3.8", "pypy3.9", "3.11", "3.10"],
+    "PythonVersion": [ "3.8", "3.11", "3.10"],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
   "include": [
+    {
+      "PyPyConfig": {
+        "ubuntu2004_pypy39": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "PythonVersion": "pypy3.9",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false"
+        }
+      }
+    },
     {
       "CoverageConfig": {
         "ubuntu2004_39_coverage": {

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,11 +10,22 @@
       "ubuntu-20.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" },
       "macos-latest": { "OSVmImage": "env:MACVMIMAGE", "Pool": "env:MACPOOL" }
     },
-    "PythonVersion": [ "3.8", "pypy3.9", "3.11", "3.10", "3.12" ],
+    "PythonVersion": [ "3.8", "3.11", "3.10", "3.12" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
   "include": [
+    {
+      "PyPyConfig": {
+        "ubuntu2004_pypy39": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "PythonVersion": "pypy3.9",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false"
+        }
+      }
+    },
     {
       "CoverageConfig": {
         "ubuntu2004_39_coverage": {


### PR DESCRIPTION
`pywin32` has a compilation failure on pypy39. `pywin32` does not ship a wheel.

I _could_ build a wheel for `pywin32`, but unfortunately because it's being brought in as a dependency, this will cause a _very_ long tail of manually patching various dev_requirements and custom tox scripts to ensure the prebuilt version gets picked up.

Instead, let's just place `pypy39` in our `include` set, which do not get remixed/multiplexed by `distribute-packages-to-matrix.ps1` in the `python - pullrequest` build. This will ensure that `pypy39` always lives on `ubuntu` and doesn't explode because of missing dependencies.

[Example failed build](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4230796)