### PR TITLE
[evaluation] Fix RetrievalEvaluator evaluate() bug for non-conversation scenario

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_48380ccf70"
+  "Tag": "python/evaluation/azure-ai-evaluation_9327f7360c"
 }

--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_acededcaea"
+  "Tag": "python/evaluation/azure-ai-evaluation_48380ccf70"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/_retrieval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/_retrieval.py
@@ -7,7 +7,7 @@ import logging
 import math
 import os
 from typing import Dict, List, Union
-from typing_extensions import overload
+from typing_extensions import overload, override
 
 from promptflow._utils.async_utils import async_run_allowing_running_loop
 from promptflow.core import AsyncPrompty
@@ -19,95 +19,6 @@ from ..._common.math import list_mean_nan_safe
 from ..._common.utils import construct_prompty_model_config, validate_model_config, parse_quality_evaluator_reason_score
 
 logger = logging.getLogger(__name__)
-
-try:
-    from .._user_agent import USER_AGENT
-except ImportError:
-    USER_AGENT = "None"
-
-
-class _AsyncRetrievalScoreEvaluator:
-    # Constants must be defined within eval's directory to be save/loadable
-    _PROMPTY_FILE = "retrieval.prompty"
-    _LLM_CALL_TIMEOUT = 600
-    _DEFAULT_OPEN_API_VERSION = "2024-02-15-preview"
-
-    def __init__(self, model_config: dict):
-        prompty_model_config = construct_prompty_model_config(
-            validate_model_config(model_config),
-            self._DEFAULT_OPEN_API_VERSION,
-            USER_AGENT,
-        )
-
-        current_dir = os.path.dirname(__file__)
-        prompty_path = os.path.join(current_dir, self._PROMPTY_FILE)
-        self._flow = AsyncPrompty.load(source=prompty_path, model=prompty_model_config)
-
-    async def __call__(self, *, query, context, conversation, **kwargs):
-        if conversation:
-            # Extract queries, responses and contexts from conversation
-            queries = []
-            responses = []
-            contexts = []
-
-            conversation = conversation.get("messages", None)
-
-            for each_turn in conversation:
-                role = each_turn["role"]
-                if role == "user":
-                    queries.append(each_turn["content"])
-                elif role == "assistant":
-                    responses.append(each_turn["content"])
-                    if "context" in each_turn:
-                        if "citations" in each_turn["context"]:
-                            citations = json.dumps(each_turn["context"]["citations"])
-                            contexts.append(citations)
-                        elif isinstance(each_turn["context"], str):
-                            contexts.append(each_turn["context"])
-
-            # Evaluate each turn
-            per_turn_scores = []
-            per_turn_reasons = []
-            for turn_num, turn_query in enumerate(queries):
-                try:
-                    if turn_num >= len(queries):
-                        turn_query = ""
-                    context = contexts[turn_num] if turn_num < len(contexts) else ""
-
-                    llm_output = await self._flow(
-                        query=turn_query, context=context, timeout=self._LLM_CALL_TIMEOUT, **kwargs
-                    )
-                    score, reason = parse_quality_evaluator_reason_score(llm_output)
-                    per_turn_scores.append(score)
-                    per_turn_reasons.append(reason)
-
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    logger.warning(
-                        "Evaluator %s failed for turn %s with exception: %s", self.__class__.__name__, turn_num + 1, e
-                    )
-
-                    per_turn_scores.append(math.nan)
-                    per_turn_reasons.append("")
-
-            mean_per_turn_score = list_mean_nan_safe(per_turn_scores)
-
-            return {
-                "retrieval": mean_per_turn_score,
-                "gpt_retrieval": mean_per_turn_score,
-                "evaluation_per_turn": {
-                    "gpt_retrieval": per_turn_scores,
-                    "retrieval": per_turn_scores,
-                    "retrieval_reason": per_turn_reasons,
-                },
-            }
-        llm_output = await self._flow(query=query, context=context, timeout=self._LLM_CALL_TIMEOUT, **kwargs)
-        score, reason = parse_quality_evaluator_reason_score(llm_output)
-
-        return {
-            "retrieval": score,
-            "retrieval_reason": reason,
-            "gpt_retrieval": score,
-        }
 
 
 class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
