### PR TITLE
`cosmos-sdk-client` doesn't need artifacts hardcoded

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -27,8 +27,4 @@ extends:
         Path: sdk/cosmos/cosmos-emulator-matrix.json
         Selection: all
         GenerateVMJobs: true
-    Artifacts:
-    - name: azure-cosmos
-      safeName: azurecosmos
-    - name: azure-mgmt-cosmosdb
-      safeName: azuremgmtcosmosdb
+    Artifacts: ${{ parameters.Artifacts }}


### PR DESCRIPTION
@swathipil was really getting tripped up as the artifact list generated for the release wasn't as she was expecting. She added an `artifact` the `Artifacts` parameter of the `ci.yml`, but nothing changed. This PR fixes why.