### PR TITLE
Add optional `connection_name` to .inference operations. Add more Inference tests.

### DIFF
--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+* Add optional input argument `connection_name` to methods `.inference.get_chat_completions_client`,
+ `.inference.get_embeddings_client` and `.inference.get_azure_openai_client`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-projects/assets.json
+++ b/sdk/ai/azure-ai-projects/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ai/azure-ai-projects",
-  "Tag": "python/ai/azure-ai-projects_12144a7ce2"
+  "Tag": "python/ai/azure-ai-projects_6dacd2aa98"
 }

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -76,20 +76,19 @@ class InferenceOperations:
 
         At least one AI model that supports chat completions must be deployed in this resource.
 
-        .. note::
-
-            The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+        .. note:: The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
 
         :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
-          resource. Optional. If not provided, the default Azure AI Services connection will be used.
+         resource. Optional. If not provided, the default Azure AI Services connection will be used.
         :type connection_name: str
 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -162,16 +161,14 @@ class InferenceOperations:
         return client
 
     @distributed_trace_async
-    async def get_embeddings_client(self, connection_name: Optional[str] = None, **kwargs) -> "EmbeddingsClient":
+    async def get_embeddings_client(self, *, connection_name: Optional[str] = None, **kwargs) -> "EmbeddingsClient":
         """Get an authenticated asynchronousEmbeddingsClient (from the package azure-ai-inference) for the default
         Azure AI Services connected resource (if `connection_name` is not specificed), or from the Azure AI
         Services resource given by its connection name.
 
         At least one AI model that supports text embeddings must be deployed in this resource.
 
-        .. note::
-
-            The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+        .. note:: The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
 
         :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
          resource. Optional. If not provided, the default Azure AI Services connection will be used.
@@ -179,10 +176,11 @@ class InferenceOperations:
 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -257,9 +255,7 @@ class InferenceOperations:
         Azure OpenAI connection (if `connection_name` is not specificed), or from the Azure OpenAI
         resource given by its connection name.
 
-        .. note::
-
-            The package `openai` must be installed prior to calling this method.
+        .. note:: The package `openai` must be installed prior to calling this method.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
@@ -272,10 +268,11 @@ class InferenceOperations:
 
         :return: An authenticated AsyncAzureOpenAI client
         :rtype: ~openai.AsyncAzureOpenAI
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `openai` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -67,9 +67,12 @@ class InferenceOperations:
         self._outer_instance = outer_instance
 
     @distributed_trace_async
-    async def get_chat_completions_client(self, **kwargs) -> "ChatCompletionsClient":
-        """Get an authenticated asynchronous ChatCompletionsClient (from the package azure-ai-inference) for
-        the default Azure AI Services connected resource.
+    async def get_chat_completions_client(
+        self, *, connection_name: Optional[str] = None, **kwargs
+    ) -> "ChatCompletionsClient":
+        """Get an authenticated asynchronous ChatCompletionsClient (from the package azure-ai-inference) for the default
+        Azure AI Services connected resource (if `connection_name` is not specificed), or from the Azure AI
+        Services resource given by its connection name.
 
         At least one AI model that supports chat completions must be deployed in this resource.
 
@@ -77,26 +80,42 @@ class InferenceOperations:
 
             The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
 
+        :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
+          resource. Optional. If not provided, the default Azure AI Services connection will be used.
+        :type connection_name: str
+
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
-        :raises ~azure.core.exceptions.ResourceNotFoundError: An Azure AI Services connection does not exist.
-        :raises ~azure.core.exceptions.ModuleNotFoundError: The `azure-ai-inference` package is not installed.
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
 
         # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection: bool = os.getenv("USE_SERVERLESS_CONNECTION", None) == "true"
 
-        if use_serverless_connection:
-            connection = await self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+        if connection_name:
+            connection = await self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
             )
         else:
-            connection = await self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
-            )
+            if use_serverless_connection:
+                connection = await self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+                )
+            else:
+                connection = await self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
+                )
+
         logger.debug("[InferenceOperations.get_chat_completions_client] connection = %s", str(connection))
 
         try:
@@ -143,9 +162,10 @@ class InferenceOperations:
         return client
 
     @distributed_trace_async
-    async def get_embeddings_client(self, **kwargs) -> "EmbeddingsClient":
-        """Get an authenticated asynchronous EmbeddingsClient (from the package azure-ai-inference) for
-        the default Azure AI Services connected resource.
+    async def get_embeddings_client(self, connection_name: Optional[str] = None, **kwargs) -> "EmbeddingsClient":
+        """Get an authenticated asynchronousEmbeddingsClient (from the package azure-ai-inference) for the default
+        Azure AI Services connected resource (if `connection_name` is not specificed), or from the Azure AI
+        Services resource given by its connection name.
 
         At least one AI model that supports text embeddings must be deployed in this resource.
 
@@ -153,26 +173,42 @@ class InferenceOperations:
 
             The packages `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
 
+        :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
+         resource. Optional. If not provided, the default Azure AI Services connection will be used.
+        :type connection_name: str
+
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
-        :raises ~azure.core.exceptions.ResourceNotFoundError: An Azure AI Services connection does not exist.
-        :raises ~azure.core.exceptions.ModuleNotFoundError: The `azure-ai-inference` package is not installed.
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
 
         # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection: bool = os.getenv("USE_SERVERLESS_CONNECTION", None) == "true"
 
-        if use_serverless_connection:
-            connection = await self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+        if connection_name:
+            connection = await self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
             )
         else:
-            connection = await self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
-            )
+            if use_serverless_connection:
+                connection = await self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+                )
+            else:
+                connection = await self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
+                )
+
         logger.debug("[InferenceOperations.get_embeddings_client] connection = %s", str(connection))
 
         try:
@@ -214,29 +250,50 @@ class InferenceOperations:
         return client
 
     @distributed_trace_async
-    async def get_azure_openai_client(self, *, api_version: Optional[str] = None, **kwargs) -> "AsyncAzureOpenAI":
+    async def get_azure_openai_client(
+        self, *, api_version: Optional[str] = None, connection_name: Optional[str] = None, **kwargs
+    ) -> "AsyncAzureOpenAI":
         """Get an authenticated AsyncAzureOpenAI client (from the `openai` package) for the default
