### PR TITLE
fixed warning for aio and get call function tools for stream within t…

### DIFF
--- a/sdk/ai/azure-ai-client/azure/ai/client/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/aio/operations/_patch.py
@@ -6,12 +6,12 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from argparse import FileType
+from ..._vendor import FileType
 import io
 import logging
 import os
 import time
-from typing import IO, Any, Dict, List, AsyncIterable, MutableMapping, Optional, Union, overload
+from typing import IO, Any, AsyncIterator, Dict, List, AsyncIterable, MutableMapping, Optional, Union, cast, overload
 
 from azure.ai.client import _types
 from ._operations import EndpointsOperations as EndpointsOperationsGenerated
@@ -322,48 +322,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
-    @overload
-    async def create_agent(
-        self,
-        model: str = _Unset,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        instructions: Optional[str] = None,
-        toolset: Optional[_models.ToolSet] = None,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-        response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
-        metadata: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> _models.Agent:
-        """
-        Creates a new agent with toolset.
-
-        :keyword model: The ID of the model to use. Required if `body` is not provided.
-        :paramtype model: str
-        :keyword name: The name of the new agent. Default value is None.
-        :paramtype name: str
-        :keyword description: A description for the new agent. Default value is None.
-        :paramtype description: str
-        :keyword instructions: System instructions for the agent. Default value is None.
-        :paramtype instructions: str
-        :keyword toolset: Collection of tools (alternative to `tools` and `tool_resources`). Default
-         value is None.
-        :paramtype toolset: ~azure.ai.client.models.ToolSet
-        :keyword temperature: Sampling temperature for generating agent responses. Default value
-         is None.
-        :paramtype temperature: float
-        :keyword top_p: Nucleus sampling parameter. Default value is None.
-        :paramtype top_p: float
-        :keyword response_format: Response format for tool calls. Default value is None.
-        :paramtype response_format: ~azure.ai.client.models.AgentsApiResponseFormatOption
-        :keyword metadata: Key/value pairs for storing additional information. Default value is None.
-        :paramtype metadata: dict[str, str]
-        :return: An Agent object.
-        :rtype: ~azure.ai.client.models.Agent
-        :raises: ~azure.core.exceptions.HttpResponseError
-        """
-
     @distributed_trace_async
     async def create_agent(
         self,
@@ -375,7 +333,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         instructions: Optional[str] = None,
         tools: Optional[List[_models.ToolDefinition]] = None,
         tool_resources: Optional[_models.ToolResources] = None,
-        toolset: Optional[_models.ToolSet] = None,
+        toolset: Optional[_models.AsyncToolSet] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
@@ -427,12 +385,12 @@ class AgentsOperations(AgentsOperationsGenerated):
             **kwargs,
         )
 
-    def get_toolset(self) -> Optional[_models.ToolSet]:
+    def get_toolset(self) -> Optional[_models.AsyncToolSet]:
         """
         Get the toolset for the agent.
 
         :return: The toolset for the agent. If not set, returns None.
-        :rtype: ~azure.ai.client.models.ToolSet        
+        :rtype: ~azure.ai.client.models.AsyncToolSet
         """
         if hasattr(self, "_toolset"):
             return self._toolset
@@ -476,7 +434,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         tool_choice: Optional["_types.AgentsApiToolChoiceOption"] = None,
         response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
         metadata: Optional[Dict[str, str]] = None,
-        event_handler: Optional[_models.AgentEventHandler] = None,
         **kwargs: Any,
     ) -> _models.ThreadRun:
         """Creates a new run for an agent thread.
@@ -548,9 +505,6 @@ class AgentsOperations(AgentsOperationsGenerated):
          64 characters in length and values may be up to 512 characters in length. Default value is
          None.
         :paramtype metadata: dict[str, str]
-        :keyword event_handler: The event handler to use for processing events during the run. Default
-            value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping
         :rtype: ~azure.ai.client.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -594,7 +548,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         tool_choice: Optional["_types.AgentsApiToolChoiceOption"] = None,
         response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
         metadata: Optional[Dict[str, str]] = None,
-        event_handler: Optional[_models.AgentEventHandler] = None,
         **kwargs: Any,
     ) -> _models.ThreadRun:
         """Creates a new run for an agent thread.
