### PR TITLE
Clean-up cosmos test pipeline 

### DIFF
--- a/sdk/cosmos/tests.yml
+++ b/sdk/cosmos/tests.yml
@@ -3,11 +3,8 @@ trigger: none
 extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      Clouds: 'Cosmos_Public'
       CloudConfig:
-        Cosmos_Public:
-          SubscriptionConfigurations:
-            - $(sub-config-cosmos-azure-cloud-test-resources)
+        Public:
           ServiceConnection: azure-sdk-tests-cosmos
       MaxParallel: 6
       BuildTargetingString: azure-cosmos

--- a/sdk/cosmos/tests.yml
+++ b/sdk/cosmos/tests.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 extends:
-    template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       CloudConfig:
         Public:


### PR DESCRIPTION
Update cosmos test pipeline as it no longer needs that sub-config as the data comes from the service connection. Also update the config name to use default name of public.