### PR TITLE
Eval/bugfix/content safety parallel

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed an issue where the `output_path` parameter in the `evaluate` API did not support relative path.
 - Output of adversarial simulators are of type `JsonLineList` and the helper function `to_eval_qr_json_lines` now outputs context from both user and assistant turns along with `category` if it exists in the conversation
 - Fixed an issue where during long-running simulations, API token expires causing "Forbidden" error. Instead, users can now set an environment variable `AZURE_TOKEN_REFRESH_INTERVAL` to refresh the token more frequently to prevent expiration and ensure continuous operation of the simulation.
+- Fixed an issue with the `ContentSafetyEvaluator` that caused parallel execution of sub-evaluators to fail. Parallel execution is now enabled by default again, but can still be disabled via the '_parallel' boolean keyword argument during class initialization.
 
 ### Other Changes
 - Refined error messages for serviced-based evaluators and simulators.

--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_f6269c684c"
+  "Tag": "python/evaluation/azure-ai-evaluation_acededcaea"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_content_safety/_content_safety.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_content_safety/_content_safety.py
@@ -69,7 +69,7 @@ class ContentSafetyEvaluator(EvaluatorBase[Union[str, float]]):
     # TODO address 3579092 to re-enabled parallel evals.
     def __init__(self, credential, azure_ai_project, **kwargs):
         super().__init__()
-        self._parallel = kwargs.pop("_parallel", False)
+        self._parallel = kwargs.pop("_parallel", True)
         self._evaluators: List[Callable[..., Dict[str, Union[str, float]]]] = [
             ViolenceEvaluator(credential, azure_ai_project),
             SexualEvaluator(credential, azure_ai_project),
@@ -152,7 +152,7 @@ class ContentSafetyEvaluator(EvaluatorBase[Union[str, float]]):
             with ThreadPoolExecutor() as executor:
                 # pylint: disable=no-value-for-parameter
                 futures = {
-                    executor.submit(query=query, response=response, conversation=conversation): evaluator
+                    executor.submit(evaluator, query=query, response=response, conversation=conversation): evaluator
                     for evaluator in self._evaluators
                 }
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -192,7 +192,8 @@ class TestEvaluate:
         finally:
             os.chdir(original_working_dir)
 
-    def test_evaluate_with_content_safety_evaluator(self, project_scope, azure_cred, data_file):
+    @pytest.mark.parametrize("parallel", [True, False])
+    def test_evaluate_with_content_safety_evaluator(self, project_scope, azure_cred, data_file, parallel):
         input_data = pd.read_json(data_file, lines=True)
 
         # CS evaluator tries to store the credential, which breaks multiprocessing at
@@ -200,7 +201,7 @@ class TestEvaluate:
         # generate a default credential at runtime.
         # Internal Parallelism is also disabled to avoid faulty recordings.
         content_safety_eval = ContentSafetyEvaluator(
-            credential=azure_cred, azure_ai_project=project_scope, _parallel=False
+            credential=azure_cred, azure_ai_project=project_scope, _parallel=parallel
         )
 
         # run the evaluation


### PR DESCRIPTION
Re-enabled the `ContentSafetyEvaluator`'s ability to run sub-evaluators in parallel. The problem a missing variable which occurred during the refactor to make the evaluator accept conversations... and somehow I missed this like 5 times when staring at diffs. Anyway, it's fixed, and the relevant e2e tests have been parameterized to make sure we don't accidentally break this again.
