### PR TITLE
make singleton gp args required

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_daf1ed16fc"
+  "Tag": "python/evaluation/azure-ai-evaluation_30a6b1ef35"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_service_groundedness/_service_groundedness.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_service_groundedness/_service_groundedness.py
@@ -105,18 +105,18 @@ class GroundednessProEvaluator(RaiServiceEvaluatorBase[Union[str, bool]]):
     def __call__(
         self,
         *,
-        query: Optional[str] = None,
-        response: Optional[str] = None,
-        context: Optional[str] = None,
+        query: str,
+        response: str,
+        context: str,
     ) -> Dict[str, Union[str, bool]]:
         """Evaluate groundedness for a given query/response/context
 
         :keyword query: The query to be evaluated.
-        :paramtype query: Optional[str]
+        :paramtype query: str
         :keyword response: The response to be evaluated.
-        :paramtype response: Optional[str]
+        :paramtype response: str
         :keyword context: The context to be evaluated.
-        :paramtype context: Optional[str]
+        :paramtype context: str
         :return: The relevance score.
         :rtype: Dict[str, Union[str, bool]]
         """


### PR DESCRIPTION
Make singleton groundedness pro eval inputs required.  Them being optional POST-conversation overload refactor is a minor bug. I also re-recorded all tests with `groundedness` in their name to be safe.