@@ -665,9 +618,6 @@ class AgentsOperations(AgentsOperationsGenerated):
          64 characters in length and values may be up to 512 characters in length. Default value is
          None.
         :paramtype metadata: dict[str, str]
-        :keyword event_handler: The event handler to use for processing events during the run. Default
-            value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping
         :rtype: ~azure.ai.client.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -727,7 +677,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         tool_choice: Optional["_types.AgentsApiToolChoiceOption"] = None,
         response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
         metadata: Optional[Dict[str, str]] = None,
-        event_handler: Optional[_models.AgentEventHandler] = None,
         sleep_interval: int = 1,
         **kwargs: Any,
     ) -> _models.ThreadRun:
@@ -799,13 +748,10 @@ class AgentsOperations(AgentsOperationsGenerated):
          64 characters in length and values may be up to 512 characters in length. Default value is
          None.
         :paramtype metadata: dict[str, str]
-        :keyword event_handler: The event handler to use for processing events during the run. Default
-            value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
         :keyword sleep_interval: The time in seconds to wait between polling the service for run status.
             Default value is 1.
         :paramtype sleep_interval: int
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -826,7 +772,6 @@ class AgentsOperations(AgentsOperationsGenerated):
             tool_choice=tool_choice,
             response_format=response_format,
             metadata=metadata,
-            event_handler=event_handler,
             **kwargs,
         )
         
@@ -835,11 +780,11 @@ class AgentsOperations(AgentsOperationsGenerated):
             time.sleep(sleep_interval)
             run = await self.get_run(thread_id=thread_id, run_id=run.id)
 
-            if run.status == "requires_action" and run.required_action.submit_tool_outputs:
+            if run.status == "requires_action" and isinstance(run.required_action, _models.SubmitToolOutputsAction):
                 tool_calls = run.required_action.submit_tool_outputs.tool_calls
                 if not tool_calls:
                     logging.warning("No tool calls provided - cancelling run")
-                    self.cancel_run(thread_id=thread_id, run_id=run.id)
+                    await self.cancel_run(thread_id=thread_id, run_id=run.id)
                     break
 
                 toolset = self.get_toolset()
@@ -850,14 +795,14 @@ class AgentsOperations(AgentsOperationsGenerated):
 
                 logging.info("Tool outputs: %s", tool_outputs)
                 if tool_outputs:
-                    self.submit_tool_outputs_to_run(thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs)
+                    await self.submit_tool_outputs_to_run(thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs)
 
             logging.info("Current run status: %s", run.status)
 
         return run
 
     @overload
