### PR TITLE
fixed thread message and message delta chunk object

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -2651,49 +2651,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         return cast(AsyncIterator[bytes], response)
 
     @distributed_trace_async
-    async def get_messages(
-        self,
-        thread_id: str,
-        *,
-        run_id: Optional[str] = None,
-        limit: Optional[int] = None,
-        order: Optional[Union[str, _models.ListSortOrder]] = None,
-        after: Optional[str] = None,
-        before: Optional[str] = None,
-        **kwargs: Any,
-    ) -> _models.ThreadMessages:
-        """Parses the OpenAIPageableListOfThreadMessage response and returns a ThreadMessages object.
-
-        :param thread_id: Identifier of the thread. Required.
-        :type thread_id: str
-        :keyword run_id: Filter messages by the run ID that generated them. Default value is None.
-        :paramtype run_id: str
-        :keyword limit: A limit on the number of objects to be returned. Limit can range between 1 and
-         100, and the default is 20. Default value is None.
-        :paramtype limit: int
-        :keyword order: Sort order by the created_at timestamp of the objects. asc for ascending order
-         and desc for descending order. Known values are: "asc" and "desc". Default value is None.
-        :paramtype order: str or ~azure.ai.projects.models.ListSortOrder
-        :keyword after: A cursor for use in pagination. after is an object ID that defines your place
-         in the list. For instance, if you make a list request and receive 100 objects, ending with
-         obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the
-         list. Default value is None.
-        :paramtype after: str
-        :keyword before: A cursor for use in pagination. before is an object ID that defines your place
-         in the list. For instance, if you make a list request and receive 100 objects, ending with
-         obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of
-         the list. Default value is None.
-        :paramtype before: str
-
-        :return: ThreadMessages. The ThreadMessages is compatible with MutableMapping
-        :rtype: ~azure.ai.projects.models.ThreadMessages
-        """
-        messages = await super().list_messages(
-            thread_id, run_id=run_id, limit=limit, order=order, after=after, before=before, **kwargs
-        )
-        return _models.ThreadMessages(pageable_list=messages)
-
-    @distributed_trace_async
     async def save_file(self, file_id: str, file_name: str, target_dir: Optional[Union[str, Path]] = None) -> None:
         """
         Asynchronously saves file content retrieved using a file identifier to the specified local directory.

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
@@ -57,7 +57,6 @@ from ._models import (
     MessageTextFileCitationAnnotation,
     MessageTextFilePathAnnotation,
     MicrosoftFabricToolDefinition,
-    OpenAIPageableListOfThreadMessage,
     OpenApiAuthDetails,
     OpenApiToolDefinition,
     OpenApiFunctionDefinition,
@@ -76,7 +75,7 @@ from ._models import (
 
 from ._models import MessageDeltaChunk as MessageDeltaChunkGenerated
 from ._models import ThreadMessage as ThreadMessageGenerated
-
+from ._models import OpenAIPageableListOfThreadMessage as OpenAIPageableListOfThreadMessageGenerated
 
 logger = logging.getLogger(__name__)
 
@@ -1459,28 +1458,7 @@ class AgentRunStream(Generic[BaseAgentEventHandlerT]):
             close_method()
 
 
-class ThreadMessages:
-    """
-    Represents a collection of messages in a thread.
-
-    :param pageable_list: The pageable list of messages.
-    :type pageable_list: ~azure.ai.projects.models.OpenAIPageableListOfThreadMessage
-
-    :return: A collection of messages.
-    :rtype: ~azure.ai.projects.models.ThreadMessages
-    """
-
-    def __init__(self, pageable_list: OpenAIPageableListOfThreadMessage):
-        self._messages = [ThreadMessage(item) for item in pageable_list.data]
-
-    @property
-    def messages(self) -> List[ThreadMessage]:
-        """Returns all messages in the messages.
-
-
-        :rtype: List[ThreadMessage]
-        """
-        return self._messages
+class OpenAIPageableListOfThreadMessage(OpenAIPageableListOfThreadMessageGenerated):
 
     @property
     def text_messages(self) -> List[MessageTextContent]:
@@ -1488,7 +1466,7 @@ class ThreadMessages:
 
         :rtype: List[MessageTextContent]
         """
