### PR TITLE
Updated _parse_operation_id regex to allow for non-standard Document Intelligence Endpoints

### DIFF
--- a/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/_operations/_patch.py
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/_operations/_patch.py
@@ -36,7 +36,7 @@ _FINISHED = frozenset(["succeeded", "canceled", "failed", "completed"])
 
 
 def _parse_operation_id(operation_location_header):
-    regex = "[^:]+://[^/]+/documentintelligence/.+/([^?/]+)"
+    regex = "[^:]+://.+/documentintelligence/.+/([^?/]+)"
     return re.match(regex, operation_location_header).group(1)
 
 


### PR DESCRIPTION
# Description

The regex within the _parse_operation_id method assumes the following URL format for Document Intelligence endpoints when interpreting the _Operation-Location_ header value:

https://xxxxxxxx.cognitiveservices.azure.com/

The full _Operation-Location_ header value would be something like (i.e., only one forward-slash character between the domain and "documentintelligence"):

https://xxxxxxxx.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-read/analyzeResults/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx?api-version=2024-07-31-preview

While this works fine when accessing Document Intelligence resources directly, this will break if the endpoint is abstracted away behind an API gateway (in our case, Azure API Management). In this configuration, your endpoint value is probably something like this:

https://apim.example.com/azure/document-intelligence/

With the full _Operation-Location_ header value being something like (i.e., more than one forward-slash character between the domain and "documentintelligence"):

https://apim.example.com/azure/document-intelligence/documentintelligence/documentModels/prebuilt-read/analyzeResults/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx?api-version=2024-07-31-preview

Adjusting the regex to allow for any character (as opposed to any character except forward-slashes) between **https://** and **/documentintelligence/** enables this scenario to work correctly and, in my testing, did not impact the use of standard endpoint URLs.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.** <-- not sure if this one qualifies for this?
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