-        Azure OpenAI connection. The package `openai` must be installed prior to calling this method.
-        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure OpenAI connection
-        does not exist.
-        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `openai` package
-        is not installed.
+        Azure OpenAI connection (if `connection_name` is not specificed), or from the Azure OpenAI
+        resource given by its connection name.
+
+        .. note::
+
+            The package `openai` must be installed prior to calling this method.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
          https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs. If this keyword
          is not specified, you must set the environment variable `OPENAI_API_VERSION` instead.
         :paramtype api_version: str
+        :keyword connection_name: The name of a connection to an Azure OpenAI resource in your AI Foundry project.
+         resource. Optional. If not provided, the default Azure OpenAI connection will be used.
+        :type connection_name: str
+
         :return: An authenticated AsyncAzureOpenAI client
         :rtype: ~openai.AsyncAzureOpenAI
-        :raises ~azure.core.exceptions.ResourceNotFoundError:
-        :raises ~azure.core.exceptions.ModuleNotFoundError:
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `openai` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
+
         """
         kwargs.setdefault("merge_span", True)
-        connection = await self._outer_instance.connections.get_default(
-            connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True, **kwargs
-        )
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
+
+        if connection_name:
+            connection = await self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
+            )
+        else:
+            connection = await self._outer_instance.connections.get_default(
+                connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True, **kwargs
+            )
+
         logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
 
         try:

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -80,20 +80,19 @@ class InferenceOperations:
 
         At least one AI model that supports chat completions must be deployed in this resource.
 
-        .. note::
-
-            The package `azure-ai-inference` must be installed prior to calling this method.
+        .. note:: The package `azure-ai-inference` must be installed prior to calling this method.
 
         :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
-          resource. Optional. If not provided, the default Azure AI Services connection will be used.
+         resource. Optional. If not provided, the default Azure AI Services connection will be used.
         :type connection_name: str
 
         :return: An authenticated chat completions client, or `None` if no Azure AI Services connection is found.
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -173,14 +172,7 @@ class InferenceOperations:
 
         At least one AI model that supports text embeddings must be deployed in this resource.
 
-        .. note::
-
-            The package `azure-ai-inference` must be installed prior to calling this method.
-
-        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
-        does not exist.
-        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
-        is not installed.
+        .. note:: The package `azure-ai-inference` must be installed prior to calling this method.
 
         :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
          resource. Optional. If not provided, the default Azure AI Services connection will be used.
@@ -188,10 +180,11 @@ class InferenceOperations:
 
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
@@ -266,9 +259,7 @@ class InferenceOperations:
         Azure OpenAI connection (if `connection_name` is not specificed), or from the Azure OpenAI
         resource given by its connection name.
 
-        .. note::
-
-            The package `openai` must be installed prior to calling this method.
+        .. note:: The package `openai` must be installed prior to calling this method.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
@@ -281,10 +272,11 @@ class InferenceOperations:
 
         :return: An authenticated AzureOpenAI client
         :rtype: ~openai.AzureOpenAI
+
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
-        does not exist.
+         does not exist.
         :raises ~azure.core.exceptions.ModuleNotFoundError: if the `openai` package
-        is not installed.
+         is not installed.
         :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -71,35 +71,55 @@ class InferenceOperations:
         self._outer_instance = outer_instance
 
     @distributed_trace
-    def get_chat_completions_client(self, **kwargs) -> "ChatCompletionsClient":
+    def get_chat_completions_client(
+        self, *, connection_name: Optional[str] = None, **kwargs
+    ) -> "ChatCompletionsClient":
         """Get an authenticated ChatCompletionsClient (from the package azure-ai-inference) for the default
