### PR TITLE
vnext emulator fix for replace + patch

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -721,7 +721,11 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
             is specified.
         :rtype: ~azure.cosmos.CosmosDict[str, Any]
         """
-        item_link = self._get_document_link(item)
+        try:
+            item_link = self._get_document_link(item)
+        except KeyError:
+            item_link = self.container_link + "/docs/" + item.get('id')
+
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -978,7 +982,10 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
 
         if self.container_link in self.__get_client_container_caches():
             request_options["containerRID"] = self.__get_client_container_caches()[self.container_link]["_rid"]
-        item_link = self._get_document_link(item)
+        try:
+            item_link = self._get_document_link(item)
+        except KeyError:
+            item_link = self.container_link + "/docs/" + item
         result = self.client_connection.PatchItem(
                 document_link=item_link, operations=patch_operations, options=request_options, **kwargs)
         return result


### PR DESCRIPTION
# Description

Cosmos vNext emulator does not store _self system property, so searching for it causes failure for replace and patch. This is a very small change to construct item_link if retrieving it from item throws an error (which would only happen for vnext emulator). 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
