### PR TITLE
Fix broken async .telemetry.enable() method, when you don't pass in "destination"

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -1,5 +1,5 @@
 
-# Azure Ai Projects client library for Python
+# Azure AI Projects client library for Python
 <!-- write necessary description of service -->
 
 ## Getting started

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -381,7 +381,7 @@ class TelemetryOperations(TelemetryOperationsGenerated):
         self._outer_instance = kwargs.pop("outer_instance")
         super().__init__(*args, **kwargs)
 
-    async def get_connection_string(self) -> Optional[str]:
+    async def get_connection_string(self) -> str:
         """
         Get the Application Insights connection string associated with the Project's Application Insights resource.
         On first call, this method makes a service call to the Application Insights resource URL to get the connection string.

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -411,12 +411,29 @@ class TelemetryOperations(TelemetryOperationsGenerated):
 
     # TODO: what about `set AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true`?
     # TODO: This could be a class method. But we don't have a class property AIProjectClient.telemetry
-    def enable(self, *, destination: Union[TextIO, str], **kwargs) -> None:
-        """Enable tracing to console (sys.stdout), or to an OpenTelemetry Protocol (OTLP) collector.
+    async def enable(self, *, destination: Union[TextIO, str, None] = None, **kwargs) -> None:
+        """Enables telemetry collection with OpenTelemetry for Azure AI clients and popular GenAI libraries.
 
-        :keyword destination: `sys.stdout` for tracing to console output, or a string holding the
-         endpoint URL of the OpenTelemetry Protocol (OTLP) collector. Required.
-        :paramtype destination: Union[TextIO, str]
+        Following instrumentations are enabled (when corresponding packages are installed):
+
+        - Azure AI Inference (`azure-ai-inference`)
+        - Azure AI Projects (`azure-ai-projects`)
+        - OpenAI (`opentelemetry-instrumentation-openai-v2`)
+        - Langchain (`opentelemetry-instrumentation-langchain`)
+
+        The recording of prompt and completion messages is disabled by default. To enable it, set the
+        `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED` environment variable to `true`.
+
+        When destination is provided, the method configures OpenTelemetry SDK to export traces to
+        stdout or OTLP (OpenTelemetry protocol) gRPC endpoint. It's recommended for local
+        development only. For production use, make sure to configure OpenTelemetry SDK directly.
+
+        :keyword destination: Recommended for local testing only. Set it to `sys.stdout` for
+            tracing to console output, or a string holding the OpenTelemetry protocol (OTLP)
+            endpoint such as "http://localhost:4317.
+            If not provided, the method enables instrumentations, but does not configure OpenTelemetry
+            SDK to export traces.
+        :paramtype destination: Union[TextIO, str, None]
         """
         _enable_telemetry(destination=destination, **kwargs)
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -413,7 +413,7 @@ def _enable_telemetry(destination: Union[TextIO, str, None], **kwargs) -> None:
             tp = cast(TracerProvider, trace.get_tracer_provider())
             tp.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
         else:
-            raise ValueError("Only `sys.stdout` is supported at the moment for type `TextIOWrapper`")
+            raise ValueError("Only `sys.stdout` is supported at the moment for type `TextIO`")
 
     # Silently try to load a set of relevant Instrumentors
     try:


### PR DESCRIPTION
* Fix broken .telemetry.enable() method, when you don't pass in "destination". The async version should have been updated to accept None as input destination, as does the sync version
* Looks like I missed updating get_connection_string() output type to 'str' instead of 'Optional[str]', as part of my previous PR to have this method throw on "error" instead of return None.
* Two other minor fixes.