### PR TITLE
[evaluation] ci: Temporarily disable 3.13

### DIFF
--- a/sdk/evaluation/ci.yml
+++ b/sdk/evaluation/ci.yml
@@ -28,6 +28,13 @@ extends:
     ServiceDirectory: evaluation
     ValidateFormatting: true
     TestProxy: true
+    # This custom matrix config should be dropped once:
+    #  * Once azure-ai-ml supports 3.13 (currently crashes due to type annotation)
+    MatrixConfigs:
+      - Name: evaluation_ci_matrix
+        Path: eng/pipelines/templates/stages/platform-matrix-no-313.json
+        Selection: sparse
+        GenerateVMJobs: true
     Artifacts:
     - name: azure-ai-evaluation
       safeName: azureaievaluation


### PR DESCRIPTION
# Description

This pull request temporarily disables Python 3.13 in the test matrix for azure-ai-evaluation.

# Background

One of azure-ai-evaluation's dependencies, `azure-ai-ml`, does not currently support Python 3.13 and immediately raises an exception on import.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
