### PR TITLE
[Storage] [STG 97] Beta Release API Views Feedback

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_8408bc5e54"
+  "Tag": "python/storage/azure-storage-file-share_f05fb1bbb2"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -1688,7 +1688,7 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def create_hard_link(
-        self, target_file: str,
+        self, target: str,
         *,
         lease: Optional[Union[ShareLeaseClient, str]] = None,
         timeout: Optional[int] = None,
@@ -1696,7 +1696,7 @@ class ShareFileClient(StorageAccountHostsMixin):
     ) -> Dict[str, Any]:
         """NFS only. Create a hard link to the file specified by path.
 
-        :param str target_file:
+        :param str target:
             Specifies the path of the target file to which the link will be created, up to 2 KiB in length.
             It should be the full path of the target starting from the root. The target file must be in the
             same share and the same storage account.
@@ -1715,7 +1715,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         """
         try:
             return cast(Dict[str, Any], self._client.file.create_hard_link(
-                target_file=target_file,
+                target_file=target,
                 lease_access_conditions=lease,
                 timeout=timeout,
                 cls=return_response_headers,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -1689,7 +1689,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin): 
 
     @distributed_trace_async
     async def create_hard_link(
-        self, target_file: str,
+        self, target: str,
         *,
         lease: Optional[Union[ShareLeaseClient, str]] = None,
         timeout: Optional[int] = None,
@@ -1697,7 +1697,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin): 
     ) -> Dict[str, Any]:
         """NFS only. Create a hard link to the file specified by path.
 
-        :param str target_file:
+        :param str target:
             Specifies the path of the target file to which the link will be created, up to 2 KiB in length.
             It should be the full path of the target starting from the root. The target file must be in the
             same share and the same storage account.
@@ -1716,7 +1716,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin): 
         """
         try:
             return cast(Dict[str, Any], await self._client.file.create_hard_link(
-                target_file=target_file,
+                target_file=target,
                 lease_access_conditions=lease,
                 timeout=timeout,
                 cls=return_response_headers,

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs.py
@@ -145,7 +145,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_download_and_copy_file_nfs(self, **kwargs):
+    def test_download_and_copy_file(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
 
         self._setup(storage_account_name)
@@ -210,7 +210,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
         hard_link_file_name = self._get_file_name('file2')
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
-        resp = hard_link_file_client.create_hard_link(target_file=f"{directory_name}/{source_file_name}")
+        resp = hard_link_file_client.create_hard_link(target=f"{directory_name}/{source_file_name}")
 
         assert resp is not None
         assert resp['file_file_type'] == 'Regular'
@@ -244,6 +244,6 @@ class TestStorageFileNFS(StorageRecordedTestCase):
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
         with pytest.raises(ResourceNotFoundError) as e:
-            hard_link_file_client.create_hard_link(target_file=source_file_client.url)
+            hard_link_file_client.create_hard_link(target=source_file_client.url)
 
         assert 'ParentNotFound' in e.value.args[0]

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
@@ -158,7 +158,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_download_and_copy_file_nfs(self, **kwargs):
+    async def test_download_and_copy_file(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
 
         await self._setup(storage_account_name)
@@ -223,7 +223,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
         hard_link_file_name = self._get_file_name('file2')
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
-        resp = await hard_link_file_client.create_hard_link(target_file=f"{directory_name}/{source_file_name}")
+        resp = await hard_link_file_client.create_hard_link(target=f"{directory_name}/{source_file_name}")
 
         assert resp is not None
         assert resp['file_file_type'] == 'Regular'
@@ -257,6 +257,6 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
         with pytest.raises(ResourceNotFoundError) as e:
-            await hard_link_file_client.create_hard_link(target_file=source_file_client.url)
+            await hard_link_file_client.create_hard_link(target=source_file_client.url)
 
         assert 'ParentNotFound' in e.value.args[0]


### PR DESCRIPTION
Modified `create_hard_link` API's param `target_file` to simply `target` to match Python Standard Library. Modified test kwarg and re-recorded test to remove `nfs` suffix name.