-        Azure AI Services connected resource. At least one AI model that supports chat completions must be deployed
-        in this resource. The package `azure-ai-inference` must be installed prior to calling this method.
-        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
-        does not exist.
-        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
-        is not installed.
+        Azure AI Services connected resource (if `connection_name` is not specificed), or from the Azure AI
+        Services resource given by its connection name.
+
+        At least one AI model that supports chat completions must be deployed in this resource.
+
+        .. note::
+
+            The package `azure-ai-inference` must be installed prior to calling this method.
+
+        :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
+          resource. Optional. If not provided, the default Azure AI Services connection will be used.
+        :type connection_name: str
 
         :return: An authenticated chat completions client, or `None` if no Azure AI Services connection is found.
         :rtype: ~azure.ai.inference.models.ChatCompletionsClient
-        :raises ~azure.core.exceptions.ResourceNotFoundError:
-        :raises ~azure.core.exceptions.ModuleNotFoundError:
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
 
         # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection: bool = os.getenv("USE_SERVERLESS_CONNECTION", None) == "true"
 
-        if use_serverless_connection:
-            connection = self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+        if connection_name:
+            connection = self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
             )
         else:
-            connection = self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
-            )
+            if use_serverless_connection:
+                connection = self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+                )
+            else:
+                connection = self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
+                )
+
         logger.debug("[InferenceOperations.get_chat_completions_client] connection = %s", str(connection))
 
         try:
@@ -146,35 +166,58 @@ class InferenceOperations:
         return client
 
     @distributed_trace
-    def get_embeddings_client(self, **kwargs) -> "EmbeddingsClient":
+    def get_embeddings_client(self, *, connection_name: Optional[str] = None, **kwargs) -> "EmbeddingsClient":
         """Get an authenticated EmbeddingsClient (from the package azure-ai-inference) for the default
-        Azure AI Services connected resource. At least one AI model that supports text embeddings must be deployed
-        in this resource. The package `azure-ai-inference` must be installed prior to calling this method.
+        Azure AI Services connected resource (if `connection_name` is not specificed), or from the Azure AI
+        Services resource given by its connection name.
+
+        At least one AI model that supports text embeddings must be deployed in this resource.
+
+        .. note::
+
+            The package `azure-ai-inference` must be installed prior to calling this method.
+
         Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure AI Services connection
         does not exist.
         Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `azure-ai-inference` package
         is not installed.
 
+        :keyword connection_name: The name of a connection to an Azure AI Services resource in your AI Foundry project.
+         resource. Optional. If not provided, the default Azure AI Services connection will be used.
+        :type connection_name: str
+
         :return: An authenticated chat completions client
         :rtype: ~azure.ai.inference.models.EmbeddingsClient
-        :raises ~azure.core.exceptions.ResourceNotFoundError:
-        :raises ~azure.core.exceptions.ModuleNotFoundError:
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure AI Services connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         kwargs.setdefault("merge_span", True)
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
 
         # Back-door way to access the old behavior where each AI model (non-OpenAI) was hosted on
         # a separate "Serverless" connection. This is now deprecated.
         use_serverless_connection: bool = os.getenv("USE_SERVERLESS_CONNECTION", None) == "true"
 
-        if use_serverless_connection:
-            connection = self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+        if connection_name:
+            connection = self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
             )
         else:
-            connection = self._outer_instance.connections.get_default(
-                connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
-            )
+            if use_serverless_connection:
+                connection = self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.SERVERLESS, include_credentials=True, **kwargs
+                )
+            else:
+                connection = self._outer_instance.connections.get_default(
+                    connection_type=ConnectionType.AZURE_AI_SERVICES, include_credentials=True, **kwargs
+                )
+
         logger.debug("[InferenceOperations.get_embeddings_client] connection = %s", str(connection))
 
         try:
@@ -216,30 +259,49 @@ class InferenceOperations:
         return client
 
     @distributed_trace
-    def get_azure_openai_client(self, *, api_version: Optional[str] = None, **kwargs) -> "AzureOpenAI":
+    def get_azure_openai_client(
+        self, *, api_version: Optional[str] = None, connection_name: Optional[str] = None, **kwargs
+    ) -> "AzureOpenAI":
         """Get an authenticated AzureOpenAI client (from the `openai` package) for the default
-        Azure OpenAI connection. The package `openai` must be installed prior to calling this method.
-        Raises ~azure.core.exceptions.ResourceNotFoundError exception if an Azure OpenAI connection
-        does not exist.
-        Raises ~azure.core.exceptions.ModuleNotFoundError exception if the `openai` package
-        is not installed.
+        Azure OpenAI connection (if `connection_name` is not specificed), or from the Azure OpenAI
+        resource given by its connection name.
+
+        .. note::
+
+            The package `openai` must be installed prior to calling this method.
 
         :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
          See "Data plane - Inference" row in the table at
          https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs. If this keyword
          is not specified, you must set the environment variable `OPENAI_API_VERSION` instead.
         :paramtype api_version: str
+        :keyword connection_name: The name of a connection to an Azure OpenAI resource in your AI Foundry project.
+         resource. Optional. If not provided, the default Azure OpenAI connection will be used.
+        :type connection_name: str
+
         :return: An authenticated AzureOpenAI client
         :rtype: ~openai.AzureOpenAI
