### PR TITLE
Evaluate aggregation robustness

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Output of adversarial simulators are of type `JsonLineList` and the helper function `to_eval_qr_json_lines` now outputs context from both user and assistant turns along with `category` if it exists in the conversation
 - Fixed an issue where during long-running simulations, API token expires causing "Forbidden" error. Instead, users can now set an environment variable `AZURE_TOKEN_REFRESH_INTERVAL` to refresh the token more frequently to prevent expiration and ensure continuous operation of the simulation.
 - Fixed an issue with the `ContentSafetyEvaluator` that caused parallel execution of sub-evaluators to fail. Parallel execution is now enabled by default again, but can still be disabled via the '_parallel' boolean keyword argument during class initialization.
+- Fix `evaluate` function not producing aggregated metrics if ANY values to be aggregated were None, NaN, or
+otherwise difficult to process. Such values are ignored fully, so the aggregated metric of `[1, 2, 3, NaN]`
+would be 2, not 1.5.
 
 ### Other Changes
 - Refined error messages for serviced-based evaluators and simulators.

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/math.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/math.py
@@ -10,7 +10,7 @@ from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, Err
 
 def list_sum(lst: List[float]) -> float:
     """Given a list of floats, return the sum of the values.
-    
+
     :param lst: A list of floats.
     :type lst: List[float]
     :return: The sum of the values in the list.
@@ -22,7 +22,7 @@ def list_sum(lst: List[float]) -> float:
 
 def list_mean(lst: List[float]) -> float:
     """Given a list of floats, calculate the mean of the values.
-    
+
     :param lst: A list of floats.
     :type lst: List[float]
     :return: The mean of the values in the list.
@@ -34,7 +34,7 @@ def list_mean(lst: List[float]) -> float:
 
 def list_mean_nan_safe(lst: List[float]) -> float:
     """Given a list of floats, remove all nan or None values, then calculate the mean of the remaining values.
-    
+
     :param lst: A list of floats.
     :type lst: List[float]
     :return: The mean of the values in the list.
@@ -79,7 +79,7 @@ def apply_transform_nan_safe(lst: List[float], transform_fn: Callable[[float], A
 
 def is_none_or_nan(val: float) -> bool:
     """math.isnan raises an error if None is inputted. This is a more robust wrapper.
-    
+
     :param val: The value to check.
     :type val: float
     :return: Whether the value is None or NaN.

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/math.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/math.py
@@ -3,20 +3,44 @@
 # ---------------------------------------------------------
 
 import math
-from typing import List
+from typing import List, Callable, Any
 
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 
 def list_sum(lst: List[float]) -> float:
+    """Given a list of floats, return the sum of the values.
+    
+    :param lst: A list of floats.
+    :type lst: List[float]
+    :return: The sum of the values in the list.
+    :rtype: float
+    """
+
     return sum(lst)
 
 
 def list_mean(lst: List[float]) -> float:
+    """Given a list of floats, calculate the mean of the values.
+    
+    :param lst: A list of floats.
+    :type lst: List[float]
+    :return: The mean of the values in the list.
+    :rtype: float
+    """
+
     return list_sum(lst) / len(lst)
 
 
 def list_mean_nan_safe(lst: List[float]) -> float:
+    """Given a list of floats, remove all nan or None values, then calculate the mean of the remaining values.
+    
+    :param lst: A list of floats.
+    :type lst: List[float]
+    :return: The mean of the values in the list.
+    :rtype: float
+    """
+
     msg = "All score values are NaN. The mean cannot be calculated."
     if all(math.isnan(l) for l in lst):
         raise EvaluationException(
@@ -26,4 +50,40 @@ def list_mean_nan_safe(lst: List[float]) -> float:
             category=ErrorCategory.INVALID_VALUE,
             target=ErrorTarget.CONVERSATION,
         )
