### PR TITLE
[EventHub] run update python snippet

### DIFF
--- a/sdk/eventhub/azure-eventhub/README.md
+++ b/sdk/eventhub/azure-eventhub/README.md
@@ -149,7 +149,7 @@ def send_event_data_batch(producer):
     # Without specifying partition_id or partition_key
     # the events will be distributed to available partitions via round-robin.
     event_data_batch = producer.create_batch()
-    event_data_batch.add(EventData('Single message'))
+    event_data_batch.add(EventData("Single message"))
     producer.send_batch(event_data_batch)
 ```
 


### PR DESCRIPTION
Fixing Update snippet step failure in CI with: `Snippet "send.send_event_data_batch" is not up to date.`

Running against CI: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4320391&view=results
