### PR TITLE
[sdk generation pipeline] update log level for ApiView

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_package.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_package.py
@@ -73,7 +73,7 @@ def main(generate_input, generate_output):
                 if "_python.json" in file and package_name in file:
                     package["apiViewArtifact"] = str(Path(package_path, file))
         except Exception as e:
-            _LOGGER.error(f"Fail to generate ApiView token file for {package_name}: {e}")
+            _LOGGER.info(f"Fail to generate ApiView token file for {package_name}: {e}")
         # Installation package
         package["installInstructions"] = {
             "full": "You can install the use using pip install of the artifacts.",


### PR DESCRIPTION
apiview is not block item for SDK generation so it is not error even if fails.