### PR TITLE
[evaluation] ci,tests,fix: Improve reliability of nltk data download in CI

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/utils.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/utils.py
@@ -48,13 +48,19 @@ def get_harm_severity_level(harm_score: int) -> Union[str, float]:
 
 def ensure_nltk_data_downloaded():
     """Download NLTK data packages if not already downloaded."""
+    nltk_data = [
+        ("wordnet", "corpora/wordnet.zip"),
+        ("perluniprops", "misc/perluniprops.zip"),
+        ("punkt", "tokenizers/punkt.zip"),
+        ("punkt_tab", "tokenizers/punkt_tab.zip"),
+    ]
+
     with _nltk_data_download_lock:
-        try:
-            from nltk.tokenize.nist import NISTTokenizer  # pylint: disable=unused-import
-        except LookupError:
-            nltk.download("perluniprops")
-            nltk.download("punkt")
-            nltk.download("punkt_tab")
+        for _id, resource_name in nltk_data:
+            try:
+                nltk.find(resource_name)
+            except LookupError:
+                nltk.download(_id)
 
 
 def nltk_tokenize(text: str) -> List[str]:

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_meteor/_meteor.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_meteor/_meteor.py
@@ -1,11 +1,10 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-import nltk
 from nltk.translate.meteor_score import meteor_score
 from promptflow._utils.async_utils import async_run_allowing_running_loop
 
-from azure.ai.evaluation._common.utils import nltk_tokenize
+from azure.ai.evaluation._common.utils import nltk_tokenize, ensure_nltk_data_downloaded
 
 
 class _AsyncMeteorScoreEvaluator:
@@ -14,10 +13,7 @@ class _AsyncMeteorScoreEvaluator:
         self._beta = beta
         self._gamma = gamma
 
-        try:
-            nltk.find("corpora/wordnet.zip")
-        except LookupError:
-            nltk.download("wordnet")
+        ensure_nltk_data_downloaded()
 
     async def __call__(self, *, ground_truth: str, response: str, **kwargs):
         reference_tokens = nltk_tokenize(ground_truth)

--- a/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
@@ -9,25 +9,27 @@ from typing import Any, Dict, Optional
 from unittest.mock import patch
 
 import pytest
-from filelock import FileLock
-from azure.core.credentials import TokenCredential
+from ci_tools.variables import in_ci
 from devtools_testutils import add_body_key_sanitizer, add_general_regex_sanitizer, add_header_regex_sanitizer, is_live
 from devtools_testutils.config import PROXY_URL
 from devtools_testutils.fake_credentials import FakeTokenCredential
 from devtools_testutils.helpers import get_recording_id
 from devtools_testutils.proxy_testcase import transform_request
+from filelock import FileLock
 from promptflow.client import PFClient
-from azure.ai.evaluation import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
 from promptflow.executor._line_execution_process_pool import _process_wrapper
 from promptflow.executor._process_manager import create_spawned_fork_process_manager
 from pytest_mock import MockerFixture
-from ci_tools.variables import in_ci
+
+from azure.ai.evaluation import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
 from azure.ai.evaluation._common.utils import ensure_nltk_data_downloaded
+from azure.core.credentials import TokenCredential
 
 # Import of optional packages
 AZURE_INSTALLED = True
 try:
     import jwt
