### PR TITLE
(engsys) ci,fix: Fix `Run Black` falsely reporting success

### DIFF
--- a/scripts/devops_tasks/validate_formatting.py
+++ b/scripts/devops_tasks/validate_formatting.py
@@ -23,9 +23,12 @@ def run_black(glob_string, service_dir):
     results = []
     logging.info("Running black for {}".format(service_dir))
 
-    discovered_packages = discover_targeted_packages(
-        glob_string, os.path.join(root_dir, "sdk", service_dir)
-    )
+    if service_dir and service_dir != "auto":
+        target_dir = os.path.join(root_dir, "sdk", service_dir)
+    else:
+        target_dir = root_dir
+
+    discovered_packages = discover_targeted_packages(glob_string, target_dir)
 
     for package in discovered_packages:
         package_name = os.path.basename(package)
@@ -43,7 +46,7 @@ def run_black(glob_string, service_dir):
                     "-e",
                     "black",
                     "--",
-                    os.path.join("sdk", service_dir, package_name),
+                    package,
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_indirect_attack_simulator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_indirect_attack_simulator.py
@@ -191,7 +191,7 @@ class IndirectAttackSimulator(AdversarialSimulator):
             template_parameters = completed_task.get("template_parameters", {})  # type: ignore
             xpia_attack_type = template_parameters.get("xpia_attack_type", "")  # type: ignore
             action = template_parameters.get("action", "")  # type: ignore
-            document_type = template_parameters.get("document_type", "")    # type: ignore
+            document_type = template_parameters.get("document_type", "")  # type: ignore
             sim_results.append(
                 {
                     "messages": completed_task["messages"],  # type: ignore

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_simulator.py
@@ -236,15 +236,19 @@ class Simulator:
                         user_turn = Turn(
                             role=ConversationRole.USER,
                             content=str(simulated_turn.get("content")),
-                            context=str(simulated_turn.get("context"))
+                            context=str(simulated_turn.get("context")),
                         )
                     else:
-                        raise ValueError("Each simulated turn must be a string or a dict with 'content' and 'context' keys")
+                        raise ValueError(
+                            "Each simulated turn must be a string or a dict with 'content' and 'context' keys"
+                        )
                     current_simulation.add_to_history(user_turn)
                     assistant_response, assistant_context = await self._get_target_response(
                         target=target, api_call_delay_sec=api_call_delay_sec, conversation_history=current_simulation
                     )
-                    assistant_turn = Turn(role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context)
+                    assistant_turn = Turn(
+                        role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context
+                    )
                     current_simulation.add_to_history(assistant_turn)
                     async with progress_bar_lock:
                         progress_bar.update(1)
@@ -286,7 +290,7 @@ class Simulator:
         prompty_model_config: Dict[str, Any],
         target: Callable,
         progress_bar: tqdm,
-        progress_bar_lock: asyncio.Lock
+        progress_bar_lock: asyncio.Lock,
     ):
         """
         Extends an ongoing conversation using a user simulator until the maximum number of turns is reached.
@@ -329,7 +333,9 @@ class Simulator:
             assistant_response, assistant_context = await self._get_target_response(
                 target=target, api_call_delay_sec=api_call_delay_sec, conversation_history=current_simulation
             )
-            assistant_turn = Turn(role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context)
+            assistant_turn = Turn(
+                role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context
+            )
             current_simulation.add_to_history(assistant_turn)
             async with progress_bar_lock:
                 progress_bar.update(1)
@@ -667,7 +673,9 @@ class Simulator:
             assistant_response, assistant_context = await self._get_target_response(
                 target=target, api_call_delay_sec=api_call_delay_sec, conversation_history=conversation_history
             )
-            assistant_turn = Turn(role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context)
+            assistant_turn = Turn(
+                role=ConversationRole.ASSISTANT, content=assistant_response, context=assistant_context
+            )
             conversation_history.add_to_history(assistant_turn)
             progress_bar.update(1)
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
@@ -59,12 +59,15 @@ class TestBuiltInEvaluators:
         conversation = {
             "messages": [
                 {"role": "user", "content": "What is the value of 2 + 2?"},
-                {"role": "assistant", "content": "2 + 2 = 4", "context": {
-                    "citations": [
+                {
+                    "role": "assistant",
+                    "content": "2 + 2 = 4",
+                    "context": {
+                        "citations": [
                             {"id": "math_doc.md", "content": "Information about additions: 1 + 2 = 3, 2 + 2 = 4"}
                         ]
-                    }
-                }
+                    },
+                },
             ]
         }
 


### PR DESCRIPTION
# Description

This pull request resolves an issue where the `Run Black` step would falsely report success, even in situations where there were formatting violations present.

[Example run against a package with known formatting violations](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4265986&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=efe9ac6d-3fdb-50af-24e1-4319f36eecb4) (Note that the step attempts to resolve packages in the non-existent `sdk/auto` service directory)




# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
