### PR TITLE
Remove non-code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,7 +152,7 @@
 
 # ServiceLabel: %Content Safety
 # PRLabel: %Content Safety
-/sdk/contentsafety/                                                  @mengaims @JieZhou000
+/sdk/contentsafety/                                                  @mengaims
 
 # ServiceLabel: %DevCenter
 # PRLabel: %DevCenter


### PR DESCRIPTION
# Description

I reached out to Jie and confirmed that they are no longer the code owner for Content Safety.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
