### PR TITLE
Skip `pypy` when testing `azure-servicebus`

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -50,6 +50,7 @@ TEST_PYTHON_DISTRO_INCOMPATIBILITY_MAP = {
     "azure-storage-file-datalake": "pypy",
     "azure-storage-file-share": "pypy",
     "azure-eventhub": "pypy",
+    "azure-servicebus": "pypy",
 }
 
 omit_regression = (


### PR DESCRIPTION
Not supported in their default matrix and so we shouldn't keep it there in `python - pullrequest` where it just fails 100% of the time.

Resolve failures like [this one](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4230796).