@@ -146,12 +57,17 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         To maintain backwards compatibility, the old key with the `gpt_` prefix is still be present in the output;
         however, it is recommended to use the new key moving forward as the old key will be deprecated in the future.
     """
+    _PROMPTY_FILE = "retrieval.prompty"
+    _RESULT_KEY = "retrieval"
 
     id = "azureml://registries/azureml/models/Retrieval-Evaluator/versions/1"
     """Evaluator identifier, experimental and to be used only with evaluation in cloud."""
 
+    @override
     def __init__(self, model_config):  # pylint: disable=super-init-not-called
-        self._async_evaluator = _AsyncRetrievalScoreEvaluator(model_config)
+        current_dir = os.path.dirname(__file__)
+        prompty_path = os.path.join(current_dir, self._PROMPTY_FILE)
+        super().__init__(model_config=model_config, prompty_file=prompty_path, result_key=self._RESULT_KEY)
 
     @overload
     def __call__(
@@ -185,6 +101,7 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :rtype: Dict[str, Union[float, Dict[str, List[float]]]]
         """
 
+    @override
     def __call__(self, *args, **kwargs):  # pylint: disable=docstring-missing-param
         """Evaluates retrieval score chat scenario. Accepts either a query and context for a single evaluation,
         or a conversation for a multi-turn evaluation. If the conversation has more than one turn,
@@ -199,30 +116,4 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :return: The scores for Chat scenario.
         :rtype: :rtype: Dict[str, Union[float, Dict[str, List[str, float]]]]
         """
-        query = kwargs.pop("query", None)
-        context = kwargs.pop("context", None)
-        conversation = kwargs.pop("conversation", None)
-
-        if (query is None or context is None) and conversation is None:
-            msg = "Either a pair of 'query'/'context' or 'conversation' must be provided."
-            raise EvaluationException(
-                message=msg,
-                internal_message=msg,
-                blame=ErrorBlame.USER_ERROR,
-                category=ErrorCategory.MISSING_FIELD,
-                target=ErrorTarget.RETRIEVAL_EVALUATOR,
-            )
-
-        if (query or context) and conversation:
-            msg = "Either a pair of 'query'/'context' or 'conversation' must be provided, but not both."
-            raise EvaluationException(
-                message=msg,
-                internal_message=msg,
-                blame=ErrorBlame.USER_ERROR,
-                category=ErrorCategory.INVALID_VALUE,
-                target=ErrorTarget.RETRIEVAL_EVALUATOR,
-            )
-
-        return async_run_allowing_running_loop(
-            self._async_evaluator, query=query, context=context, conversation=conversation, **kwargs
-        )
+        return super().__call__(*args, **kwargs)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/_retrieval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/_retrieval.py
@@ -2,21 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-import json
 import logging
-import math
 import os
 from typing import Dict, List, Union
 from typing_extensions import overload, override
 
