### PR TITLE
[Scheduler] deprecate azure-mgmt-scheduler

### DIFF
--- a/sdk/scheduler/azure-mgmt-scheduler/CHANGELOG.md
+++ b/sdk/scheduler/azure-mgmt-scheduler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 7.0.0 (2024-10-31)
+
+### Other Changes
+
+- This package has been deprecated and will no longer be maintained after 01-31-2022. This package will only receive security fixes until 01-31-2022. To receive updates on new features and non-security bug fixes, upgrade to the replacement service, [Azure Logic Apps](https://learn.microsoft.com/azure/logic-apps/logic-apps-overview). Refer to the migration guide (https://learn.microsoft.com/azure/scheduler/migrate-from-scheduler-to-logic-apps) for guidance on upgrading.
+
 ## 7.0.0b1 (2020-10-22)
 
 This is beta preview version.

--- a/sdk/scheduler/azure-mgmt-scheduler/README.md
+++ b/sdk/scheduler/azure-mgmt-scheduler/README.md
@@ -1,28 +1,3 @@
 # Microsoft Azure SDK for Python
 
-This is the Microsoft Azure Scheduler Management Client Library.
-This package has been tested with Python 3.7+.
-For a more complete view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).
-
-## _Disclaimer_
-
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
-# Usage
-
-
-To learn how to use this package, see the [quickstart guide](https://aka.ms/azsdk/python/mgmt)
- 
-For docs and references, see [Python SDK References](https://docs.microsoft.com/python/api/overview/azure/scheduler)
-Code samples for this package can be found at [Scheduler Management](https://docs.microsoft.com/samples/browse/?languages=python&term=Getting%20started%20-%20Managing&terms=Getting%20started%20-%20Managing) on docs.microsoft.com.
-Additional code samples for different Azure services are available at [Samples Repo](https://github.com/Azure-Samples/azure-samples-python-management/tree/main/samples/scheduler)
-
-
-# Provide Feedback
-
-If you encounter any bugs or have suggestions, please file an issue in the
-[Issues](https://github.com/Azure/azure-sdk-for-python/issues)
-section of the project. 
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fazure-mgmt-scheduler%2FREADME.png)
+This package has been deprecated and will no longer be maintained after 01-31-2022. This package will only receive security fixes until 01-31-2022. To receive updates on new features and non-security bug fixes, upgrade to the replacement service, [Azure Logic Apps](https://learn.microsoft.com/azure/logic-apps/logic-apps-overview). Refer to the migration guide (https://learn.microsoft.com/azure/scheduler/migrate-from-scheduler-to-logic-apps) for guidance on upgrading.

--- a/sdk/scheduler/azure-mgmt-scheduler/azure/mgmt/scheduler/_version.py
+++ b/sdk/scheduler/azure-mgmt-scheduler/azure/mgmt/scheduler/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "7.0.0b1"
+VERSION = "7.0.0"


### PR DESCRIPTION
Deprecating azure-mgmt-scheduler as the service retired on Jan 31, 2022. Updating docs to refer to replacement service, Logic Apps.