### PR TITLE
Opt smoke-test pipeline out of FederatedAuth for now

### DIFF
--- a/eng/pipelines/templates/steps/smoke-test-steps.yml
+++ b/eng/pipelines/templates/steps/smoke-test-steps.yml
@@ -104,6 +104,7 @@ steps:
       SubscriptionConfiguration: $(SubscriptionConfiguration)
       Location: $(Location)
       ArmTemplateParameters: $(ArmTemplateParameters)
+      UseFederatedAuth: false
 
   - script: python $(Build.SourcesDirectory)/common/smoketest/program.py
     displayName: Run Smoke Test
@@ -112,4 +113,5 @@ steps:
     parameters:
       ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'
       SubscriptionConfiguration: $(SubscriptionConfiguration)
+      UseFederatedAuth: false
 


### PR DESCRIPTION
Once the global federated auth default was flipped to true this broke the smoke tests because they weren't correctly setup to use federated auth. To unblock until they are moved we can opt-out. 