### PR TITLE
add disableLocalAuth while creating aml compute

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Features Added
 
 ### Bugs Fixed
-
+  - Fixed disableLocalAuthentication handling while creating amlCompute
 
 ## 1.23.0 (2024-12-05)
 

--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_d220df7fea"
+  "Tag": "python/ml/azure-ai-ml_003b900b39"
 }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -247,7 +247,7 @@ class AmlCompute(Compute):
         disableLocalAuth = True
         if self.ssh_public_access_enabled is not None:
             remote_login_public_access = "Enabled" if self.ssh_public_access_enabled else "Disabled"
-            disableLocalAuth = False if self.ssh_public_access_enabled else True
+            disableLocalAuth = not self.ssh_public_access_enabled
 
         else:
             remote_login_public_access = "NotSpecified"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -252,10 +252,9 @@ class AmlCompute(Compute):
             ),
         )
         remote_login_public_access = "Enabled"
-        disableLocalAuth = True
+        disableLocalAuth = not (self.ssh_public_access_enabled and self.ssh_settings is not None)
         if self.ssh_public_access_enabled is not None:
             remote_login_public_access = "Enabled" if self.ssh_public_access_enabled else "Disabled"
-            disableLocalAuth = not self.ssh_public_access_enabled
 
         else:
             remote_login_public_access = "NotSpecified"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -71,9 +71,7 @@ class AmlComputeSshSettings:
         )
 
     @classmethod
-    def _from_user_account_credentials(
-        cls, credentials: UserAccountCredentials
-    ) -> "AmlComputeSshSettings":
+    def _from_user_account_credentials(cls, credentials: UserAccountCredentials) -> "AmlComputeSshSettings":
         return cls(
             admin_username=credentials.admin_user_name,
             admin_password=credentials.admin_user_password,
@@ -173,17 +171,13 @@ class AmlCompute(Compute):
         prop = rest_obj.properties
 
         network_settings = None
-        if prop.properties.subnet or (
-            prop.properties.enable_node_public_ip is not None
-        ):
+        if prop.properties.subnet or (prop.properties.enable_node_public_ip is not None):
             network_settings = NetworkSettings(
                 subnet=prop.properties.subnet.id if prop.properties.subnet else None,
             )
 
         ssh_settings = (
-            AmlComputeSshSettings._from_user_account_credentials(
-                prop.properties.user_account_credentials
-            )
+            AmlComputeSshSettings._from_user_account_credentials(prop.properties.user_account_credentials)
             if prop.properties.user_account_credentials
             else None
         )
@@ -192,9 +186,7 @@ class AmlCompute(Compute):
             name=rest_obj.name,
             id=rest_obj.id,
             description=prop.description,
-            location=(
-                prop.compute_location if prop.compute_location else rest_obj.location
-            ),
+            location=(prop.compute_location if prop.compute_location else rest_obj.location),
             tags=rest_obj.tags if rest_obj.tags else None,
             provisioning_state=prop.provisioning_state,
             provisioning_errors=(
@@ -204,37 +196,22 @@ class AmlCompute(Compute):
             ),
             size=prop.properties.vm_size,
             tier=camel_to_snake(prop.properties.vm_priority),
-            min_instances=(
-                prop.properties.scale_settings.min_node_count
-                if prop.properties.scale_settings
-                else None
-            ),
-            max_instances=(
-                prop.properties.scale_settings.max_node_count
-                if prop.properties.scale_settings
-                else None
-            ),
+            min_instances=(prop.properties.scale_settings.min_node_count if prop.properties.scale_settings else None),
+            max_instances=(prop.properties.scale_settings.max_node_count if prop.properties.scale_settings else None),
             network_settings=network_settings or None,
             ssh_settings=ssh_settings,
-            ssh_public_access_enabled=(
-                prop.properties.remote_login_port_public_access == "Enabled"
-            ),
+            ssh_public_access_enabled=(prop.properties.remote_login_port_public_access == "Enabled"),
             idle_time_before_scale_down=(
                 prop.properties.scale_settings.node_idle_time_before_scale_down.total_seconds()
-                if prop.properties.scale_settings
-                and prop.properties.scale_settings.node_idle_time_before_scale_down
+                if prop.properties.scale_settings and prop.properties.scale_settings.node_idle_time_before_scale_down
                 else None
             ),
             identity=(
-                IdentityConfiguration._from_compute_rest_object(rest_obj.identity)
-                if rest_obj.identity
-                else None
+                IdentityConfiguration._from_compute_rest_object(rest_obj.identity) if rest_obj.identity else None
             ),
             created_on=prop.additional_properties.get("createdOn", None),
             enable_node_public_ip=(
-                prop.properties.enable_node_public_ip
-                if prop.properties.enable_node_public_ip is not None
-                else True
+                prop.properties.enable_node_public_ip if prop.properties.enable_node_public_ip is not None else True
             ),
         )
         return response