-        texts = [content for msg in self._messages for content in msg.text_messages]
+        texts = [content for msg in self.data for content in msg.text_messages]
         return texts
 
     @property
@@ -1497,7 +1475,7 @@ class ThreadMessages:
 
         :rtype: List[MessageImageFileContent]
         """
-        return [content for msg in self._messages for content in msg.image_contents]
+        return [content for msg in self.data for content in msg.image_contents]
 
     @property
     def file_citation_annotations(self) -> List[MessageTextFileCitationAnnotation]:
@@ -1505,7 +1483,7 @@ class ThreadMessages:
 
         :rtype: List[MessageTextFileCitationAnnotation]
         """
-        annotations = [annotation for msg in self._messages for annotation in msg.file_citation_annotations]
+        annotations = [annotation for msg in self.data for annotation in msg.file_citation_annotations]
         return annotations
 
     @property
@@ -1514,7 +1492,7 @@ class ThreadMessages:
 
         :rtype: List[MessageTextFilePathAnnotation]
         """
-        annotations = [annotation for msg in self._messages for annotation in msg.file_path_annotations]
+        annotations = [annotation for msg in self.data for annotation in msg.file_path_annotations]
         return annotations
 
     def get_last_message_by_sender(self, sender: str) -> Optional[ThreadMessage]:
@@ -1526,7 +1504,7 @@ class ThreadMessages:
         :return: The last message from the specified sender.
         :rtype: ~azure.ai.projects.models.ThreadMessage
         """
-        for msg in self._messages:
+        for msg in self.data:
             if msg.role == sender:
                 return msg
         return None
@@ -1540,7 +1518,7 @@ class ThreadMessages:
         :return: The last text message from the specified sender.
         :rtype: ~azure.ai.projects.models.MessageTextContent
         """
-        for msg in self._messages:
+        for msg in self.data:
             if msg.role == sender:
                 for content in msg.content:
                     if isinstance(content, MessageTextContent):
@@ -1559,7 +1537,7 @@ __all__: List[str] = [
     "CodeInterpreterTool",
     "ConnectionProperties",
     "AsyncAgentEventHandler",
-    "ThreadMessages",
+    "OpenAIPageableListOfThreadMessage",
     "FileSearchTool",
     "FunctionTool",
     "OpenApiTool",

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -2742,49 +2742,6 @@ class AgentsOperations(AgentsOperationsGenerated):
         return cast(Iterator[bytes], response)
 
     @distributed_trace
-    def get_messages(
-        self,
-        thread_id: str,
-        *,
-        run_id: Optional[str] = None,
-        limit: Optional[int] = None,
-        order: Optional[Union[str, _models.ListSortOrder]] = None,
-        after: Optional[str] = None,
-        before: Optional[str] = None,
-        **kwargs: Any,
-    ) -> _models.ThreadMessages:
-        """Parses the OpenAIPageableListOfThreadMessage response and returns a ThreadMessages object.
-
-        :param thread_id: Identifier of the thread. Required.
-        :type thread_id: str
-        :keyword run_id: Filter messages by the run ID that generated them. Default value is None.
-        :paramtype run_id: str
-        :keyword limit: A limit on the number of objects to be returned. Limit can range between 1 and
-         100, and the default is 20. Default value is None.
-        :paramtype limit: int
-        :keyword order: Sort order by the created_at timestamp of the objects. asc for ascending order
-         and desc for descending order. Known values are: "asc" and "desc". Default value is None.
-        :paramtype order: str or ~azure.ai.projects.models.ListSortOrder
-        :keyword after: A cursor for use in pagination. after is an object ID that defines your place
-         in the list. For instance, if you make a list request and receive 100 objects, ending with
-         obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the
-         list. Default value is None.
-        :paramtype after: str
-        :keyword before: A cursor for use in pagination. before is an object ID that defines your place
-         in the list. For instance, if you make a list request and receive 100 objects, ending with
-         obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of
-         the list. Default value is None.
-        :paramtype before: str
-
-        :return: ThreadMessages. The ThreadMessages is compatible with MutableMapping
-        :rtype: ~azure.ai.projects.models.ThreadMessages
-        """
-        messages = super().list_messages(
-            thread_id, run_id=run_id, limit=limit, order=order, after=after, before=before, **kwargs
-        )
-        return _models.ThreadMessages(pageable_list=messages)
-
-    @distributed_trace
     def save_file(self, file_id: str, file_name: str, target_dir: Optional[Union[str, Path]] = None) -> None:
         """
         Synchronously saves file content retrieved using a file identifier to the specified local directory.

