### PR TITLE
[Core] Fix circular import

### DIFF
--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -43,9 +43,12 @@ from typing import (
     Generic,
     Mapping,
     List,
+    TYPE_CHECKING,
 )
-from azure.core.tracing import AbstractSpan
 from ._azure_clouds import AzureClouds
+
+if TYPE_CHECKING:
+    from azure.core.tracing import AbstractSpan
 
 ValidInputType = TypeVar("ValidInputType")
 ValueType = TypeVar("ValueType")


### PR DESCRIPTION
An import used for typing is now guarded behind the `TYPE_CHECKING` flag from the typing module.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/38723

