### PR TITLE
Updating the commit ID from main branch instead of from the fork

### DIFF
--- a/sdk/translation/azure-ai-translation-document/tsp-location.yaml
+++ b/sdk/translation/azure-ai-translation-document/tsp-location.yaml
@@ -1,3 +1,3 @@
-commit: 17a3ee0a2a03dbfbf1359a1370f994862e02925d
+commit: ccc08b40afbff1abe17c8250ed03a87e81fbf673
 repo: Azure/azure-rest-api-specs
 directory: specification/translation/Azure.AI.DocumentTranslation


### PR DESCRIPTION
Updating the commit ID from main branch instead of from the fork.

Trying to release the SDK, threw an error: 
##[error]Commit 17a3ee0a2a03dbfbf1359a1370f994862e02925d doesn't exist in 'main' branch of Azure/azure-rest-api-specs repository. ServiceDir:translation, PackageName:azure-ai-translation-document, please check the config file:/mnt/vss/_work/1/s/sdk/translation/azure-ai-translation-document/tsp-location.yaml. The spec used to release SDK should be from the main branch of Azure/azure-rest-api-specs repository.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4320838&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=7abbbe6b-d005-5c95-feb6-99ffe4e699e1&l=20

And by looking at the PR(https://github.com/Azure/azure-rest-api-specs/pull/31191) in rest repo, figured out the actual commitID that went into main was : https://github.com/Azure/azure-rest-api-specs/commit/ccc08b40afbff1abe17c8250ed03a87e81fbf673.
Hence updating it.