### PR TITLE
Handle service specific changes as direct package updates

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -19,6 +19,7 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
     $AllPkgProps
   )
   $additionalValidationPackages = @()
+  $uniqueResultSet = @()
 
   function isOther($fileName) {
     $startsWithPrefixes = @(".config", ".devcontainer", ".github", ".vscode", "common", "conda", "doc", "eng", "scripts")
@@ -68,7 +69,6 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
   $engChanged = $diffObj.ChangedFiles | Where-Object { $_.StartsWith("eng")}
   $othersChanged = $diffObj.ChangedFiles | Where-Object { isOther($_) }
   $changedServices = $changedServices | Get-Unique
-  $uniqueResultSet = @()
 
   if ($toolChanged) {
     $additionalPackages = @(

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -33,6 +33,11 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
     return $startsWith
   }
 
+  # this section will identify the list of packages that we should treat as
+  # "directly" changed for a given service level change. While that doesn't
+  # directly change a package within the service, I do believe we should directly include all
+  # packages WITHIN that service. This is because the service level file changes are likely to
+  # have an impact on the packages within that service.
   $changedServices = @()
   foreach($file in $diffObj.ChangedFiles) {
     $pathComponents = $file -split "/"
@@ -46,11 +51,24 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
       changedServices += "template"
     }
   }
+  foreach ($changedService in $changedServices) {
+    $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
+
+    foreach ($pkg in $additionalPackages) {
+      if ($uniqueResultSet -notcontains $pkg -and $LocatedPackages -notcontains $pkg) {
+        # notice the lack of setting IncludedForValidation to true. This is because these "changed services"
+        # are specifically where a file within the service, but not an individual package within that service has changed.
+        # we want this package to be fully validated
+        $uniqueResultSet += $pkg
+      }
+    }
+  }
 
   $toolChanged = $diffObj.ChangedFiles | Where-Object { $_.StartsWith("tool")}
   $engChanged = $diffObj.ChangedFiles | Where-Object { $_.StartsWith("eng")}
   $othersChanged = $diffObj.ChangedFiles | Where-Object { isOther($_) }
   $changedServices = $changedServices | Get-Unique
+  $uniqueResultSet = @()
 
   if ($toolChanged) {
     $additionalPackages = @(
@@ -88,12 +106,7 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
     $additionalValidationPackages += $additionalPackages
   }
 
-  foreach ($changedService in $changedServices) {
-    $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
-    $additionalValidationPackages += $additionalPackages
-  }
 
-  $uniqueResultSet = @()
   foreach ($pkg in $additionalValidationPackages) {
     if ($uniqueResultSet -notcontains $pkg -and $LocatedPackages -notcontains $pkg) {
       $pkg.IncludedForValidation = $true


### PR DESCRIPTION
@kdestin asked a couple clarifying questions over the course of today about how we resolve the targeted packages + spread them to the matrix.

Over the course of that discussion, I realized that we were treating `sdk/<service>/<file>.<extension>` changes as INDIRECT package changes. So we will sparsely run tests for the packages of that changed service, but not treat it to the full matrix.

This PR changes that so that packages that are added due to changed service-level file will be counted as

> yes, this package was directly changed in this PR

Even if it wasn't really.