### PR TITLE
[SDK generation pipeline] disable optimization for multiapi SDK generation

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -239,7 +239,8 @@ def main(generate_input, generate_output):
         try:
             if "resource-manager" in readme_or_tsp:
                 relative_path_readme = str(Path(spec_folder, readme_or_tsp))
-                update_metadata_for_multiapi_package(spec_folder, readme_or_tsp)
+                # we begin to trim package size so don't need opimization to speed SDK generation for now
+                # update_metadata_for_multiapi_package(spec_folder, readme_or_tsp)
                 del_outdated_files(relative_path_readme)
                 config = generate(
                     CONFIG_FILE,


### PR DESCRIPTION
We begin to trim multiapi package so the generation will not be too long then the optimization is not needed for now.