### PR TITLE
typing

### DIFF
--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/_pipeline_client.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/_pipeline_client.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import TypeVar, Any
+from typing import TypeVar, Any, Generic
 from collections.abc import MutableSequence
 from azure.core import PipelineClient
 from .policies import ARMAutoResourceProviderRegistrationPolicy, ARMHttpLoggingPolicy
@@ -32,7 +32,7 @@ HTTPResponseType = TypeVar("HTTPResponseType")
 HTTPRequestType = TypeVar("HTTPRequestType")
 
 
-class ARMPipelineClient(PipelineClient[HTTPRequestType, HTTPResponseType]):
+class ARMPipelineClient(PipelineClient, Generic[HTTPResponseType, HTTPRequestType]):
     """A pipeline client designed for ARM explicitly.
 
     :param str base_url: URL for the request.


### PR DESCRIPTION
PipelineClient[HTTPRequestType, HTTPResponseType] was raising https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4370370&view=logs&j=42ded549-05ee-5cdb-7ba7-7a948a0cc056&t=b938c548-640d-5101-7a83-c666c2d131df&l=397 an error after the release of azure-mgmt-core 1.5.0. 


I'm not sure if this is the correct way to fix this but I modeled after azure-core 