### PR TITLE
online-eval - make service name an optional field

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -427,7 +427,7 @@ class ApplicationInsightsConfiguration(InputData, discriminator="app_insights"):
     :vartype resource_id: str
     :ivar query: Query to fetch the data. Required.
     :vartype query: str
-    :ivar service_name: Service name. Required.
+    :ivar service_name: Service name.
     :vartype service_name: str
     :ivar connection_string: Connection String to connect to ApplicationInsights.
     :vartype connection_string: str
@@ -439,8 +439,8 @@ class ApplicationInsightsConfiguration(InputData, discriminator="app_insights"):
     """LogAnalytic Workspace resourceID associated with ApplicationInsights. Required."""
     query: str = rest_field()
     """Query to fetch the data. Required."""
-    service_name: str = rest_field(name="serviceName")
-    """Service name. Required."""
+    service_name: Optional[str] = rest_field(name="serviceName")
+    """Service name."""
     connection_string: Optional[str] = rest_field(name="connectionString")
     """Connection String to connect to ApplicationInsights."""
 
@@ -450,7 +450,7 @@ class ApplicationInsightsConfiguration(InputData, discriminator="app_insights"):
         *,
         resource_id: str,
         query: str,
-        service_name: str,
+        service_name: Optional[str] = None,
         connection_string: Optional[str] = None,
     ) -> None: ...
 

--- a/sdk/ai/azure-ai-projects/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/Azure.AI.Projects
-commit: 17ab26e678f06460cd154e2c0cb187aae158f4bf
+commit: bd451f87456c94d528ec198c0cc845b031ada94a
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 

--- a/sdk/ai/azure-ai-projects/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/Azure.AI.Projects
-commit: bd451f87456c94d528ec198c0cc845b031ada94a
+commit: 17ab26e678f06460cd154e2c0cb187aae158f4bf
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Make service name of AppInsightsConfiguration an optional field
Spec change PR: https://github.com/Azure/azure-rest-api-specs/pull/31603/