### PR TITLE
[Core] Allow operation-level tracing attributes

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a default implementation to handle token challenges in `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy`.
 
+### Bugs Fixed
+
+- Fixed an issue where the `tracing_attributes` keyword argument wasn't being handled at the request/method level. #38164
+
 ### Other Changes
 
 - Log "x-vss-e2eid" and "x-msedge-ref" headers in `HttpLoggingPolicy`.

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -93,10 +93,11 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
                 return
 
             namer = ctxt.pop("network_span_namer", self._network_span_namer)
+            tracing_attributes = ctxt.pop("tracing_attributes", self._tracing_attributes)
             span_name = namer(request.http_request)
 
             span = span_impl_type(name=span_name, kind=SpanKind.CLIENT)
-            for attr, value in self._tracing_attributes.items():
+            for attr, value in tracing_attributes.items():
                 span.add_attribute(attr, value)
             span.start()
 

--- a/sdk/core/azure-core/azure/core/tracing/decorator.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator.py
@@ -97,6 +97,9 @@ def distributed_trace(
             merge_span = kwargs.pop("merge_span", False)
             passed_in_parent = kwargs.pop("parent_span", None)
 
+            # Assume this will be popped in DistributedTracingPolicy.
+            func_tracing_attributes = kwargs.pop("tracing_attributes", tracing_attributes)
+
             span_impl_type = settings.tracing_implementation()
             if span_impl_type is None:
                 return func(*args, **kwargs)
@@ -108,7 +111,7 @@ def distributed_trace(
             with change_context(passed_in_parent):
                 name = name_of_span or get_function_and_class_name(func, *args)
                 with span_impl_type(name=name, kind=kind) as span:
-                    for key, value in tracing_attributes.items():
+                    for key, value in func_tracing_attributes.items():
                         span.add_attribute(key, value)
                     return func(*args, **kwargs)
 

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -106,6 +106,9 @@ def distributed_trace_async(  # pylint: disable=unused-argument
             merge_span = kwargs.pop("merge_span", False)
             passed_in_parent = kwargs.pop("parent_span", None)
 
+            # Assume this will be popped in DistributedTracingPolicy.
+            func_tracing_attributes = kwargs.get("tracing_attributes", tracing_attributes)
+
             span_impl_type = settings.tracing_implementation()
             if span_impl_type is None:
                 return await func(*args, **kwargs)
@@ -117,7 +120,7 @@ def distributed_trace_async(  # pylint: disable=unused-argument
             with change_context(passed_in_parent):
                 name = name_of_span or get_function_and_class_name(func, *args)
                 with span_impl_type(name=name, kind=kind) as span:
-                    for key, value in tracing_attributes.items():
+                    for key, value in func_tracing_attributes.items():
                         span.add_attribute(key, value)
                     return await func(*args, **kwargs)
 


### PR DESCRIPTION
Our documentation advertises ([here](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core#configurations) and [here](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#available-policies)) that the `tracing_attributes` keyword argument can be passed in at both the client constructor level and the operation/method level. This makes this actually the case.

Users can now pass in the `tracing_attributes` keyword argument to a client operation and have the corresponding spans created for theoperation have the passed-in attributes. Example:

```python
blob_service_client = BlobServiceClient("https://example.blob.core.windows.net", credential)
blob = blob_service_client.get_blob_client("foo", "foo.txt")

blob.delete_blob(tracing_attributes={"custom_attribute": "example"})
```

Per-operation customization of tracing attributes can help users mark/identify spans from specific operations. This can allow greater flexibility in processing spans through custom span processors.



