### PR TITLE
Improve tracing samples and add docs on telemetry.enable

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -363,7 +363,7 @@ def _enable_telemetry(destination: Union[TextIOWrapper, str, None], **kwargs) ->
 
     :keyword destination: `sys.stdout` for tracing to console output, or a string holding the
         OpenTelemetry protocol (OTLP) endpoint.
-        If not provided, thee method enables instrumentation, but does not configure OpenTelemetry
+        If not provided, this method enables instrumentation, but does not configure OpenTelemetry
         SDK to export traces.
     :paramtype destination: Union[TextIOWrapper, str, None]
     """

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -63,7 +63,7 @@ class InferenceOperations:
         """
         kwargs.setdefault("merge_span", True)
 
-        # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on 
+        # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection : bool = (os.getenv("USE_SERVERLESS_CONNECTION", None) == "true")
 
@@ -132,7 +132,7 @@ class InferenceOperations:
         """
         kwargs.setdefault("merge_span", True)
 
-        # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on 
+        # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection : bool = (os.getenv("USE_SERVERLESS_CONNECTION", None) == "true")
 
@@ -358,15 +358,17 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
 
 
 # Internal helper function to enable tracing, used by both sync and async clients
-def _enable_telemetry(destination: Union[TextIOWrapper, str], **kwargs) -> None:
-    """Enable tracing to console (sys.stdout), or to an OpenTelemetry Protocol (OTLP) collector.
+def _enable_telemetry(destination: Union[TextIOWrapper, str, None], **kwargs) -> None:
+    """Enable tracing to console (sys.stdout), or to an OpenTelemetry Protocol (OTLP) endpoint.
 
     :keyword destination: `sys.stdout` for tracing to console output, or a string holding the
-        endpoint URL of the OpenTelemetry Protocol (OTLP) collector. Required.
-    :paramtype destination: Union[TextIOWrapper, str]
+        OpenTelemetry protocol (OTLP) endpoint.
+        If not provided, thee method enables instrumentation, but does not configure OpenTelemetry
+        SDK to export traces.
+    :paramtype destination: Union[TextIOWrapper, str, None]
     """
     if isinstance(destination, str):
-        # `destination`` is the OTLP collector URL
+        # `destination` is the OTLP endpoint
         # See: https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html#usage
         try:
             from opentelemetry import trace
@@ -374,17 +376,14 @@ def _enable_telemetry(destination: Union[TextIOWrapper, str], **kwargs) -> None:
             from opentelemetry.sdk.trace.export import SimpleSpanProcessor
         except ModuleNotFoundError as _:
             raise ModuleNotFoundError(
-                "OpenTelemetry package is not installed. Please install it using 'pip install opentelemetry-sdk'"
+                "OpenTelemetry SDK is not installed. Please install it using 'pip install opentelemetry-sdk'"
             )
         try:
-            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
         except ModuleNotFoundError as _:
             raise ModuleNotFoundError(
-                "OpenTelemetry package is not installed. Please install it using 'pip install opentelemetry-exporter-otlp-proto-http'"
+                "OpenTelemetry OTLP exporter is not installed. Please install it using 'pip install opentelemetry-exporter-otlp-proto-grpc'"
             )
-        from azure.core.settings import settings
-
-        settings.tracing_implementation = "opentelemetry"
         trace.set_tracer_provider(TracerProvider())
         trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint=destination)))
 
@@ -397,19 +396,23 @@ def _enable_telemetry(destination: Union[TextIOWrapper, str], **kwargs) -> None:
                 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
             except ModuleNotFoundError as _:
                 raise ModuleNotFoundError(
-                    "OpenTelemetry package is not installed. Please install it using 'pip install opentelemetry-sdk'"
+                    "OpenTelemetry SDK is not installed. Please install it using 'pip install opentelemetry-sdk'"
                 )
-            from azure.core.settings import settings
-
-            settings.tracing_implementation = "opentelemetry"
             trace.set_tracer_provider(TracerProvider())
             trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
         else:
             raise ValueError("Only `sys.stdout` is supported at the moment for type `TextIOWrapper`")
-    else:
-        raise ValueError("Destination must be a string or a `TextIOWrapper` object")
 
     # Silently try to load a set of relevant Instrumentors
