### PR TITLE
cryptography max version

### DIFF
--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -60,7 +60,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "azure-core>=1.31.0",
-        "cryptography>=2.5",
+        "cryptography>=2.5,<=43.0.3",
         "msal>=1.30.0",
         "msal-extensions>=1.2.0",
         "typing-extensions>=4.0.0",


### PR DESCRIPTION
# Description

Pin cryptography max version to fix the breaking changes in latest cryptography release for azure-identity sdk
https://cryptography.io/en/latest/changelog/#v44-0-0
