### PR TITLE
[Storage] Fix for invalid `x-ms-expiry-time` header in request

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -371,7 +371,8 @@ class DataLakeFileClient(PathClient):
         try:
             expires_on = convert_datetime_to_rfc1123(expires_on)
         except AttributeError:
-            expires_on = str(expires_on)
+            if expires_on is not None:
+                expires_on = str(expires_on)
         self._datalake_client_for_blob_operation.path \
             .set_expiry(expiry_options, expires_on=expires_on, **kwargs)
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -331,7 +331,8 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
         try:
             expires_on = convert_datetime_to_rfc1123(expires_on)
         except AttributeError:
-            expires_on = str(expires_on)
+            if expires_on is not None:
+                expires_on = str(expires_on)
         await self._datalake_client_for_blob_operation.path.set_expiry(expiry_options, expires_on=expires_on,
                                                                        **kwargs)
 

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -1188,12 +1188,21 @@ class TestFile(StorageRecordedTestCase):
             content_disposition='inline')
         expiry_time = self.get_datetime_variable(variables, 'expiry_time', datetime.utcnow() + timedelta(hours=1))
         file_client = directory_client.create_file("newfile", metadata=metadata, content_settings=content_settings)
-        file_client.set_file_expiry("Absolute", expires_on=expiry_time)
-        properties = file_client.get_file_properties()
 
-        # Assert
+        # Act / Assert
+        # ---Absolute---
+        file_client.set_file_expiry("Absolute", expires_on=expiry_time)
+
+        properties = file_client.get_file_properties()
         assert properties
         assert properties.expiry_time is not None
+
+        # ---NeverExpire---
+        file_client.set_file_expiry("NeverExpire")
+
+        properties = file_client.get_file_properties()
+        assert properties
+        assert properties.expiry_time is None
 
         return variables
 

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -1137,12 +1137,21 @@ class TestFileAsync(AsyncStorageRecordedTestCase):
             content_disposition='inline')
         expiry_time = self.get_datetime_variable(variables, 'expiry_time', datetime.utcnow() + timedelta(hours=1))
         file_client = await directory_client.create_file("newfile", metadata=metadata, content_settings=content_settings)
-        await file_client.set_file_expiry("Absolute", expires_on=expiry_time)
-        properties = await file_client.get_file_properties()
 
-        # Assert
+        # Act / Assert
+        # ---Absolute---
+        await file_client.set_file_expiry("Absolute", expires_on=expiry_time)
+
+        properties = await file_client.get_file_properties()
         assert properties
         assert properties.expiry_time is not None
+
+        # ---NeverExpire---
+        await file_client.set_file_expiry("NeverExpire")
+
+        properties = await file_client.get_file_properties()
+        assert properties
+        assert properties.expiry_time is None
 
         return variables
 


### PR DESCRIPTION
# Description

This pull request addresses the issue (#38518) with the `DataLakeFileClient.set_file_expiry()` method when using `expiry_options="NeverExpire"`. Previously, the method failed due to an incorrect format in the HTTP headers, specifically the redundant `x-ms-expiry-time` header.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