+
     from azure.ai.ml._ml_client import MLClient
 except ImportError:
     AZURE_INSTALLED = False

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -10,7 +10,6 @@ import requests
 from ci_tools.variables import in_ci
 
 from azure.ai.evaluation import (
-    evaluate,
     ContentSafetyEvaluator,
     F1ScoreEvaluator,
     FluencyEvaluator,

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_metrics_upload.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_metrics_upload.py
@@ -8,10 +8,10 @@ import pytest
 from devtools_testutils import is_live
 from promptflow.tracing import _start_trace
 
+from azure.ai.evaluation import F1ScoreEvaluator
 from azure.ai.evaluation._evaluate import _utils as ev_utils
 from azure.ai.evaluation._evaluate._eval_run import EvalRun
 from azure.ai.evaluation._evaluate._evaluate import evaluate
-from azure.ai.evaluation import F1ScoreEvaluator
 
 
 @pytest.fixture

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_sim_and_eval.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_sim_and_eval.py
@@ -1,23 +1,19 @@
+import asyncio
 import json
 import os
 import pathlib
 import time
-from typing import Dict, List, Any
-import asyncio
+from typing import Any, Dict, List
+
 import pandas as pd
 import pytest
 import requests
 from ci_tools.variables import in_ci
 from devtools_testutils import is_live
-from azure.identity import DefaultAzureCredential
 
-from azure.ai.evaluation import (
-    evaluate,
-    ProtectedMaterialEvaluator,
-    ViolenceEvaluator,
-)
-
+from azure.ai.evaluation import ProtectedMaterialEvaluator, ViolenceEvaluator, evaluate
 from azure.ai.evaluation.simulator import AdversarialScenario, AdversarialSimulator
+from azure.identity import DefaultAzureCredential
 
 
 @pytest.fixture

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_batch_run_context.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_batch_run_context.py
@@ -5,8 +5,8 @@ import pytest
 from promptflow.client import PFClient
 
 from azure.ai.evaluation._constants import PF_BATCH_TIMEOUT_SEC, PF_BATCH_TIMEOUT_SEC_DEFAULT
+from azure.ai.evaluation._evaluate._batch_run import CodeClient, EvalRunContext, ProxyClient
 from azure.ai.evaluation._user_agent import USER_AGENT
-from azure.ai.evaluation._evaluate._batch_run import EvalRunContext, CodeClient, ProxyClient
 
 
 @pytest.fixture

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from azure.ai.evaluation import FluencyEvaluator, RetrievalEvaluator, SimilarityEvaluator
 from azure.ai.evaluation._exceptions import EvaluationException
-from azure.ai.evaluation import FluencyEvaluator, SimilarityEvaluator, RetrievalEvaluator
 
 
 async def quality_async_mock():

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_defect_rate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_defect_rate.py
@@ -4,8 +4,8 @@ import pathlib
 import pandas as pd
 import pytest
 
-from azure.ai.evaluation._evaluate._evaluate import _aggregate_metrics
 from azure.ai.evaluation import ContentSafetyEvaluator
+from azure.ai.evaluation._evaluate._evaluate import _aggregate_metrics
 
 
 def _get_file(name):

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
@@ -6,9 +6,6 @@ from typing import Any, Iterator, MutableMapping, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
-from azure.core.exceptions import HttpResponseError
-from azure.core.rest import AsyncHttpResponse, HttpRequest
-from azure.identity import DefaultAzureCredential
 
 from azure.ai.evaluation._common.constants import EvaluationMetrics, HarmSeverityLevel, RAIService
 from azure.ai.evaluation._common.rai_service import (
@@ -21,6 +18,9 @@ from azure.ai.evaluation._common.rai_service import (
     parse_response,
     submit_request,
 )
+from azure.core.exceptions import HttpResponseError
+from azure.core.rest import AsyncHttpResponse, HttpRequest
+from azure.identity import DefaultAzureCredential
 
 
 @pytest.fixture

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_eval_run.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_eval_run.py
@@ -9,9 +9,9 @@ import jwt
 import pytest
 from promptflow.azure._utils._token_cache import ArmTokenCache
 
-from azure.ai.evaluation._exceptions import EvaluationException
 import azure.ai.evaluation._evaluate._utils as ev_utils
 from azure.ai.evaluation._evaluate._eval_run import EvalRun, RunStatus
+from azure.ai.evaluation._exceptions import EvaluationException
 
 
 def generate_mock_token():

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -9,6 +9,13 @@ import pytest
 from pandas.testing import assert_frame_equal
 from promptflow.client import PFClient
 
+from azure.ai.evaluation import (
+    ContentSafetyEvaluator,
+    F1ScoreEvaluator,
+    GroundednessEvaluator,
+    ProtectedMaterialEvaluator,
+    evaluate,
+)
 from azure.ai.evaluation._constants import DEFAULT_EVALUATION_RESULTS_FILE_NAME
 from azure.ai.evaluation._evaluate._evaluate import (
     _aggregate_metrics,
@@ -16,15 +23,8 @@ from azure.ai.evaluation._evaluate._evaluate import (
     _rename_columns_conditionally,
 )
 from azure.ai.evaluation._evaluate._utils import _apply_column_mapping, _trace_destination_from_project_scope
-from azure.ai.evaluation import (
-    evaluate,
-    ContentSafetyEvaluator,
-    F1ScoreEvaluator,
-    GroundednessEvaluator,
-    ProtectedMaterialEvaluator,
-)
-from azure.ai.evaluation._exceptions import EvaluationException
 from azure.ai.evaluation._evaluators._eci._eci import ECIEvaluator
+from azure.ai.evaluation._exceptions import EvaluationException
 
 
 def _get_file(name):
@@ -557,7 +557,7 @@ class TestEvaluate:
 
     @pytest.mark.parametrize("use_pf_client", [True, False])
     def test_optional_inputs_with_data(self, questions_file, questions_answers_basic_file, use_pf_client):
-        from test_evaluators.test_inputs_evaluators import NonOptionalEval, HalfOptionalEval, OptionalEval, NoInputEval
+        from test_evaluators.test_inputs_evaluators import HalfOptionalEval, NoInputEval, NonOptionalEval, OptionalEval
 
         # All variants work with both keyworded inputs
         results = evaluate(

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate_telemetry.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate_telemetry.py
@@ -10,8 +10,8 @@ import pandas as pd
 import pytest
 from promptflow.client import load_flow
 
-from azure.ai.evaluation._evaluate._telemetry import log_evaluate_activity
 from azure.ai.evaluation import F1ScoreEvaluator, HateUnfairnessEvaluator
+from azure.ai.evaluation._evaluate._telemetry import log_evaluate_activity
 
 
 def _add_nans(df, n, column_name):

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_non_adv_simulator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_non_adv_simulator.py
@@ -7,6 +7,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
 from azure.ai.evaluation.simulator import Simulator
 from azure.ai.evaluation.simulator._utils import JsonLineChatProtocol
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_synthetic_conversation_bot.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_synthetic_conversation_bot.py
@@ -2,7 +2,6 @@ from unittest.mock import AsyncMock, patch
 
 import jinja2
 import pytest
-from azure.core.pipeline.policies import AsyncRetryPolicy, RetryMode
 
 from azure.ai.evaluation._http_utils import get_async_http_client
 from azure.ai.evaluation.simulator._conversation import (
@@ -12,6 +11,7 @@ from azure.ai.evaluation.simulator._conversation import (
     LLMBase,
     OpenAIChatCompletionsModel,
 )
+from azure.core.pipeline.policies import AsyncRetryPolicy, RetryMode
 
 
 # Mock classes for dependencies


### PR DESCRIPTION
# Description

This pull request is an attempt to reduce test flakiness for the azure-ai-evaluation SDK, by remedying a class of test failures caused by `nltk.download`

# Background

`azure-ai-evaluation` depends on the `nltk` library. The typical workflow with `nltk` is that you must first download (i.e `nltk.download`) some resource before using the related `nltk` class.

In CI, this causes several issues that manifest as non-deterministic test failures:

* _nltk data fails to download due to a certifcate error_

  The azure-sdk-for-python repository uses a dev certificate to record traffic sent over https. We've observed download failures for nltk data due to certificate issues.


* _nltk data downloads, but cannot be read because the downloaded zip file is malformed_

  Potentially the manifestation of a race condition where multiple processes attempt to download the same nltk resource at the same time (each entry in our test matrix runs 3 instances of our test suite in parallel). This theory is unproven.



# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
