### PR TITLE
Fix remaining mypy errors, all related to mismatching variable types

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -521,9 +521,9 @@ def _enable_telemetry(destination: Union[TextIO, str, None], **kwargs) -> None:
     try:
         from azure.ai.inference.tracing import AIInferenceInstrumentor  # type: ignore
 
-        instrumentor = AIInferenceInstrumentor()
-        if not instrumentor.is_instrumented():
-            instrumentor.instrument()
+        inference_instrumentor = AIInferenceInstrumentor()
+        if not inference_instrumentor.is_instrumented():
+            inference_instrumentor.instrument()
     except ModuleNotFoundError:
         logger.warning(
             "Could not call `AIInferenceInstrumentor().instrument()` since `azure-ai-inference` is not installed"
@@ -532,9 +532,9 @@ def _enable_telemetry(destination: Union[TextIO, str, None], **kwargs) -> None:
     try:
         from azure.ai.projects.telemetry.agents import AIAgentsInstrumentor
 
-        instrumentor = AIAgentsInstrumentor()
-        if not instrumentor.is_instrumented():
-            instrumentor.instrument()
+        agents_instrumentor = AIAgentsInstrumentor()
+        if not agents_instrumentor.is_instrumented():
+            agents_instrumentor.instrument()
     except Exception as exc:
         logger.warning("Could not call `AIAgentsInstrumentor().instrument()`", exc_info=exc)
 

--- a/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
@@ -104,7 +104,7 @@ async def sample_connections_async() -> None:
         else:
             raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-        response = await aoai_client.chat.completions.create(
+        aoai_response = await aoai_client.chat.completions.create(
             model=model_deployment_name,
             messages=[
                 {
@@ -114,13 +114,12 @@ async def sample_connections_async() -> None:
             ],
         )
         await aoai_client.close()
-        print(response.choices[0].message.content)
+        print(aoai_response.choices[0].message.content)
 
     elif connection.connection_type == ConnectionType.AZURE_AI_SERVICES:
 
         from azure.ai.inference.aio import ChatCompletionsClient
         from azure.ai.inference.models import UserMessage
-        from azure.core.credentials_async import AsyncTokenCredential
 
         if connection.authentication_type == AuthenticationType.API_KEY:
             print("====> Creating ChatCompletionsClient using API key authentication")
@@ -130,6 +129,7 @@ async def sample_connections_async() -> None:
                 endpoint=connection.endpoint_url, credential=AzureKeyCredential(connection.key or "")
             )
         elif connection.authentication_type == AuthenticationType.ENTRA_ID:
+            from azure.core.credentials_async import AsyncTokenCredential
             # MaaS models do not yet support EntraID auth
             print("====> Creating ChatCompletionsClient using Entra ID authentication")
             inference_client = ChatCompletionsClient(
@@ -138,11 +138,11 @@ async def sample_connections_async() -> None:
         else:
             raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-        response = await inference_client.complete(
+        inference_response = await inference_client.complete(
             model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
         )
         await inference_client.close()
-        print(response.choices[0].message.content)
+        print(inference_response.choices[0].message.content)
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
@@ -99,7 +99,7 @@ if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
     else:
         raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-    response = aoai_client.chat.completions.create(
+    aoai_response = aoai_client.chat.completions.create(
         model=model_deployment_name,
         messages=[
             {
@@ -109,7 +109,7 @@ if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
         ],
     )
     aoai_client.close()
-    print(response.choices[0].message.content)
+    print(aoai_response.choices[0].message.content)
 
 elif connection.connection_type == ConnectionType.SERVERLESS:
 
@@ -124,16 +124,17 @@ elif connection.connection_type == ConnectionType.SERVERLESS:
             endpoint=connection.endpoint_url, credential=AzureKeyCredential(connection.key or "")
         )
     elif connection.authentication_type == AuthenticationType.ENTRA_ID:
+        from azure.core.credentials import TokenCredential
         # MaaS models do not yet support EntraID auth
         print("====> Creating ChatCompletionsClient using Entra ID authentication")
         inference_client = ChatCompletionsClient(
-            endpoint=connection.endpoint_url, credential=connection.token_credential
+            endpoint=connection.endpoint_url, credential= cast(TokenCredential, connection.token_credential)
         )
     else:
         raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-    response = inference_client.complete(
+    inference_response = inference_client.complete(
         model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
     )
     inference_client.close()
-    print(response.choices[0].message.content)
+    print(inference_response.choices[0].message.content)


### PR DESCRIPTION
The same variable name was reused but re-assigned different object types and that caused mypy errors. Replace with unique names so there is no reuse of the same variable.