### PR TITLE
Fix escape related SyntaxWarning in scripts

### DIFF
--- a/scripts/auto_release/main.py
+++ b/scripts/auto_release/main.py
@@ -535,7 +535,7 @@ class CodegenTestPR:
         self.pr_number = res_create.number
 
     def zero_version_policy(self):
-        if re.match(re.compile("0\.0\.0"), self.next_version):
+        if re.match(re.compile(r"0\.0\.0"), self.next_version):
             api_request = GhApi(owner="Azure", repo="sdk-release-request", token=self.bot_token)
             if self.issue_link:
                 issue_number = int(self.issue_link.split("/")[-1])

--- a/scripts/collect_api_version_for_multi_api_sdk/main.py
+++ b/scripts/collect_api_version_for_multi_api_sdk/main.py
@@ -149,7 +149,7 @@ class CollectApiVersion:
         else:
             api_version = api_version_info.default_api_version + str(api_version_info.profile)
 
-        return set(re.findall("\d{4}-\d{2}-\d{2}[-a-z]*", api_version))
+        return set(re.findall(r"\d{4}-\d{2}-\d{2}[-a-z]*", api_version))
 
     @staticmethod
     def write_file(file_name, content):

--- a/scripts/devops_tasks/create_coverage.py
+++ b/scripts/devops_tasks/create_coverage.py
@@ -66,10 +66,10 @@ def fix_coverage_xml(coverage_file):
         line = cov_file.read()
 
         # replace relative paths in folder structure pattern
-        out = re.sub("\/\.tox\/[\s\S_]*?\/site-packages", "", line)
+        out = re.sub(r"\/\.tox\/[\s\S_]*?\/site-packages", "", line)
 
         # replace relative paths in python import pattern
-        out = re.sub("\.?\.tox[\s\S\.\d]*?\.site-packages", "", out)
+        out = re.sub(r"\.?\.tox[\s\S\.\d]*?\.site-packages", "", out)
 
     if out:
         with open(coverage_file, "w") as cov_file:

--- a/scripts/release_helper/utils.py
+++ b/scripts/release_helper/utils.py
@@ -62,7 +62,7 @@ def get_python_release_pipeline(output_folder):
                                       creds=BasicAuthentication(os.getenv('PIPELINE_TOKEN'), ''))
     pipelines = pipeline_client.list_pipelines(project='internal')
     for pipeline in pipelines:
-        if re.findall('^python - \w*$', pipeline.name):
+        if re.findall(r'^python - \w*$', pipeline.name):
             key = pipeline.name.replace('python - ', '')
             if key == output_folder:
                 pipeline_url = 'https://dev.azure.com/azure-sdk/internal/_build?definitionId={}'.format(pipeline.id)

--- a/scripts/release_sdk_status/main.py
+++ b/scripts/release_sdk_status/main.py
@@ -313,7 +313,7 @@ def read_file(file_name):
 def find_test_path(line: str) -> str:
     line = line.strip('\n') + '\n'
     try:
-        return re.findall('output-folder: \$\(python-sdks-folder\)/(.*?)\n', line)[0]
+        return re.findall('output-folder: \\$\\(python-sdks-folder\\)/(.*?)\n', line)[0]
     except:
         FAILED_RESULT.append('[Fail to find sdk path] ' + line)
         return ''
@@ -321,7 +321,7 @@ def find_test_path(line: str) -> str:
 
 def sdk_info_from_swagger() -> List[Dict[str, str]]:
     sdk_name_re = re.compile(r'azure-mgmt-[a-z]+-*([a-z])+')
-    sdk_folder_re = re.compile('output-folder: \$\(python-sdks-folder\)/')
+    sdk_folder_re = re.compile(r'output-folder: \$\(python-sdks-folder\)/')
     resource_manager = []
     SWAGGER_FOLDER = os.getenv('SWAGGER_REPO')
     target_file_pattern = str(Path(f'{SWAGGER_FOLDER}/specification/*/resource-manager/readme.md'))
@@ -395,10 +395,10 @@ def get_latest_pr_from_readme(rest_repo: Repository, service_html: str):
         latest_commit = commit
         break
     latest_pr_brief = latest_commit.commit.message
-    latest_pr_number = re.findall('\(\#[0-9]+\)', latest_pr_brief)
+    latest_pr_number = re.findall(r'\(\#[0-9]+\)', latest_pr_brief)
     latest_pr_number_int = []
     for number in latest_pr_number:
-        number = int(re.search('\d+', number).group())
+        number = int(re.search(r'\d+', number).group())
         latest_pr_number_int.append(number)
     latest_pr_number_int.sort()
 

--- a/scripts/release_sdk_status/main.py
+++ b/scripts/release_sdk_status/main.py
@@ -313,7 +313,7 @@ def read_file(file_name):
 def find_test_path(line: str) -> str:
     line = line.strip('\n') + '\n'
     try:
-        return re.findall('output-folder: \\$\\(python-sdks-folder\\)/(.*?)\n', line)[0]
+        return re.findall(r'output-folder: \$\(python-sdks-folder\)/(.*?)\n', line)[0]
     except:
         FAILED_RESULT.append('[Fail to find sdk path] ' + line)
         return ''


### PR DESCRIPTION
# Description

Python gives a `SyntaxWarning` for invalid escapes starting from 3.12. This change fixes the invalid escapes for `scripts`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