-        :raises ~azure.core.exceptions.ResourceNotFoundError:
-        :raises ~azure.core.exceptions.ModuleNotFoundError:
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
+        does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `openai` package
+        is not installed.
+        :raises ValueError: if the connection name is an empty string.
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-
         kwargs.setdefault("merge_span", True)
-        connection = self._outer_instance.connections.get_default(
-            connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True, **kwargs
-        )
+
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
+
+        if connection_name:
+            connection = self._outer_instance.connections.get(
+                connection_name=connection_name, include_credentials=True, **kwargs
+            )
+        else:
+            connection = self._outer_instance.connections.get_default(
+                connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True, **kwargs
+            )
+
         logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
 
         try:

--- a/sdk/ai/azure-ai-projects/azure_ai_projects_tests.env
+++ b/sdk/ai/azure-ai-projects/azure_ai_projects_tests.env
@@ -1,5 +1,5 @@
 #
-# Environment variables required for running tests
+# Environment variables required for running tests.
 #
 # All values should be empty by default. Fill them in locally before running live tests on your dev box,
 # but do not commit these changes to the repository.
@@ -27,22 +27,27 @@ AZURE_AI_PROJECTS_CONNECTIONS_TESTS_AISERVICES_CONNECTION_NAME=
 # Inference tests
 #
 # To run inference tests you need an AI Foundry project with
-# - A default AIServices resource with at least one chat-completions model deployed (from OpenAI or non-OpenAI)
-# - A default Azure OpenAI resource connected with at least one chat-completions OpenAI model deployed
-# Populate the Azure OpenAI api-version and model deployment names below.
-# Note: See Azure OpenAI api-versions here: https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+# - A default AI Services resource that uses api-key auth, with three models deployed:
+#   OpenAI chat-completions, non-OpenAI chat-completions, non-OpenAI text embeddings.
+# - Another AI Services resource, that uses Entra-ID auth, with the same three models models.
+# 
+# Note: See Azure OpenAI api-versions here: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
+# use api-version from the "Data plane - Inference" row, "Latest GA release" column.
 #
-AZURE_AI_PROJECTS_INFERENCE_TESTS_PROJECT_CONNECTION_STRING=
+AZURE_AI_PROJECTS_INFERENCE_TESTS_PROJECT_CONNECTION_STRING=${AZURE_AI_PROJECTS_CONNECTIONS_TESTS_PROJECT_CONNECTION_STRING}
 AZURE_AI_PROJECTS_INFERENCE_TESTS_AOAI_API_VERSION=
 AZURE_AI_PROJECTS_INFERENCE_TESTS_AOAI_MODEL_DEPLOYMENT_NAME=
-AZURE_AI_PROJECTS_INFERENCE_TESTS_AISERVICES_MODEL_DEPLOYMENT_NAME=
-
+AZURE_AI_PROJECTS_INFERENCE_TESTS_CHAT_COMPLETIONS_MODEL_DEPLOYMENT_NAME=
+AZURE_AI_PROJECTS_INFERENCE_TESTS_EMBEDDINGS_MODEL_DEPLOYMENT_NAME=
+AZURE_AI_PROJECTS_INFERENCE_TESTS_AISERVICES_CONNECTION_NAME=
+AZURE_AI_PROJECTS_INFERENCE_TESTS_AOAI_CONNECTION_NAME=
 
 ########################################################################################################################
 # Telemetry tests
 #
-AZURE_AI_PROJECTS_TELEMETRY_TESTS_PROJECT_CONNECTION_STRING=
-
+# To run telemetry tests you need an AI Foundry project with a connected Application Insights resource.
+#
+AZURE_AI_PROJECTS_TELEMETRY_TESTS_PROJECT_CONNECTION_STRING=${AZURE_AI_PROJECTS_CONNECTIONS_TESTS_PROJECT_CONNECTION_STRING}
 
 ########################################################################################################################
 # Agents tests
@@ -51,17 +56,18 @@ AZURE_AI_PROJECTS_AGENTS_TESTS_PROJECT_CONNECTION_STRING=
 AZURE_AI_PROJECTS_AGENTS_TESTS_DATA_PATH=
 AZURE_AI_PROJECTS_AGENTS_TESTS_STORAGE_QUEUE=
 
-
 ########################################################################################################################
 # Evaluations tests
 #
-# To run evaluation test you need AI Foundry project with
-# - A default AIServices resource with at least one chat-completions model deployed (from OpenAI or non-OpenAI)
-# - A default Azure OpenAI resource connected with at least one chat-completions OpenAI model deployed
-# Populate the Azure OpenAI api-version and model deployment names below.
+# To run evaluation test you need an AI Foundry project with an Azure OpenAI connection, and a chat-completions 
+# model deployed.
 #
