### PR TITLE
[evaluation] Switch to query response pairs in JsonLineChatProtocol

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Breaking Changes
 - Renamed environment variable `PF_EVALS_BATCH_USE_ASYNC` to `AI_EVALS_BATCH_USE_ASYNC`.
+- Outputs of `Simulator` and `AdversarialSimulator` previously had `to_eval_qa_json_lines` and now has `to_eval_qr_json_lines`. Where `to_eval_qa_json_lines` had:
+```json 
+{"question": <user_message>, "answer": <assistant_message>}
+```
+`to_eval_qr_json_lines` now has:
+```json 
+{"query": <user_message>, "response": assistant_message}
+```
+
 
 ### Bugs Fixed
 - Non adversarial simulator works with `gpt-4o` models using the `json_schema` response format

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_utils.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_utils.py
@@ -26,9 +26,9 @@ class JsonLineList(list):
             json_lines += json.dumps(item) + "\n"
         return json_lines
 
-    def to_eval_qa_json_lines(self):
+    def to_eval_qr_json_lines(self):
         """
-        Converts the list to a string of JSON lines suitable for evaluation in a Q&A format.
+        Converts the list to a string of JSON lines suitable for evaluation in a query & reponse format.
         Each item in the list is expected to be a dictionary with
         'messages' key. The 'messages' value is a list of
         dictionaries, each with a 'role' key and a 'content' key.
@@ -80,9 +80,9 @@ class JsonLineChatProtocol(dict):
         """
         return json.dumps(self)
 
-    def to_eval_qa_json_lines(self) -> str:
+    def to_eval_qr_json_lines(self) -> str:
         """
-        Converts the object to a string of JSON lines suitable for evaluation in a Q&A format.
+        Converts the object to a string of JSON lines suitable for evaluation in a query and response format.
         The object is expected to be a dictionary with 'messages' key.
 
         :returns: A json lines document
@@ -105,10 +105,10 @@ class JsonLineChatProtocol(dict):
             if user_message and assistant_message:
                 if context:
                     json_lines += (
-                        json.dumps({"question": user_message, "answer": assistant_message, "context": context}) + "\n"
+                        json.dumps({"query": user_message, "response": assistant_message, "context": context}) + "\n"
                     )
                     user_message = assistant_message = None
                 else:
-                    json_lines += json.dumps({"question": user_message, "answer": assistant_message}) + "\n"
+                    json_lines += json.dumps({"query": user_message, "response": assistant_message}) + "\n"
                     user_message = assistant_message = None
         return json_lines

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_utils.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_utils.py
@@ -28,7 +28,7 @@ class JsonLineList(list):
 
     def to_eval_qr_json_lines(self):
         """
-        Converts the list to a string of JSON lines suitable for evaluation in a query & reponse format.
+        Converts the list to a string of JSON lines suitable for evaluation in a query & response format.
         Each item in the list is expected to be a dictionary with
         'messages' key. The 'messages' value is a list of
         dictionaries, each with a 'role' key and a 'content' key.


### PR DESCRIPTION
# Description

Changes from question / answer to query / response in `JsonLineChatProtocol`. Additionally, renames the utils `to_eval_qa_json_lines` to `to_eval_qr_json_lines`.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
