### PR TITLE
[ServiceBus] send disposition back on auth ok

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
@@ -17,6 +17,7 @@ from .error import (
     TokenAuthFailure,
     TokenExpired,
 )
+from .outcomes import Accepted
 from .constants import (
     CbsState,
     CbsAuthState,
@@ -178,6 +179,13 @@ class CBSAuthenticator:  # pylint:disable=too-many-instance-attributes, disable=
 
         if execute_operation_result == ManagementExecuteOperationResult.OK:
             self.auth_state = CbsAuthState.OK
+            self._mgmt_link._response_link.send_disposition(
+                first_delivery_id=0,
+                last_delivery_id=0,
+                delivery_tag=b"$cbs",   # CBS auth sends disposition back on put token 202, set fake delivery tag
+                settled=True,
+                delivery_state=Accepted()
+            )
         elif execute_operation_result == ManagementExecuteOperationResult.ERROR:
             self.auth_state = CbsAuthState.ERROR
             # put-token-message sending failure, rejected

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -109,7 +109,7 @@ class ReceiverLink(Link):
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
     ):
-        if delivery_tag not in self._received_delivery_tags:
+        if delivery_tag != b"$cbs" and delivery_tag not in self._received_delivery_tags:
             raise AMQPException(condition=ErrorCondition.IllegalState, description = "Delivery tag not found.")
 
         disposition_frame = DispositionFrame(
@@ -118,7 +118,8 @@ class ReceiverLink(Link):
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
-        self._received_delivery_tags.remove(delivery_tag)
+        if delivery_tag != b"$cbs":
+            self._received_delivery_tags.remove(delivery_tag)
 
     def attach(self):
         super().attach()


### PR DESCRIPTION
Found during #38067.

- Updating the CBS put token auth interaction to send a Disposition(...state="Accepted") after receiving one from the service. Otherwise, the service will re-send the original "Accepted" Disposition (in the middle of receiving messages).
- Previous amqp stack does this and does not get the re-sent "Accepted" disposition from the service.
 
- TODO:
  - async
  - tests
  - compare with Go frames