### PR TITLE
azure.identity logging throws exceptions because the "appid" key is not always in json_dict

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -31,9 +31,12 @@ def log_get_token(fn):
                     json_string = json_bytes.decode("utf-8")
                     json_dict = json.loads(json_string)
                     upn = json_dict.get("upn", "unavailableUpn")
+                    appid = json_dict.get("appid", "<unavailable>")
+                    tid = json_dict.get("tid", "<unavailable>")
+                    oid = json_dict.get("oid", "<unavailable>")
                     log_string = (
-                        "[Authenticated account] Client ID: {}. Tenant ID: {}. User Principal Name: {}. "
-                        "Object ID (user): {}".format(json_dict.get("appid",""), json_dict.get("tid",""), upn, json_dict.get("oid",""))
+                        f"[Authenticated account] Client ID: {appid}. "
+                        f"Tenant ID: {tid}. User Principal Name: {upn}. Object ID (user): {oid}"
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -33,7 +33,7 @@ def log_get_token(fn):
                     upn = json_dict.get("upn", "unavailableUpn")
                     log_string = (
                         "[Authenticated account] Client ID: {}. Tenant ID: {}. User Principal Name: {}. "
-                        "Object ID (user): {}".format(json_dict["appid"], json_dict["tid"], upn, json_dict["oid"])
+                        "Object ID (user): {}".format(json_dict.get("appid",""), json_dict.get("tid",""), upn, json_dict.get("oid",""))
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
@@ -30,9 +30,12 @@ def log_get_token_async(fn):
                     json_string = json_bytes.decode("utf-8")
                     json_dict = json.loads(json_string)
                     upn = json_dict.get("upn", "unavailableUpn")
+                    appid = json_dict.get("appid", "<unavailable>")
+                    tid = json_dict.get("tid", "<unavailable>")
+                    oid = json_dict.get("oid", "<unavailable>")
                     log_string = (
-                        "[Authenticated account] Client ID: {}. Tenant ID: {}. User Principal Name: {}. "
-                        "Object ID (user): {}".format(json_dict["appid"], json_dict["tid"], upn, json_dict["oid"])
+                        f"[Authenticated account] Client ID: {appid}. "
+                        f"Tenant ID: {tid}. User Principal Name: {upn}. Object ID (user): {oid}"
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
If you enable logging, things blow up because "appid" isn't always there. I've just made all of these optional:

Traceback (most recent call last):
  File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/identity/_internal/decorators.py", line 36, in wrapper
    "Object ID (user): {}".format(json_dict["appid"], json_dict["tid"], upn, json_dict["oid"])

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
