### PR TITLE
Fix doc string errors

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -394,7 +394,7 @@ class TelemetryOperations(TelemetryOperationsGenerated):
 
         :return: The Application Insights connection string if a the resource was enabled for the Project.
         :rtype: str
-        :raises ~azure.core.exceptions.ResourceNotFoundError
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         """
         if not self._connection_string:
             # Get the AI Studio Project properties, including Application Insights resource URL if exists

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -5746,14 +5746,14 @@ class VectorStoreDataSource(_model_base.Model):
 
     :ivar asset_identifier: Asset URI. Required.
     :vartype asset_identifier: str
-    :ivar asset_type: The asset type *. Required. Known values are: "uri_asset" and "id_asset".
+    :ivar asset_type: The asset type. Required. Known values are: "uri_asset" and "id_asset".
     :vartype asset_type: str or ~azure.ai.projects.models.VectorStoreDataSourceAssetType
     """
 
     asset_identifier: str = rest_field(name="uri")
     """Asset URI. Required."""
     asset_type: Union[str, "_models.VectorStoreDataSourceAssetType"] = rest_field(name="type")
-    """The asset type *. Required. Known values are: \"uri_asset\" and \"id_asset\"."""
+    """The asset type. Required. Known values are: \"uri_asset\" and \"id_asset\"."""
 
     @overload
     def __init__(

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -486,7 +486,7 @@ class TelemetryOperations(TelemetryOperationsGenerated):
 
         :return: The Application Insights connection string if a the resource was enabled for the Project.
         :rtype: str
-        :raises ~azure.core.exceptions.ResourceNotFoundError
+        :raises ~azure.core.exceptions.ResourceNotFoundError:
         """
         if not self._connection_string:
             # Get the AI Studio Project properties, including Application Insights resource URL if exists


### PR DESCRIPTION
Fix doc string errors found by running:

tox run -e sphinx -c ../../../eng/tox/tox.ini --root .

I'm assuming the issue in the auto-generated file `_models.py` was a result of mistaken manual edit, and not a bug in the emitter tool. We will see next time someone runs the Python emitter if it comes back.