### PR TITLE
[CI] Update autorest CI to use Python 3.9

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -15,7 +15,7 @@ pr:
 
 variables:
   NodeVersion: '18.x'
-  PythonVersion: '3.8'
+  PythonVersion: '3.9'
   auto_rest_clone_url: 'https://github.com/Azure/autorest.python.git'
   source_path_azure_core: 'sdk/core/azure-core'
   source_path_azure_mgmt_core: 'sdk/core/azure-mgmt-core'


### PR DESCRIPTION
Bumping the Python version up as some CI dependencies no longer support Python 3.8
