### PR TITLE
[Storage] [STG 97] Exposed `mode_copy_mode` and `owner_copy_mode` in `start_copy_from_url`

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_8af5942fd9"
+  "Tag": "python/storage/azure-storage-file-share_a6f58a3103"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -725,6 +725,20 @@ class ShareFileClient(StorageAccountHostsMixin):
             NFS only. The owning group of the file.
         :keyword str file_mode:
             NFS only. The file mode of the file.
+        :keyword mode_copy_mode:
+            NFS only. Applicable only when the copy source is a File. Determines the copy behavior
+            of the mode bits of the file. Possible values are:
+
+            source - The mode on the destination file is copied from the source file.
+            override - The mode on the destination file is determined via the file_mode keyword.
+        :paramtype mode_copy_mode: Literal['source', 'override']
+        :keyword owner_copy_mode:
+            NFS only. Applicable only when the copy source is a File. Determines the copy behavior
+            of the owner and group of the file. Possible values are:
+
+            source - The owner and group on the destination file is copied from the source file.
+            override - The owner and group on the destination file is determined via the owner and group keywords.
+        :paramtype owner_copy_mode: Literal['source', 'override']
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-file-service-operations.
@@ -749,8 +763,8 @@ class ShareFileClient(StorageAccountHostsMixin):
         owner = kwargs.pop('owner', None)
         group = kwargs.pop('group', None)
         file_mode = kwargs.pop('file_mode', None)
-        file_mode_copy_mode = 'override' if file_mode else None
-        file_owner_copy_mode = 'override' if owner or group else None
+        file_mode_copy_mode = kwargs.pop('mode_copy_mode', None)
+        file_owner_copy_mode = kwargs.pop('owner_copy_mode', None)
         headers = kwargs.pop('headers', {})
         headers.update(add_metadata_headers(metadata))
         kwargs.update(get_smb_properties(kwargs))

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
@@ -310,7 +310,7 @@ def _create_xml_node(tag, prefix=None, ns=None):
     return ET.Element(tag)
 
 
-class Model(object):
+class Model:
     """Mixin for all client request body/response body models to support
     serialization and deserialization.
     """
@@ -563,7 +563,7 @@ def _decode_attribute_map_key(key):
     return key.replace("\\.", ".")
 
 
-class Serializer(object):  # pylint: disable=too-many-public-methods
+class Serializer:  # pylint: disable=too-many-public-methods
     """Request object model serializer."""
 
     basic_types = {str: "str", int: "int", bool: "bool", float: "float"}
@@ -1441,7 +1441,7 @@ def xml_key_extractor(attr, attr_desc, data):  # pylint: disable=unused-argument
     return children[0]
 
 
