### PR TITLE
removing optional from capability host parameter (#38847)

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/_ai_workspaces/capability_host.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/_ai_workspaces/capability_host.py
@@ -53,7 +53,7 @@ class CapabilityHost(Resource):
     :type storage_connections: Optional[List[str]]
     :param capability_host_kind: The kind of capability host, either as a string or CapabilityHostKind enum.
         Default is AGENTS.
-    :type capability_host_kind: Optional[Union[str, CapabilityHostKind]]
+    :type capability_host_kind: Union[str, CapabilityHostKind]
     :param kwargs: Additional keyword arguments.
     :type kwargs: Any
 
@@ -75,7 +75,7 @@ class CapabilityHost(Resource):
         vector_store_connections: Optional[List[str]] = None,
         ai_services_connections: Optional[List[str]] = None,
         storage_connections: Optional[List[str]] = None,
-        capability_host_kind: Optional[Union[str, CapabilityHostKind]] = CapabilityHostKind.AGENTS,
+        capability_host_kind: Union[str, CapabilityHostKind] = CapabilityHostKind.AGENTS,
         **kwargs: Any,
     ):
         super().__init__(name=name, description=description, **kwargs)


### PR DESCRIPTION
# Description

removing optional from capability host parameter

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