-AZURE_AI_PROJECTS_EVALUATIONS_TESTS_PROJECT_CONNECTION_STRING=
+# Note: See Azure OpenAI api-versions here: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
+# use api-version from the "Data plane - Inference" row, "Latest GA release" column.
+#
+AZURE_AI_PROJECTS_EVALUATIONS_TESTS_PROJECT_CONNECTION_STRING=${AZURE_AI_PROJECTS_CONNECTIONS_TESTS_PROJECT_CONNECTION_STRING}
 AZURE_AI_PROJECTS_EVALUATIONS_TESTS_DEFAULT_AOAI_CONNECTION_NAME=
 AZURE_AI_PROJECTS_EVALUATIONS_TESTS_DEPLOYMENT_NAME=
 AZURE_AI_PROJECTS_EVALUATIONS_TESTS_API_VERSION=
 AZURE_AI_PROJECTS_EVALUATIONS_TESTS_DATASET_ID=
+

--- a/sdk/ai/azure-ai-projects/tests/inference/inference_test_base.py
+++ b/sdk/ai/azure-ai-projects/tests/inference/inference_test_base.py
@@ -14,9 +14,12 @@ servicePreparerInferenceTests = functools.partial(
     EnvironmentVariableLoader,
     "azure_ai_projects_inference_tests",
     azure_ai_projects_inference_tests_project_connection_string="region.api.azureml.ms;00000000-0000-0000-0000-000000000000;rg-name;project-name",
+    azure_ai_projects_inference_tests_aoai_connection_name="aoai-connection-name",
+    azure_ai_projects_inference_tests_aiservices_connection_name="aiservices-connection-name",
     azure_ai_projects_inference_tests_aoai_api_version="aoai-api-version",
     azure_ai_projects_inference_tests_aoai_model_deployment_name="aoai-model-deployment-name",
-    azure_ai_projects_inference_tests_aiservices_model_deployment_name="aoai-model-deployment-name",
+    azure_ai_projects_inference_tests_chat_completions_model_deployment_name="chat-completions-model-deployment-name",
+    azure_ai_projects_inference_tests_embeddings_model_deployment_name="embeddings-model-deployment-name",
 )
 
 # Set to True to enable SDK logging
@@ -34,6 +37,13 @@ if LOGGING_ENABLED:
 
 
 class InferenceTestBase(AzureRecordedTestCase):
+
+    NON_EXISTING_CONNECTION_NAME = "non-existing-connection-name"
+    EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME = (
+        f"Connection {NON_EXISTING_CONNECTION_NAME} can't be found in this workspace"
+    )
+
+    EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME = f"Connection name cannot be empty"
 
     def get_sync_client(self, **kwargs) -> AIProjectClient:
         conn_str = kwargs.pop("azure_ai_projects_inference_tests_project_connection_string")

--- a/sdk/ai/azure-ai-projects/tests/inference/test_inference.py
+++ b/sdk/ai/azure-ai-projects/tests/inference/test_inference.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import pprint
+import pytest
 from devtools_testutils import recorded_by_proxy, is_live_and_not_recording
 from inference_test_base import InferenceTestBase, servicePreparerInferenceTests
 from azure.ai.inference.models import SystemMessage, UserMessage
+from azure.core.exceptions import ResourceNotFoundError
 
 
 # The test class name needs to start with "Test" to get collected by pytest
@@ -13,7 +15,7 @@ class TestInference(InferenceTestBase):
 
     @servicePreparerInferenceTests()
     @recorded_by_proxy
-    def test_inference_get_azure_openai_client(self, **kwargs):
+    def test_inference_get_aoai_client_key_auth(self, **kwargs):
         api_version = kwargs.pop("azure_ai_projects_inference_tests_aoai_api_version")
         model = kwargs.pop("azure_ai_projects_inference_tests_aoai_model_deployment_name")
         with self.get_sync_client(**kwargs) as project_client:
@@ -39,11 +41,69 @@ class TestInference(InferenceTestBase):
 
     @servicePreparerInferenceTests()
     @recorded_by_proxy
