### PR TITLE
Connections APIs throw instead of returning None if a connection name/type is not found

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -52,6 +52,89 @@ Use the returned token credential to authenticate the client:
 
 ```
 
+## Troubleshooting
+
+### Exceptions
+
+Client methods that make service calls raise an [HttpResponseError](https://learn.microsoft.com/python/api/azure-core/azure.core.exceptions.httpresponseerror) exception for a non-success HTTP status code response from the service. The exception's `status_code` will hold the HTTP response status code (with `reason` showing the friendly name). The exception's `error.message` contains a detailed message that may be helpful in diagnosing the issue:
+
+```python
+from azure.core.exceptions import HttpResponseError
+
+...
+
+try:
+    result = client.connections.list()
+except HttpResponseError as e:
+    print(f"Status code: {e.status_code} ({e.reason})")
+    print(e.message)
+```
+
+For example, when you provide a wrong authentication key:
+
+```text
+Status code: 401 (Unauthorized)
+Operation returned an invalid status 'Unauthorized'
+```
+
+Or when you create an `EmbeddingsClient` and call `embed` on the client, but the endpoint does not
+support the `/embeddings` route:
+
+```text
+Status code: 405 (Method Not Allowed)
+Operation returned an invalid status 'Method Not Allowed'
+```
+
+### Logging
+
+The client uses the standard [Python logging library](https://docs.python.org/3/library/logging.html). The SDK logs HTTP request and response details, which may be useful in troubleshooting. To log to stdout, add the following:
+
+```python
+import sys
+import logging
+
+# Acquire the logger for this client library. Use 'azure' to affect both
+# 'azure.core` and `azure.ai.inference' libraries.
+logger = logging.getLogger("azure")
+
+# Set the desired logging level. logging.INFO or logging.DEBUG are good options.
+logger.setLevel(logging.DEBUG)
+
+# Direct logging output to stdout:
+handler = logging.StreamHandler(stream=sys.stdout)
+# Or direct logging output to a file:
+# handler = logging.FileHandler(filename="sample.log")
+logger.addHandler(handler)
+
+# Optional: change the default logging format. Here we add a timestamp.
+#formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+#handler.setFormatter(formatter)
+```
+
+By default logs redact the values of URL query strings, the values of some HTTP request and response headers (including `Authorization` which holds the key or token), and the request and response payloads. To create logs without redaction, add `logging_enable = True` to the client constructor:
+
+```python
+client = AIProjectClient.from_connection_string(
+    credential=DefaultAzureCredential(),
+    conn_str=project_connection_string,
+    logging_enable = True
+)
+```
+
+Note that the log level must be set to `logging.DEBUG` (see above code). Logs will be redacted with any other log level.
+
+Be sure to protect non redacted logs to avoid compromising security.
+
+For more information, see [Configure logging in the Azure libraries for Python](https://aka.ms/azsdk/python/logging)
+
+### Reporting issues
+
+To report issues with the client library, or request additional features, please open a GitHub issue [here](https://github.com/Azure/azure-sdk-for-python/issues)
+
+## Next steps
+
+Have a look at the [Samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-projects/samples) folder, containing fully runnable Python code for synchronous and asynchronous clients.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -1,5 +1,4 @@
 
-
 # Azure Ai Projects client library for Python
 <!-- write necessary description of service -->
 
@@ -362,21 +361,6 @@ project_client.agents.delete_agent(agent.id)
 print("Deleted agent")
 ```
 
-## Examples
-
-```python
->>> from azure.ai.projects import AIProjectClient
->>> from azure.identity import DefaultAzureCredential
->>> from azure.core.exceptions import HttpResponseError
-
->>> client = AIProjectClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
->>> try:
-        <!-- write test code here -->
-    except HttpResponseError as e:
-        print('service responds error: {}'.format(e.response.json()))
-
-```
-
 ## Troubleshooting
 
 ### Exceptions