-    return list_mean([l for l in lst if not math.isnan(l)])
+    return list_mean([l for l in lst if not is_none_or_nan(l)])
+
+
+def apply_transform_nan_safe(lst: List[float], transform_fn: Callable[[float], Any]) -> List[Any]:
+    """Given a list of floats, remove all nan values, then apply the inputted transform function
+    to the remaining values, and return the resulting list of outputted values.
+
+    :param lst: A list of floats.
+    :type lst: List[float]
+    :param transform_fn: A function that produces something when applied to a float.
+    :type transform_fn: Callable[[float], Any]
+    :return: A list of the transformed values.
+    :rtype: List[Any]
+    """
+
+    msg = "All score values are NaN. The mean cannot be calculated."
+    if all(math.isnan(l) for l in lst):
+        raise EvaluationException(
+            message=msg,
+            internal_message=msg,
+            blame=ErrorBlame.USER_ERROR,
+            category=ErrorCategory.INVALID_VALUE,
+            target=ErrorTarget.CONVERSATION,
+        )
+    return [transform_fn(l) for l in lst if not is_none_or_nan(l)]
+
+
+def is_none_or_nan(val: float) -> bool:
+    """math.isnan raises an error if None is inputted. This is a more robust wrapper.
+    
+    :param val: The value to check.
+    :type val: float
+    :return: Whether the value is None or NaN.
+    :rtype: bool
+    """
+
+    return val is None or math.isnan(val)

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -119,7 +119,7 @@ def _get_run_from_run_history(flow_run_id, ml_client, project_scope):
 @pytest.mark.usefixtures("recording_injection", "recorded_test")
 @pytest.mark.localtest
 class TestEvaluate:
-    # @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
+    @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
     def test_evaluate_with_groundedness_evaluator(self, model_config, data_file):
         # data
         input_data = pd.read_json(data_file, lines=True)
@@ -156,7 +156,7 @@ class TestEvaluate:
         assert row_result_df["outputs.f1_score.f1_score"][2] == 1
         assert result["studio_url"] is None
 
-    # @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
+    @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
     def test_evaluate_with_relative_data_path(self, model_config):
         original_working_dir = os.getcwd()
 
@@ -192,7 +192,7 @@ class TestEvaluate:
         finally:
             os.chdir(original_working_dir)
 
-    # @pytest.mark.parametrize("parallel", [True, False])
+    @pytest.mark.parametrize("parallel", [True, False])
     def test_evaluate_with_content_safety_evaluator(self, project_scope, azure_cred, data_file, parallel):
         input_data = pd.read_json(data_file, lines=True)
 
@@ -386,26 +386,15 @@ class TestEvaluate:
         # Internal Parallelism is also disabled to avoid faulty recordings.
         gp_eval = GroundednessProEvaluator(azure_ai_project=project_scope, credential=azure_cred)
 
-        # convo_input_data = pd.read_json(data_convo_file, lines=True)
+        convo_input_data = pd.read_json(data_convo_file, lines=True)
         # run the evaluation
