### PR TITLE
Cherry-Pick (SHA - cfc9b85) - Azure-AI-Evaluation 1.0.0 - Protected-Material

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_9327f7360c"
+  "Tag": "python/evaluation/azure-ai-evaluation_fdb88346b8"
 }

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_builtin_evaluators.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_builtin_evaluators.py
@@ -989,9 +989,9 @@ class TestBuiltInEvaluators:
         score = evaluator(conversation=conversation)
 
         assert score is not None
-        # assert not result["artwork_label"]
-        # assert "artwork was not found" in result["artwork_reason"]
-        # assert not result["protected_material_label"]
-        # assert "material was not found" in result["protected_material_reason"]
-        # assert not result["protected_material_label"]
-        # assert "material was not found" in result["protected_material_reason"]
+        assert score["artwork_label"] in [True, False]
+        assert score["artwork_reason"], "artwork_reason must not be None or empty."
+        assert score["fictional_characters_label"] in [True, False]
+        assert score["fictional_characters_reason"], "fictional_characters_reason must not be None or empty."
+        assert score["logos_and_brands_label"] in [True, False]
+        assert score["fictional_characters_reason"], "fictional_characters_reason must not be None or empty."

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -13,6 +13,7 @@ from azure.ai.evaluation import (
     ContentSafetyEvaluator,
     ContentSafetyMultimodalEvaluator,
     SexualMultimodalEvaluator,
+    ProtectedMaterialMultimodalEvaluator,
     F1ScoreEvaluator,
     FluencyEvaluator,
     GroundednessEvaluator,
@@ -412,6 +413,44 @@ class TestEvaluate:
         # Check that label is renamed to passing rate in metrics
         assert "groundedness_pro.groundedness_pro_passing_rate" in convo_metrics.keys()
         assert 0 <= convo_metrics.get("groundedness_pro.groundedness_pro_passing_rate") <= 1
+
+    def test_evaluate_with_protected_material_multimodal_evaluator(
+        self, project_scope, azure_cred, multimodal_file_with_imageurls
+    ):
+        os.environ["PF_EVALS_BATCH_USE_ASYNC"] = "false"
+        input_data = pd.read_json(multimodal_file_with_imageurls, lines=True)
+        eval = ProtectedMaterialMultimodalEvaluator(azure_ai_project=project_scope, credential=azure_cred)
+        result = evaluate(
+            evaluation_name=f"test-multimodal-protected-material-eval-dataset-{str(uuid.uuid4())}",
+            azure_ai_project=project_scope,
+            data=multimodal_file_with_imageurls,
+            evaluators={"protected_material": eval},
+            evaluator_config={
+                "protected_material": {"conversation": "${data.conversation}"},
+            },
+        )
+
+        row_result_df = pd.DataFrame(result["rows"])
+        metrics = result["metrics"]
+        # validate the results
+        assert result is not None
+        assert result["rows"] is not None
+        assert row_result_df.shape[0] == len(input_data)
+
+        assert "outputs.protected_material.artwork_label" in row_result_df.columns.to_list()
+        assert "outputs.protected_material.artwork_reason" in row_result_df.columns.to_list()
+        assert "outputs.protected_material.fictional_characters_label" in row_result_df.columns.to_list()
+        assert "outputs.protected_material.fictional_characters_reason" in row_result_df.columns.to_list()
+        assert "outputs.protected_material.logos_and_brands_label" in row_result_df.columns.to_list()
+        assert "outputs.protected_material.logos_and_brands_reason" in row_result_df.columns.to_list()
+
+        assert "protected_material.fictional_characters_label" in metrics.keys()
+        assert "protected_material.logos_and_brands_label" in metrics.keys()
+        assert "protected_material.artwork_label" in metrics.keys()
+
+        assert 0 <= metrics.get("protected_material.fictional_characters_label") <= 1
+        assert 0 <= metrics.get("protected_material.logos_and_brands_label") <= 1
+        assert 0 <= metrics.get("protected_material.artwork_label") <= 1
 
     # @pytest.mark.performance_test
     @pytest.mark.skip(reason="Temporary skip to merge 37201, will re-enable in subsequent pr")


### PR DESCRIPTION
We have the Protected Material Evaluator for multi-modal - [link](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_multimodal/_protected_material.py)

For multi-modal, we receive 3 new attributes in backend service response.
artwork, fictional_characters, logos

<img width="1875" alt="image" src="https://github.com/user-attachments/assets/8115fd28-a5ac-4292-b2c2-f10eb0f51c08">


Example
AI Studio Protected Material Eval Run - [here](https://int.ai.azure.com/build/evaluation/f7e1e75c-67c1-4b60-8886-d1aee4f71728?wsid=/subscriptions/b17253fa-f327-42d6-9686-f3e553e24763/resourceGroups/hanchi-test/providers/Microsoft.MachineLearningServices/workspaces/hancwang-eus2-0339&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)