### PR TITLE
Fix scopes to use Auth2.0 instead of Auth1.0

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -68,7 +68,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2020-02-02",
-            credential_scopes=["https://management.azure.com"],
+            credential_scopes=["https://management.azure.com/.default"],
             **kwargs0,
         )
 
@@ -106,7 +106,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",
-            credential_scopes=["https://management.azure.com"],
+            credential_scopes=["https://management.azure.com/.default"],
             **kwargs1,
         )
         _policies1 = kwargs1.pop("policies", None)
@@ -137,7 +137,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",  # TODO: Update me
-            credential_scopes=["https://ml.azure.com"],
+            credential_scopes=["https://ml.azure.com/.default"],
             **kwargs2,
         )
         _policies2 = kwargs2.pop("policies", None)
@@ -169,7 +169,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",  # TODO: Update me
-            credential_scopes=["https://ml.azure.com"],  # TODO: Update once service changes are ready
+            credential_scopes=["https://ml.azure.com/.default"],  # TODO: Update once service changes are ready
             **kwargs3,
         )
         _policies3 = kwargs3.pop("policies", None)

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -74,7 +74,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2020-02-02",
-            credential_scopes=["https://management.azure.com"],
+            credential_scopes=["https://management.azure.com/.default"],
             **kwargs0,
         )
 
@@ -106,7 +106,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",
-            credential_scopes=["https://management.azure.com"],
+            credential_scopes=["https://management.azure.com/.default"],
             **kwargs1,
         )
         _policies1 = kwargs1.pop("policies", None)
@@ -137,7 +137,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",  # TODO: Update me
-            credential_scopes=["https://ml.azure.com"],
+            credential_scopes=["https://ml.azure.com/.default"],
             **kwargs2,
         )
         _policies2 = kwargs2.pop("policies", None)
@@ -169,7 +169,7 @@ class AIProjectClient(
             project_name=project_name,
             credential=credential,
             api_version="2024-07-01-preview",  # TODO: Update me
-            credential_scopes=["https://ml.azure.com"],  # TODO: Update once service changes are ready
+            credential_scopes=["https://ml.azure.com/.default"],  # TODO: Update once service changes are ready
             **kwargs3,
         )
         _policies3 = kwargs3.pop("policies", None)


### PR DESCRIPTION
Pamela fox is writing a GitHub template that uses the SDK, and run into some auth issues on Mac. After debugging it together, we discovered we needed this fix. She verified the fix on her side using a private build of the package I shared with her.