### PR TITLE
Distro release 1.6.4: Fix instrumentation bug

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.6.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.6.4 (2024-11-04)
 
 ### Bugs Fixed
 
-### Other Changes
+- Removed version of OpenTelemetry that broke instrumentation logic in switch to importlib.
+    ([#38366](https://github.com/Azure/azure-sdk-for-python/pull/38366))
 
 ## 1.6.3 (2024-11-04)
 

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -92,7 +92,7 @@ setup(
         "opentelemetry-instrumentation-urllib~=0.48b0",
         "opentelemetry-instrumentation-urllib3~=0.48b0",
         "opentelemetry-resource-detector-azure~=0.1.4",
-        "opentelemetry-sdk~=1.27",
+        "opentelemetry-sdk==1.27.0",
     ],
     entry_points={
         "opentelemetry_distro": [


### PR DESCRIPTION
# Description

OpenTelemetry recently release a version that broke Autoinstrumentation and the dependency conflict logic the distro uses for instrumentations:

```
  File "C:\Users\<PATH TO SITE PACKAGES>\site-packages\opentelemetry\instrumentation\dependencies.py", line 48, in get_dist_dependency_conflicts
    for dep in dist.requires:
TypeError: 'method' object is not iterable
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