-from promptflow._utils.async_utils import async_run_allowing_running_loop
-from promptflow.core import AsyncPrompty
-
 from azure.ai.evaluation._evaluators._common._base_prompty_eval import PromptyEvaluatorBase
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 from azure.ai.evaluation._model_configurations import Conversation
-from ..._common.math import list_mean_nan_safe
-from ..._common.utils import construct_prompty_model_config, validate_model_config, parse_quality_evaluator_reason_score
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +49,7 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         To maintain backwards compatibility, the old key with the `gpt_` prefix is still be present in the output;
         however, it is recommended to use the new key moving forward as the old key will be deprecated in the future.
     """
+
     _PROMPTY_FILE = "retrieval.prompty"
     _RESULT_KEY = "retrieval"
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -847,9 +847,7 @@ class TestEvaluate:
         assert "outputs.retrieval.evaluation_per_turn" in row_result_df.columns.to_list()
         assert "retrieval.retrieval" in metrics.keys()
         assert "retrieval.gpt_retrieval" in metrics.keys()
-        assert metrics.get("retrieval.retrieval") == list_mean_nan_safe(
-            row_result_df["outputs.retrieval.retrieval"]
-        )
+        assert metrics.get("retrieval.retrieval") == list_mean_nan_safe(row_result_df["outputs.retrieval.retrieval"])
         assert row_result_df["outputs.retrieval.retrieval"][1] in [0.0, 1.0, 2.0]
         assert row_result_df["outputs.retrieval.evaluation_per_turn"][0]["retrieval"][0] in [0.0, 1.0, 2.0]
         assert row_result_df["outputs.retrieval.evaluation_per_turn"][0]["retrieval_reason"][0] is not None
@@ -879,8 +877,6 @@ class TestEvaluate:
         assert "outputs.retrieval.gpt_retrieval" in row_result_df.columns.to_list()
         assert "retrieval.retrieval" in metrics.keys()
         assert "retrieval.gpt_retrieval" in metrics.keys()
-        assert metrics.get("retrieval.retrieval") == list_mean_nan_safe(
-            row_result_df["outputs.retrieval.retrieval"]
-        )
+        assert metrics.get("retrieval.retrieval") == list_mean_nan_safe(row_result_df["outputs.retrieval.retrieval"])
         assert row_result_df["outputs.retrieval.retrieval"][1] in [0.0, 1.0, 2.0]
         assert result["studio_url"] is None

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_built_in_evaluator.py
@@ -70,7 +70,7 @@ class TestBuiltInEvaluators:
 
     def test_retrieval_evaluator_keys(self, mock_model_config):
         retrieval_eval = RetrievalEvaluator(model_config=mock_model_config)
-        retrieval_eval._async_evaluator._flow = MagicMock(return_value=quality_response_async_mock())
+        retrieval_eval._flow = MagicMock(return_value=quality_response_async_mock())
         result = retrieval_eval(
             query="What is the value of 2 + 2?",
             context="1 + 2 = 2",
@@ -80,7 +80,7 @@ class TestBuiltInEvaluators:
         assert result["retrieval_reason"]
 
         retrieval_eval = RetrievalEvaluator(model_config=mock_model_config)
-        retrieval_eval._async_evaluator._flow = MagicMock(return_value=quality_response_async_mock())
+        retrieval_eval._flow = MagicMock(return_value=quality_response_async_mock())
         conversation = {
             "messages": [
                 {"role": "user", "content": "What is the value of 2 + 2?"},
@@ -100,7 +100,7 @@ class TestBuiltInEvaluators:
         assert result["retrieval"] == result["gpt_retrieval"] == 1
 
         retrieval_eval = RetrievalEvaluator(model_config=mock_model_config)
-        retrieval_eval._async_evaluator._flow = MagicMock(return_value=quality_response_async_mock())
+        retrieval_eval._flow = MagicMock(return_value=quality_response_async_mock())
         conversation = {
             "messages": [
                 {"role": "user", "content": "What is the value of 2 + 2?"},
@@ -117,22 +117,12 @@ class TestBuiltInEvaluators:
 
     def test_quality_evaluator_missing_input(self, mock_model_config):
         """All evaluators that inherit from EvaluatorBase are covered by this test"""
-        quality_eval = RelevanceEvaluator(model_config=mock_model_config)
+        quality_eval = RetrievalEvaluator(model_config=mock_model_config)
         quality_eval._flow = MagicMock(return_value=quality_response_async_mock())
 
         with pytest.raises(EvaluationException) as exc_info:
-            quality_eval(response="The capital of Japan is Tokyo.")  # Relevance requires "query"
+            quality_eval(response="The capital of Japan is Tokyo.")  # Retrieval requires query and context
 
         assert (
-            "RelevanceEvaluator: Either 'conversation' or individual inputs must be provided." in exc_info.value.args[0]
+            "RetrievalEvaluator: Either 'conversation' or individual inputs must be provided." in exc_info.value.args[0]
         )
-
-    def test_retrieval_evaluator_missing_input(self, mock_model_config):
-        """This test can be removed if RetrievalEvaluator is refactored to be a child of EvaluatorBase"""
-        retrieval_eval = RetrievalEvaluator(model_config=mock_model_config)
-        retrieval_eval._async_evaluator._flow = MagicMock(return_value=quality_response_async_mock())
-
-        with pytest.raises(EvaluationException) as exc_info:
-            retrieval_eval(context="1 + 2 = 2.")  # Retrieval requires "query"
-
-        assert "Either a pair of 'query'/'context' or 'conversation' must be provided." in exc_info.value.args[0]


### PR DESCRIPTION

# Description

This PR fixes a bug where `RetrievalEvaluator` wasn't working with `evaluate()` when column mappings were used (only in conversation mode)

The issue was that `RetrievalEvaluator`, despite inheriting from `PromptyEvaluatorBase` like the other prompt-based evaluators, was overriding many of the methods and thus, it was bypassing the logic that allows non-conversational inputs for `evaluate`. This PR removes those overrides, matches its logic to the other prompt-based evaluators, and adds tests to ensure that both column mapping and conversation scenarios work correctly.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
