### PR TITLE
[Key Vault] Prepare for mypy 1.13.0

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/ecdsa.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/ecdsa.py
@@ -2,9 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import abc
-import sys
-
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import utils
@@ -12,13 +9,6 @@ from cryptography.hazmat.primitives.asymmetric import utils
 from ..algorithm import SignatureAlgorithm
 from ..transform import SignatureTransform
 from ..._enums import SignatureAlgorithm as KeyVaultSignatureAlgorithm
-
-if sys.version_info < (3, 3):
-    abstractproperty = abc.abstractproperty
-else:  # abc.abstractproperty is deprecated as of 3.3
-    import functools
-
-    abstractproperty = functools.partial(property, abc.abstractmethod)
 
 
 class _EcdsaSignatureTransform(SignatureTransform):
@@ -38,10 +28,6 @@ class _EcdsaSignatureTransform(SignatureTransform):
 class _Ecdsa(SignatureAlgorithm):
     def create_signature_transform(self, key):
         return _EcdsaSignatureTransform(key, self.default_hash_algorithm)
-
-    @abstractproperty
-    def coordinate_length(self):
-        pass
 
 
 class Ecdsa256(_Ecdsa):


### PR DESCRIPTION
# Description

Mypy 1.13.0 identified a typing issue with the `coordinate_length` property in a cryptography base class. This was an abstract property that wasn't actually necessary to keep, so this PR removes it (and in the process, removes a conditional import left over from Python 2.7).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
