### PR TITLE
Update docIndex to kick off the docs SDK CI run for main

### DIFF
--- a/eng/docsSDKCIConfig.json
+++ b/eng/docsSDKCIConfig.json
@@ -1,7 +1,7 @@
 {
     "target_repo": {
         "url": "https://github.com/MicrosoftDocs/azure-docs-sdk-python",
-        "branch": "%%DailyDocsBranchName%%"
+        "branch": "%%DocsBranchName%%"
     },
     "run_post_toc_script": false 
 }

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -7,6 +7,12 @@ parameters:
   type: boolean
   default: true
 
+  - name: StartMainSDKCIRun
+  displayName: |
+    Kick off the main SDK CI docs run when manually running the pipeline
+  type: boolean
+  default: false
+
 - name: ForceDailyUpdate
   displayName: |
     Force the daily branch update (includes starting daily branch run).
@@ -110,6 +116,24 @@ jobs:
             TargetRepoOwner: $(DocRepoOwner)
             WorkingDirectory: $(DocRepoLocation)
 
+        - task: AzureCLI@2
+          displayName: Queue Docs CI build for main
+          condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(${{ parameters.StartMainSDKCIRun }}, true)))
+          inputs:
+            azureSubscription: msdocs-apidrop-connection
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              # Resource here is the Devops API scope
+              $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
+              $buildParamJson = (@{ params = (Get-Content ./eng/docsSDKCIConfig.json -Raw) -replace '%%DocsBranchName%%', "main" } | ConvertTo-Json)
+              eng/common/scripts/Queue-Pipeline.ps1 `
+                -Organization "apidrop" `
+                -Project "Content%20CI" `
+                -DefinitionId 5533 `
+                -BuildParametersJson $buildParamJson `
+                -BearerToken $accessToken
+
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.
       - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), parameters.ForceDailyUpdate) }}:
@@ -177,14 +201,15 @@ jobs:
             PushArgs: -f
 
         - task: AzureCLI@2
-          displayName: Queue Docs CI build
+          displayName: Queue Docs CI build for daily branch
           inputs:
             azureSubscription: msdocs-apidrop-connection
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
+              # Resource here is the Devops API scope
               $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
-              $buildParamJson = (@{ params = (Get-Content ./eng/dailydocsconfig.json -Raw) -replace '%%DailyDocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
+              $buildParamJson = (@{ params = (Get-Content ./eng/docsSDKCIConfig.json -Raw) -replace '%%DocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
               eng/common/scripts/Queue-Pipeline.ps1 `
                 -Organization "apidrop" `
                 -Project "Content%20CI" `

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -7,7 +7,7 @@ parameters:
   type: boolean
   default: true
 
-  - name: StartMainSDKCIRun
+- name: StartMainSDKCIRun
   displayName: |
     Kick off the main SDK CI docs run when manually running the pipeline
   type: boolean


### PR DESCRIPTION
Right now, the docs SDK CI runs run a scheduled run against main and the timing of the runs is isn't great. The solution here is to have the docIndex runs kick off SDK CI the run against main the same way we're kicking off the run against the daily branch. This will remove anything fiddly.

As part of this change, add a parameter, defaulting to false, to determine whether or not the SDK CI run should be kicked off.

This is what the parameter I'd added looks like. It's the second checkbox down, unchecked by default.
![image](https://github.com/user-attachments/assets/87519b73-8c51-4cab-8e53-0d58afb476ef)


This is the [docIndex run with it unchecked](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4391841&view=results). Notice it didn't kick off the SDK CI run.
This is the [docIndex run with it checked](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4391903&view=results). Notice the SDK CI run was kicked off.