### PR TITLE
Use b"" instead of bytes(). Don't use str on a string.

### DIFF
--- a/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/receipt/_receipt_verification.py
+++ b/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/receipt/_receipt_verification.py
@@ -258,7 +258,7 @@ def _compute_root_node_hash(leaf_hash: bytes, proof: List[ProofElement]) -> byte
                     "Invalid proof element in receipt: element must contain either one left or right node hash."
                 )
 
-            parent_node_hash = bytes()
+            parent_node_hash = b""
 
             # If the current element contains a left hash, concatenate the left hash and the current node hash
             if element.left is not None:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -94,7 +94,7 @@ _UNAVAIL = {errno.EAGAIN, errno.EINTR, errno.ENOENT, errno.EWOULDBLOCK}
 AMQP_PORT = 5672
 AMQPS_PORT = 5671
 AMQP_FRAME = memoryview(b"AMQP")
-EMPTY_BUFFER = bytes()
+EMPTY_BUFFER = b""
 SIGNED_INT_MAX = 0x7FFFFFFF
 
 # Match things like: [fe80::1]:5432, from RFC 2732

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -125,7 +125,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
         envelope.tags.update(_utils._populate_part_a_fields(resource))  # pylint: disable=W0212
         envelope.instrumentation_key = self._instrumentation_key
         data_point = MetricDataPoint(
-            name=str("_OTELRESOURCE_")[:1024],
+            name="_OTELRESOURCE_"[:1024],
             value=0,
         )
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -93,7 +93,7 @@ _UNAVAIL = {errno.EAGAIN, errno.EINTR, errno.ENOENT, errno.EWOULDBLOCK}
 AMQP_PORT = 5672
 AMQPS_PORT = 5671
 AMQP_FRAME = memoryview(b"AMQP")
-EMPTY_BUFFER = bytes()
+EMPTY_BUFFER = b""
 SIGNED_INT_MAX = 0x7FFFFFFF
 
 # Match things like: [fe80::1]:5432, from RFC 2732

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -185,7 +185,7 @@ def serialize_batch_body(requests, batch_id):
     # final line of body MUST have \r\n at the end, or it will not be properly read by the service
     batch_body.append(newline_bytes)
 
-    return bytes().join(batch_body)
+    return b"".join(batch_body)
 
 
 def _get_batch_request_delimiter(batch_id, is_prepend_dashes=False, is_append_dashes=False):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -185,7 +185,7 @@ def serialize_batch_body(requests, batch_id):
     # final line of body MUST have \r\n at the end, or it will not be properly read by the service
     batch_body.append(newline_bytes)
 
-    return bytes().join(batch_body)
+    return b"".join(batch_body)
 
 
 def _get_batch_request_delimiter(batch_id, is_prepend_dashes=False, is_append_dashes=False):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -185,7 +185,7 @@ def serialize_batch_body(requests, batch_id):
     # final line of body MUST have \r\n at the end, or it will not be properly read by the service
     batch_body.append(newline_bytes)
 
-    return bytes().join(batch_body)
+    return b"".join(batch_body)
 
 
 def _get_batch_request_delimiter(batch_id, is_prepend_dashes=False, is_append_dashes=False):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -185,7 +185,7 @@ def serialize_batch_body(requests, batch_id):
     # final line of body MUST have \r\n at the end, or it will not be properly read by the service
     batch_body.append(newline_bytes)
 
-    return bytes().join(batch_body)
+    return b"".join(batch_body)
 
 
 def _get_batch_request_delimiter(batch_id, is_prepend_dashes=False, is_append_dashes=False):


### PR DESCRIPTION
# Description

https://docs.astral.sh/ruff/rules/native-literals/

Fixed using
```sh
ruff check --exclude="script*" --exclude="tools*" --select "UP018" --fix
```

Performance improvements:
```
In [1]: %timeit b""
6.85 ns ± 0.222 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)

In [2]: %timeit bytes()
41.1 ns ± 0.245 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit "Azure"
6.75 ns ± 0.037 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)

In [4]: %timeit str("Azure")
25.8 ns ± 0.124 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.