### PR TITLE
Remove a defunct variable from docindex.yml

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -12,7 +12,6 @@ jobs:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-python
-      DocValidationImageId: azuresdkimages.azurecr.io/pyrefautocr:latest
     steps:
       # py2docfx requires Python >= 3.11
       - task: UsePythonVersion@0


### PR DESCRIPTION
The DocValidationImageId should have been removed with this [PR](https://github.com/Azure/azure-sdk-for-python/pull/38085) but was overlooked. It's not hurting anything or used, just annoying that it's still there.