--- a/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_code_interpreter_async.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_code_interpreter_async.py
@@ -76,7 +76,7 @@ async def main() -> None:
             # Check if you got "Rate limit is exceeded.", then you want to get more quota
             print(f"Run failed: {run.last_error}")
 
-        messages = await project_client.agents.get_messages(thread_id=thread.id)
+        messages = await project_client.agents.list_messages(thread_id=thread.id)
         print(f"Messages: {messages}")
 
         last_msg = messages.get_last_text_message_by_sender("assistant")

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_code_interpreter.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_code_interpreter.py
@@ -80,7 +80,7 @@ with project_client:
     print("Deleted file")
 
     # [START get_messages_and_save_files]
-    messages = project_client.agents.get_messages(thread_id=thread.id)
+    messages = project_client.agents.list_messages(thread_id=thread.id)
     print(f"Messages: {messages}")
 
     for image_content in messages.image_contents:

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_file_search.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_file_search.py
@@ -93,7 +93,7 @@ with project_client:
     # [END teardown]
 
     # Fetch and log all messages
-    messages = project_client.agents.get_messages(thread_id=thread.id)
+    messages = project_client.agents.list_messages(thread_id=thread.id)
 
     # Print citations from the messages
     for citation in messages.file_citation_annotations:

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_with_code_interpreter_file_attachment.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_with_code_interpreter_file_attachment.py
@@ -82,7 +82,7 @@ with project_client:
     project_client.agents.delete_file(file.id)
     print("Deleted file")
 
-    messages = project_client.agents.get_messages(thread_id=thread.id)
+    messages = project_client.agents.list_messages(thread_id=thread.id)
     print(f"Messages: {messages}")
 
     last_msg = messages.get_last_text_message_by_sender("assistant")

--- a/sdk/ai/azure-ai-projects/tests/README.md
+++ b/sdk/ai/azure-ai-projects/tests/README.md
@@ -15,9 +15,9 @@ The instructions below are for running tests locally, on a Windows machine, agai
     pip install wheel
     python setup.py bdist_wheel
     ```
-- Install the resulting wheel (update version `1.0.0b1` to the current one):
+- Install the resulting wheel (update version `1.0.0b3` to the current one):
     ```bash
-    pip install dist\azure_ai_projects-1.0.0b1-py3-none-any.whl --user --force-reinstall
+    pip install dist\azure_ai_projects-1.0.0b3-py3-none-any.whl --user --force-reinstall
     ```
 
 ## Log in to Azure

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agents_client.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agents_client.py
@@ -1833,7 +1833,7 @@ class TestagentClient(AzureRecordedTestCase):
                 print("Deleted file")
 
                 # get messages
-                messages = client.agents.get_messages(thread_id=thread.id)
+                messages = client.agents.list_messages(thread_id=thread.id)
                 print(f"Messages: {messages}")
 
                 last_msg = messages.get_last_text_message_by_sender("assistant")


### PR DESCRIPTION
fixed thread message and message delta chunk object
Also get rid of get_messages function and ThreadMessages class.   Because we already have list_messages function from auto code gen returned OpenAIPageableListOfThreadMessage object.   Instead of having get_messages() returned ThreadMessages subclassing from OpenAIPageableListOfThreadMessage with helper properties, now I extend OpenAIPageableListOfThreadMessage in patch file and include the same helper properties defined from the ThreadMessages class.