@@ -395,19 +379,11 @@ except HttpResponseError as e:
     print(e.message)
 ```
 
-For example, when you provide a wrong authentication key:
+For example, when you provide wrong credentials:
 
 ```text
 Status code: 401 (Unauthorized)
 Operation returned an invalid status 'Unauthorized'
-```
-
-Or when you create an `EmbeddingsClient` and call `embed` on the client, but the endpoint does not
-support the `/embeddings` route:
-
-```text
-Status code: 405 (Method Not Allowed)
-Operation returned an invalid status 'Method Not Allowed'
 ```
 
 ### Logging
@@ -485,6 +461,3 @@ additional questions or comments.
 [default_azure_credential]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity#defaultazurecredential
 [pip]: https://pypi.org/project/pip/
 [azure_sub]: https://azure.microsoft.com/free/
-
-
-

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -42,7 +42,7 @@ class AIProjectClient(ClientGenerated):
         if not project_name:
             raise ValueError("project_name is required")
         if not credential:
-            raise ValueError("Credential is required")
+            raise ValueError("credential is required")
         if "api_version" in kwargs:
             raise ValueError("No support for overriding the API version")
         if "credential_scopes" in kwargs:

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -45,7 +45,7 @@ class AIProjectClient(ClientGenerated):
         if not project_name:
             raise ValueError("project_name is required")
         if not credential:
-            raise ValueError("Credential is required")
+            raise ValueError("credential is required")
         if "api_version" in kwargs:
             raise ValueError("No support for overriding the API version")
         if "credential_scopes" in kwargs:

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from azure.ai.projects import _types
     from azure.ai.inference.aio import ChatCompletionsClient, EmbeddingsClient
     from openai import AsyncAzureOpenAI
-    from azure.identity import get_bearer_token_provider
+    from azure.identity.aio import get_bearer_token_provider
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +243,7 @@ class InferenceOperations:
         ):
 
             try:
-                from azure.identity import get_bearer_token_provider
+                from azure.identity.aio import get_bearer_token_provider
             except ModuleNotFoundError as _:
                 raise ModuleNotFoundError(
                     "azure.identity package not installed. Please install it using 'pip install azure-identity'"
@@ -282,7 +282,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :param with_credentials: Whether to populate the connection properties with authentication credentials. Optional.
         :type with_credentials: bool
         :return: The connection properties, or `None` if there are no connections of the specified type.
-        :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :rtype: ~azure.ai.projects.model.ConnectionProperties
         :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -314,7 +314,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :param with_credentials: Whether to populate the connection properties with authentication credentials. Optional.
         :type with_credentials: bool
         :return: The connection properties, or `None` if a connection with this name does not exist.
-        :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :rtype: ~azure.ai.projects.models.ConnectionProperties
         :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -70,9 +70,15 @@ class InferenceOperations:
         """Get an authenticated asynchronous ChatCompletionsClient (from the package azure-ai-inference) for the default
         Azure AI Services connected resource. At least one AI model that supports chat completions must be deployed
         in this resource. The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
+        is not installed.
 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -85,14 +91,10 @@ class InferenceOperations:
             connection = await self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.SERVERLESS, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
         else:
             connection = await self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.AZURE_AI_SERVICES, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
 
         try:
             from azure.ai.inference.aio import ChatCompletionsClient
@@ -135,9 +137,15 @@ class InferenceOperations:
         """Get an authenticated asynchronous EmbeddingsClient (from the package azure-ai-inference) for the default
         Azure AI Services connected resource. At least one AI model that supports text embeddings must be deployed
         in this resource. The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
+        is not installed.
 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -150,14 +158,10 @@ class InferenceOperations:
             connection = await self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.SERVERLESS, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
         else:
             connection = await self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.AZURE_AI_SERVICES, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
 
         try:
             from azure.ai.inference.aio import EmbeddingsClient
@@ -199,6 +203,10 @@ class InferenceOperations:
     async def get_azure_openai_client(self, *, api_version: Optional[str] = None, **kwargs) -> "AsyncAzureOpenAI":
         """Get an authenticated AsyncAzureOpenAI client (from the `openai` package) for the default
         Azure OpenAI connection. The package `openai` must be installed prior to calling this method.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure OpenAI connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `openai` package
+        is not installed.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
@@ -207,14 +215,14 @@ class InferenceOperations:
         :paramtype api_version: str
         :return: An authenticated AsyncAzureOpenAI client
         :rtype: ~openai.AsyncAzureOpenAI
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
         connection = await self._outer_instance.connections.get_default(
             connection_type=ConnectionType.AZURE_OPEN_AI, with_credentials=True, **kwargs
         )
-        if not connection:
-            raise ValueError("No Azure OpenAI connection found.")
 
         try:
             from openai import AsyncAzureOpenAI
@@ -263,9 +271,10 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
     @distributed_trace_async
     async def get_default(
         self, *, connection_type: ConnectionType, with_credentials: bool = False, **kwargs: Any
-    ) -> Optional[ConnectionProperties]:
+    ) -> ConnectionProperties:
         """Get the properties of the default connection of a certain connection type, with or without
-        populating authentication credentials.
+        populating authentication credentials. Raises ~azure.core.exceptions.ResourceNotFoundError
+        exception if a connection with the given name was not found.
 
         :param connection_type: The connection type. Required.
         :type connection_type: ~azure.ai.projects.models._models.ConnectionType
@@ -273,6 +282,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :type with_credentials: bool
         :return: The connection properties, or `None` if there are no connections of the specified type.
         :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -288,15 +298,15 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
                 )
             else:
                 return connection_properties_list[0]
-        else:
-            return None
+        raise ResourceNotFoundError(f"No connection of type {connection_type} found")
 
     @distributed_trace_async
     async def get(
         self, *, connection_name: str, with_credentials: bool = False, **kwargs: Any
-    ) -> Optional[ConnectionProperties]:
+    ) -> ConnectionProperties:
         """Get the properties of a single connection, given its connection name, with or without
-        populating authentication credentials.
+        populating authentication credentials. Raises ~azure.core.exceptions.ResourceNotFoundError
+        exception if a connection with the given name was not found.
 
         :param connection_name: Connection Name. Required.
         :type connection_name: str
@@ -304,18 +314,16 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :type with_credentials: bool
         :return: The connection properties, or `None` if a connection with this name does not exist.
         :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
         if not connection_name:
             raise ValueError("Endpoint name cannot be empty")
         if with_credentials:
-            try:
-                connection: GetConnectionResponse = await self._get_connection_with_secrets(
-                    connection_name=connection_name, ignored="ignore", **kwargs
-                )
-            except ResourceNotFoundError as _:
-                return None
+            connection: GetConnectionResponse = await self._get_connection_with_secrets(
+                connection_name=connection_name, ignored="ignore", **kwargs
+            )
             if connection.properties.auth_type == AuthenticationType.ENTRA_ID:
                 return ConnectionProperties(connection=connection, token_credential=self._config.credential)
             elif connection.properties.auth_type == AuthenticationType.SAS:
@@ -335,10 +343,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
 
             return ConnectionProperties(connection=connection)
         else:
-            try:
-                connection = await self._get_connection(connection_name=connection_name, **kwargs)
-            except ResourceNotFoundError as _:
-                return None
+            connection = await self._get_connection(connection_name=connection_name, **kwargs)
             return ConnectionProperties(connection=connection)
 
     @distributed_trace_async
@@ -370,7 +375,6 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
 class TelemetryOperations(TelemetryOperationsGenerated):
 
     _connection_string: Optional[str] = None
-    _get_connection_string_called: bool = False
 
     def __init__(self, *args, **kwargs):
         self._outer_instance = kwargs.pop("outer_instance")
@@ -379,27 +383,29 @@ class TelemetryOperations(TelemetryOperationsGenerated):
     async def get_connection_string(self) -> Optional[str]:
         """
         Get the Application Insights connection string associated with the Project's Application Insights resource.
-        On first call, this method makes a GET call to the Application Insights resource URL to get the connection string.
-        Subsequent calls return the cached connection string.
+        On first call, this method makes a service call to the Application Insights resource URL to get the connection string.
+        Subsequent calls return the cached connection string, if one exists.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Application Insights resource was not
+        enabled for this project.
 
-        :return: The connection string, or `None` if an Application Insights resource was not enabled for the Project.
+        :return: The Application Insights connection string if a the resource was enabled for the Project.
         :rtype: str
+        :raises ~azure.core.exceptions.ResourceNotFoundError
         """
-        if not self._get_connection_string_called:
+        if not self._connection_string:
             # Get the AI Studio Project properties, including Application Insights resource URL if exists
             get_workspace_response: GetWorkspaceResponse = await self._outer_instance.connections._get_workspace()
 
-            # Continue only if Application Insights resource was enabled for this Project
-            if get_workspace_response.properties.application_insights:
+            if not get_workspace_response.properties.application_insights:
+                raise ResourceNotFoundError("Application Insights resource was not enabled for this Project.")
 
-                # Make a GET call to the Application Insights resource URL to get the connection string
-                app_insights_respose: GetAppInsightsResponse = await self._get_app_insights(
-                    app_insights_resource_url=get_workspace_response.properties.application_insights
-                )
+            # Make a GET call to the Application Insights resource URL to get the connection string
+            app_insights_respose: GetAppInsightsResponse = await self._get_app_insights(
+                app_insights_resource_url=get_workspace_response.properties.application_insights
+            )
 
-                self._connection_string = app_insights_respose.properties.connection_string
+            self._connection_string = app_insights_respose.properties.connection_string
 
-        self._get_connection_string_called = True
         return self._connection_string
 
     # TODO: what about `set AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true`?

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -57,13 +57,19 @@ class InferenceOperations:
         self._outer_instance = outer_instance
 
     @distributed_trace
-    def get_chat_completions_client(self, **kwargs) -> "Optional[ChatCompletionsClient]":
+    def get_chat_completions_client(self, **kwargs) -> "ChatCompletionsClient":
         """Get an authenticated ChatCompletionsClient (from the package azure-ai-inference) for the default
         Azure AI Services connected resource. At least one AI model that supports chat completions must be deployed
         in this resource. The package `azure-ai-inference` must be installed prior to calling this method.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
+        is not installed.
 
         :return: An authenticated chat completions client, or `None` if no Azure AI Services connection is found.
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -76,14 +82,10 @@ class InferenceOperations:
             connection = self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.SERVERLESS, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
         else:
             connection = self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.AZURE_AI_SERVICES, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
 
         try:
             from azure.ai.inference import ChatCompletionsClient
@@ -126,9 +128,15 @@ class InferenceOperations:
         """Get an authenticated EmbeddingsClient (from the package azure-ai-inference) for the default
         Azure AI Services connected resource. At least one AI model that supports text embeddings must be deployed
         in this resource. The package `azure-ai-inference` must be installed prior to calling this method.
-
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
+        is not installed.
+ 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -141,14 +149,10 @@ class InferenceOperations:
             connection = self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.SERVERLESS, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
         else:
             connection = self._outer_instance.connections.get_default(
                 connection_type=ConnectionType.AZURE_AI_SERVICES, with_credentials=True, **kwargs
             )
-            if not connection:
-                return None
 
         try:
             from azure.ai.inference import EmbeddingsClient
@@ -190,6 +194,10 @@ class InferenceOperations:
     def get_azure_openai_client(self, *, api_version: Optional[str] = None, **kwargs) -> "AzureOpenAI":
         """Get an authenticated AzureOpenAI client (from the `openai` package) for the default
         Azure OpenAI connection. The package `openai` must be installed prior to calling this method.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure OpenAI connection
+        does not exist.
+        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `openai` package
+        is not installed.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
@@ -198,6 +206,8 @@ class InferenceOperations:
         :paramtype api_version: str
         :return: An authenticated AzureOpenAI client
         :rtype: ~openai.AzureOpenAI
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
+        :raises ~azure.core.exceptions.ModuleNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
@@ -205,8 +215,6 @@ class InferenceOperations:
         connection = self._outer_instance.connections.get_default(
             connection_type=ConnectionType.AZURE_OPEN_AI, with_credentials=True, **kwargs
         )
-        if not connection:
-            raise ValueError("No Azure OpenAI connection found")
 
         try:
             from openai import AzureOpenAI
@@ -254,9 +262,10 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
     @distributed_trace
     def get_default(
         self, *, connection_type: ConnectionType, with_credentials: bool = False, **kwargs: Any
-    ) -> Optional[ConnectionProperties]:
+    ) -> ConnectionProperties:
         """Get the properties of the default connection of a certain connection type, with or without
-        populating authentication credentials.
+        populating authentication credentials. Raises ~azure.core.exceptions.ResourceNotFoundError
+        exception if a connection with the given name was not found.
 
         :param connection_type: The connection type. Required.
         :type connection_type: ~azure.ai.projects.models._models.ConnectionType
@@ -264,6 +273,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :type with_credentials: bool
         :return: The connection properties, or `None` if there are no connections of the specified type.
         :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
@@ -279,15 +289,15 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
                 )
             else:
                 return connection_properties_list[0]
-        else:
-            return None
+        raise ResourceNotFoundError(f"No connection of type {connection_type} found")
 
     @distributed_trace
     def get(
         self, *, connection_name: str, with_credentials: bool = False, **kwargs: Any
-    ) -> Optional[ConnectionProperties]:
+    ) -> ConnectionProperties:
         """Get the properties of a single connection, given its connection name, with or without
-        populating authentication credentials.
+        populating authentication credentials. Raises ~azure.core.exceptions.ResourceNotFoundError
+        exception if a connection with the given name was not found.
 
         :param connection_name: Connection Name. Required.
         :type connection_name: str
@@ -295,18 +305,16 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :type with_credentials: bool
         :return: The connection properties, or `None` if a connection with this name does not exist.
         :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
         if not connection_name:
             raise ValueError("Connection name cannot be empty")
         if with_credentials:
-            try:
-                connection: GetConnectionResponse = self._get_connection_with_secrets(
-                    connection_name=connection_name, ignored="ignore", **kwargs
-                )
-            except ResourceNotFoundError as _:
-                return None
+            connection: GetConnectionResponse = self._get_connection_with_secrets(
+                connection_name=connection_name, ignored="ignore", **kwargs
+            )
             if connection.properties.auth_type == AuthenticationType.ENTRA_ID:
                 return ConnectionProperties(connection=connection, token_credential=self._config.credential)
             elif connection.properties.auth_type == AuthenticationType.SAS:
@@ -326,10 +334,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
 
             return ConnectionProperties(connection=connection)
         else:
-            try:
-                connection = self._get_connection(connection_name=connection_name, **kwargs)
-            except ResourceNotFoundError as _:
-                return None
+            connection = self._get_connection(connection_name=connection_name, **kwargs)
             return ConnectionProperties(connection=connection)
 
     @distributed_trace
@@ -463,36 +468,37 @@ def _enable_telemetry(destination: Union[TextIOWrapper, str, None], **kwargs) ->
 class TelemetryOperations(TelemetryOperationsGenerated):
 
     _connection_string: Optional[str] = None
-    _get_connection_string_called: bool = False
 
     def __init__(self, *args, **kwargs):
         self._outer_instance = kwargs.pop("outer_instance")
         super().__init__(*args, **kwargs)
 
-    def get_connection_string(self) -> Optional[str]:
+    def get_connection_string(self) -> str:
         """
         Get the Application Insights connection string associated with the Project's Application Insights resource.
-        On first call, this method makes a GET call to the Application Insights resource URL to get the connection string.
-        Subsequent calls return the cached connection string.
+        On first call, this method makes a service call to the Application Insights resource URL to get the connection string.
+        Subsequent calls return the cached connection string, if one exists.
+        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Application Insights resource was not
+        enabled for this project.
 
-        :return: The connection string, or `None` if an Application Insights resource was not enabled for the Project.
+        :return: The Application Insights connection string if a the resource was enabled for the Project.
         :rtype: str
+        :raises ~azure.core.exceptions.ResourceNotFoundError
         """
-        if not self._get_connection_string_called:
+        if not self._connection_string:
             # Get the AI Studio Project properties, including Application Insights resource URL if exists
             get_workspace_response: GetWorkspaceResponse = self._outer_instance.connections._get_workspace()
 
-            # Continue only if Application Insights resource was enabled for this Project
-            if get_workspace_response.properties.application_insights:
+            if not get_workspace_response.properties.application_insights:
+                raise ResourceNotFoundError("Application Insights resource was not enabled for this Project.")
 
-                # Make a GET call to the Application Insights resource URL to get the connection string
-                app_insights_respose: GetAppInsightsResponse = self._get_app_insights(
-                    app_insights_resource_url=get_workspace_response.properties.application_insights
-                )
+            # Make a GET call to the Application Insights resource URL to get the connection string
+            app_insights_respose: GetAppInsightsResponse = self._get_app_insights(
+                app_insights_resource_url=get_workspace_response.properties.application_insights
+            )
 
-                self._connection_string = app_insights_respose.properties.connection_string
+            self._connection_string = app_insights_respose.properties.connection_string
 
-        self._get_connection_string_called = True
         return self._connection_string
 
     # TODO: what about `set AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true`?

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -272,7 +272,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :param with_credentials: Whether to populate the connection properties with authentication credentials. Optional.
         :type with_credentials: bool
         :return: The connection properties, or `None` if there are no connections of the specified type.
-        :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :rtype: ~azure.ai.projects.models.ConnectionProperties
         :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -304,7 +304,7 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
         :param with_credentials: Whether to populate the connection properties with authentication credentials. Optional.
         :type with_credentials: bool
         :return: The connection properties, or `None` if a connection with this name does not exist.
-        :rtype: ~azure.ai.projects.models._models.ConnectionProperties
+        :rtype: ~azure.ai.projects.models.ConnectionProperties
         :raises ~azure.core.exceptions.ResourceNotFoundError:
         :raises ~azure.core.exceptions.HttpResponseError:
         """

--- a/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
@@ -14,7 +14,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects aiohttp azure-identity
+    pip install azure-ai-projects azure-identity azure-ai-inference openai aiohttp
 
     Set these environment variables with your own values:
     1) PROJECT_CONNECTION_STRING - the Azure AI Project connection string, as found in the "Project overview"
@@ -88,7 +88,7 @@ async def sample_connections_async():
             )
         elif connection.authentication_type == AuthenticationType.ENTRA_ID:
             print("====> Creating AzureOpenAI client using Entra ID authentication")
-            from azure.identity import get_bearer_token_provider
+            from azure.identity.aio import get_bearer_token_provider
 
             client = AsyncAzureOpenAI(
                 # See https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
@@ -14,7 +14,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-identity
+    pip install azure-ai-projects azure-identity azure-ai-inference openai
 
     Set these environment variables with your own values:
     1) PROJECT_CONNECTION_STRING - The Azure AI Project connection string, as found in the "Project overview"
@@ -27,11 +27,9 @@ USAGE:
 import os
 from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import ConnectionType, AuthenticationType
-from openai import AzureOpenAI
-from azure.ai.inference import ChatCompletionsClient
-from azure.ai.inference.models import UserMessage
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
-from azure.core.credentials import AzureKeyCredential
+from azure.identity import DefaultAzureCredential
+
+#from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 project_connection_string = os.environ["PROJECT_CONNECTION_STRING"]
 connection_name = os.environ["CONNECTION_NAME"]
@@ -77,6 +75,8 @@ with project_client:
 # Examples of how you would create Inference client
 if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
 
+    from openai import AzureOpenAI
+
     if connection.authentication_type == AuthenticationType.API_KEY:
         print("====> Creating AzureOpenAI client using API key authentication")
         client = AzureOpenAI(
@@ -86,6 +86,8 @@ if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
         )
     elif connection.authentication_type == AuthenticationType.ENTRA_ID:
         print("====> Creating AzureOpenAI client using Entra ID authentication")
+        from azure.identity import get_bearer_token_provider
+
         client = AzureOpenAI(
             # See https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider
             azure_ad_token_provider=get_bearer_token_provider(
@@ -111,8 +113,13 @@ if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
 
 elif connection.connection_type == ConnectionType.SERVERLESS:
 
+    from azure.ai.inference import ChatCompletionsClient
+    from azure.ai.inference.models import UserMessage
+
     if connection.authentication_type == AuthenticationType.API_KEY:
         print("====> Creating ChatCompletionsClient using API key authentication")
+        from azure.core.credentials import AzureKeyCredential
+
         client = ChatCompletionsClient(endpoint=connection.endpoint_url, credential=AzureKeyCredential(connection.key))
     elif connection.authentication_type == AuthenticationType.ENTRA_ID:
         # MaaS models do not yet support EntraID auth

--- a/sdk/ai/azure-ai-projects/tests/connections/connection_test_base.py
+++ b/sdk/ai/azure-ai-projects/tests/connections/connection_test_base.py
@@ -38,6 +38,12 @@ if LOGGING_ENABLED:
 
 class ConnectionsTestBase(AzureRecordedTestCase):
 
+    NON_EXISTING_CONNECTION_NAME = "non-existing-connection-name"
+    EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME = f"Connection {NON_EXISTING_CONNECTION_NAME} can't be found in this workspace"
+
+    NON_EXISTING_CONNECTION_TYPE = "non-existing-connection-type"
+    EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_TYPE = f"No connection of type {NON_EXISTING_CONNECTION_TYPE} found"
+
     def get_sync_client(self, **kwargs) -> AIProjectClient:
         conn_str = kwargs.pop("azure_ai_projects_connections_tests_project_connection_string")
         project_client = AIProjectClient.from_connection_string(

--- a/sdk/ai/azure-ai-projects/tests/connections/test_connections.py
+++ b/sdk/ai/azure-ai-projects/tests/connections/test_connections.py
@@ -6,6 +6,7 @@
 from devtools_testutils import recorded_by_proxy
 from connection_test_base import ConnectionsTestBase, servicePreparerConnectionsTests
 from azure.ai.projects.models import ConnectionType
+from azure.core.exceptions import ResourceNotFoundError
 
 
 # The test class name needs to start with "Test" to get collected by pytest
@@ -20,13 +21,13 @@ class TestConnections(ConnectionsTestBase):
 
         with self.get_sync_client(**kwargs) as project_client:
 
-            assert (
-                project_client.connections.get(connection_name="Some non-existing name", with_credentials=False) == None
-            )
-
-            assert (
-                project_client.connections.get(connection_name="Some non-existing name", with_credentials=True) == None
-            )
+            for with_credentials in [True, False]:
+                try:
+                    connection_properties = project_client.connections.get(connection_name=ConnectionsTestBase.NON_EXISTING_CONNECTION_NAME, with_credentials=with_credentials)
+                    assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert ConnectionsTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
 
             connection = project_client.connections.get(connection_name=aoai_connection, with_credentials=False)
             print(connection)
@@ -75,15 +76,13 @@ class TestConnections(ConnectionsTestBase):
 
         with self.get_sync_client(**kwargs) as project_client:
 
-            assert (
-                project_client.connections.get_default(connection_type="Some unrecognized type", with_credentials=False)
-                == None
-            )
-
-            assert (
-                project_client.connections.get_default(connection_type="Some unrecognized type", with_credentials=True)
-                == None
-            )
+            for with_credentials in [True, False]:
+                try:
+                    connection_properties = project_client.connections.get_default(connection_type=ConnectionsTestBase.NON_EXISTING_CONNECTION_TYPE, with_credentials=with_credentials)
+                    assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert ConnectionsTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_TYPE in e.message
 
             connection = project_client.connections.get_default(
                 connection_type=ConnectionType.AZURE_OPEN_AI, with_credentials=False

--- a/sdk/ai/azure-ai-projects/tests/connections/test_connections_async.py
+++ b/sdk/ai/azure-ai-projects/tests/connections/test_connections_async.py
@@ -6,6 +6,7 @@
 from devtools_testutils.aio import recorded_by_proxy_async
 from connection_test_base import ConnectionsTestBase, servicePreparerConnectionsTests
 from azure.ai.projects.models import ConnectionType
+from azure.core.exceptions import ResourceNotFoundError
 
 
 # The test class name needs to start with "Test" to get collected by pytest
@@ -19,15 +20,13 @@ class TestConnectionsAsync(ConnectionsTestBase):
 
         async with self.get_async_client(**kwargs) as project_client:
 
-            assert (
-                await project_client.connections.get(connection_name="Some non-existing name", with_credentials=False)
-                == None
-            )
-
-            assert (
-                await project_client.connections.get(connection_name="Some non-existing name", with_credentials=True)
-                == None
-            )
+            for with_credentials in [True, False]:
+                try:
+                    connection_properties = await project_client.connections.get(connection_name=ConnectionsTestBase.NON_EXISTING_CONNECTION_NAME, with_credentials=with_credentials)
+                    assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert ConnectionsTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
 
             connection = await project_client.connections.get(connection_name=aoai_connection, with_credentials=False)
             print(connection)
@@ -80,19 +79,13 @@ class TestConnectionsAsync(ConnectionsTestBase):
 
         async with self.get_async_client(**kwargs) as project_client:
 
-            assert (
-                await project_client.connections.get_default(
-                    connection_type="Some unrecognized type", with_credentials=False
-                )
-                == None
-            )
-
-            assert (
-                await project_client.connections.get_default(
-                    connection_type="Some unrecognized type", with_credentials=True
-                )
-                == None
-            )
+            for with_credentials in [True, False]:
+                try:
+                    connection_properties = await project_client.connections.get_default(connection_type=ConnectionsTestBase.NON_EXISTING_CONNECTION_TYPE, with_credentials=with_credentials)
+                    assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert ConnectionsTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_TYPE in e.message
 
             connection = await project_client.connections.get_default(
                 connection_type=ConnectionType.AZURE_OPEN_AI, with_credentials=False


### PR DESCRIPTION
* Connections APIs "get" and "get_default" throws instead of returning None if a connection name/type is not found
* Telemetry API "get_connection_string" throws instead of returning None if there is no App Insights resource in the project
* Update the caching logic of the Telemetry API "get_connection_string" to attempt another service call if previously this method was called but there was no App Insights resource available in the project. This is feedback from the bug bash we had today, where the first API call was made, then the user went and added an App Insights resource to their Project, then a second call was made. 
* Start populating the general sections of the package README.md
* Address some minor PR review comments from Krista. I already resolved the relevant comments based on fixes from this PR.
* Fix package imports in the connection samples. Only import the packages needed for the 2nd part of the sample (creating and inference client), at the place where it's needed. This is because the first part, where we show the .connection API calls, is the more important and I would like only the relevant imports for those calls to appear at the top of the sample.