### PR TITLE
[engsys] docs,fix: `--root` is required for `tox run -e black`

### DIFF
--- a/doc/eng_sys_checks.md
+++ b/doc/eng_sys_checks.md
@@ -253,9 +253,9 @@ to opt into the black invocation.
 #### Running locally
 
 1. Go to package root directory.
-2. Execute command: `tox run -e black -c ../../../eng/tox/tox.ini -- .`
+2. Execute command: `tox run -e black -c ../../../eng/tox/tox.ini --root . -- .`
 
-**Tip**: You can provide any arguments that `black` accepts after the `--`. Example: `tox run -e black -c ../../../eng/tox/tox.ini -- path/to/file.py`
+**Tip**: You can provide any arguments that `black` accepts after the `--`. Example: `tox run -e black -c ../../../eng/tox/tox.ini --root . -- path/to/file.py`
 
 ### Change log verification
 


### PR DESCRIPTION
# Description

This pull request updates `eng_sys_checks.md` to specify that the `--root` parameter needs to point to a package's root directory when running `tox run -e black`.

cc: @scbedd 

# Background

`tox run -e black` used to be a thin wrapper around an invocation of `black`, which meant we didn't need to specify `--root` so long as positional arguments could be forwarded to the underlying invocation of black.

#38212 updated `tox run -e black` to instead run a script which invokes black. The script depends on the `dev-requirements.txt` in a package's root directory, which makes it mandatory to specify `--root` now.


# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