-    async def create_stream(
+    def create_stream(
         self, thread_id: str, body: JSON, *, content_type: str = "application/json", **kwargs: Any
     ) -> _models.AsyncAgentRunStream:
         """Creates a new stream for an agent thread.  terminating when the Run enters a terminal state with a ``data: [DONE]`` message.
@@ -869,7 +814,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
          Default value is "application/json".
         :paramtype content_type: str
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -897,7 +842,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         event_handler: Optional[_models.AsyncAgentEventHandler] = None,
         **kwargs: Any,
     ) -> _models.AsyncAgentRunStream:
-        """Creates a new run for an agent thread.
+        """Creates a new stream for an agent thread.
 
         :param thread_id: Required.
         :type thread_id: str
@@ -968,8 +913,8 @@ class AgentsOperations(AgentsOperationsGenerated):
         :paramtype metadata: dict[str, str]
         :keyword event_handler: The event handler to use for processing events during the run. Default
             value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :paramtype event_handler: ~azure.ai.client.models.AsyncAgentEventHandler
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -987,7 +932,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Default value is "application/json".
         :paramtype content_type: str
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1085,8 +1030,8 @@ class AgentsOperations(AgentsOperationsGenerated):
         :paramtype metadata: dict[str, str]
         :keyword event_handler: The event handler to use for processing events during the run. Default
             value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :paramtype event_handler: ~azure.ai.client.models.AsyncAgentEventHandler
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1123,8 +1068,10 @@ class AgentsOperations(AgentsOperationsGenerated):
 
         else:
             raise ValueError("Invalid combination of arguments provided.")
+        
+        response_iterator: AsyncIterator[bytes] = cast(AsyncIterator[bytes], await response)
 
-        return _models.AsyncAgentRunStream(await response, event_handler)
+        return _models.AsyncAgentRunStream(response_iterator, self._handle_submit_tool_outputs, event_handler)
 
     @overload
     async def submit_tool_outputs_to_run(
@@ -1174,7 +1121,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :paramtype content_type: str
         :keyword event_handler: The event handler to use for processing events during the run. Default
             value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
+        :paramtype event_handler: ~azure.ai.client.models.AsyncAgentEventHandler
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping
         :rtype: ~azure.ai.client.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -1255,7 +1202,7 @@ class AgentsOperations(AgentsOperationsGenerated):
     async def submit_tool_outputs_to_stream(
         self, thread_id: str, run_id: str, body: JSON, *, content_type: str = "application/json", **kwargs: Any
     ) -> _models.AsyncAgentRunStream:
-        """Submits outputs from tools as requested by tool calls in a run. Runs that need submitted tool
+        """Submits outputs from tools as requested by tool calls in a stream. Runs that need submitted tool
         outputs will have a status of 'requires_action' with a required_action.type of
         'submit_tool_outputs'.  terminating when the Run enters a terminal state with a ``data: [DONE]`` message.
 
@@ -1268,7 +1215,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
          Default value is "application/json".
         :paramtype content_type: str
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1284,7 +1231,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         event_handler: Optional[_models.AsyncAgentEventHandler] = None,
         **kwargs: Any,
     ) -> _models.AsyncAgentRunStream:
-        """Submits outputs from tools as requested by tool calls in a run. Runs that need submitted tool
+        """Submits outputs from tools as requested by tool calls in a stream. Runs that need submitted tool
         outputs will have a status of 'requires_action' with a required_action.type of
         'submit_tool_outputs'.  terminating when the Run enters a terminal state with a ``data: [DONE]`` message.
 
@@ -1299,8 +1246,8 @@ class AgentsOperations(AgentsOperationsGenerated):
         :paramtype content_type: str
         :keyword event_handler: The event handler to use for processing events during the run. Default
             value is None.
-        :paramtype event_handler: ~azure.ai.client.models.AgentEventHandler
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :paramtype event_handler: ~azure.ai.client.models.AsyncAgentEventHandler
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1309,7 +1256,7 @@ class AgentsOperations(AgentsOperationsGenerated):
     async def submit_tool_outputs_to_stream(
         self, thread_id: str, run_id: str, body: IO[bytes], *, content_type: str = "application/json", **kwargs: Any
     ) -> _models.AsyncAgentRunStream:
-        """Submits outputs from tools as requested by tool calls in a run. Runs that need submitted tool
+        """Submits outputs from tools as requested by tool calls in a stream. Runs that need submitted tool
         outputs will have a status of 'requires_action' with a required_action.type of
         'submit_tool_outputs'.
 
@@ -1322,7 +1269,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Default value is "application/json".
         :paramtype content_type: str
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1335,10 +1282,10 @@ class AgentsOperations(AgentsOperationsGenerated):
         body: Union[JSON, IO[bytes]] = _Unset,
         *,
         tool_outputs: List[_models.ToolOutput] = _Unset,
-        event_handler: Optional[_models.AgentEventHandler] = None,
+        event_handler: Optional[_models.AsyncAgentEventHandler] = None,
         **kwargs: Any,
     ) -> _models.AsyncAgentRunStream:
-        """Submits outputs from tools as requested by tool calls in a run. Runs that need submitted tool
+        """Submits outputs from tools as requested by tool calls in a stream. Runs that need submitted tool
         outputs will have a status of 'requires_action' with a required_action.type of
         'submit_tool_outputs'.  terminating when the Run enters a terminal state with a ``data: [DONE]`` message.
 
@@ -1352,7 +1299,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :paramtype tool_outputs: list[~azure.ai.client.models.ToolOutput]
         :param event_handler: The event handler to use for processing events during the run.
         :param kwargs: Additional parameters.
-        :return: AsyncAgentRunStream.  AsyncAgentRunStream is compatible with Iterable and supports streaming.
+        :return: AgentRunStream.  AgentRunStream is compatible with Iterable and supports streaming.
         :rtype: ~azure.ai.client.models.AsyncAgentRunStream
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -1373,9 +1320,34 @@ class AgentsOperations(AgentsOperationsGenerated):
         else:
             raise ValueError("Invalid combination of arguments provided.")
 
-        return _models.AsyncAgentRunStream(await response, event_handler)
+        # Cast the response to Iterator[bytes] for type correctness
+        response_iterator: AsyncIterator[bytes] = cast(AsyncIterator[bytes], await response)
 
-        
+        return _models.AsyncAgentRunStream(response_iterator, self._handle_submit_tool_outputs, event_handler)
+    
+    async def _handle_submit_tool_outputs(self, run: _models.ThreadRun, event_handler: Optional[_models.AsyncAgentEventHandler] = None) -> None:
+        if isinstance(run.required_action, _models.SubmitToolOutputsAction):
+            tool_calls = run.required_action.submit_tool_outputs.tool_calls
+            if not tool_calls:
+                logger.debug("No tool calls to execute.")
+                return
+
+            toolset = self.get_toolset()
+            if toolset:
+                tool_outputs = await toolset.execute_tool_calls(tool_calls)
+            else:
+                raise ValueError("Toolset is not available in the client.")
+            
+            logger.info(f"Tool outputs: {tool_outputs}")
+            if tool_outputs:
+                async with await self.submit_tool_outputs_to_stream(
+                    thread_id=run.thread_id, 
+                    run_id=run.id, 
+                    tool_outputs=tool_outputs, 
+                    event_handler=event_handler
+            ) as stream:
+                    await stream.until_done()    
+
     @overload
     async def upload_file(self, body: JSON, **kwargs: Any) -> _models.OpenAIFile:
         """Uploads a file for use by other operations.
@@ -1461,7 +1433,7 @@ class AgentsOperations(AgentsOperationsGenerated):
                 raise FileNotFoundError(f"The file path provided does not exist: {file_path}")
 
             try:
-                with open(file_path, 'rb') as f:
+                with open(file_path, "rb") as f:
                     content = f.read()
 
                 # Determine filename and create correct FileType
@@ -1473,7 +1445,7 @@ class AgentsOperations(AgentsOperationsGenerated):
                 raise IOError(f"Unable to read file: {file_path}. Reason: {str(e)}")
 
         raise ValueError("Invalid parameters for upload_file. Please provide the necessary arguments.")
-    
+
     @overload
     async def upload_file_and_poll(self, body: JSON, sleep_interval: float = 1, **kwargs: Any) -> _models.OpenAIFile:
         """Uploads a file for use by other operations.
@@ -1558,13 +1530,23 @@ class AgentsOperations(AgentsOperationsGenerated):
         :raises IOError: If there are issues with reading the file.
         :raises: HttpResponseError for HTTP errors.
         """
-        file = await self.upload_file(body=body, file=file, file_path=file_path, purpose=purpose, filename=filename, **kwargs)
-    
-        while file.status in ["uploaded", "pending", "running"]:
+        if body is not None:
+            uploaded_file = await self.upload_file(body=body, **kwargs)
+        elif file is not None and purpose is not None:
+            uploaded_file = await self.upload_file(file=file, purpose=purpose, filename=filename, **kwargs)
+        elif file_path is not None and purpose is not None:
+            uploaded_file = await self.upload_file(file_path=file_path, purpose=purpose, **kwargs)
+        else:
+            raise ValueError(
+                "Invalid parameters for upload_file_and_poll. Please provide either 'body', "
+                "or both 'file' and 'purpose', or both 'file_path' and 'purpose'."
+            )
+
+        while uploaded_file.status in {"uploaded", "pending", "running"}:
             time.sleep(sleep_interval)
-            file = await self.get_file(file.id)
-            
-        return file
+            uploaded_file = await self.get_file(uploaded_file.id)
+
+        return uploaded_file
     
     @overload
     async def create_vector_store_and_poll(
@@ -1644,17 +1626,19 @@ class AgentsOperations(AgentsOperationsGenerated):
         :rtype: ~azure.ai.client.models.VectorStore
         :raises ~azure.core.exceptions.HttpResponseError:
         """
+
     @distributed_trace_async
     async def create_vector_store_and_poll(
         self,
-        body: Union[JSON, IO[bytes]] = None,
+        body: Union[JSON, IO[bytes], None] = None,
         *,
+        content_type: str = "application/json",
         file_ids: Optional[List[str]] = None,
         name: Optional[str] = None,
         expires_after: Optional[_models.VectorStoreExpirationPolicy] = None,
         chunking_strategy: Optional[_models.VectorStoreChunkingStrategyRequest] = None,
         metadata: Optional[Dict[str, str]] = None,
-        sleep_interval: float = 1, 
+        sleep_interval: float = 1,
         **kwargs: Any
     ) -> _models.VectorStore:
         """Creates a vector store.
@@ -1684,20 +1668,30 @@ class AgentsOperations(AgentsOperationsGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         
-        vector_store = await self.create_vector_store(
-            body=body,
-            file_ids=file_ids,
-            name=name,
-            expires_after=expires_after,
-            chunking_strategy=chunking_strategy,
-            metadata=metadata,
-            **kwargs
-        )
+        if body is not None:
+            vector_store = await self.create_vector_store(body=body, content_type=content_type, **kwargs)
+        elif file_ids is not None or (name is not None and expires_after is not None):
+            vector_store = await self.create_vector_store(
+                content_type=content_type,
+                file_ids=file_ids,
+                name=name,
+                expires_after=expires_after,
+                chunking_strategy=chunking_strategy,
+                metadata=metadata,
+                **kwargs
+            )
+        else:
+            raise ValueError(
+                "Invalid parameters for create_vector_store_and_poll. Please provide either 'body', "
+                "'file_ids', or 'name' and 'expires_after'."
+            )
+
         while vector_store.status == "in_progress":
             time.sleep(sleep_interval)
             vector_store = await self.get_vector_store(vector_store.id)
-            
+
         return vector_store
+
 
 __all__: List[str] = [
     "AgentsOperations",

--- a/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
@@ -604,7 +604,7 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
     def __init__(
         self,
         response_iterator: AsyncIterator[bytes],
-        submit_tool_outputs: Callable[[ThreadRun, AsyncAgentEventHandler], Awaitable[None]],
+        submit_tool_outputs: Callable[[ThreadRun, Optional[AsyncAgentEventHandler]], Awaitable[None]],
         event_handler: Optional['AsyncAgentEventHandler'] = None,
     ):
         self.response_iterator = response_iterator
@@ -751,7 +751,7 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
     def __init__(
         self,
         response_iterator: Iterator[bytes],
-        submit_tool_outputs: Callable[[ThreadRun, AgentEventHandler], None],
+        submit_tool_outputs: Callable[[ThreadRun, Optional[AgentEventHandler]], None],
         event_handler: Optional[AgentEventHandler] = None,
     ):
         self.response_iterator = response_iterator

--- a/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
@@ -19,6 +19,7 @@ from ._enums import AgentStreamEvent
 from ._models import (
     ConnectionsListSecretsResponse,
     MessageDeltaChunk,
+    SubmitToolOutputsAction,
     ThreadRun,
     RunStep,
     ThreadMessage,
@@ -35,7 +36,7 @@ from ._models import (
 )
 
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, List, Dict, Any, Type, Optional, Iterator, Tuple, get_origin
+from typing import AsyncIterator, Awaitable, Callable, List, Dict, Any, Type, Optional, Iterator, Tuple, get_origin
 
 logger = logging.getLogger(__name__)
 
@@ -603,12 +604,14 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
     def __init__(
         self,
         response_iterator: AsyncIterator[bytes],
+        submit_tool_outputs: Callable[[ThreadRun, AsyncAgentEventHandler], Awaitable[None]],
         event_handler: Optional['AsyncAgentEventHandler'] = None,
     ):
         self.response_iterator = response_iterator
         self.event_handler = event_handler
         self.done = False
         self.buffer = ""
+        self.submit_tool_outputs = submit_tool_outputs        
 
     async def __aenter__(self):
         return self
@@ -707,6 +710,8 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
     async def _process_event(self, event_data_str: str) -> Tuple[str, Any]:
         event_type, event_data_obj = self._parse_event_data(event_data_str)
 
+        if isinstance(event_data_obj, ThreadRun) and event_data_obj.status == "requires_action" and isinstance(event_data_obj.required_action, SubmitToolOutputsAction):
+            await self.submit_tool_outputs(event_data_obj, self.event_handler)  
         if self.event_handler:
             try:
                 if isinstance(event_data_obj, MessageDeltaChunk):
@@ -746,12 +751,14 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
     def __init__(
         self,
         response_iterator: Iterator[bytes],
+        submit_tool_outputs: Callable[[ThreadRun, AgentEventHandler], None],
         event_handler: Optional[AgentEventHandler] = None,
     ):
         self.response_iterator = response_iterator
         self.event_handler = event_handler
         self.done = False
         self.buffer = ""
+        self.submit_tool_outputs = submit_tool_outputs
 
     def __enter__(self):
         return self
@@ -846,6 +853,8 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
     def _process_event(self, event_data_str: str) -> Tuple[str, Any]:
         event_type, event_data_obj = self._parse_event_data(event_data_str)
 
+        if isinstance(event_data_obj, ThreadRun) and event_data_obj.status == "requires_action" and isinstance(event_data_obj.required_action, SubmitToolOutputsAction):
+            self.submit_tool_outputs(event_data_obj, self.event_handler)  
         if self.event_handler:
             try:
                 if isinstance(event_data_obj, MessageDeltaChunk):

--- a/sdk/ai/azure-ai-client/azure/ai/client/operations/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/operations/_patch.py
@@ -820,7 +820,7 @@ class AgentsOperations(AgentsOperationsGenerated):
     @overload
     def create_stream(
         self, thread_id: str, body: JSON, *, content_type: str = "application/json", **kwargs: Any
-    ) -> Union[_models.ThreadRun, _models.AgentRunStream]:
+    ) -> _models.AgentRunStream:
         """Creates a new stream for an agent thread.  terminating when the Run enters a terminal state with a ``data: [DONE]`` message.
 
         :param thread_id: Required.

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_basics_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_basics_async.py
@@ -77,7 +77,7 @@ async def main():
         print(f"Run completed with status: {run.status}")
 
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
 
         messages = await ai_client.agents.list_messages(thread_id=thread.id)
         print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_functions_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_functions_async.py
@@ -110,9 +110,9 @@ async def main():
 
         print(f"Run completed with status: {run.status}")
 
-        # Delete the assistant when done
+        # Delete the agent when done
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
 
         # Fetch and log all messages
         messages = await ai_client.agents.list_messages(thread_id=thread.id)

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_async.py
@@ -99,7 +99,7 @@ async def main():
             await stream.until_done()
 
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
 
         messages = await ai_client.agents.list_messages(thread_id=thread.id)
         print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_with_toolset_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_with_toolset_async.py
@@ -24,7 +24,7 @@ import asyncio
 from typing import Any
 
 from azure.ai.client.aio import AzureAIClient
-from azure.ai.client.models import MessageDeltaChunk, MessageDeltaTextContent, RunStep, SubmitToolOutputsAction, ThreadMessage, ThreadRun
+from azure.ai.client.models import MessageDeltaChunk, MessageDeltaTextContent, RunStep, ThreadMessage, ThreadRun
 from azure.ai.client.models import AsyncAgentEventHandler, AsyncFunctionTool, AsyncToolSet
 from azure.ai.client.aio.operations import AgentsOperations
 from azure.identity import DefaultAzureCredential
@@ -35,9 +35,6 @@ from user_async_functions import user_async_functions
 
 
 class MyEventHandler(AsyncAgentEventHandler):
-
-    def __init__(self, agents: AgentsOperations) -> None:
-        self._agents = agents
 
     async def on_message_delta(self, delta: "MessageDeltaChunk") -> None:
         for content_part in delta.delta.content:
@@ -54,9 +51,6 @@ class MyEventHandler(AsyncAgentEventHandler):
         if run.status == "failed":
             print(f"Run failed. Error: {run.last_error}")
 
-        if run.status == "requires_action" and isinstance(run.required_action, SubmitToolOutputsAction):
-            await self._handle_submit_tool_outputs(run)
-
     async def on_run_step(self, step: "RunStep") -> None:
         print(f"RunStep type: {step.type}, Status: {step.status}")
 
@@ -68,32 +62,6 @@ class MyEventHandler(AsyncAgentEventHandler):
 
     async def on_unhandled_event(self, event_type: str, event_data: Any) -> None:
         print(f"Unhandled Event Type: {event_type}, Data: {event_data}")
-
-    async def _handle_submit_tool_outputs(self, run: "ThreadRun") -> None:
-        if isinstance(run.required_action, SubmitToolOutputsAction):
-            tool_calls = run.required_action.submit_tool_outputs.tool_calls
-            if not tool_calls:
-                print("No tool calls to execute.")
-                return
-            if not self._agents:
-                print("AssistantClient not set. Cannot execute tool calls using toolset.")
-                return
-
-            toolset = self._agents.get_toolset()
-            if toolset:
-                tool_outputs = await toolset.execute_tool_calls(tool_calls)
-            else:
-                raise ValueError("Toolset is not available in the client.")
-            
-            print(f"Tool outputs: {tool_outputs}")
-            if tool_outputs:
-                async with await self._agents.submit_tool_outputs_to_stream(
-                    thread_id=run.thread_id, 
-                    run_id=run.id, 
-                    tool_outputs=tool_outputs, 
-                    event_handler=self
-            ) as stream:
-                    await stream.until_done()
 
 
 async def main():
@@ -140,12 +108,12 @@ async def main():
         async with await ai_client.agents.create_stream(
             thread_id=thread.id, 
             assistant_id=agent.id,
-            event_handler=MyEventHandler(ai_client.agents)
+            event_handler=MyEventHandler()
         ) as stream:
             await stream.until_done()
 
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
 
         messages = await ai_client.agents.list_messages(thread_id=thread.id)
         print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_iteration_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_iteration_async.py
@@ -93,7 +93,7 @@ async def main():
                     print(f"Unhandled Event Type: {event_type}, Data: {event_data}")
 
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
 
         messages = await ai_client.agents.list_messages(thread_id=thread.id)
         print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_with_file_search_attachment_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_with_file_search_attachment_async.py
@@ -91,7 +91,7 @@ async def main():
         print("Deleted vectore store")
 
         await ai_client.agents.delete_agent(agent.id)
-        print("Deleted assistant")
+        print("Deleted agent")
         
         messages = await ai_client.agents.list_messages(thread_id=thread.id)        
         print(f"Messages: {messages}")      

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_code_interpreter_attachment.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_code_interpreter_attachment.py
@@ -80,7 +80,7 @@ with ai_client:
     print("Deleted file")
 
     ai_client.agents.delete_agent(agent.id)
-    print("Deleted assistant")
+    print("Deleted agent")
 
     messages = ai_client.agents.list_messages(thread_id=thread.id)
     print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_file_search.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_file_search.py
@@ -93,9 +93,9 @@ with ai_client:
     ai_client.agents.delete_vector_store(openai_vectorstore.id)
     print("Deleted vector store")
 
-    # Delete the assistant when done
+    # Delete the agent when done
     ai_client.agents.delete_agent(agent.id)
-    print("Deleted assistant")
+    print("Deleted agent")
 
     # Fetch and log all messages
     messages = ai_client.agents.list_messages(thread_id=thread.id)

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration_with_toolset.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration_with_toolset.py
@@ -24,7 +24,7 @@ USAGE:
 import os
 from azure.ai.client import AzureAIClient
 from azure.ai.client.models import AgentStreamEvent
-from azure.ai.client.models import MessageDeltaChunk, MessageDeltaTextContent, RunStep, SubmitToolOutputsAction, ThreadMessage, ThreadRun
+from azure.ai.client.models import MessageDeltaChunk, MessageDeltaTextContent, RunStep, ThreadMessage, ThreadRun
 from azure.ai.client.models import FunctionTool, ToolSet
 from azure.ai.client.operations import AgentsOperations
 from azure.identity import DefaultAzureCredential
@@ -113,21 +113,6 @@ with ai_client:
                 
                 if event_data.status == "failed":
                     print(f"Run failed. Error: {event_data.last_error}")
-
-                if event_data.status == "requires_action" and isinstance(event_data.required_action, SubmitToolOutputsAction):
-                    tool_calls = event_data.required_action.submit_tool_outputs.tool_calls
-                    if not tool_calls:
-                        print("No tool calls to execute.")
-                        break
-
-                    toolset = ai_client.agents.get_toolset()
-                    if toolset:
-                        tool_outputs = toolset.execute_tool_calls(tool_calls)
-                    else:
-                        raise ValueError("Toolset is not available in the client.")
-
-                    if tool_outputs:
-                        handle_submit_tool_outputs(ai_client.agents, event_data.thread_id, event_data.id, tool_outputs)
                            
             elif isinstance(event_data, RunStep):
                 print(f"RunStep type: {event_data.type}, Status: {event_data.status}")
@@ -143,7 +128,7 @@ with ai_client:
                 print(f"Unhandled Event Type: {event_type}, Data: {event_data}")
 
     ai_client.agents.delete_agent(agent.id)
-    print("Deleted assistant")
+    print("Deleted agent")
 
     messages = ai_client.agents.list_messages(thread_id=thread.id)
     print(f"Messages: {messages}")

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_with_file_search_attachment.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_with_file_search_attachment.py
@@ -90,7 +90,7 @@ with ai_client:
     print("Deleted vectore store")
 
     ai_client.agents.delete_agent(agent.id)
-    print("Deleted assistant")
+    print("Deleted agent")
     
     messages = ai_client.agents.list_messages(thread_id=thread.id)    
     print(f"Messages: {messages}")


### PR DESCRIPTION
…he SDK

# Description

Get rid of warning in aio AgentOperation.    TO do that, I copied the AgentsOperation from sync to async/aio and modify accordingly.

Call functions within SDK for streaming instead of asking developers to call in their code.   I will do this for non-streaming.


Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