+    try:
+        from azure.core.settings import settings
+        settings.tracing_implementation = "opentelemetry"
+        _ = settings.tracing_implementation()
+    except ModuleNotFoundError as _:
+        logger.warning(
+            "Azure SDK tracing plugin is not installed. Please install it using 'pip install azure-core-tracing-opentelemetry'"
+        )
+
     try:
         from azure.ai.inference.tracing import AIInferenceInstrumentor
 
@@ -433,7 +436,7 @@ def _enable_telemetry(destination: Union[TextIOWrapper, str], **kwargs) -> None:
         )
 
     try:
-        from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+        from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
         OpenAIInstrumentor().instrument()
     except ModuleNotFoundError as _:
@@ -488,12 +491,29 @@ class TelemetryOperations(TelemetryOperationsGenerated):
 
     # TODO: what about `set AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true`?
     # TODO: This could be a class method. But we don't have a class property AIProjectClient.telemetry
-    def enable(self, *, destination: Union[TextIOWrapper, str], **kwargs) -> None:
-        """Enable tracing to console (sys.stdout), or to an OpenTelemetry Protocol (OTLP) collector.
+    def enable(self, *, destination: Union[TextIOWrapper, str, None] = None, **kwargs) -> None:
+        """Enables telemetry collection with OpenTelemetry for Azure AI clients and popular GenAI libraries.
 
-        :keyword destination: `sys.stdout` for tracing to console output, or a string holding the
-         endpoint URL of the OpenTelemetry Protocol (OTLP) collector. Required.
-        :paramtype destination: Union[TextIOWrapper, str]
+        Following instrumentations are enabled (when corresponding packages are installed):
+
+        - Azure AI Inference (`azure-ai-inference`)
+        - Azure AI Projects (`azure-ai-projects`)
+        - OpenAI (`opentelemetry-instrumentation-openai-v2`)
+        - Langchain (`opentelemetry-instrumentation-langchain`)
+
+        The recording of prompt and completion messages is disabled by default. To enable it, set the
+        `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED` environment variable to `true`.
+
+        When destination is provided, the method configures OpenTelemetry SDK to export traces to
+        stdout or OTLP (OpenTelemetry protocol) gRPC endpoint. It's recommended for local
+        development only. For production use, make sure to configure OpenTelemetry SDK directly.
+
+        :keyword destination: Recommended for local testing only. Set it to `sys.stdout` for
+            tracing to console output, or a string holding the OpenTelemetry protocol (OTLP)
+            endpoint such as "http://localhost:4317.
+            If not provided, the method enables instrumentations, but does not configure OpenTelemetry
+            SDK to export traces.
+        :paramtype destination: Union[TextIOWrapper, str, None]
         """
         _enable_telemetry(destination=destination, **kwargs)
 
@@ -689,9 +709,9 @@ class AgentsOperations(AgentsOperationsGenerated):
         :return: An Agent object.
         :raises: HttpResponseError for HTTP errors.
         """
-        
+
         self._validate_tools_and_tool_resources(tools, tool_resources)
-        
+
         if body is not _Unset:
             if isinstance(body, io.IOBase):
                 return super().create_agent(body=body, content_type=content_type, **kwargs)
@@ -715,7 +735,7 @@ class AgentsOperations(AgentsOperationsGenerated):
             metadata=metadata,
             **kwargs,
         )
