### PR TITLE
datastore auth fix

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.22.2 (2024-11-18)
+
+### Bugs Fixed
+  - **#3620407** - Fix Datastore credentials show up as NoneCredentials
+
 ## 1.22.1 (2024-11-13)
 
 ### Bugs Fixed

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_version.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.22.1"
+VERSION = "1.22.2"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/utils.py
@@ -7,6 +7,7 @@
 from typing import Any, Optional, Union, cast
 
 from azure.ai.ml._restclient.v2023_04_01_preview import models
+from azure.ai.ml._restclient.v2024_07_01_preview import models as models2024
 from azure.ai.ml.entities._credentials import (
     AccountKeyConfiguration,
     CertificateConfiguration,
@@ -28,13 +29,17 @@ def from_rest_datastore_credentials(
 ]:
     config_class: Any = NoneCredentialConfiguration
 
-    if isinstance(rest_credentials, models.AccountKeyDatastoreCredentials):
+    if isinstance(rest_credentials, (models.AccountKeyDatastoreCredentials, models2024.AccountKeyDatastoreCredentials)):
         config_class = AccountKeyConfiguration
-    elif isinstance(rest_credentials, models.SasDatastoreCredentials):
+    elif isinstance(rest_credentials, (models.SasDatastoreCredentials, models2024.SasDatastoreCredentials)):
         config_class = SasTokenConfiguration
-    elif isinstance(rest_credentials, models.ServicePrincipalDatastoreCredentials):
+    elif isinstance(
+        rest_credentials, (models.ServicePrincipalDatastoreCredentials, models2024.ServicePrincipalDatastoreCredentials)
+    ):
         config_class = ServicePrincipalConfiguration
-    elif isinstance(rest_credentials, models.CertificateDatastoreCredentials):
+    elif isinstance(
+        rest_credentials, (models.CertificateDatastoreCredentials, models2024.CertificateDatastoreCredentials)
+    ):
         config_class = CertificateConfiguration
 
     return cast(


### PR DESCRIPTION
# Description

There is bug identified in datastore deserialization, where credential is always coming back as NoneType.
![image](https://github.com/user-attachments/assets/5d15e973-4780-4911-8eff-476211effa67)

- Before fix
**NoneTypeCredentails** 
- Post Fix
**{'type': 'sas', 'sas_token': '?sp=racwdli&st=2024-11-18T07:34:01Z&se=**

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