-    def test_inference_get_chat_completions_client(self, **kwargs):
-        model = kwargs.pop("azure_ai_projects_inference_tests_aiservices_model_deployment_name")
+    def test_inference_get_aoai_client_entra_id_auth(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aoai_connection_name")
+        api_version = kwargs.pop("azure_ai_projects_inference_tests_aoai_api_version")
+        model = kwargs.pop("azure_ai_projects_inference_tests_aoai_model_deployment_name")
         with self.get_sync_client(**kwargs) as project_client:
-            with project_client.inference.get_chat_completions_client() as azure_ai_inference_client:
-                response = azure_ai_inference_client.complete(
+            # See API versions in https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+            with project_client.inference.get_azure_openai_client(
+                api_version=api_version, connection_name=connection_name
+            ) as azure_openai_client:
+                if is_live_and_not_recording():
+                    response = azure_openai_client.chat.completions.create(
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "How many feet are in a mile?",
+                            }
+                        ],
+                        model=model,
+                    )
+                    print("\nAzureOpenAI response:")
+                    pprint.pprint(response)
+                    contains = ["5280", "5,280"]
+                    assert any(item in response.choices[0].message.content for item in contains)
+                else:
+                    print("Skipped chat completions call with AOAI client, because it cannot be recorded.")
+                    pass
+
+    @servicePreparerInferenceTests()
+    def test_inference_get_aoai_client_with_empty_connection_name(self, **kwargs):
+        with self.get_sync_client(**kwargs) as project_client:
+            try:
+                with project_client.inference.get_azure_openai_client(connection_name="") as azure_openai_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy
+    def test_inference_get_aoai_client_with_nonexisting_connection_name(self, **kwargs):
+        if is_live_and_not_recording():
+            with self.get_sync_client(**kwargs) as project_client:
+                try:
+                    with project_client.inference.get_azure_openai_client(
+                        connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                    ) as azure_openai_client:
+                        assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
+        else:
+            print("Skipped chat completions call with AOAI client, because it cannot be recorded.")
+            pass
+
+    # ----------------------------------------------------------------------------------------------------------------------
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy
+    def test_inference_get_chat_completions_client_key_auth(self, **kwargs):
+        model = kwargs.pop("azure_ai_projects_inference_tests_chat_completions_model_deployment_name")
+        with self.get_sync_client(**kwargs) as project_client:
+            with project_client.inference.get_chat_completions_client() as chat_completions_client:
+                response = chat_completions_client.complete(
                     model=model,
                     messages=[
                         SystemMessage(content="You are a helpful assistant."),
@@ -56,8 +116,115 @@ class TestInference(InferenceTestBase):
                 assert any(item in response.choices[0].message.content for item in contains)
 
     @servicePreparerInferenceTests()
+    @pytest.mark.skip("Entra ID auth not yet supported for models in AI Services connection")
     @recorded_by_proxy
-    def test_inference_get_embeddings_client(self, **kwargs):
+    def test_inference_get_chat_completions_client_entra_id_auth(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aiservices_connection_name")
+        model = kwargs.pop("azure_ai_projects_inference_tests_chat_completions_model_deployment_name")
         with self.get_sync_client(**kwargs) as project_client:
-            # TODO: Add test code here
-            pass
+            with project_client.inference.get_chat_completions_client(
+                connection_name=connection_name
+            ) as chat_completions_client:
+                response = chat_completions_client.complete(
+                    model=model,
+                    messages=[
+                        SystemMessage(content="You are a helpful assistant."),
+                        UserMessage(content="How many feet are in a mile?"),
+                    ],
+                )
+                print("\nChatCompletionsClient response:")
+                pprint.pprint(response)
+                contains = ["5280", "5,280"]
+                assert any(item in response.choices[0].message.content for item in contains)
+
+    @servicePreparerInferenceTests()
+    def test_inference_get_chat_completions_client_with_empty_connection_name(self, **kwargs):
+        with self.get_sync_client(**kwargs) as project_client:
+            try:
+                with project_client.inference.get_chat_completions_client(
+                    connection_name=""
+                ) as chat_completions_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy
+    def test_inference_get_chat_completions_client_with_nonexisting_connection_name(self, **kwargs):
+        with self.get_sync_client(**kwargs) as project_client:
+            try:
+                with project_client.inference.get_chat_completions_client(
+                    connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                ) as chat_completions_client:
+                    assert False
+            except ResourceNotFoundError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
+
+    # ----------------------------------------------------------------------------------------------------------------------
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy
+    def test_inference_get_embeddings_client_key_auth(self, **kwargs):
+        model = kwargs.pop("azure_ai_projects_inference_tests_embeddings_model_deployment_name")
+        with self.get_sync_client(**kwargs) as project_client:
+            with project_client.inference.get_embeddings_client() as embeddings_client:
+                response = embeddings_client.embed(model=model, input=["first phrase", "second phrase", "third phrase"])
+                print("\nEmbeddingsClient response:")
+                for item in response.data:
+                    length = len(item.embedding)
+                    print(
+                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                    )
+                assert len(response.data) == 3
+                for item in response.data:
+                    assert len(item.embedding) > 0
+                    assert item.embedding[0] != 0
+                    assert item.embedding[-1] != 0
+
+    @servicePreparerInferenceTests()
+    @pytest.mark.skip("Entra ID auth not yet supported for models in AI Services connection")
+    @recorded_by_proxy
+    def test_inference_get_embeddings_client_entra_id_auth(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aiservices_connection_name")
+        model = kwargs.pop("azure_ai_projects_inference_tests_embeddings_model_deployment_name")
+        with self.get_sync_client(**kwargs) as project_client:
+            with project_client.inference.get_embeddings_client(connection_name=connection_name) as embeddings_client:
+                response = embeddings_client.embed(model=model, input=["first phrase", "second phrase", "third phrase"])
+                print("\nEmbeddingsClient response:")
+                for item in response.data:
+                    length = len(item.embedding)
+                    print(
+                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                    )
+                assert len(response.data) == 3
+                for item in response.data:
+                    assert len(item.embedding) > 0
+                    assert item.embedding[0] != 0
+                    assert item.embedding[-1] != 0
+
+    @servicePreparerInferenceTests()
+    def test_inference_get_embeddings_client_with_empty_connection_name(self, **kwargs):
+        with self.get_sync_client(**kwargs) as project_client:
+            try:
+                with project_client.inference.get_embeddings_client(connection_name="") as embeddings_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy
+    def test_inference_get_embeddings_client_with_nonexisting_connection_name(self, **kwargs):
+        with self.get_sync_client(**kwargs) as project_client:
+            try:
+                with project_client.inference.get_embeddings_client(
+                    connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                ) as embeddings_client:
+                    assert False
+            except ResourceNotFoundError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message

--- a/sdk/ai/azure-ai-projects/tests/inference/test_inference_async.py
+++ b/sdk/ai/azure-ai-projects/tests/inference/test_inference_async.py
@@ -3,10 +3,12 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import pprint
+import pytest
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils import is_live_and_not_recording
 from inference_test_base import InferenceTestBase, servicePreparerInferenceTests
 from azure.ai.inference.models import SystemMessage, UserMessage
+from azure.core.exceptions import ResourceNotFoundError
 
 
 # The test class name needs to start with "Test" to get collected by pytest
@@ -14,7 +16,7 @@ class TestInferenceAsync(InferenceTestBase):
 
     @servicePreparerInferenceTests()
     @recorded_by_proxy_async
-    async def test_inference_get_azure_openai_client_async(self, **kwargs):
+    async def test_inference_get_azure_openai_client_key_auth_async(self, **kwargs):
         api_version = kwargs.pop("azure_ai_projects_inference_tests_aoai_api_version")
         model = kwargs.pop("azure_ai_projects_inference_tests_aoai_model_deployment_name")
         async with self.get_async_client(**kwargs) as project_client:
@@ -42,11 +44,71 @@ class TestInferenceAsync(InferenceTestBase):
 
     @servicePreparerInferenceTests()
     @recorded_by_proxy_async
-    async def test_inference_get_chat_completions_client_async(self, **kwargs):
-        model = kwargs.pop("azure_ai_projects_inference_tests_aiservices_model_deployment_name")
+    async def test_inference_get_azure_openai_client_entra_id_auth_async(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aoai_connection_name")
+        api_version = kwargs.pop("azure_ai_projects_inference_tests_aoai_api_version")
+        model = kwargs.pop("azure_ai_projects_inference_tests_aoai_model_deployment_name")
         async with self.get_async_client(**kwargs) as project_client:
-            async with await project_client.inference.get_chat_completions_client() as azure_ai_inference_client:
-                response = await azure_ai_inference_client.complete(
+            # See API versions in https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+            async with await project_client.inference.get_azure_openai_client(
+                api_version=api_version, connection_name=connection_name
+            ) as azure_openai_client:
+                if is_live_and_not_recording():
+                    response = await azure_openai_client.chat.completions.create(
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "How many feet are in a mile?",
+                            }
+                        ],
+                        model=model,
+                    )
+                    print("\nAsyncAzureOpenAI response:")
+                    pprint.pprint(response)
+                    contains = ["5280", "5,280"]
+                    assert any(item in response.choices[0].message.content for item in contains)
+                else:
+                    print("Skipped chat completions call with AOAI client, because it cannot be recorded.")
+                    pass
+
+    @servicePreparerInferenceTests()
+    async def test_inference_get_aoai_client_with_empty_connection_name_async(self, **kwargs):
+        async with self.get_async_client(**kwargs) as project_client:
+            try:
+                async with await project_client.inference.get_azure_openai_client(
+                    connection_name=""
+                ) as azure_openai_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy_async
+    async def test_inference_get_aoai_client_with_nonexisting_connection_name_async(self, **kwargs):
+        if is_live_and_not_recording():
+            async with self.get_async_client(**kwargs) as project_client:
+                try:
+                    async with await project_client.inference.get_azure_openai_client(
+                        connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                    ) as azure_openai_client:
+                        assert False
+                except ResourceNotFoundError as e:
+                    print(e)
+                    assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
+        else:
+            print("Skipped chat completions call with AOAI client, because it cannot be recorded.")
+            pass
+
+    # ----------------------------------------------------------------------------------------------------------------------
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy_async
+    async def test_inference_get_chat_completions_client_key_auth_async(self, **kwargs):
+        model = kwargs.pop("azure_ai_projects_inference_tests_chat_completions_model_deployment_name")
+        async with self.get_async_client(**kwargs) as project_client:
+            async with await project_client.inference.get_chat_completions_client() as chat_completions_client:
+                response = await chat_completions_client.complete(
                     model=model,
                     messages=[
                         SystemMessage(content="You are a helpful assistant."),
@@ -59,8 +121,123 @@ class TestInferenceAsync(InferenceTestBase):
                 assert any(item in response.choices[0].message.content for item in contains)
 
     @servicePreparerInferenceTests()
+    @pytest.mark.skip("Entra ID auth not yet supported for models in AI Services connection")
     @recorded_by_proxy_async
-    async def test_inference_get_embeddings_client_async(self, **kwargs):
+    async def test_inference_get_chat_completions_client_entra_id_auth_async(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aiservices_connection_name")
+        model = kwargs.pop("azure_ai_projects_inference_tests_chat_completions_model_deployment_name")
         async with self.get_async_client(**kwargs) as project_client:
-            # TODO: Add test code here
-            pass
+            async with await project_client.inference.get_chat_completions_client(
+                connection_name=connection_name
+            ) as chat_completions_client:
+                response = await chat_completions_client.complete(
+                    model=model,
+                    messages=[
+                        SystemMessage(content="You are a helpful assistant."),
+                        UserMessage(content="How many feet are in a mile?"),
+                    ],
+                )
+                print("\nAsync ChatCompletionsClient response:")
+                pprint.pprint(response)
+                contains = ["5280", "5,280"]
+                assert any(item in response.choices[0].message.content for item in contains)
+
+    @servicePreparerInferenceTests()
+    async def test_inference_get_chat_completions_client_with_empty_connection_name_async(self, **kwargs):
+        async with self.get_async_client(**kwargs) as project_client:
+            try:
+                async with await project_client.inference.get_chat_completions_client(
+                    connection_name=""
+                ) as chat_completions_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy_async
+    async def test_inference_get_chat_completions_client_with_nonexisting_connection_name_async(self, **kwargs):
+        async with self.get_async_client(**kwargs) as project_client:
+            try:
+                async with await project_client.inference.get_chat_completions_client(
+                    connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                ) as chat_completions_client:
+                    assert False
+            except ResourceNotFoundError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message
+
+    # ----------------------------------------------------------------------------------------------------------------------
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy_async
+    async def test_inference_get_embeddings_client_key_auth_async(self, **kwargs):
+        model = kwargs.pop("azure_ai_projects_inference_tests_embeddings_model_deployment_name")
+        async with self.get_async_client(**kwargs) as project_client:
+            async with await project_client.inference.get_embeddings_client() as embeddings_client:
+                response = await embeddings_client.embed(
+                    model=model, input=["first phrase", "second phrase", "third phrase"]
+                )
+                print("\nEmbeddingsClient response:")
+                for item in response.data:
+                    length = len(item.embedding)
+                    print(
+                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                    )
+                assert len(response.data) == 3
+                for item in response.data:
+                    assert len(item.embedding) > 0
+                    assert item.embedding[0] != 0
+                    assert item.embedding[-1] != 0
+
+    @servicePreparerInferenceTests()
+    @pytest.mark.skip("Entra ID auth not yet supported for models in AI Services connection")
+    @recorded_by_proxy_async
+    async def test_inference_get_embeddings_client_entra_id_auth_async(self, **kwargs):
+        connection_name = kwargs.pop("azure_ai_projects_inference_tests_aiservices_connection_name")
+        model = kwargs.pop("azure_ai_projects_inference_tests_embeddings_model_deployment_name")
+        async with self.get_async_client(**kwargs) as project_client:
+            async with await project_client.inference.get_embeddings_client(
+                connection_name=connection_name
+            ) as embeddings_client:
+                response = await embeddings_client.embed(
+                    model=model, input=["first phrase", "second phrase", "third phrase"]
+                )
+                print("\nEmbeddingsClient response:")
+                for item in response.data:
+                    length = len(item.embedding)
+                    print(
+                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                    )
+                assert len(response.data) == 3
+                for item in response.data:
+                    assert len(item.embedding) > 0
+                    assert item.embedding[0] != 0
+                    assert item.embedding[-1] != 0
+
+    @servicePreparerInferenceTests()
+    async def test_inference_get_embeddings_client_with_empty_connection_name_async(self, **kwargs):
+        async with self.get_async_client(**kwargs) as project_client:
+            try:
+                async with await project_client.inference.get_embeddings_client(
+                    connection_name=""
+                ) as embeddings_client:
+                    assert False
+            except ValueError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_EMPTY_CONNECTION_NAME in e.__str__()
+
+    @servicePreparerInferenceTests()
+    @recorded_by_proxy_async
+    async def test_inference_get_embeddings_client_with_nonexisting_connection_name_async(self, **kwargs):
+        async with self.get_async_client(**kwargs) as project_client:
+            try:
+                async with await project_client.inference.get_embeddings_client(
+                    connection_name=InferenceTestBase.NON_EXISTING_CONNECTION_NAME
+                ) as embeddings_client:
+                    assert False
+            except ResourceNotFoundError as e:
+                print(e)
+                assert InferenceTestBase.EXPECTED_EXCEPTION_MESSAGE_FOR_NON_EXISTING_CONNECTION_NAME in e.message


### PR DESCRIPTION
# Description

* Update `.inference.get_chat_completions_client()`, `.inference.get_embeddings_client()` and `.inference.get_azure_openai_client()` method to accept optional `connection_name`. This allows getting inference clients for more than one connection in your AI Foundry project. In our new AI Foundry project we use for testing, we have one connection that uses api-key for auth, and the other that uses Entra ID auth. The API change allows us to do inference on both connections.
* Add more inference tests for all inference clients (chat completions, embeddings, AOAI): tests with connection name explicitly specified (instead of the SDK assuming the "default" connection); tests with Entra ID auth; tests with empty or non-existing connection names. The Entra ID test only works with AOAI models. I'm following up with the service team on why I can't get non-OpenAI models to work with Entra ID. They only work with api-key auth. These tests are disabled for now.