@@ -277,9 +254,7 @@ class AmlCompute(Compute):
         remote_login_public_access = "Enabled"
         disableLocalAuth = True
         if self.ssh_public_access_enabled is not None:
-            remote_login_public_access = (
-                "Enabled" if self.ssh_public_access_enabled else "Disabled"
-            )
+            remote_login_public_access = "Enabled" if self.ssh_public_access_enabled else "Disabled"
             disableLocalAuth = not self.ssh_public_access_enabled
 
         else:
@@ -287,11 +262,7 @@ class AmlCompute(Compute):
         aml_prop = AmlComputeProperties(
             vm_size=self.size if self.size else ComputeDefaults.VMSIZE,
             vm_priority=snake_to_pascal(self.tier),
-            user_account_credentials=(
-                self.ssh_settings._to_user_account_credentials()
-                if self.ssh_settings
-                else None
-            ),
+            user_account_credentials=(self.ssh_settings._to_user_account_credentials() if self.ssh_settings else None),
             scale_settings=scale_settings,
             subnet=subnet_resource,
             remote_login_port_public_access=remote_login_public_access,
@@ -307,8 +278,6 @@ class AmlCompute(Compute):
         return ComputeResource(
             location=self.location,
             properties=aml_comp,
-            identity=(
-                self.identity._to_compute_rest_object() if self.identity else None
-            ),
+            identity=(self.identity._to_compute_rest_object() if self.identity else None),
             tags=self.tags,
         )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -6,7 +6,9 @@
 
 from typing import Any, Dict, Optional
 
-from azure.ai.ml._restclient.v2022_12_01_preview.models import AmlCompute as AmlComputeRest
+from azure.ai.ml._restclient.v2022_12_01_preview.models import (
+    AmlCompute as AmlComputeRest,
+)
 from azure.ai.ml._restclient.v2022_12_01_preview.models import (
     AmlComputeProperties,
     ComputeResource,
@@ -16,7 +18,11 @@ from azure.ai.ml._restclient.v2022_12_01_preview.models import (
 )
 from azure.ai.ml._schema._utils.utils import get_subnet_str
 from azure.ai.ml._schema.compute.aml_compute import AmlComputeSchema
-from azure.ai.ml._utils.utils import camel_to_snake, snake_to_pascal, to_iso_duration_format
+from azure.ai.ml._utils.utils import (
+    camel_to_snake,
+    snake_to_pascal,
+    to_iso_duration_format,
+)
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, TYPE
 from azure.ai.ml.constants._compute import ComputeDefaults, ComputeType
 from azure.ai.ml.entities._credentials import IdentityConfiguration
@@ -65,7 +71,9 @@ class AmlComputeSshSettings:
         )
 
     @classmethod
-    def _from_user_account_credentials(cls, credentials: UserAccountCredentials) -> "AmlComputeSshSettings":
+    def _from_user_account_credentials(
+        cls, credentials: UserAccountCredentials
+    ) -> "AmlComputeSshSettings":
         return cls(
             admin_username=credentials.admin_user_name,
             admin_password=credentials.admin_user_password,
@@ -165,13 +173,17 @@ class AmlCompute(Compute):
         prop = rest_obj.properties
 
         network_settings = None
-        if prop.properties.subnet or (prop.properties.enable_node_public_ip is not None):
+        if prop.properties.subnet or (
+            prop.properties.enable_node_public_ip is not None
+        ):
             network_settings = NetworkSettings(
                 subnet=prop.properties.subnet.id if prop.properties.subnet else None,
             )
 
         ssh_settings = (
-            AmlComputeSshSettings._from_user_account_credentials(prop.properties.user_account_credentials)
+            AmlComputeSshSettings._from_user_account_credentials(
+                prop.properties.user_account_credentials
+            )
             if prop.properties.user_account_credentials
             else None
         )
@@ -180,7 +192,9 @@ class AmlCompute(Compute):
             name=rest_obj.name,
             id=rest_obj.id,
             description=prop.description,
-            location=prop.compute_location if prop.compute_location else rest_obj.location,
+            location=(
+                prop.compute_location if prop.compute_location else rest_obj.location
+            ),
             tags=rest_obj.tags if rest_obj.tags else None,
             provisioning_state=prop.provisioning_state,
             provisioning_errors=(
@@ -190,20 +204,37 @@ class AmlCompute(Compute):
             ),
             size=prop.properties.vm_size,
             tier=camel_to_snake(prop.properties.vm_priority),
-            min_instances=prop.properties.scale_settings.min_node_count if prop.properties.scale_settings else None,
-            max_instances=prop.properties.scale_settings.max_node_count if prop.properties.scale_settings else None,
-            network_settings=network_settings or None,
-            ssh_settings=ssh_settings,
-            ssh_public_access_enabled=(prop.properties.remote_login_port_public_access == "Enabled"),
-            idle_time_before_scale_down=(
-                prop.properties.scale_settings.node_idle_time_before_scale_down.total_seconds()
-                if prop.properties.scale_settings and prop.properties.scale_settings.node_idle_time_before_scale_down
+            min_instances=(
+                prop.properties.scale_settings.min_node_count
+                if prop.properties.scale_settings
                 else None
             ),
-            identity=IdentityConfiguration._from_compute_rest_object(rest_obj.identity) if rest_obj.identity else None,
+            max_instances=(
+                prop.properties.scale_settings.max_node_count
+                if prop.properties.scale_settings
+                else None
+            ),
+            network_settings=network_settings or None,
+            ssh_settings=ssh_settings,
+            ssh_public_access_enabled=(
+                prop.properties.remote_login_port_public_access == "Enabled"
+            ),
+            idle_time_before_scale_down=(
+                prop.properties.scale_settings.node_idle_time_before_scale_down.total_seconds()
+                if prop.properties.scale_settings
+                and prop.properties.scale_settings.node_idle_time_before_scale_down
+                else None
+            ),
+            identity=(
+                IdentityConfiguration._from_compute_rest_object(rest_obj.identity)
+                if rest_obj.identity
+                else None
+            ),
             created_on=prop.additional_properties.get("createdOn", None),
             enable_node_public_ip=(
-                prop.properties.enable_node_public_ip if prop.properties.enable_node_public_ip is not None else True
+                prop.properties.enable_node_public_ip
+                if prop.properties.enable_node_public_ip is not None
+                else True
             ),
         )
         return response
@@ -246,7 +277,9 @@ class AmlCompute(Compute):
         remote_login_public_access = "Enabled"
         disableLocalAuth = True
         if self.ssh_public_access_enabled is not None:
-            remote_login_public_access = "Enabled" if self.ssh_public_access_enabled else "Disabled"
+            remote_login_public_access = (
+                "Enabled" if self.ssh_public_access_enabled else "Disabled"
+            )
             disableLocalAuth = not self.ssh_public_access_enabled
 
         else:
@@ -254,7 +287,11 @@ class AmlCompute(Compute):
         aml_prop = AmlComputeProperties(
             vm_size=self.size if self.size else ComputeDefaults.VMSIZE,
             vm_priority=snake_to_pascal(self.tier),
-            user_account_credentials=self.ssh_settings._to_user_account_credentials() if self.ssh_settings else None,
+            user_account_credentials=(
+                self.ssh_settings._to_user_account_credentials()
+                if self.ssh_settings
+                else None
+            ),
             scale_settings=scale_settings,
             subnet=subnet_resource,
             remote_login_port_public_access=remote_login_public_access,
@@ -265,11 +302,13 @@ class AmlCompute(Compute):
             description=self.description,
             compute_type=self.type,
             properties=aml_prop,
-            disable_local_auth=disableLocalAuth
+            disable_local_auth=disableLocalAuth,
         )
         return ComputeResource(
             location=self.location,
             properties=aml_comp,
-            identity=(self.identity._to_compute_rest_object() if self.identity else None),
+            identity=(
+                self.identity._to_compute_rest_object() if self.identity else None
+            ),
             tags=self.tags,
         )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -6,8 +6,8 @@
 
 from typing import Any, Dict, Optional
 
-from azure.ai.ml._restclient.v2022_10_01_preview.models import AmlCompute as AmlComputeRest
-from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+from azure.ai.ml._restclient.v2022_12_01_preview.models import AmlCompute as AmlComputeRest
+from azure.ai.ml._restclient.v2022_12_01_preview.models import (
     AmlComputeProperties,
     ComputeResource,
     ResourceId,
@@ -244,8 +244,11 @@ class AmlCompute(Compute):
             ),
         )
         remote_login_public_access = "Enabled"
+        disableLocalAuth = True
         if self.ssh_public_access_enabled is not None:
             remote_login_public_access = "Enabled" if self.ssh_public_access_enabled else "Disabled"
+            disableLocalAuth = False if self.ssh_public_access_enabled else True
+
         else:
             remote_login_public_access = "NotSpecified"
         aml_prop = AmlComputeProperties(
@@ -258,7 +261,12 @@ class AmlCompute(Compute):
             enable_node_public_ip=self.enable_node_public_ip,
         )
 
-        aml_comp = AmlComputeRest(description=self.description, compute_type=self.type, properties=aml_prop)
+        aml_comp = AmlComputeRest(
+            description=self.description,
+            compute_type=self.type,
+            properties=aml_prop,
+            disable_local_auth=disableLocalAuth
+        )
         return ComputeResource(
             location=self.location,
             properties=aml_comp,

--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
@@ -54,8 +54,9 @@ class TestComputeEntity:
 
     def _test_loaded_compute(self, compute: AmlCompute):
         assert compute.name == "banchaml"
-        assert compute.ssh_settings.admin_username == "azureuser"
-        assert compute.identity.type == "user_assigned"
+        assert compute.type == "amlcompute"   
+        assert compute.location == "eastus"
+        assert compute.description == "some_desc_aml"
 
     def test_compute_from_yaml(self):
         compute: AmlCompute = verify_entity_load_and_dump(
@@ -63,12 +64,14 @@ class TestComputeEntity:
             self._test_loaded_compute,
             "tests/test_configs/compute/compute-aml.yaml",
         )[0]
-        assert compute.location == "eastus"
+        assert compute.ssh_settings.admin_username == "azureuser"
+        assert compute.identity.type == "user_assigned"
 
         rest_intermediate = compute._to_rest_object()
         assert rest_intermediate.properties.compute_type == "AmlCompute"
         assert rest_intermediate.properties.properties.user_account_credentials.admin_user_name == "azureuser"
         assert rest_intermediate.properties.properties.enable_node_public_ip
+        assert rest_intermediate.properties.disable_local_auth is False
         assert rest_intermediate.location == compute.location
         assert rest_intermediate.tags is not None
         assert rest_intermediate.tags["test"] == "true"
@@ -80,6 +83,21 @@ class TestComputeEntity:
             compute.identity.user_assigned_identities
         )
         assert body["location"] == compute.location
+    
+    def test_aml_compute_from_yaml_with_disable_public_access(self):
+
+        compute: AmlCompute = verify_entity_load_and_dump(
+            load_compute,
+            self._test_loaded_compute,
+            "tests/test_configs/compute/compute-aml-disable-public-access.yaml",
+        )[0]
+
+        rest_intermediate = compute._to_rest_object()
+
+        assert rest_intermediate.properties.compute_type == "AmlCompute"
+        assert rest_intermediate.properties.properties.enable_node_public_ip
+        assert rest_intermediate.properties.disable_local_auth is True
+        assert rest_intermediate.location == compute.location
 
     def test_compute_vm_from_yaml(self):
         resource_id = "/subscriptions/13e50845-67bc-4ac5-94db-48d493a6d9e8/resourceGroups/myrg/providers/Microsoft.Compute/virtualMachines/myvm"

--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
@@ -98,7 +98,7 @@ class TestComputeEntity:
         assert rest_intermediate.properties.properties.enable_node_public_ip
         assert rest_intermediate.properties.disable_local_auth is True
         assert rest_intermediate.location == compute.location
-    
+
     def test_aml_compute_from_yaml_with_disable_public_access_when_no_sshSettings(self):
 
         compute: AmlCompute = verify_entity_load_and_dump(

--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
@@ -54,7 +54,7 @@ class TestComputeEntity:
 
     def _test_loaded_compute(self, compute: AmlCompute):
         assert compute.name == "banchaml"
-        assert compute.type == "amlcompute"   
+        assert compute.type == "amlcompute"
         assert compute.location == "eastus"
         assert compute.description == "some_desc_aml"
 
@@ -83,7 +83,7 @@ class TestComputeEntity:
             compute.identity.user_assigned_identities
         )
         assert body["location"] == compute.location
-    
+
     def test_aml_compute_from_yaml_with_disable_public_access(self):
 
         compute: AmlCompute = verify_entity_load_and_dump(

--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
@@ -98,6 +98,21 @@ class TestComputeEntity:
         assert rest_intermediate.properties.properties.enable_node_public_ip
         assert rest_intermediate.properties.disable_local_auth is True
         assert rest_intermediate.location == compute.location
+    
+    def test_aml_compute_from_yaml_with_disable_public_access_when_no_sshSettings(self):
+
+        compute: AmlCompute = verify_entity_load_and_dump(
+            load_compute,
+            self._test_loaded_compute,
+            "tests/test_configs/compute/compute-aml-public-access-no-ssh.yaml",
+        )[0]
+
+        rest_intermediate = compute._to_rest_object()
+
+        assert rest_intermediate.properties.compute_type == "AmlCompute"
+        assert rest_intermediate.properties.properties.enable_node_public_ip
+        assert rest_intermediate.properties.disable_local_auth is True
+        assert rest_intermediate.location == compute.location
 
     def test_compute_vm_from_yaml(self):
         resource_id = "/subscriptions/13e50845-67bc-4ac5-94db-48d493a6d9e8/resourceGroups/myrg/providers/Microsoft.Compute/virtualMachines/myvm"

--- a/sdk/ml/azure-ai-ml/tests/test_configs/compute/compute-aml-disable-public-access.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/compute/compute-aml-disable-public-access.yaml
@@ -1,0 +1,9 @@
+name: banchaml
+type: amlcompute
+tier: dedicated
+description: some_desc_aml
+size: Standard_DS2_v2
+min_instances: 0
+max_instances: 2
+location: eastus
+idle_time_before_scale_down: 120

--- a/sdk/ml/azure-ai-ml/tests/test_configs/compute/compute-aml-public-access-no-ssh.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/compute/compute-aml-public-access-no-ssh.yaml
@@ -1,0 +1,11 @@
+name: banchaml
+type: amlcompute
+description: some_desc_aml
+size: Standard_DS2_v2
+location: eastus
+tags:
+   test: "true"
+ssh_public_access_enabled: true
+max_instances: 2
+idle_time_before_scale_down: 100
+enable_node_public_ip: true


### PR DESCRIPTION
# Description

In AML compute - disableLocalAuthentication field was not being handled while creating compute cluster. This field is determined from ssh_public_access_enabled in yaml. If ssh_public_access_enabled=true and ssh_settings is available, then disableLocalAuthentication = false else true

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