-        # convo_result = evaluate(
-        #    data=data_convo_file,
-        #    evaluators={"groundedness_pro": gp_eval},
-        # )
-
-        # convo_row_result_df = pd.DataFrame(convo_result["rows"])
-        # convo_metrics = convo_result["metrics"]
-
-        direct_result = evaluate(
-            data=data_file,
-            evaluators={"groundedness_pro": gp_eval},
+        convo_result = evaluate(
+           data=data_convo_file,
+           evaluators={"groundedness_pro": gp_eval},
         )
 
-        import pdb
-
-        pdb.set_trace()
-        convo_row_result_df = pd.DataFrame(direct_result["rows"])
-        convo_metrics = direct_result["metrics"]
+        convo_row_result_df = pd.DataFrame(convo_result["rows"])
+        convo_metrics = convo_result["metrics"]
 
         assert convo_row_result_df.shape[0] == len(direct_result)
         assert "outputs.groundedness_pro.groundedness_pro_label" in convo_row_result_df.columns.to_list()

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -378,7 +378,7 @@ class TestEvaluate:
         assert "sexual.sexual_defect_rate" in metrics.keys()
         assert 0 <= metrics.get("sexual.sexual_defect_rate") <= 1
 
-    def test_evaluate_with_groundedness_pro_evaluator(self, project_scope, data_convo_file, data_file, azure_cred):
+    def test_evaluate_with_groundedness_pro_evaluator(self, project_scope, data_convo_file, azure_cred):
 
         # CS evaluator tries to store the credential, which breaks multiprocessing at
         # pickling stage. So we pass None for credential and let child evals
@@ -389,14 +389,14 @@ class TestEvaluate:
         convo_input_data = pd.read_json(data_convo_file, lines=True)
         # run the evaluation
         convo_result = evaluate(
-           data=data_convo_file,
-           evaluators={"groundedness_pro": gp_eval},
+            data=data_convo_file,
+            evaluators={"groundedness_pro": gp_eval},
         )
 
         convo_row_result_df = pd.DataFrame(convo_result["rows"])
         convo_metrics = convo_result["metrics"]
-
-        assert convo_row_result_df.shape[0] == len(direct_result)
+        assert convo_row_result_df.shape[0] == len(convo_input_data)
+        
         assert "outputs.groundedness_pro.groundedness_pro_label" in convo_row_result_df.columns.to_list()
         assert "outputs.groundedness_pro.evaluation_per_turn" in convo_row_result_df.columns.to_list()
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -119,7 +119,7 @@ def _get_run_from_run_history(flow_run_id, ml_client, project_scope):
 @pytest.mark.usefixtures("recording_injection", "recorded_test")
 @pytest.mark.localtest
 class TestEvaluate:
-    @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
+    # @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
     def test_evaluate_with_groundedness_evaluator(self, model_config, data_file):
         # data
         input_data = pd.read_json(data_file, lines=True)
@@ -156,7 +156,7 @@ class TestEvaluate:
         assert row_result_df["outputs.f1_score.f1_score"][2] == 1
         assert result["studio_url"] is None
 
-    @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
+    # @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")
     def test_evaluate_with_relative_data_path(self, model_config):
         original_working_dir = os.getcwd()
 
@@ -192,7 +192,7 @@ class TestEvaluate:
         finally:
             os.chdir(original_working_dir)
 
-    @pytest.mark.parametrize("parallel", [True, False])
+    # @pytest.mark.parametrize("parallel", [True, False])
     def test_evaluate_with_content_safety_evaluator(self, project_scope, azure_cred, data_file, parallel):
         input_data = pd.read_json(data_file, lines=True)
 
@@ -378,7 +378,7 @@ class TestEvaluate:
         assert "sexual.sexual_defect_rate" in metrics.keys()
         assert 0 <= metrics.get("sexual.sexual_defect_rate") <= 1
 
-    def test_evaluate_with_groundedness_pro_evaluator(self, project_scope, data_convo_file, azure_cred):
+    def test_evaluate_with_groundedness_pro_evaluator(self, project_scope, data_convo_file, data_file, azure_cred):
 
         # CS evaluator tries to store the credential, which breaks multiprocessing at
         # pickling stage. So we pass None for credential and let child evals
@@ -386,16 +386,28 @@ class TestEvaluate:
         # Internal Parallelism is also disabled to avoid faulty recordings.
         gp_eval = GroundednessProEvaluator(azure_ai_project=project_scope, credential=azure_cred)
 
-        convo_input_data = pd.read_json(data_convo_file, lines=True)
+        # convo_input_data = pd.read_json(data_convo_file, lines=True)
         # run the evaluation
-        convo_result = evaluate(
-            data=data_convo_file,
+        # convo_result = evaluate(
+        #    data=data_convo_file,
+        #    evaluators={"groundedness_pro": gp_eval},
+        # )
+
+        # convo_row_result_df = pd.DataFrame(convo_result["rows"])
+        # convo_metrics = convo_result["metrics"]
+
+        direct_result = evaluate(
+            data=data_file,
             evaluators={"groundedness_pro": gp_eval},
         )
 
-        convo_row_result_df = pd.DataFrame(convo_result["rows"])
-        convo_metrics = convo_result["metrics"]
-        assert convo_row_result_df.shape[0] == len(convo_input_data)
+        import pdb
+
+        pdb.set_trace()
+        convo_row_result_df = pd.DataFrame(direct_result["rows"])
+        convo_metrics = direct_result["metrics"]
+
+        assert convo_row_result_df.shape[0] == len(direct_result)
         assert "outputs.groundedness_pro.groundedness_pro_label" in convo_row_result_df.columns.to_list()
         assert "outputs.groundedness_pro.evaluation_per_turn" in convo_row_result_df.columns.to_list()
 
@@ -403,7 +415,7 @@ class TestEvaluate:
         assert "groundedness_pro_label" in per_turn_results.keys()
         assert "groundedness_pro_reason" in per_turn_results.keys()
 
-        # Check that label is renamed to passsing rate in metrics
+        # Check that label is renamed to passing rate in metrics
         assert "groundedness_pro.groundedness_pro_passing_rate" in convo_metrics.keys()
         assert 0 <= convo_metrics.get("groundedness_pro.groundedness_pro_passing_rate") <= 1
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -396,7 +396,6 @@ class TestEvaluate:
         convo_row_result_df = pd.DataFrame(convo_result["rows"])
         convo_metrics = convo_result["metrics"]
         assert convo_row_result_df.shape[0] == len(convo_input_data)
-        
         assert "outputs.groundedness_pro.groundedness_pro_label" in convo_row_result_df.columns.to_list()
         assert "outputs.groundedness_pro.evaluation_per_turn" in convo_row_result_df.columns.to_list()
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -2,6 +2,7 @@ import json
 import math
 import os
 import pathlib
+import numpy as np
 from unittest.mock import patch
 
 import pandas as pd
@@ -483,10 +484,10 @@ class TestEvaluate:
     def test_content_safety_aggregation(self):
         data = {
             # 10 zeroes in a list fully written out
-            "content_safety.violence_score": [0, 0, 1, 2, 5, 5, 6, 7, 9, 6],
-            "content_safety.sexual_score": [0, 0, 2, 3, 3, 3, 8, 8, 8, 8],
-            "content_safety.self_harm_score": [0, 0, 0, 0, 1, 1, 1, 1, 7, 7],
-            "content_safety.hate_unfairness_score": [0, 0, 1, 1, 2, 2, 3, 3, 3, 6],
+            "content_safety.violence_score": [0, 0, 1, 2, 5, 5, 6, 7, np.nan, None],
+            "content_safety.sexual_score": [0, 0, 2, 3, 3, 3, 8, 8, np.nan, None],
+            "content_safety.self_harm_score": [0, 0, 0, 0, 1, 1, 1, 1, np.nan, None],
+            "content_safety.hate_unfairness_score": [0, 0, 1, 1, 2, 2, 3, 5, 6, 7],
             "content_safety.violence": [
                 "low",
                 "low",
@@ -514,18 +515,18 @@ class TestEvaluate:
         aggregation = _aggregate_metrics(data_df, evaluators)
 
         assert len(aggregation) == 4
-        assert aggregation["content_safety.violence_defect_rate"] == 0.6
-        assert aggregation["content_safety.sexual_defect_rate"] == 0.4
-        assert aggregation["content_safety.self_harm_defect_rate"] == 0.2
-        assert aggregation["content_safety.hate_unfairness_defect_rate"] == 0.1
+        assert aggregation["content_safety.violence_defect_rate"] == 0.5
+        assert aggregation["content_safety.sexual_defect_rate"] == 0.25
+        assert aggregation["content_safety.self_harm_defect_rate"] == 0.0
+        assert aggregation["content_safety.hate_unfairness_defect_rate"] == 0.3
 
     def test_label_based_aggregation(self):
         data = {
-            "eci.eci_label": [True, False, True, False, True],
+            "eci.eci_label": [True, True, True, np.nan, None],
             "eci.eci_reasoning": ["a", "b", "c", "d", "e"],
             "protected_material.protected_material_label": [False, False, False, False, True],
             "protected_material.protected_material_reasoning": ["f", "g", "h", "i", "j"],
-            "unknown.unaccounted_label": [True, False, False, False, True],
+            "unknown.unaccounted_label": [False, False, False, True, True],
             "unknown.unaccounted_reasoning": ["k", "l", "m", "n", "o"],
         }
         data_df = pd.DataFrame(data)
@@ -540,18 +541,31 @@ class TestEvaluate:
         assert "protected_material.protected_material_label" not in aggregation
         assert aggregation["unknown.unaccounted_label"] == 0.4
 
-        assert aggregation["eci.eci_defect_rate"] == 0.6
+        assert aggregation["eci.eci_defect_rate"] == 1.0
         assert aggregation["protected_material.protected_material_defect_rate"] == 0.2
         assert "unaccounted_defect_rate" not in aggregation
 
+    def test_other_aggregation(self):
+        data = {
+            "thing.groundedness_pro_label": [True, False, True, False, np.nan, None],
+        }
+        data_df = pd.DataFrame(data)
+        evaluators = {}
+        aggregation = _aggregate_metrics(data_df, evaluators)
+
+        assert len(aggregation) == 1
+        assert aggregation["thing.groundedness_pro_passing_rate"] == 0.5
+
     def test_general_aggregation(self):
         data = {
-            "thing.metric": [1, 2, 3, 4, 5],
-            "thing.reasoning": ["a", "b", "c", "d", "e"],
-            "other_thing.other_meteric": [-1, -2, -3, -4, -5],
-            "other_thing.other_reasoning": ["f", "g", "h", "i", "j"],
-            "final_thing.final_metric": [False, False, False, True, True],
-            "bad_thing.mixed_metric": [0, 1, False, True, True],
+            "thing.metric": [1, 2, 3, 4, 5, np.nan, None],
+            "thing.reasoning": ["a", "b", "c", "d", "e", "f", "g"],
+            "other_thing.other_meteric": [-1, -2, -3, -4, -5, np.nan, None],
+            "other_thing.other_reasoning": ["f", "g", "h", "i", "j", "i", "j"],
+            "final_thing.final_metric": [False, False, False, True, True, True, False],
+            "bad_thing.mixed_metric": [0, 1, False, True, 0.5, True, False],
+            "bad_thing.boolean_with_nan": [True, False, True, False, True, False, np.nan],
+            "bad_thing.boolean_with_none": [True, False, True, False, True, False, None],
         }
         data_df = pd.DataFrame(data)
         evaluators = {}
@@ -560,7 +574,10 @@ class TestEvaluate:
         assert len(aggregation) == 3
         assert aggregation["thing.metric"] == 3
         assert aggregation["other_thing.other_meteric"] == -3
-        assert aggregation["final_thing.final_metric"] == 0.4
+        assert aggregation["final_thing.final_metric"] == 3 / 7.0
+        assert "bad_thing.mixed_metric" not in aggregation
+        assert "bad_thing.boolean_with_nan" not in aggregation
+        assert "bad_thing.boolean_with_none" not in aggregation
 
     @pytest.mark.parametrize("use_pf_client", [True, False])
     def test_optional_inputs_with_data(self, questions_file, questions_answers_basic_file, use_pf_client):

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -520,9 +520,8 @@ class TestEvaluate:
         assert aggregation["content_safety.self_harm_defect_rate"] == 0.0
         assert aggregation["content_safety.hate_unfairness_defect_rate"] == 0.3
 
-        with pytest.raises(EvaluationException) as exc_info:
-            _aggregate_metrics(pd.DataFrame({"content_safety.violence_score": [np.nan, None]}), evaluators)
-        assert "column content_safety.violence_score" in exc_info.value.args[0]
+        no_results = _aggregate_metrics(pd.DataFrame({"content_safety.violence_score": [np.nan, None]}), evaluators)
+        assert len(no_results) == 0
 
     def test_label_based_aggregation(self):
         data = {
@@ -549,9 +548,8 @@ class TestEvaluate:
         assert aggregation["protected_material.protected_material_defect_rate"] == 0.2
         assert "unaccounted_defect_rate" not in aggregation
 
-        with pytest.raises(EvaluationException) as exc_info:
-            _aggregate_metrics(pd.DataFrame({"eci.eci_label": [np.nan, None]}), evaluators)
-        assert "column eci.eci_label" in exc_info.value.args[0]
+        no_results = _aggregate_metrics(pd.DataFrame({"eci.eci_label": [np.nan, None]}), evaluators)
+        assert len(no_results) == 0
 
     def test_other_aggregation(self):
         data = {
@@ -564,9 +562,8 @@ class TestEvaluate:
         assert len(aggregation) == 1
         assert aggregation["thing.groundedness_pro_passing_rate"] == 0.5
 
-        with pytest.raises(EvaluationException) as exc_info:
-            _aggregate_metrics(pd.DataFrame({"thing.groundedness_pro_label": [np.nan, None]}), {})
-        assert "column thing.groundedness_pro_label" in exc_info.value.args[0]
+        no_results = _aggregate_metrics(pd.DataFrame({"thing.groundedness_pro_label": [np.nan, None]}), {})
+        assert len(no_results) == 0
 
     def test_general_aggregation(self):
         data = {

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -520,6 +520,10 @@ class TestEvaluate:
         assert aggregation["content_safety.self_harm_defect_rate"] == 0.0
         assert aggregation["content_safety.hate_unfairness_defect_rate"] == 0.3
 
+        with pytest.raises(EvaluationException) as exc_info:
+            _aggregate_metrics(pd.DataFrame({"content_safety.violence_score": [np.nan, None]}), evaluators)
+        assert "column content_safety.violence_score" in exc_info.value.args[0]
+
     def test_label_based_aggregation(self):
         data = {
             "eci.eci_label": [True, True, True, np.nan, None],
@@ -545,6 +549,10 @@ class TestEvaluate:
         assert aggregation["protected_material.protected_material_defect_rate"] == 0.2
         assert "unaccounted_defect_rate" not in aggregation
 
+        with pytest.raises(EvaluationException) as exc_info:
+            _aggregate_metrics(pd.DataFrame({"eci.eci_label": [np.nan, None]}), evaluators)
+        assert "column eci.eci_label" in exc_info.value.args[0]
+
     def test_other_aggregation(self):
         data = {
             "thing.groundedness_pro_label": [True, False, True, False, np.nan, None],
@@ -555,6 +563,10 @@ class TestEvaluate:
 
         assert len(aggregation) == 1
         assert aggregation["thing.groundedness_pro_passing_rate"] == 0.5
+
+        with pytest.raises(EvaluationException) as exc_info:
+            _aggregate_metrics(pd.DataFrame({"thing.groundedness_pro_label": [np.nan, None]}), {})
+        assert "column thing.groundedness_pro_label" in exc_info.value.args[0]
 
     def test_general_aggregation(self):
         data = {


### PR DESCRIPTION
Nan/None values were contagious when aggregating metrics in `evaluate` function. For example, both [1,2,3, np.nan] or [True, False, None] would aggregatre to np.nan instead of 2 and 0.5 respectively.

I changed the averaging math used in out specific aggregation functions to avoid this - Note that the general aggregation is still vulnerable to this, but we need this fix now to hopefully address https://msdata.visualstudio.com/Vienna/_workitems/edit/3600498