-class Deserializer(object):
+class Deserializer:
     """Response object model deserializer.
 
     :param dict classes: Class type dictionary for deserializing complex types.
@@ -1683,17 +1683,21 @@ class Deserializer(object):
             subtype = getattr(response, "_subtype_map", {})
             try:
                 readonly = [
-                    k for k, v in response._validation.items() if v.get("readonly")  # pylint: disable=protected-access
+                    k
+                    for k, v in response._validation.items()  # pylint: disable=protected-access  # type: ignore
+                    if v.get("readonly")
                 ]
                 const = [
-                    k for k, v in response._validation.items() if v.get("constant")  # pylint: disable=protected-access
+                    k
+                    for k, v in response._validation.items()  # pylint: disable=protected-access  # type: ignore
+                    if v.get("constant")
                 ]
                 kwargs = {k: v for k, v in attrs.items() if k not in subtype and k not in readonly + const}
                 response_obj = response(**kwargs)
                 for attr in readonly:
                     setattr(response_obj, attr, attrs.get(attr))
                 if additional_properties:
-                    response_obj.additional_properties = additional_properties
+                    response_obj.additional_properties = additional_properties  # type: ignore
                 return response_obj
             except TypeError as err:
                 msg = "Unable to deserialize {} into model {}. ".format(kwargs, response)  # type: ignore

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_file_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_file_operations.py
@@ -149,7 +149,7 @@ class FileOperations:  # pylint: disable=too-many-public-methods
          None.
         :type file_mode: str
         :param nfs_file_type: Optional, NFS only. Type of the file or directory. Known values are:
-         "Regular", "Directory", and "Symlink". Default value is None.
+         "Regular", "Directory", and "SymLink". Default value is None.
         :type nfs_file_type: str or ~azure.storage.fileshare.models.NfsFileType
         :param file_http_headers: Parameter group. Default value is None.
         :type file_http_headers: ~azure.storage.fileshare.models.FileHTTPHeaders

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_azure_file_storage_enums.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_azure_file_storage_enums.py
@@ -108,7 +108,7 @@ class NfsFileType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 
     REGULAR = "Regular"
     DIRECTORY = "Directory"
-    SYMLINK = "Symlink"
+    SYM_LINK = "SymLink"
 
 
 class OwnerCopyMode(str, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
@@ -1387,7 +1387,7 @@ class FileOperations:  # pylint: disable=too-many-public-methods
          None.
         :type file_mode: str
         :param nfs_file_type: Optional, NFS only. Type of the file or directory. Known values are:
-         "Regular", "Directory", and "Symlink". Default value is None.
+         "Regular", "Directory", and "SymLink". Default value is None.
         :type nfs_file_type: str or ~azure.storage.fileshare.models.NfsFileType
         :param file_http_headers: Parameter group. Default value is None.
         :type file_http_headers: ~azure.storage.fileshare.models.FileHTTPHeaders

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -720,6 +720,20 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin): 
             NFS only. The owning group of the file.
         :keyword str file_mode:
             NFS only. The file mode of the file.
+        :keyword mode_copy_mode:
+            NFS only. Applicable only when the copy source is a File. Determines the copy behavior
+            of the mode bits of the file. Possible values are:
+
+            source - The mode on the destination file is copied from the source file.
+            override - The mode on the destination file is determined via the file_mode keyword.
+        :paramtype mode_copy_mode: Literal['source', 'override']
+        :keyword owner_copy_mode:
+            NFS only. Applicable only when the copy source is a File. Determines the copy behavior
+            of the owner and group of the file. Possible values are:
+
+            source - The owner and group on the destination file is copied from the source file.
+            override - The owner and group on the destination file is determined via the owner and group keywords.
+        :paramtype owner_copy_mode: Literal['source', 'override']
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-file-service-operations.
@@ -744,8 +758,8 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin): 
         owner = kwargs.pop('owner', None)
         group = kwargs.pop('group', None)
         file_mode = kwargs.pop('file_mode', None)
-        file_mode_copy_mode = 'override' if file_mode else None
-        file_owner_copy_mode = 'override' if owner or group else None
+        file_mode_copy_mode = kwargs.pop('mode_copy_mode', None)
+        file_owner_copy_mode = kwargs.pop('owner_copy_mode', None)
         headers = kwargs.pop("headers", {})
         headers.update(add_metadata_headers(metadata))
         kwargs.update(get_smb_properties(kwargs))

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs.py
@@ -4,9 +4,22 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
-from azure.storage.fileshare import ContentSettings, ShareFileClient, ShareDirectoryClient, ShareServiceClient
+from typing import Any, Dict, Optional, Union
 
+from azure.core.exceptions import (
+    ClientAuthenticationError,
+    HttpResponseError,
+    ResourceExistsError,
+    ResourceNotFoundError
+)
+from azure.storage.fileshare import (
+    ContentSettings,
+    FileProperties,
+    DirectoryProperties,
+    ShareFileClient,
+    ShareDirectoryClient,
+    ShareServiceClient
+)
 from devtools_testutils import recorded_by_proxy
 from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import FileSharePreparer
@@ -21,7 +34,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
     fsc: ShareServiceClient = None
 
-    def _setup(self, storage_account_name):
+    def _setup(self, storage_account_name: str):
         self.account_url = self.account_url(storage_account_name, 'file')
         self.credential = self.get_credential(ShareServiceClient)
         self.fsc = ShareServiceClient(
@@ -44,16 +57,40 @@ class TestStorageFileNFS(StorageRecordedTestCase):
                 pass
 
     # --Helpers----------------------------------------------------------
-    def _get_file_name(self, prefix=TEST_FILE_PREFIX):
+    def _get_file_name(self, prefix: str = TEST_FILE_PREFIX):
         return self.get_resource_name(prefix)
 
-    def _get_directory_name(self, prefix=TEST_DIRECTORY_PREFIX):
+    def _get_directory_name(self, prefix: str = TEST_DIRECTORY_PREFIX):
         return self.get_resource_name(prefix)
+
+    def _assert_props(
+        self, props: Optional[Union[DirectoryProperties, FileProperties]],
+        owner: str,
+        group: str,
+        file_mode: str,
+        nfs_file_type: Optional[str] = None
+    ) -> None:
+        assert props is not None
+        assert props.owner == owner
+        assert props.group == group
+        assert props.file_mode == file_mode
+        assert props.file_attributes is None
+        assert props.permission_key is None
+
+        if nfs_file_type:
+            assert props.nfs_file_type == nfs_file_type
+        if isinstance(props, FileProperties):
+            assert props.link_count == 1
+
+    def _assert_copy(self, copy: Optional[Dict[str, Any]]) -> None:
+        assert copy is not None
+        assert copy['copy_status'] == 'success'
+        assert copy['copy_id'] is not None
 
     # --Test cases for NFS ----------------------------------------------
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_create_directory_and_set_directory_properties(self, **kwargs):
+    def test_create_directory_and_set_directory_properties(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         self._setup(storage_account_name)
@@ -71,29 +108,15 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
         directory_client.create_directory(owner=create_owner, group=create_group, file_mode=create_file_mode)
         props = directory_client.get_directory_properties()
-
-        assert props is not None
-        assert props.owner == create_owner
-        assert props.group == create_group
-        assert props.file_mode == create_file_mode
-        assert props.nfs_file_type == 'Directory'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, create_owner, create_group, create_file_mode, 'Directory')
 
         directory_client.set_http_headers(owner=set_owner, group=set_group, file_mode=set_file_mode)
         props = directory_client.get_directory_properties()
-
-        assert props is not None
-        assert props.owner == set_owner
-        assert props.group == set_group
-        assert props.file_mode == set_file_mode
-        assert props.nfs_file_type == 'Directory'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, set_owner, set_group, set_file_mode, 'Directory')
 
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_create_file_and_set_file_properties(self, **kwargs):
+    def test_create_file_and_set_file_properties(self, **kwargs: Any):
         storage_account_name = kwargs.pop("storage_account_name")
 
         self._setup(storage_account_name)
@@ -116,15 +139,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
         file_client.create_file(1024, owner=create_owner, group=create_group, file_mode=create_file_mode)
         props = file_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == create_owner
-        assert props.group == create_group
-        assert props.file_mode == create_file_mode
-        assert props.link_count == 1
-        assert props.nfs_file_type == 'Regular'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, create_owner, create_group, create_file_mode, 'Regular')
 
         file_client.set_http_headers(
             content_settings=content_settings,
@@ -133,70 +148,80 @@ class TestStorageFileNFS(StorageRecordedTestCase):
             file_mode=set_file_mode
         )
         props = file_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == set_owner
-        assert props.group == set_group
-        assert props.file_mode == set_file_mode
-        assert props.link_count == 1
-        assert props.nfs_file_type == 'Regular'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, set_owner, set_group, set_file_mode, 'Regular')
 
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_download_and_copy_file(self, **kwargs):
+    def test_download_and_copy_file(self, **kwargs: Any):
         storage_account_name = kwargs.pop("storage_account_name")
 
         self._setup(storage_account_name)
 
-        owner, group, file_mode = '0', '0', '0664'
+        default_owner, default_group, default_file_mode = '0', '0', '0664'
+        source_owner, source_group, source_file_mode = '999', '888', '0111'
+        override_owner, override_group, override_file_mode = '54321', '12345', '7777'
         data = b'abcdefghijklmnop' * 32
 
         share_client = self.fsc.get_share_client(self.share_name)
 
         file_name = self._get_file_name()
         file_client = share_client.get_file_client(file_name)
-        file_client.create_file(size=1024)
-
-        new_client = ShareFileClient(
-            self.account_url,
-            share_name=self.share_name,
-            file_path='file1copy',
-            credential=self.credential,
-            token_intent=TEST_INTENT
-        )
+        file_client.create_file(size=1024, owner=source_owner, group=source_group, file_mode=source_file_mode)
 
         file_client.upload_range(data, offset=0, length=512)
         props = file_client.download_file().properties
+        self._assert_props(props, source_owner, source_group, source_file_mode)
 
-        assert props is not None
-        assert props.owner == owner
-        assert props.group == group
-        assert props.file_mode == file_mode
-        assert props.link_count == 1
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        new_client_source_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientsourcecopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = new_client_source_copy.start_copy_from_url(
+            file_client.url,
+            mode_copy_mode='source',
+            owner_copy_mode='source'
+        )
+        self._assert_copy(copy)
+        props = new_client_source_copy.get_file_properties()
+        self._assert_props(props, source_owner, source_group, source_file_mode)
 
-        copy = new_client.start_copy_from_url(file_client.url, owner=owner, group=group, file_mode=file_mode)
+        new_client_default_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientdefaultcopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = new_client_default_copy.start_copy_from_url(file_client.url)
+        self._assert_copy(copy)
+        props = new_client_default_copy.get_file_properties()
+        self._assert_props(props, default_owner, default_group, default_file_mode)
 
-        assert copy is not None
-        assert copy['copy_status'] == 'success'
-        assert copy['copy_id'] is not None
-
-        props = new_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == owner
-        assert props.group == group
-        assert props.file_mode == file_mode
-        assert props.link_count == 1
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        new_client_override_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientoverridecopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = new_client_override_copy.start_copy_from_url(
+            file_client.url,
+            owner=override_owner,
+            group=override_group,
+            file_mode=override_file_mode,
+            mode_copy_mode='override',
+            owner_copy_mode='override'
+        )
+        self._assert_copy(copy)
+        props = new_client_override_copy.get_file_properties()
+        self._assert_props(props, override_owner, override_group, override_file_mode)
 
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_create_hard_link(self, **kwargs):
+    def test_create_hard_link(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         self._setup(storage_account_name)
@@ -230,7 +255,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy
-    def test_create_hard_link_error(self, **kwargs):
+    def test_create_hard_link_error(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         self._setup(storage_account_name)

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
@@ -4,8 +4,20 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
-from azure.storage.fileshare import ContentSettings, ShareServiceClient
+from typing import Any, Dict, Optional, Union
+
+from azure.core.exceptions import (
+    ClientAuthenticationError,
+    HttpResponseError,
+    ResourceExistsError,
+    ResourceNotFoundError
+)
+from azure.storage.fileshare import (
+    ContentSettings,
+    DirectoryProperties,
+    FileProperties,
+    ShareServiceClient
+)
 from azure.storage.fileshare.aio import ShareServiceClient as AsyncShareServiceClient
 from azure.storage.fileshare.aio import ShareFileClient, ShareDirectoryClient
 
@@ -23,7 +35,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
     fsc: AsyncShareServiceClient = None
 
-    async def _setup(self, storage_account_name):
+    async def _setup(self, storage_account_name: str):
         self.account_url = self.account_url(storage_account_name, 'file')
         self.credential = self.get_credential(AsyncShareServiceClient, is_async=True)
         self.fsc = AsyncShareServiceClient(
@@ -57,16 +69,40 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
                 pass
 
     # --Helpers----------------------------------------------------------
-    def _get_file_name(self, prefix=TEST_FILE_PREFIX):
+    def _get_file_name(self, prefix: str = TEST_FILE_PREFIX):
         return self.get_resource_name(prefix)
 
-    def _get_directory_name(self, prefix=TEST_DIRECTORY_PREFIX):
+    def _get_directory_name(self, prefix: str = TEST_DIRECTORY_PREFIX):
         return self.get_resource_name(prefix)
+
+    def _assert_props(
+        self, props: Optional[Union[DirectoryProperties, FileProperties]],
+        owner: str,
+        group: str,
+        file_mode: str,
+        nfs_file_type: Optional[str] = None
+    ) -> None:
+        assert props is not None
+        assert props.owner == owner
+        assert props.group == group
+        assert props.file_mode == file_mode
+        assert props.file_attributes is None
+        assert props.permission_key is None
+
+        if nfs_file_type:
+            assert props.nfs_file_type == nfs_file_type
+        if isinstance(props, FileProperties):
+            assert props.link_count == 1
+
+    def _assert_copy(self, copy: Optional[Dict[str, Any]]) -> None:
+        assert copy is not None
+        assert copy['copy_status'] == 'success'
+        assert copy['copy_id'] is not None
 
     # --Test cases for NFS ----------------------------------------------
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_create_directory_and_set_directory_properties(self, **kwargs):
+    async def test_create_directory_and_set_directory_properties(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         await self._setup(storage_account_name)
@@ -84,29 +120,15 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
         await directory_client.create_directory(owner=create_owner, group=create_group, file_mode=create_file_mode)
         props = await directory_client.get_directory_properties()
-
-        assert props is not None
-        assert props.owner == create_owner
-        assert props.group == create_group
-        assert props.file_mode == create_file_mode
-        assert props.nfs_file_type == 'Directory'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, create_owner, create_group, create_file_mode, 'Directory')
 
         await directory_client.set_http_headers(owner=set_owner, group=set_group, file_mode=set_file_mode)
         props = await directory_client.get_directory_properties()
-
-        assert props is not None
-        assert props.owner == set_owner
-        assert props.group == set_group
-        assert props.file_mode == set_file_mode
-        assert props.nfs_file_type == 'Directory'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, set_owner, set_group, set_file_mode, 'Directory')
 
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_create_file_and_set_file_properties(self, **kwargs):
+    async def test_create_file_and_set_file_properties(self, **kwargs: Any):
         storage_account_name = kwargs.pop("storage_account_name")
 
         await self._setup(storage_account_name)
@@ -129,15 +151,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
         await file_client.create_file(1024, owner=create_owner, group=create_group, file_mode=create_file_mode)
         props = await file_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == create_owner
-        assert props.group == create_group
-        assert props.file_mode == create_file_mode
-        assert props.link_count == 1
-        assert props.nfs_file_type == 'Regular'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, create_owner, create_group, create_file_mode, 'Regular')
 
         await file_client.set_http_headers(
             content_settings=content_settings,
@@ -146,70 +160,80 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
             file_mode=set_file_mode
         )
         props = await file_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == set_owner
-        assert props.group == set_group
-        assert props.file_mode == set_file_mode
-        assert props.link_count == 1
-        assert props.nfs_file_type == 'Regular'
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        self._assert_props(props, set_owner, set_group, set_file_mode, 'Regular')
 
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_download_and_copy_file(self, **kwargs):
+    async def test_download_and_copy_file(self, **kwargs: Any):
         storage_account_name = kwargs.pop("storage_account_name")
 
         await self._setup(storage_account_name)
 
-        owner, group, file_mode = '0', '0', '0664'
+        default_owner, default_group, default_file_mode = '0', '0', '0664'
+        source_owner, source_group, source_file_mode = '999', '888', '0111'
+        override_owner, override_group, override_file_mode = '54321', '12345', '7777'
         data = b'abcdefghijklmnop' * 32
 
         share_client = self.fsc.get_share_client(self.share_name)
 
         file_name = self._get_file_name()
         file_client = share_client.get_file_client(file_name)
-        await file_client.create_file(size=1024)
-
-        new_client = ShareFileClient(
-            self.account_url,
-            share_name=self.share_name,
-            file_path='file1copy',
-            credential=self.credential,
-            token_intent=TEST_INTENT
-        )
+        await file_client.create_file(size=1024, owner=source_owner, group=source_group, file_mode=source_file_mode)
 
         await file_client.upload_range(data, offset=0, length=512)
         props = (await file_client.download_file()).properties
+        self._assert_props(props, source_owner, source_group, source_file_mode)
 
-        assert props is not None
-        assert props.owner == owner
-        assert props.group == group
-        assert props.file_mode == file_mode
-        assert props.link_count == 1
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        new_client_source_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientsourcecopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = await new_client_source_copy.start_copy_from_url(
+            file_client.url,
+            mode_copy_mode='source',
+            owner_copy_mode='source'
+        )
+        self._assert_copy(copy)
+        props = await new_client_source_copy.get_file_properties()
+        self._assert_props(props, source_owner, source_group, source_file_mode)
 
-        copy = await new_client.start_copy_from_url(file_client.url, owner=owner, group=group, file_mode=file_mode)
+        new_client_default_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientdefaultcopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = await new_client_default_copy.start_copy_from_url(file_client.url)
+        self._assert_copy(copy)
+        props = await new_client_default_copy.get_file_properties()
+        self._assert_props(props, default_owner, default_group, default_file_mode)
 
-        assert copy is not None
-        assert copy['copy_status'] == 'success'
-        assert copy['copy_id'] is not None
-
-        props = await new_client.get_file_properties()
-
-        assert props is not None
-        assert props.owner == owner
-        assert props.group == group
-        assert props.file_mode == file_mode
-        assert props.link_count == 1
-        assert props.file_attributes is None
-        assert props.permission_key is None
+        new_client_override_copy = ShareFileClient(
+            self.account_url,
+            share_name=self.share_name,
+            file_path='newclientoverridecopy',
+            credential=self.credential,
+            token_intent=TEST_INTENT
+        )
+        copy = await new_client_override_copy.start_copy_from_url(
+            file_client.url,
+            owner=override_owner,
+            group=override_group,
+            file_mode=override_file_mode,
+            mode_copy_mode='override',
+            owner_copy_mode='override'
+        )
+        self._assert_copy(copy)
+        props = await new_client_override_copy.get_file_properties()
+        self._assert_props(props, override_owner, override_group, override_file_mode)
 
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_create_hard_link(self, **kwargs):
+    async def test_create_hard_link(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         await self._setup(storage_account_name)
@@ -243,7 +267,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy_async
-    async def test_create_hard_link_error(self, **kwargs):
+    async def test_create_hard_link_error(self, **kwargs: Any):
         storage_account_name = kwargs.pop('storage_account_name')
 
         await self._setup(storage_account_name)


### PR DESCRIPTION
NFS over REST 97 Changes. This contains a refactoring of the test file to reduce redundant assertions of file/directory properties, as well as added some typing to make the file more readable.