### PR TITLE
[Draft] Mocking Transports Work

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
 CONTENT_CHUNK_SIZE = 10 * 1024
 _LOGGER = logging.getLogger(__name__)
 
-
+# Here is the real async transport implementation.
 class AioHttpTransport(AsyncHttpTransport):
     """AioHttp HTTP sender implementation.
 
@@ -247,6 +247,7 @@ class AioHttpTransport(AsyncHttpTransport):
         :keyword MutableMapping proxies: dict of proxy to used based on protocol. Proxy is a dict (protocol, url)
         """
 
+# This is the real send() on the transport object. This is what we are mocking out
     async def send(
         self,
         request: Union[HttpRequest, RestHttpRequest],
@@ -316,6 +317,7 @@ class AioHttpTransport(AsyncHttpTransport):
             if _is_rest(request):
                 from azure.core.rest._aiohttp import RestAioHttpTransportResponse
 
+# This is where the real response would be built, so we know that we are going to mock this out
                 response = RestAioHttpTransportResponse(
                     request=request,
                     internal_response=result,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
@@ -52,7 +52,7 @@ async def is_checksum_retry(response):
         except (StreamClosedError, StreamConsumedError):
             pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
-                       encode_base64(StorageContentValidation.get_content_md5(response.http_response.content))
+                       encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:
             return True
     return False

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
@@ -46,7 +46,9 @@ async def is_checksum_retry(response):
     # retry if invalid content md5
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
         try:
-            await response.http_response.read()  # Load the body in memory and close the socket
+            # Fix Start
+            await response.http_response.load_body()  # Load the body in memory and close the socket
+            # Fix End
         except (StreamClosedError, StreamConsumedError):
             pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -49,6 +49,9 @@ async def process_content(data: Any, start_offset: int, end_offset: int, encrypt
     # Fix Start
     await data.response.load_body()  # Load the body in memory and close the socket
     # Fix End
+
+    # This is where the content is received. Place a breakpoint on the line below.
+
     content = cast(bytes, data.response.body())
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -19,7 +19,7 @@ from typing import (
     Tuple, TypeVar, Union, TYPE_CHECKING
 )
 
-from azure.core.exceptions import DecodeError, HttpResponseError, IncompleteReadError
+from azure.core.exceptions import DecodeError, HttpResponseError, IncompleteReadError, ServiceRequestError
 
 from .._shared.request_handlers import validate_and_format_range_headers
 from .._shared.response_handlers import parse_length_from_content_range, process_storage_error
@@ -46,7 +46,9 @@ T = TypeVar('T', bytes, str)
 async def process_content(data: Any, start_offset: int, end_offset: int, encryption: Dict[str, Any]) -> bytes:
     if data is None:
         raise ValueError("Response cannot be None.")
-    await data.response.read()
+    # Fix Start
+    await data.response.load_body()  # Load the body in memory and close the socket
+    # Fix End
     content = cast(bytes, data.response.content)
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -49,7 +49,7 @@ async def process_content(data: Any, start_offset: int, end_offset: int, encrypt
     # Fix Start
     await data.response.load_body()  # Load the body in memory and close the socket
     # Fix End
-    content = cast(bytes, data.response.content)
+    content = cast(bytes, data.response.body())
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:
             return decrypt_blob(

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -172,9 +172,14 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
             retry_total=0 # As mentioned by Pamela, this is required to avoid unnecessary network trips
         )
 
+        blob_client = BlobClient(
+            blob_service_client.url, container_name='test_cont', blob_name='test_blob', credential=storage_account_key, transport=transport, retry_total=0)
+
         # Assert
-        service_properties = await blob_service_client.get_service_properties()
-        assert service_properties is not None
+        content = await blob_client.download_blob()
+        assert content is not None
+        # service_properties = await blob_service_client.get_service_properties()
+        # assert service_properties is not None
 
     @BlobPreparer()
     @recorded_by_proxy_async

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -161,8 +161,6 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
     @pytest.mark.live_test_only
     @BlobPreparer()
     async def test_mocking_transport(self, **kwargs):
-        # TODO:
-        # 1. Get rid of any actual network calls (mock out creds)
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 

--- a/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
@@ -72,10 +72,11 @@ class MockAioHttpClientResponse(ClientResponse):
         self.reason = "OK"
         self._url = url
         # self._content = b"test content"
+        # self.content = b"test content"
 
 class MockStorageTransport(AsyncHttpTransport):
-    async def send(self, request: HttpRequest, **kwargs) -> AsyncHttpResponse:
-        return AioHttpTransportResponse(
+    async def send(self, request: HttpRequest, **kwargs) -> AioHttpTransportResponse:
+        aiohttp_transport_resp = AioHttpTransportResponse(
             request,
             MockAioHttpClientResponse(
                 request.url,
@@ -87,6 +88,12 @@ class MockStorageTransport(AsyncHttpTransport):
                 },
             ),
         )
+        # Since in async-land, we load the body either in pipeline policy for content validation path, or loads in process_content
+        # So we need to inject it into the upper Response object (AioHttpTransportResponse)
+        # This may not be the correct thing to do.. failing on deserialization
+        # aiohttp_transport_resp._content = b"test content"
+
+        return aiohttp_transport_resp
 
     async def __aenter__(self):
         return self

--- a/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
@@ -88,11 +88,13 @@ class MockStorageTransport(AsyncHttpTransport):
                 },
             ),
         )
-        # Since in async-land, we load the body either in pipeline policy for content validation path, or loads in process_content
-        # So we need to inject it into the upper Response object (AioHttpTransportResponse)
-        # This may not be the correct thing to do.. failing on deserialization
-        # aiohttp_transport_resp._content = b"test content"
 
+        # Everything is working as expected, but AttributeError: 'AioHttpTransportResponse' object has no attribute 'content'
+        # I believe this is because typically in the real REST transport, we would switch to a RestAioHttpTransportResponse in the send()
+        # logic, will which give the 'content' @property, which calls into the intermediary layer to do whatever works needs to be done
+        # to retrieve the response from the underlying internal response.
+
+        # aiohttp_transport_resp.content = aiohttp_transport_resp.internal_response._body
         return aiohttp_transport_resp
 
     async def __aenter__(self):


### PR DESCRIPTION
This is my first-pass at it, still not working as I cannot resolve how to get the `content` to be visible at the `AioHttpTransportResponse` level. It is properly embedded in the `internal_response` but currently the mocked transport never calls any of the places to enact `self.internal_response.read()`
![image](https://github.com/user-attachments/assets/c6ebca26-8f91-49e3-b438-f3d9253ded16)



i.e. 
https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py#L533

And then this is made even more tricky by the deserialization layer. . .