### PR TITLE
Fix Default Matrix

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -17,8 +17,8 @@
     {
       "MacTestConfig": {
         "macos311": {
-          "OSVmImage": "env:LINUXVMIMAGE",
-          "Pool": "env:LINUXPOOL",
+          "OSVmImage": "env:MACVMIMAGE",
+          "Pool": "env:MACPOOL",
           "PythonVersion": "3.11",
           "CoverageArg": "--disablecov",
           "TestSamples": "false"


### PR DESCRIPTION
MacOS assigned to python 3.11

follow-up to #38491