### PR TITLE
fix reading blob chars in text mode using StorageStreamDownloader.read()

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -656,7 +656,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            size = chars if chars is not None or chars > 0 else sys.maxsize
+            if chars is None:
+                size = sys.maxsize
+            if chars < 0:
+                size = sys.maxsize
+            size = sys.maxsize if chars is None or chars < 0 else chars
         else:
             output_stream = BytesIO()
             size = size if size > 0 else sys.maxsize

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -656,7 +656,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            size = sys.maxsize if chars is None or chars < 0 else chars
+            size = sys.maxsize if chars is None or chars <= 0 else chars
         else:
             output_stream = BytesIO()
             size = size if size > 0 else sys.maxsize

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -656,7 +656,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            size = chars if chars else sys.maxsize
+            size = chars if chars > 0 else sys.maxsize
         else:
             output_stream = BytesIO()
             size = size if size > 0 else sys.maxsize

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -656,10 +656,6 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            if chars is None:
-                size = sys.maxsize
-            if chars < 0:
-                size = sys.maxsize
             size = sys.maxsize if chars is None or chars < 0 else chars
         else:
             output_stream = BytesIO()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -656,7 +656,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            size = chars if chars > 0 else sys.maxsize
+            size = chars if chars is not None or chars > 0 else sys.maxsize
         else:
             output_stream = BytesIO()
             size = size if size > 0 else sys.maxsize

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -558,7 +558,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         output_stream: Union[BytesIO, StringIO]
         if self._text_mode:
             output_stream = StringIO()
-            size = chars if chars else sys.maxsize
+            size = sys.maxsize if chars is None or chars <= 0 else chars
         else:
             output_stream = BytesIO()
             size = size if size > 0 else sys.maxsize


### PR DESCRIPTION
# Description
`StorageStreamDownloader.read()` on blob behaves differently when using chars vs size, but this should behave the same (according to documentation). This single change fixes discrepancies in number of chars read when specifying negative number in `StorageStreamDownloader.read()`

Example 
`download_blob().read(size=-1)` behaves differently than `download_blob(encoding='utf-8').read(chars=-1)`

```
>>> upload("123456", ...)
>>> download_blob().read(size=-1)
# will return "123456" in bytes
>>> download_blob(encoding='utf-8').read(chars=-1)
"12345" # will return len(content) - 1 characters instead of full content
```


# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
