### PR TITLE
Filter parameters, returned by SSE event

### DIFF
--- a/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
@@ -612,15 +612,29 @@ class ParamCorrector():
         in the list of attributes and if they are not, the error is being raised. This check may not
         be relevant for classes, not inherited from azure.ai.client._model_base.Model.
         :param model_class: The class of model to be used.
-        :param parameters: The parsed dictionary with parameters. 
+        :param parameters: The parsed dictionary with parameters.
+        :return: The dictionary with all invalid parameters removed.
         """
         new_params = {}
         valid_parameters = set(
-            filter(lambda x: not x.startswith('_') and hasattr(ThreadRun.__dict__[x], "_type"), ThreadRun.__dict__.keys())
+            filter(lambda x: not x.startswith('_') and hasattr(model_class.__dict__[x], "_type"), model_class.__dict__.keys())
         )
         for k in filter(lambda x: x in valid_parameters, parameters.keys()):
             new_params[k] = parameters[k]
         return new_params
+
+    @staticmethod
+    def safe_instantiate(model_class: Type, parameters: Dict[str, Any]) -> Any:
+        """
+        Instantiate class with the set of parameters from the server.
+
+        :param model_class: The class of model to be used.
+        :param parameters: The parsed dictionary with parameters.
+        :return: The class of model_class type if parameters is a dictionary, or the parameters themselves otherwise.
+        """
+        if not isinstance(parameters, dict):
+            return parameters
+        return model_class(**ParamCorrector.filter_parameters(model_class, parameters))
 
 
 class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
@@ -700,9 +714,7 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_CANCELLED,
             AgentStreamEvent.THREAD_RUN_EXPIRED,
         }:
-            ParamCorrector
-            event_data_obj = ThreadRun(**ParamCorrector.filter_parameters(
-                ThreadRun, parsed_data)) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(ThreadRun, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_RUN_STEP_CREATED,
             AgentStreamEvent.THREAD_RUN_STEP_IN_PROGRESS,
@@ -711,18 +723,18 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_STEP_CANCELLED,
             AgentStreamEvent.THREAD_RUN_STEP_EXPIRED,
         }:
-            event_data_obj = RunStep(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(RunStep, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_MESSAGE_CREATED,
             AgentStreamEvent.THREAD_MESSAGE_IN_PROGRESS,
             AgentStreamEvent.THREAD_MESSAGE_COMPLETED,
             AgentStreamEvent.THREAD_MESSAGE_INCOMPLETE,
         }:
-            event_data_obj = ThreadMessage(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(ThreadMessage, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_MESSAGE_DELTA:
-            event_data_obj = MessageDeltaChunk(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(MessageDeltaChunk, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_RUN_STEP_DELTA:
-            event_data_obj = RunStepDeltaChunk(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj =ParamCorrector.safe_instantiate(RunStepDeltaChunk, parsed_data)
         else:
             event_data_obj = parsed_data
 
@@ -849,8 +861,7 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_CANCELLED,
             AgentStreamEvent.THREAD_RUN_EXPIRED,
         }:
-            event_data_obj = ThreadRun(**ParamCorrector.filter_parameters(
-                ThreadRun, parsed_data)) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(ThreadRun, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_RUN_STEP_CREATED,
             AgentStreamEvent.THREAD_RUN_STEP_IN_PROGRESS,
@@ -859,18 +870,18 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_STEP_CANCELLED,
             AgentStreamEvent.THREAD_RUN_STEP_EXPIRED,
         }:
-            event_data_obj = RunStep(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(RunStep, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_MESSAGE_CREATED,
             AgentStreamEvent.THREAD_MESSAGE_IN_PROGRESS,
             AgentStreamEvent.THREAD_MESSAGE_COMPLETED,
             AgentStreamEvent.THREAD_MESSAGE_INCOMPLETE,
         }:
-            event_data_obj = ThreadMessage(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(ThreadMessage, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_MESSAGE_DELTA:
-            event_data_obj = MessageDeltaChunk(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(MessageDeltaChunk, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_RUN_STEP_DELTA:
-            event_data_obj = RunStepDeltaChunk(**parsed_data) if isinstance(parsed_data, dict) else parsed_data
+            event_data_obj = ParamCorrector.safe_instantiate(RunStepDeltaChunk, parsed_data)
         else:
             event_data_obj = parsed_data
 

--- a/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
+++ b/sdk/ai/azure-ai-client/azure/ai/client/models/_patch.py
@@ -41,6 +41,39 @@ from typing import AsyncIterator, Awaitable, Callable, List, Dict, Any, Type, Op
 logger = logging.getLogger(__name__)
 
 
+def _filter_parameters(model_class: Type, parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Remove the parameters, non present in class public fields; return shallow copy of a dictionary.
+
+    **Note:** Classes inherited from the model check that the parameters are present
+    in the list of attributes and if they are not, the error is being raised. This check may not
+    be relevant for classes, not inherited from azure.ai.client._model_base.Model.
+    :param model_class: The class of model to be used.
+    :param parameters: The parsed dictionary with parameters.
+    :return: The dictionary with all invalid parameters removed.
+    """
+    new_params = {}
+    valid_parameters = set(
+        filter(lambda x: not x.startswith('_') and hasattr(model_class.__dict__[x], "_type"), model_class.__dict__.keys())
+    )
+    for k in filter(lambda x: x in valid_parameters, parameters.keys()):
+        new_params[k] = parameters[k]
+    return new_params
+
+
+def _safe_instantiate(model_class: Type, parameters: Dict[str, Any]) -> Any:
+    """
+    Instantiate class with the set of parameters from the server.
+
+    :param model_class: The class of model to be used.
+    :param parameters: The parsed dictionary with parameters.
+    :return: The class of model_class type if parameters is a dictionary, or the parameters themselves otherwise.
+    """
+    if not isinstance(parameters, dict):
+        return parameters
+    return model_class(**_filter_parameters(model_class, parameters))
+
+
 class ConnectionProperties:
 
     def __init__(self, *, connection: ConnectionsListSecretsResponse, token_credential: TokenCredential = None) -> None:
