### PR TITLE
fixed message attachment defect

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
@@ -17,7 +17,6 @@ import math
 import re
 from abc import ABC, abstractmethod
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Awaitable,
@@ -39,7 +38,6 @@ from typing import (
     overload,
 )
 
-from azure.ai.projects import _model_base
 from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 


### PR DESCRIPTION
# Description
Our samples failed at

    attachment = MessageAttachment(file_id=file.id, tools=CodeInterpreterTool().definitions)

And

    attachment = MessageAttachment(file_id=file.id, tools=FileSearchTool().definitions)

It is because tools keyword expects List["MessageAttachmentToolDefinition"] where MessageAttachmentToolDefinitionis Union of FIleSearchToolDefinition and CodeInterpreterToolDefinition.

To fix it, I did 2 things:
1.  change CodeInterpreterTool().definitions and FileSearchTool().definitions to return List[CodeInterpreterToolDefinition] and List[FIleSearchToolDefinition] instead of List[ToolDefinition].   But to do this, I need to change for all tools to return their specific types of tool definitions.
2. List doesn't support covariant types.   With that said, with tool: List[Union[FIleSearchToolDefinition, CodeInterpreterToolDefinition]], you can't assign it List[CodeInterpreterToolDefinition] or List[FIleSearchToolDefinition] .   So I overload constructor of MessageAttachment.


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
