### PR TITLE
[Core] [Storage] Proposed changes to `transport/_aiohttp.py` to allow for decompression to be configurable

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -275,6 +275,9 @@ class AioHttpTransport(AsyncHttpTransport):
             # auto_decompress is introduced in aiohttp 3.7. We need this to handle aiohttp 3.6-.
             auto_decompress = False
 
+        # Pop out the 'decompress' variable to see if customer manually set decompression to on or off
+        decompress = config.pop("decompress", None)
+
         proxy = config.pop("proxy", None)
         if proxies and not proxy:
             # aiohttp needs a single proxy, so iterating until we found the right protocol
@@ -320,7 +323,7 @@ class AioHttpTransport(AsyncHttpTransport):
                     request=request,
                     internal_response=result,
                     block_size=self.connection_config.data_block_size,
-                    decompress=not auto_decompress,
+                    decompress=decompress if decompress is not None else not auto_decompress,
                 )
                 if not stream_response:
                     await _handle_no_stream_rest_response(response)
@@ -332,7 +335,7 @@ class AioHttpTransport(AsyncHttpTransport):
                     request,
                     result,
                     self.connection_config.data_block_size,
-                    decompress=not auto_decompress,
+                    decompress=decompress if decompress is not None else not auto_decompress,
                 )
                 if not stream_response:
                     await response.load_body()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations/_blob_operations.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations/_blob_operations.py
@@ -205,7 +205,7 @@ class BlobOperations:  # pylint: disable=too-many-public-methods
         _decompress = kwargs.pop("decompress", True)
         _stream = True
         pipeline_response: PipelineResponse = await self._client._pipeline.run(  # pylint: disable=protected-access
-            _request, stream=_stream, **kwargs
+            _request, stream=_stream, decompress=_decompress, **kwargs
         )
 
         response = pipeline_response.http_response

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -3455,4 +3455,29 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         # Assert
         result = await (await blob.download_blob()).readall()
         assert result == data[:length]
+
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    async def test_download_blob_decompress(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        await self._setup(storage_account_name, storage_account_key)
+        blob_name = self._get_blob_reference()
+        blob = self.bsc.get_blob_client(self.container_name, blob_name)
+        compressed_data = b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xcaH\xcd\xc9\xc9WH+\xca\xcfUH\xaf\xca,\x00\x00\x00\x00\xff\xff\x03\x00d\xaa\x8e\xb5\x0f\x00\x00\x00'
+        decompressed_data = b"hello from gzip"
+        content_settings = ContentSettings(content_encoding='gzip')
+
+        # Act / Assert
+        await blob.upload_blob(data=compressed_data, content_settings=content_settings, overwrite=True)
+
+        downloaded = await blob.download_blob(decompress=True)
+        result = await downloaded.readall()
+        assert result == decompressed_data
+
+        downloaded = await blob.download_blob(decompress=False)
+        result = await downloaded.readall()
+        assert result == compressed_data
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
As it currently stands, there is no way for us to turn auto-decompression off even if the customer specifically passes `decompress=False`. There is two adjustments that need to be made:

1. Some sort of configurable variable, `decompress`, that is popped in `_aiohttp.py` and has an effect on the value of the `decompress` parameter to `AioHttpTransportResponse`'s constructor
2. Additionally passing `decompress` in the generated `download` method to the pipeline `run()` so that it can be used by `_aiohttp.py` to enact change in behavior