### PR TITLE
[evaluation] ci,tests,fix: Ensure pf service isolation across parallel pytest sessions

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/tests/__pf_service_isolation.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/__pf_service_isolation.py
@@ -21,3 +21,8 @@ from pathlib import Path
 
 if "TOX_ENV_DIR" in os.environ:
     os.environ["PF_HOME_DIRECTORY"] = str(Path(os.environ["TOX_ENV_DIR"], ".promptflow"))
+
+    import promptflow._sdk._constants
+
+    # Reduce the potential for parallel tox invocations to try to spawn their PF SERVICE on identical ports
+    promptflow._sdk._constants.PF_SERVICE_DEFAULT_PORT += hash(os.environ["TOX_ENV_DIR"]) % 300

--- a/sdk/evaluation/azure-ai-evaluation/tests/__pf_service_isolation.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/__pf_service_isolation.py
@@ -1,0 +1,23 @@
+"""Ensure isolation of the .promptflow directory if test suite is invoked through tox.
+
+.. note::
+
+    This is especially relevant when run in the ci for Azure/azure-sdk-for-python, since 3 instances of the test suite
+    are run in parallel (using `tox run-parallel`).
+
+    Giving each process its own promptflow directory should allow each pytest session to better manage the life cycle
+    of its promptflow service (and avoid issues when the service gets orphaned even after attempts to clean it up).
+
+.. warning::
+
+    This module has side-effects!
+
+    Importing this module will relocate the promptflow home directory if the test suite is run through tox.
+
+"""
+
+import os
+from pathlib import Path
+
+if "TOX_ENV_DIR" in os.environ:
+    os.environ["PF_HOME_DIRECTORY"] = str(Path(os.environ["TOX_ENV_DIR"], ".promptflow"))

--- a/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
@@ -1,4 +1,5 @@
 from .__openai_patcher import TestProxyConfig, TestProxyHttpxClientBase  # isort: split
+from . import __pf_service_isolation  # isort: split  # noqa: F401
 
 import json
 import multiprocessing


### PR DESCRIPTION
# Description

This pull request is a follow up to #37411, which attempts to make the cleanup of the promptflow service more robust by isolating the service across test sessions (when run through tox).

# Background

Our test suite spawns a separate process (promptflow service) that gets orphaned. This is an issue for our windows tests since that orphaned process holds handles to files that our CI tries to delete, which fails and causes the CI step to fail (See #37411 for more detail).

#37411 provided an initial attempt at a fix. However, the issue persisted intermittently and rerunning the failed job eventually fixes the issue. 

The non-determinism suggested that this was potentially a race condition stemming from the fact that our CI runs 3 test sessions concurrently. So this PR attempts to rectify this by ensuring that each session manages its own promptflow service.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
