### PR TITLE
[Identity] Allow integration test request retries

### DIFF
--- a/sdk/identity/azure-identity/tests/integration/test_azure_functions.py
+++ b/sdk/identity/azure-identity/tests/integration/test_azure_functions.py
@@ -5,8 +5,9 @@
 import os
 import pytest
 
-from azure.core import PipelineClient
 from azure.core.rest import HttpRequest, HttpResponse
+
+from utils import get_pipeline_client
 
 
 @pytest.fixture(scope="module")
@@ -24,7 +25,7 @@ class TestAzureFunctionsIntegration:
     )
     def test_azure_functions_integration_sync(self, base_url):
         """Test the Azure Functions endpoint where the sync MI credential is used."""
-        client = PipelineClient(base_url)
+        client = get_pipeline_client(base_url)
         request = HttpRequest("GET", f"{base_url}RunTest")
         response: HttpResponse = client.send_request(request)
         assert response.status_code == 200
@@ -35,7 +36,7 @@ class TestAzureFunctionsIntegration:
     )
     def test_azure_functions_integration_async(self, base_url):
         """Test the Azure Functions endpoint where the async MI credential is used."""
-        client = PipelineClient(base_url)
+        client = get_pipeline_client(base_url)
         request = HttpRequest("GET", f"{base_url}RunAsyncTest")
         response: HttpResponse = client.send_request(request)
         assert response.status_code == 200

--- a/sdk/identity/azure-identity/tests/integration/test_azure_web_apps.py
+++ b/sdk/identity/azure-identity/tests/integration/test_azure_web_apps.py
@@ -5,8 +5,9 @@
 import os
 import pytest
 
-from azure.core import PipelineClient
 from azure.core.rest import HttpRequest, HttpResponse
+
+from utils import get_pipeline_client
 
 
 @pytest.fixture(scope="module")
@@ -24,7 +25,7 @@ class TestAzureWebAppsIntegration:
     )
     def test_azure_web_app_integration_sync(self, base_url):
         """Test the Azure Web App endpoint where the sync MI credential is used."""
-        client = PipelineClient(base_url)
+        client = get_pipeline_client(base_url)
         request = HttpRequest("GET", f"{base_url}sync")
         response: HttpResponse = client.send_request(request)
         assert response.status_code == 200
@@ -35,7 +36,7 @@ class TestAzureWebAppsIntegration:
     )
     def test_azure_web_app_integration_async(self, base_url):
         """Test the Azure Web App endpoint where the async MI credential is used."""
-        client = PipelineClient(base_url)
+        client = get_pipeline_client(base_url)
         request = HttpRequest("GET", f"{base_url}async")
         response: HttpResponse = client.send_request(request)
         assert response.status_code == 200

--- a/sdk/identity/azure-identity/tests/integration/utils.py
+++ b/sdk/identity/azure-identity/tests/integration/utils.py
@@ -5,6 +5,9 @@
 import subprocess
 import sys
 
+from azure.core import PipelineClient
+from azure.core.pipeline import policies
+
 
 def run_command(command, exit_on_failure=True) -> str:
     try:
@@ -16,3 +19,11 @@ def run_command(command, exit_on_failure=True) -> str:
             print(result)
             sys.exit(1)
         return result
+
+
+def get_pipeline_client(base_url: str) -> PipelineClient:
+    policy_list = [
+        policies.RetryPolicy(),
+        policies.ContentDecodePolicy(),
+    ]
+    return PipelineClient(base_url, policies=policy_list)

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -131,6 +131,9 @@ Write-Host "Deploying Azure Container Instance"
 az container create -g $($DeploymentOutputs['IDENTITY_RESOURCE_GROUP']) -n $($DeploymentOutputs['IDENTITY_CONTAINER_INSTANCE_NAME']) --image $image `
   --acr-identity $($DeploymentOutputs['IDENTITY_USER_DEFINED_IDENTITY']) `
   --assign-identity [system] $($DeploymentOutputs['IDENTITY_USER_DEFINED_IDENTITY']) `
+  --cpu 1 `
+  --memory 1.0 `
+  --os-type Linux `
   --role "Storage Blob Data Reader" `
   --scope $($DeploymentOutputs['IDENTITY_STORAGE_ID_1']) `
   -e IDENTITY_STORAGE_NAME=$($DeploymentOutputs['IDENTITY_STORAGE_NAME_1']) `


### PR DESCRIPTION
Some managed identity integration tests occasionally fail with gateway timeouts. This ensures that the requests to the app endpoints are retried in these cases by adding the RetryPolicy to the PipelineClient.

Also updated the `az` command to specify additional fields when creating a container instance in the post deploy script.