@@ -600,43 +633,6 @@ class AsyncAgentEventHandler:
         pass
 
 
-class ParamCorrector():
-    """The class, holding static method to orrect ThreadRun parameters."""
-    
-    @staticmethod
-    def filter_parameters(model_class: Type, parameters: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Remove the parameters, non present in class public fields; return shallow copy of a dictionary.
-
-        **Note:** Classes inherited from the model check that the parameters are present
-        in the list of attributes and if they are not, the error is being raised. This check may not
-        be relevant for classes, not inherited from azure.ai.client._model_base.Model.
-        :param model_class: The class of model to be used.
-        :param parameters: The parsed dictionary with parameters.
-        :return: The dictionary with all invalid parameters removed.
-        """
-        new_params = {}
-        valid_parameters = set(
-            filter(lambda x: not x.startswith('_') and hasattr(model_class.__dict__[x], "_type"), model_class.__dict__.keys())
-        )
-        for k in filter(lambda x: x in valid_parameters, parameters.keys()):
-            new_params[k] = parameters[k]
-        return new_params
-
-    @staticmethod
-    def safe_instantiate(model_class: Type, parameters: Dict[str, Any]) -> Any:
-        """
-        Instantiate class with the set of parameters from the server.
-
-        :param model_class: The class of model to be used.
-        :param parameters: The parsed dictionary with parameters.
-        :return: The class of model_class type if parameters is a dictionary, or the parameters themselves otherwise.
-        """
-        if not isinstance(parameters, dict):
-            return parameters
-        return model_class(**ParamCorrector.filter_parameters(model_class, parameters))
-
-
 class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
     def __init__(
         self,
@@ -714,7 +710,7 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_CANCELLED,
             AgentStreamEvent.THREAD_RUN_EXPIRED,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(ThreadRun, parsed_data)
+            event_data_obj = _safe_instantiate(ThreadRun, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_RUN_STEP_CREATED,
             AgentStreamEvent.THREAD_RUN_STEP_IN_PROGRESS,
@@ -723,18 +719,18 @@ class AsyncAgentRunStream(AsyncIterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_STEP_CANCELLED,
             AgentStreamEvent.THREAD_RUN_STEP_EXPIRED,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(RunStep, parsed_data)
+            event_data_obj = _safe_instantiate(RunStep, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_MESSAGE_CREATED,
             AgentStreamEvent.THREAD_MESSAGE_IN_PROGRESS,
             AgentStreamEvent.THREAD_MESSAGE_COMPLETED,
             AgentStreamEvent.THREAD_MESSAGE_INCOMPLETE,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(ThreadMessage, parsed_data)
+            event_data_obj = _safe_instantiate(ThreadMessage, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_MESSAGE_DELTA:
-            event_data_obj = ParamCorrector.safe_instantiate(MessageDeltaChunk, parsed_data)
+            event_data_obj = _safe_instantiate(MessageDeltaChunk, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_RUN_STEP_DELTA:
-            event_data_obj =ParamCorrector.safe_instantiate(RunStepDeltaChunk, parsed_data)
+            event_data_obj =_safe_instantiate(RunStepDeltaChunk, parsed_data)
         else:
             event_data_obj = parsed_data
 
@@ -861,7 +857,7 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_CANCELLED,
             AgentStreamEvent.THREAD_RUN_EXPIRED,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(ThreadRun, parsed_data)
+            event_data_obj = _safe_instantiate(ThreadRun, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_RUN_STEP_CREATED,
             AgentStreamEvent.THREAD_RUN_STEP_IN_PROGRESS,
@@ -870,18 +866,18 @@ class AgentRunStream(Iterator[Tuple[str, Any]]):
             AgentStreamEvent.THREAD_RUN_STEP_CANCELLED,
             AgentStreamEvent.THREAD_RUN_STEP_EXPIRED,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(RunStep, parsed_data)
+            event_data_obj = _safe_instantiate(RunStep, parsed_data)
         elif event_type in {
             AgentStreamEvent.THREAD_MESSAGE_CREATED,
             AgentStreamEvent.THREAD_MESSAGE_IN_PROGRESS,
             AgentStreamEvent.THREAD_MESSAGE_COMPLETED,
             AgentStreamEvent.THREAD_MESSAGE_INCOMPLETE,
         }:
-            event_data_obj = ParamCorrector.safe_instantiate(ThreadMessage, parsed_data)
+            event_data_obj = _safe_instantiate(ThreadMessage, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_MESSAGE_DELTA:
-            event_data_obj = ParamCorrector.safe_instantiate(MessageDeltaChunk, parsed_data)
+            event_data_obj = _safe_instantiate(MessageDeltaChunk, parsed_data)
         elif event_type == AgentStreamEvent.THREAD_RUN_STEP_DELTA:
-            event_data_obj = ParamCorrector.safe_instantiate(RunStepDeltaChunk, parsed_data)
+            event_data_obj = _safe_instantiate(RunStepDeltaChunk, parsed_data)
         else:
             event_data_obj = parsed_data
 

--- a/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
+++ b/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
@@ -2,12 +2,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import copy
 import sys
 import logging
 import datetime
+import pytest
 from azure.ai.client.models import SASTokenCredential
 from azure.core.credentials import TokenCredential, AccessToken
 from azure.core.exceptions import HttpResponseError
+from azure.ai.client.models._models import ThreadRun
+from azure.ai.client.models._patch import ParamCorrector
+
 
 # import azure.ai.client as sdk
 
@@ -112,3 +117,49 @@ class TestUnit:
 
         print(f"[TEST]   Actual expiration date: {sas_token_credential._expires_on}")
         assert sas_token_credential._expires_on == expiration_datatime_utc
+
+
+    def test_correct_thread_params(self):
+        """Test that if service returned extra parameter in SSE response, it does not create issues."""
+        valid_params = {
+            'id': '12345',
+             'object': "thread.run",
+             'thread_id': "6789",
+             'assistant_id': "101112",
+             'status': 'in_progress',
+             'required_action': 'test',
+             'last_error': 'none',
+             'model': 'gpt-4',
+             'instructions': "Test instruction",
+             'tools': 'Test function',
+             'created_at': datetime.datetime(2024, 11, 14),
+             'expires_at': datetime.datetime(2024, 11, 17),
+             'started_at': datetime.datetime(2024, 11, 15),
+             'completed_at': datetime.datetime(2024, 11, 16),
+             'cancelled_at': datetime.datetime(2024, 11, 16),
+             'failed_at': datetime.datetime(2024, 11, 16),
+             'incomplete_details': 'max_completion_tokens',
+             'usage': 'in_progress',
+             'temperature': 1.0,
+             'top_p': 1.0,
+             'max_completion_tokens': 1000,
+             'truncation_strategy': 'test',
+             'tool_choice': "tool name",
+             'response_format': "json",
+             'metadata': {'foo': 'bar'},
+             'tool_resources': "test",
+             'parallel_tool_calls': True
+        }
+        bad_params = {'foo': 'bar'}
+        params = copy.deepcopy(valid_params)
+        params.update(bad_params)
+        # We should bot e able to create Thread Run with bad parameters.
+        with pytest.raises(TypeError):
+            ThreadRun(**params)
+        filtered_params = ParamCorrector.filter_parameters(ThreadRun, params)
+        for k in valid_params:
+            assert k in filtered_params
+        for k in bad_params:
+            assert k not in filtered_params
+        # Implicitly check that we can create object with the filtered parameters.
+        ThreadRun(**filtered_params)

--- a/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
+++ b/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
@@ -11,7 +11,7 @@ from azure.ai.client.models import SASTokenCredential
 from azure.core.credentials import TokenCredential, AccessToken
 from azure.core.exceptions import HttpResponseError
 from azure.ai.client.models._models import ThreadRun, RunStep, ThreadMessage
-from azure.ai.client.models._patch import ParamCorrector
+from azure.ai.client.models._patch import _safe_instantiate, _filter_parameters
 
 
 # import azure.ai.client as sdk
@@ -178,7 +178,7 @@ class TestUnit:
         # We should bot e able to create Thread Run with bad parameters.
         with pytest.raises(TypeError):
             model_cls(**params)
-        filtered_params = ParamCorrector.filter_parameters(model_cls, params)
+        filtered_params = _filter_parameters(model_cls, params)
         for k in valid_params:
             assert k in filtered_params
         for k in bad_params:
@@ -186,9 +186,9 @@ class TestUnit:
         # Implicitly check that we can create object with the filtered parameters.
         model_cls(**filtered_params)
         # Check safe initialization.
-        assert isinstance(ParamCorrector.safe_instantiate(model_cls, params), model_cls)
+        assert isinstance(_safe_instantiate(model_cls, params), model_cls)
         
 
     def test_safe_instantiate_non_dict(self):
         """Test that safe_instantiate method when user supplies not a dictionary."""
-        assert ParamCorrector.safe_instantiate(RunStep, 42) == 42
+        assert _safe_instantiate(RunStep, 42) == 42

--- a/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
+++ b/sdk/ai/azure-ai-client/tests/endpoints/unit_tests.py
@@ -10,7 +10,7 @@ import pytest
 from azure.ai.client.models import SASTokenCredential
 from azure.core.credentials import TokenCredential, AccessToken
 from azure.core.exceptions import HttpResponseError
-from azure.ai.client.models._models import ThreadRun
+from azure.ai.client.models._models import ThreadRun, RunStep, ThreadMessage
 from azure.ai.client.models._patch import ParamCorrector
 
 
@@ -119,47 +119,76 @@ class TestUnit:
         assert sas_token_credential._expires_on == expiration_datatime_utc
 
 
-    def test_correct_thread_params(self):
+    @pytest.mark.parametrize(
+        'valid_params,model_cls',
+        [
+            ({
+                'id': '12345',
+                'object': "thread.run",
+                'thread_id': "6789",
+                'assistant_id': "101112",
+                'status': 'in_progress',
+                'required_action': 'test',
+                'last_error': 'none',
+                'model': 'gpt-4',
+                'instructions': "Test instruction",
+                'tools': 'Test function',
+                'created_at': datetime.datetime(2024, 11, 14),
+                'expires_at': datetime.datetime(2024, 11, 17),
+                'started_at': datetime.datetime(2024, 11, 15),
+                'completed_at': datetime.datetime(2024, 11, 16),
+                'cancelled_at': datetime.datetime(2024, 11, 16),
+                'failed_at': datetime.datetime(2024, 11, 16),
+                'incomplete_details': 'max_completion_tokens',
+                'usage': 'in_progress',
+                'temperature': 1.0,
+                'top_p': 1.0,
+                'max_completion_tokens': 1000,
+                'truncation_strategy': 'test',
+                'tool_choice': "tool name",
+                'response_format': "json",
+                'metadata': {'foo': 'bar'},
+                'tool_resources': "test",
+                'parallel_tool_calls': True
+            }, ThreadRun),
+            ({
+                'id': '1233',
+                'object': 'thread.message',
+                'created_at': datetime.datetime(2024, 11, 14),
+                'thread_id': '5678',
+                'status': 'incomplete',
+                'incomplete_details': "test",
+                'completed_at': datetime.datetime(2024, 11, 16),
+                'incomplete_at': datetime.datetime(2024, 11, 16),
+                'role': 'assistant',
+                'content': 'Test',
+                'assistant_id': '9911',
+                'run_id': '11',
+                'attachments': ['4', '8', '15', '16', '23', '42'],
+                'metadata': {'foo', 'bar'}
+            }, ThreadMessage)
+        ]
+    )
+    def test_correct_thread_params(self, valid_params, model_cls):
         """Test that if service returned extra parameter in SSE response, it does not create issues."""
-        valid_params = {
-            'id': '12345',
-             'object': "thread.run",
-             'thread_id': "6789",
-             'assistant_id': "101112",
-             'status': 'in_progress',
-             'required_action': 'test',
-             'last_error': 'none',
-             'model': 'gpt-4',
-             'instructions': "Test instruction",
-             'tools': 'Test function',
-             'created_at': datetime.datetime(2024, 11, 14),
-             'expires_at': datetime.datetime(2024, 11, 17),
-             'started_at': datetime.datetime(2024, 11, 15),
-             'completed_at': datetime.datetime(2024, 11, 16),
-             'cancelled_at': datetime.datetime(2024, 11, 16),
-             'failed_at': datetime.datetime(2024, 11, 16),
-             'incomplete_details': 'max_completion_tokens',
-             'usage': 'in_progress',
-             'temperature': 1.0,
-             'top_p': 1.0,
-             'max_completion_tokens': 1000,
-             'truncation_strategy': 'test',
-             'tool_choice': "tool name",
-             'response_format': "json",
-             'metadata': {'foo': 'bar'},
-             'tool_resources': "test",
-             'parallel_tool_calls': True
-        }
+        
         bad_params = {'foo': 'bar'}
         params = copy.deepcopy(valid_params)
         params.update(bad_params)
         # We should bot e able to create Thread Run with bad parameters.
         with pytest.raises(TypeError):
-            ThreadRun(**params)
-        filtered_params = ParamCorrector.filter_parameters(ThreadRun, params)
+            model_cls(**params)
+        filtered_params = ParamCorrector.filter_parameters(model_cls, params)
         for k in valid_params:
             assert k in filtered_params
         for k in bad_params:
             assert k not in filtered_params
         # Implicitly check that we can create object with the filtered parameters.
-        ThreadRun(**filtered_params)
+        model_cls(**filtered_params)
+        # Check safe initialization.
+        assert isinstance(ParamCorrector.safe_instantiate(model_cls, params), model_cls)
+        
+
+    def test_safe_instantiate_non_dict(self):
+        """Test that safe_instantiate method when user supplies not a dictionary."""
+        assert ParamCorrector.safe_instantiate(RunStep, 42) == 42


### PR DESCRIPTION
# Description

In the scenario when we use event handlers, we are launching actions in response to SSE events. In this case we create the `ThreadRun` object, based on the received JSON response. If the Bakend was changed and returns extra parameters, this will result in failure. In this PR we are filtering the fields, based on the Class (in this example ThreadRun)  attributes.
See Work item https://github.com/orgs/ai-platform-ml-platform/projects/7/views/2?sliceBy%5Bvalue%5D=markhiet_microsoft&pane=issue&itemId=82283437

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
