### PR TITLE
Improve API docs for DAC and CTC

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -37,8 +37,8 @@ class ChainedTokenCredential:
     """A sequence of credentials that is itself a credential.
 
     Its :func:`get_token` method calls ``get_token`` on each credential in the sequence, in order, returning the first
-    valid token received. For more information, see
-    https://aka.ms/azsdk/python/identity/credential-chains#chainedtokencredential-overview.
+    valid token received. For more information, see `ChainedTokenCredential overview 
+    <"https://aka.ms/azsdk/python/identity/credential-chains#chainedtokencredential-overview">`__.
 
     :param credentials: credential instances to form the chain
     :type credentials: ~azure.core.credentials.TokenCredential

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -37,7 +37,7 @@ class ChainedTokenCredential:
     """A sequence of credentials that is itself a credential.
 
     Its :func:`get_token` method calls ``get_token`` on each credential in the sequence, in order, returning the first
-    valid token received. For more information, see `ChainedTokenCredential overview 
+    valid token received. For more information, see `ChainedTokenCredential overview
     <"https://aka.ms/azsdk/python/identity/credential-chains#chainedtokencredential-overview">`__.
 
     :param credentials: credential instances to form the chain

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -24,8 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class DefaultAzureCredential(ChainedTokenCredential):
-    """A credential capable of handling most Azure SDK authentication scenarios. See
-    https://aka.ms/azsdk/python/identity/credential-chains#usage-guidance-for-defaultazurecredential.
+    """A credential capable of handling most Azure SDK authentication scenarios. For more information, See
+    `Usage guidance for DefaultAzureCredential 
+    <"https://aka.ms/azsdk/python/identity/credential-chains#usage-guidance-for-defaultazurecredential">`__.
 
     The identity it uses depends on the environment. When an access token is needed, it requests one using these
     identities in turn, stopping when one provides a token:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class DefaultAzureCredential(ChainedTokenCredential):
     """A credential capable of handling most Azure SDK authentication scenarios. For more information, See
-    `Usage guidance for DefaultAzureCredential 
+    `Usage guidance for DefaultAzureCredential
     <"https://aka.ms/azsdk/python/identity/credential-chains#usage-guidance-for-defaultazurecredential">`__.
 
     The identity it uses depends on the environment. When an access token is needed, it requests one using these


### PR DESCRIPTION
Add link text to make it clear what the Learn docs describe. This is an improvement upon the current display:
![image](https://github.com/user-attachments/assets/caa5f6a7-69cd-4b4e-838e-9d9eb9a9ed32)