-        
+
     @overload
     def update_agent(
         self, assistant_id: str, body: JSON, *, content_type: str = "application/json", **kwargs: Any
@@ -801,7 +821,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :rtype: ~azure.ai.projects.models.Agent
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        
+
     @overload
     def update_agent(
         self,
@@ -863,7 +883,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :rtype: ~azure.ai.projects.models.Agent
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        
+
 
     @overload
     def update_agent(
@@ -895,7 +915,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         instructions: Optional[str] = None,
         tools: Optional[List[_models.ToolDefinition]] = None,
         tool_resources: Optional[_models.ToolResources] = None,
-        toolset: Optional[_models.ToolSet] = None,        
+        toolset: Optional[_models.ToolSet] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         response_format: Optional["_types.AgentsApiResponseFormatOption"] = None,
@@ -955,7 +975,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         self._validate_tools_and_tool_resources(tools, tool_resources)
-        
+
         if body is not _Unset:
             if isinstance(body, io.IOBase):
                 return super().update_agent(body=body, content_type=content_type, **kwargs)
@@ -980,18 +1000,18 @@ class AgentsOperations(AgentsOperationsGenerated):
             metadata=metadata,
             **kwargs,
         )
-        
+
     def _validate_tools_and_tool_resources(self, tools: Optional[List[_models.ToolDefinition]], tool_resources: Optional[_models.ToolResources]):
         if tool_resources is None:
             return
         if tools is None:
             tools = []
-            
+
         if tool_resources.file_search is not None and not any(isinstance(tool, _models.FileSearchToolDefinition) for tool in tools):
             raise ValueError("Tools must contain a FileSearchToolDefinition when tool_resources.file_search is provided")
         if tool_resources.code_interpreter is not None and not any(isinstance(tool, _models.CodeInterpreterToolDefinition) for tool in tools):
             raise ValueError("Tools must contain a CodeInterpreterToolDefinition when tool_resources.code_interpreter is provided")
-    
+
     def _get_toolset(self) -> Optional[_models.ToolSet]:
         """
         Get the toolset for the agent.
@@ -2534,7 +2554,7 @@ class AgentsOperations(AgentsOperationsGenerated):
                         file.write(chunk)
                     else:
                         raise TypeError(f"Expected bytes or bytearray, got {type(chunk).__name__}")
-            
+
             logger.debug(f"File '{sanitized_file_name}' saved successfully at '{target_file_path}'.")
 
         except (ValueError, RuntimeError, TypeError, IOError) as e:

--- a/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
@@ -16,8 +16,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
-    pip install azure.monitor.opentelemetry 
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-monitor-opentelemetry
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.

--- a/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_console_tracing.py
@@ -15,7 +15,13 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-core-tracing-opentelemetry
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
@@ -27,7 +33,6 @@ import time
 import sys
 from azure.ai.projects.aio import AIProjectClient
 from azure.identity import DefaultAzureCredential
-from azure.ai.projects.tracing.agents import AIAgentsInstrumentor
 from opentelemetry import trace
 import os
 
@@ -46,6 +51,8 @@ async def main():
     )
 
     # Enable console tracing
+    # or, if you have local OTLP endpoint running, change it to
+    # project_client.telemetry.enable(destination="http://localhost:4317")
     project_client.telemetry.enable(destination=sys.stdout)
 
     async with project_client:

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
@@ -16,8 +16,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
-    pip install azure.monitor.opentelemetry 
+    pip install azure-ai-projects azure-identity azure-monitor-opentelemetry
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
@@ -41,6 +40,7 @@ project_client = AIProjectClient.from_connection_string(
 )
 
 # Enable Azure Monitor tracing
+
 application_insights_connection_string = project_client.telemetry.get_connection_string()
 if not application_insights_connection_string:
     print("Application Insights was not enabled for this project.")

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_console_tracing.py
@@ -15,7 +15,13 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-core-tracing-opentelemetry
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
@@ -38,6 +44,8 @@ project_client = AIProjectClient.from_connection_string(
 )
 
 # Enable console tracing
+# or, if you have local OTLP endpoint running, change it to
+# project_client.telemetry.enable(destination="http://localhost:4317")
 project_client.telemetry.enable(destination=sys.stdout)
 
 scenario = os.path.basename(__file__)

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_azure_monitor_tracing.py
@@ -16,8 +16,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
-    pip install azure.monitor.opentelemetry 
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-monitor-opentelemetry
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_console_tracing.py
@@ -15,7 +15,13 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-core-tracing-opentelemetry
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
@@ -42,6 +48,8 @@ project_client = AIProjectClient.from_connection_string(
 )
 
 # Enable console tracing
+# or, if you have local OTLP endpoint running, change it to
+# project_client.telemetry.enable(destination="http://localhost:4317")
 project_client.telemetry.enable(destination=sys.stdout)
 
 scenario = os.path.basename(__file__)

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
@@ -16,8 +16,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
-    pip install azure.monitor.opentelemetry 
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-monitor-opentelemetry
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_console_tracing.py
@@ -15,13 +15,18 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure.ai.projects azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects azure-identity opentelemetry-sdk azure-core-tracing-opentelemetry
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
     * AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
       messages, which may contain personal data. False by default.
-
 """
 
 import os,sys
@@ -79,6 +84,8 @@ class MyEventHandler(AgentEventHandler):
         print(f"Unhandled Event Type: {event_type}, Data: {event_data}")
 
 # Enable console tracing
+# or, if you have local OTLP endpoint running, change it to
+# project_client.telemetry.enable(destination="http://localhost:4317")
 project_client.telemetry.enable(destination=sys.stdout)
 
 scenario = os.path.basename(__file__)

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated
     ChatCompletionsClient from the azure.ai.inference package. The client
     is already instrumented to upload traces to Azure Monitor. View the results
     in the "Tracing" tab in your Azure AI Studio project page.
@@ -15,7 +15,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-inference azure-identity azure.monitor.opentelemetry
+    pip install azure-ai-projects azure-ai-inference azure-identity azure-monitor-opentelemetry
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
@@ -43,6 +43,10 @@ with AIProjectClient.from_connection_string(
         print("Application Insights was not enabled for this project.")
         print("Enable it via the 'Tracing' tab in your AI Studio project page.")
         exit()
+
+    # Enable additional instrumentations for openai and langchain
+    # which are not included by Azure Monitor out of the box
+    project_client.telemetry.enable()
     configure_azure_monitor(connection_string=application_insights_connection_string)
 
     # Get an authenticated azure.ai.inference ChatCompletionsClient for your default Serverless connection:

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated
     ChatCompletionsClient from the azure.ai.inference package. The client
     is already instrumented with console OpenTelemetry tracing.
 
@@ -14,7 +14,13 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-inference azure-identity opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects azure-ai-inference azure-identity opentelemetry-sdk azure-core-tracing-opentelemetry
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
@@ -37,6 +43,8 @@ with AIProjectClient.from_connection_string(
 ) as project_client:
 
     # Enable console tracing
+    # or, if you have local OTLP endpoint running, change it to
+    # project_client.telemetry.enable(destination="http://localhost:4317")
     project_client.telemetry.enable(destination=sys.stdout)
 
     # Get an authenticated azure.ai.inference ChatCompletionsClient for your default Serverless connection:

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated
     AzureOpenAI client from the openai package. The client is already instrumented
     to upload traces to Azure Monitor. View the results in the "Tracing" tab in your
     Azure AI Studio project page.
@@ -15,12 +15,12 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects openai azure.monitor.opentelemetry opentelemetry-instrumentation-openai
+    pip install azure-ai-projects openai azure-monitor-opentelemetry opentelemetry-instrumentation-openai-v2
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in your AI Studio Project.
     * MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Studio Project.
-    * AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
+    * OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT - Optional. Set to `true` to trace the content of chat
       messages, which may contain personal data. False by default.
 
     Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
@@ -45,6 +45,10 @@ with AIProjectClient.from_connection_string(
         print("Application Insights was not enabled for this project.")
         print("Enable it via the 'Tracing' tab in your AI Studio project page.")
         exit()
+
+    # Enable additional instrumentations for openai and langchain
+    # which are not included by Azure Monitor out of the box
+    project_client.telemetry.enable()
     configure_azure_monitor(connection_string=application_insights_connection_string)
 
     # Get an authenticated OpenAI client for your default Azure OpenAI connection:

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client_and_console_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client_and_console_tracing.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated
     AzureOpenAI client from the openai package. The client is already instrumented
     with console OpenTelemetry tracing.
 
@@ -14,12 +14,18 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects openai opentelemetry.instrumentation.openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    pip install azure-ai-projects openai opentelemetry-sdk opentelemetry-instrumentation-openai-v2
+
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
 
     Set these environment variables with your own values:
     * PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in your AI Studio Project.
     * MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Studio Project.
-    * AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
+    * OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT - Optional. Set to `true` to trace the content of chat
       messages, which may contain personal data. False by default.
 
     Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
@@ -39,6 +45,8 @@ with AIProjectClient.from_connection_string(
 ) as project_client:
 
     # Enable console tracing
+    # or, if you have local OTLP endpoint running, change it to
+    # project_client.telemetry.enable(destination="http://localhost:4317")
     project_client.telemetry.enable(destination=sys.stdout)
 
     # Get an authenticated OpenAI client for your default Azure OpenAI connection:


### PR DESCRIPTION
Changes to `project_client.telemetry.enable()`
- use https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-openai-v2 which is about to be released
- add docs on enabled instrumentations and packages containing them
- use OTLP gRPC exporter (it's easier to configure and Aspire dashboard supports it a bit better) instead of HTTP
- make destination not-required and only enable instrumentations if it's not provided.

Changes to samples:
- call `telemetry.enable` from AzMon samples too (for OpenAI) so we enable OpenAI instr
- add comments about gRPC endpoint
- clean up required package names
