### PR TITLE
[core] add servicemanagement legacy to ci for release

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -55,3 +55,5 @@ extends:
       safeName: azurecoreexperimental
     - name: corehttp
       safeName: corehttp
+    - name: azure-servicemanagement-legacy
+      safeName: azureservicemanagementlegacy


### PR DESCRIPTION
Adding azure-servicemanagement-legacy to the CI for deprecation release.