### PR TITLE
[Core] Allow disablement option for tracing implementation

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Other Changes
 
 - Log "x-vss-e2eid" and "x-msedge-ref" headers in `HttpLoggingPolicy`.
+- To avoid implicit tracing enablement in some scenarios, `settings.tracing_implementation` can now be set to `"none"` to ensure tracing is disabled. #38137
 
 ## 1.31.0 (2024-09-12)
 

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -196,6 +196,7 @@ def _get_opentelemetry_span_if_opentelemetry_is_imported() -> Optional[Type[Abst
 _tracing_implementation_dict: Dict[str, Callable[[], Optional[Type[AbstractSpan]]]] = {
     "opencensus": _get_opencensus_span,
     "opentelemetry": _get_opentelemetry_span,
+    "none": lambda: None,
 }
 
 
@@ -207,6 +208,7 @@ def convert_tracing_impl(value: Optional[Union[str, Type[AbstractSpan]]]) -> Opt
 
     * "opencensus"
     * "opentelemetry"
+    * "none"
 
     :param value: the value to convert
     :type value: string


### PR DESCRIPTION
Tracing is enabled by default if "opentelemetry" has been imported and the `azure-core-tracing-opentelemetry` package has been installed.

However, in some cases, a user might not want this implicit enablement. For example, the `azure-monitor-opentelemetry` package allows users to disable Azure SDK tracing, so a way to explicitly disable tracing is needed to avoid the implicit enablement.

Here, we let users set the `tracing_implementation` value to the string "none" to ensure tracing is disabled in cases where it would be implicitly enabled. We don't use the Nonetype since a value of `None` currently has the implicit behavior.
