### PR TITLE
[Identity][Monitor] Updates live test setup

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -66,6 +66,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: false
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 jobs:
   - job:
@@ -132,6 +135,7 @@ jobs:
             SubscriptionConfiguration: $(SubscriptionConfiguration)
             ArmTemplateParameters: $(ArmTemplateParameters)
             UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+            PersistOidcToken: ${{ parameters.PersistOidcToken }}
             ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
             EnvVars:
               Pool: $(Pool)

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -97,6 +97,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -139,6 +142,7 @@ extends:
                       TestProxy: ${{ parameters.TestProxy }}
                       ToxTestEnv: ${{ parameters.ToxTestEnv }}
                       UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+                      PersistOidcToken: ${{ parameters.PersistOidcToken }}
                     MatrixConfigs:
                       # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
                       - ${{ each config in parameters.MatrixConfigs }}:

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -16,11 +16,12 @@ param (
     [string] $TestApplicationId,
 
     [Parameter()]
-    [string] $TestApplicationSecret,
-
-    [Parameter()]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $SubscriptionId,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Environment,
 
     [Parameter()]
     [hashtable] $AdditionalParameters = @{},
@@ -50,10 +51,11 @@ Start-Sleep -s 45
 
 $az_version = az version
 Write-Host "Azure CLI version: $az_version"
+az cloud set --name $Environment
 az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
 az account set --subscription $SubscriptionId
-$versions = az aks get-versions -l westus -o json | ConvertFrom-Json
-Write-Host "AKS versions: $($versions | ConvertTo-Json -Depth 100)"
+$versions = az aks get-versions -l $Location -o json | ConvertFrom-Json
+Write-Host "AKS versions for ${Location}: $($versions | ConvertTo-Json -Depth 100)"
 $patchVersions = $versions.values | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty patchVersions
 Write-Host "AKS patch versions: $($patchVersions | ConvertTo-Json -Depth 100)"
 $latestAksVersion = $patchVersions | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -15,7 +15,7 @@ param testApplicationOid string
 param acrName string = 'acr${uniqueString(resourceGroup().id)}'
 
 @description('The latest AKS version available in the region.')
-param latestAksVersion string = '1.27.7'
+param latestAksVersion string = '1.29.8'
 
 @description('The SSH public key to use for the Linux VMs.')
 param sshPubKey string = ''

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -5,18 +5,8 @@ trigger: none
 extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      PreSteps:
-        - task: AzureCLI@2
-          displayName: Set OIDC variables
-          inputs:
-            azureSubscription: azure-sdk-tests-public
-            scriptType: pscore
-            scriptLocation: inlineScript
-            addSpnToEnvironment: true
-            inlineScript: |
-              Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
-              Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
-              Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
+      Location: westus2
+      PersistOidcToken: true
       ServiceDirectory: identity
       EnvVars:
         AZURE_CLIENT_ID: $(IDENTITY_SP_CLIENT_ID)
@@ -25,7 +15,6 @@ extends:
         PEM_CONTENT: $(python-identity-certificate)
         AZURE_TEST_RUN_LIVE: true
         AZURE_SKIP_LIVE_RECORDING: 'True'
-        ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
       CloudConfig:
         Public:
           SubscriptionConfigurations:

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -1,25 +1,13 @@
-# cSpell:ignore pscore
-# cSpell:ignore issecret
 trigger: none
 
 extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      PreSteps:
-        - task: AzureCLI@2
-          displayName: Set OIDC variables
-          inputs:
-            azureSubscription: azure-sdk-tests-public
-            scriptType: pscore
-            scriptLocation: inlineScript
-            addSpnToEnvironment: true
-            inlineScript: |
-              Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
       ServiceDirectory: monitor
       TestTimeoutInMinutes: 300
       BuildTargetingString: azure-monitor-*
+      PersistOidcToken: true
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(MONITOR_SUBSCRIPTION_ID)
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SKIP_LIVE_RECORDING: 'true'
-        ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)


### PR DESCRIPTION
Adapts changes from https://github.com/Azure/azure-sdk-for-python/pull/37785 to get the identity integration test pipeline working again.

Managed to get all test resources successfully deployed in the TME tenant using the `westus2` region.

[Pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4270524&view=logs&s=e5fcbab0-6a29-5768-3af2-288e2e30708a&j=b6c3f4b4-4e59-54fb-cb00-b66f9cdd651f)

Other pipeline failures unrelated to this PR. 