### PR TITLE
Rename connection string environment variables

### DIFF
--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_basics_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_basics_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 import time
@@ -36,7 +36,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     async with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_functions_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_functions_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 import time
@@ -38,7 +38,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     async with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 from typing import Any
@@ -63,7 +63,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     async with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_with_toolset_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_eventhandler_with_toolset_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 from typing import Any
@@ -70,7 +70,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     # Initialize toolset with user functions

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_iteration_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_stream_iteration_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 
@@ -36,7 +36,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     async with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_vector_store_batch_file_search_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_vector_store_batch_file_search_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import asyncio
@@ -35,7 +35,7 @@ async def main():
 
     ai_client = AzureAIClient.from_connection_string(
         credential=DefaultAzureCredential(),
-        conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     # Or, you can create the Azure AI Client by giving all required parameters directly

--- a/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_with_file_search_attachment_async.py
+++ b/sdk/ai/azure-ai-client/samples/agents/async_samples/sample_agents_with_file_search_attachment_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 
@@ -36,7 +36,7 @@ async def main():
     # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
     ai_client = AzureAIClient.from_connection_string(
-        credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+        credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
     )
 
     # upload a file and wait for it to be processed

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_basics.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_basics.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os, time
@@ -31,7 +31,7 @@ from azure.identity import DefaultAzureCredential
 
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_code_interpreter_attachment.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_code_interpreter_attachment.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -34,7 +34,7 @@ from azure.identity import DefaultAzureCredential
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_file_search.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_file_search.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 # ------------------------------------
@@ -37,7 +37,7 @@ from azure.identity import DefaultAzureCredential
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_functions.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_functions.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os, time
 from azure.ai.client import AzureAIClient
@@ -32,7 +32,7 @@ from user_functions import user_functions
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 # Initialize function tool with user functions

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_run_with_toolset.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_run_with_toolset.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -34,7 +34,7 @@ from user_functions import user_functions
 
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 )
 
 # Initialize agent toolset with user functions and code interpreter

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -43,7 +43,7 @@ from typing import Any
 
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 )
 
 

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler_with_functions.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler_with_functions.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -38,7 +38,7 @@ from user_functions import user_functions
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 class MyEventHandler(AgentEventHandler):

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler_with_toolset.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_eventhandler_with_toolset.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -41,7 +41,7 @@ from user_functions import user_functions
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 # When using FunctionTool with ToolSet in agent creation, the tool call events are handled inside the create_stream

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -40,7 +40,7 @@ from azure.ai.client.models import (
 
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration_with_toolset.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_stream_iteration_with_toolset.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -36,7 +36,7 @@ from user_functions import user_functions
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 # Function to handle tool stream iteration

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_vector_store_batch_file_search.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_vector_store_batch_file_search.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -33,7 +33,7 @@ from azure.identity import DefaultAzureCredential
 
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 # Or, you can create the Azure AI Client by giving all required parameters directly

--- a/sdk/ai/azure-ai-client/samples/agents/sample_agents_with_file_search_attachment.py
+++ b/sdk/ai/azure-ai-client/samples/agents/sample_agents_with_file_search_attachment.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -34,7 +34,7 @@ from azure.identity import DefaultAzureCredential
 # Customer needs to login to Azure subscription via Azure CLI and set the environment variables
 
 ai_client = AzureAIClient.from_connection_string(
-    credential=DefaultAzureCredential(), conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"]
+    credential=DefaultAzureCredential(), conn_str=os.environ["PROJECT_CONNECTION_STRING"]
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/connections/async_samples/sample_connections_async.py
+++ b/sdk/ai/azure-ai-client/samples/connections/async_samples/sample_connections_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client aiohttp azure-identity
 
     Set the environment variables with your own values:
-    1) AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    1) PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import asyncio
@@ -33,7 +33,7 @@ async def sample_connections_async():
     # It should be in the format "<Endpoint>;<AzureSubscriptionId>;<ResourceGroup>;<WorkspaceName>"
     ai_client = AzureAIClient.from_connection_string(
         credential=DefaultAzureCredential(),
-        conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+        conn_str=os.environ["PROJECT_CONNECTION_STRING"],
     )
 
     async with ai_client:

--- a/sdk/ai/azure-ai-client/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-client/samples/connections/sample_connections.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set the environment variables with your own values:
-    1) AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    1) PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 
 import os
@@ -34,7 +34,7 @@ from azure.core.credentials import AzureKeyCredential
 # It should be in the format "<Endpoint>;<AzureSubscriptionId>;<ResourceGroup>;<WorkspaceName>"
 ai_client = AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 )
 
 with ai_client:

--- a/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_azure_openai_client_async.py
+++ b/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_azure_openai_client_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client aiohttp openai_async
 
     Set this environment variable with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os
 import asyncio
@@ -30,7 +30,7 @@ async def sample_get_azure_openai_client_async():
 
     async with AzureAIClient.from_connection_string(
         credential=DefaultAzureCredential(),
-        conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+        conn_str=os.environ["PROJECT_CONNECTION_STRING"],
     ) as ai_client:
 
         # Get an authenticated AsyncAzureOpenAI client for your default Azure OpenAI connection:

--- a/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_chat_completions_client_async.py
+++ b/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_chat_completions_client_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client aiohttp azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os
 import asyncio
@@ -31,7 +31,7 @@ async def sample_get_chat_completions_client_async():
 
     async with AzureAIClient.from_connection_string(
         credential=DefaultAzureCredential(),
-        conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+        conn_str=os.environ["PROJECT_CONNECTION_STRING"],
     ) as ai_client:
 
         # Get an authenticated async ChatCompletionsClient (from azure.ai.inference) for your default Serverless connection:

--- a/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_embeddings_client_async.py
+++ b/sdk/ai/azure-ai-client/samples/inference/async_samples/sample_get_embeddings_client_async.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client aiohttp azure-identity
 
     Set this environment variable with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import asyncio
 import os
@@ -30,7 +30,7 @@ async def sample_get_embeddings_client_async():
 
     async with AzureAIClient.from_connection_string(
         credential=DefaultAzureCredential(),
-        conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+        conn_str=os.environ["PROJECT_CONNECTION_STRING"],
     ) as ai_client:
 
         # Get an authenticated async azure.ai.inference embeddings client for your default Serverless connection:

--- a/sdk/ai/azure-ai-client/samples/inference/sample_get_azure_openai_client.py
+++ b/sdk/ai/azure-ai-client/samples/inference/sample_get_azure_openai_client.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client openai
 
     Set this environment variable with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os
 from azure.ai.client import AzureAIClient
@@ -26,7 +26,7 @@ from azure.identity import DefaultAzureCredential
 
 with AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 ) as ai_client:
 
     # Get an authenticated OpenAI client for your default Azure OpenAI connection:

--- a/sdk/ai/azure-ai-client/samples/inference/sample_get_chat_completions_client.py
+++ b/sdk/ai/azure-ai-client/samples/inference/sample_get_chat_completions_client.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variables with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os
 from azure.ai.client import AzureAIClient
@@ -27,7 +27,7 @@ from azure.identity import DefaultAzureCredential
 
 with AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 ) as ai_client:
 
     # Get an authenticated azure.ai.inference chat completions client for your default Serverless connection:

--- a/sdk/ai/azure-ai-client/samples/inference/sample_get_embeddings_client.py
+++ b/sdk/ai/azure-ai-client/samples/inference/sample_get_embeddings_client.py
@@ -18,7 +18,7 @@ USAGE:
     pip install azure.ai.client azure-identity
 
     Set this environment variable with your own values:
-    AI_CLIENT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
+    PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
 """
 import os
 from azure.ai.client import AzureAIClient
@@ -26,7 +26,7 @@ from azure.identity import DefaultAzureCredential
 
 with AzureAIClient.from_connection_string(
     credential=DefaultAzureCredential(),
-    conn_str=os.environ["AI_CLIENT_CONNECTION_STRING"],
+    conn_str=os.environ["PROJECT_CONNECTION_STRING"],
 ) as ai_client:
 
     # Get an authenticated azure.ai.inference embeddings client for your default Serverless connection:

--- a/sdk/ai/azure-ai-client/tests/agents/test_agents_client.py
+++ b/sdk/ai/azure-ai-client/tests/agents/test_agents_client.py
@@ -46,7 +46,7 @@ if LOGGING_ENABLED:
 agentClientPreparer = functools.partial(
     EnvironmentVariableLoader,
     "azure_ai_client",
-    azure_ai_client_agents_connection_string="https://foo.bar.some-domain.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
+    project_connection_string_agents_tests="https://foo.bar.some-domain.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
 )
 """
 agentClientPreparer = functools.partial(
@@ -96,7 +96,7 @@ class TestagentClient(AzureRecordedTestCase):
     # helper function: create client and using environment variables
     def create_client(self, **kwargs):
         # fetch environment variables
-        connection_string = kwargs.pop("azure_ai_client_agents_connection_string")
+        connection_string = kwargs.pop("project_connection_string_agents_tests")
         credential = self.get_credential(AzureAIClient, is_async=False)
 
         # create and return client


### PR DESCRIPTION
Rename AI_CLIENT_CONNECTION_STRING to PROJECT_CONNECTION_STRING, to match how it's shown in Azure AI Studio.

Also rename AZURE_AI_CLIENT_AGENTS_CONNECTION_STRING (used in Agents tests) to PROJECT_CONNECTION_STRING_AGENTS_TESTS