### PR TITLE
Use "async with DefaultAzureCredential() as credential" in async .inference/.connections/.evaluation samples

### DIFF
--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -1,18 +1,17 @@
 # Release History
 
-## 1.0.0b4 (Unreleased)
+## 1.0.0b4 (2024-12-20)
+
+### Bugs Fixed
+
+* Fix for Agent streaming issue (see [GitHub issue 38918](https://github.com/Azure/azure-sdk-for-python/issues/38918))
+* Fix for Agent async function `send_email_async` is not called (see [GitHub issue 38898](https://github.com/Azure/azure-sdk-for-python/issues/38898))
+* Fix for Agent streaming with event handler fails with "AttributeError: 'MyEventHandler' object has no attribute 'buffer'" (see [GitHub issue 38897](https://github.com/Azure/azure-sdk-for-python/issues/38897))
 
 ### Features Added
 
 * Add optional input argument `connection_name` to methods `.inference.get_chat_completions_client`,
  `.inference.get_embeddings_client` and `.inference.get_azure_openai_client`.
-
-### Breaking Changes
-
-### Bugs Fixed
-* Fix for streaming issue, https://github.com/Azure/azure-sdk-for-python/issues/38918
-* Fix for Async function send_email_async is not called, https://github.com/Azure/azure-sdk-for-python/issues/38898
-* Fix for Streaming with eventhandler fails with AttributeError: 'MyEventHandler' object has no attribute 'buffer', https://github.com/Azure/azure-sdk-for-python/issues/38897
 
 ## 1.0.0b3 (2024-12-13)
 

--- a/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_connections_async.py
@@ -34,41 +34,41 @@ async def sample_connections_async() -> None:
     project_connection_string = os.environ["PROJECT_CONNECTION_STRING"]
     connection_name = os.environ["CONNECTION_NAME"]
 
-    project_client = AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=project_connection_string,
-    )
+    async with DefaultAzureCredential() as credential:
 
-    async with project_client:
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=project_connection_string,
+        ) as project_client:
 
-        # List the properties of all connections
-        connections = await project_client.connections.list()
-        print(f"====> Listing of all connections (found {len(connections)}):")
-        for connection in connections:
+            # List the properties of all connections
+            connections = await project_client.connections.list()
+            print(f"====> Listing of all connections (found {len(connections)}):")
+            for connection in connections:
+                print(connection)
+
+            # List the properties of all connections of a particular "type" (in this sample, Azure OpenAI connections)
+            connections = await project_client.connections.list(
+                connection_type=ConnectionType.AZURE_OPEN_AI,
+            )
+            print(f"====> Listing of all Azure Open AI connections (found {len(connections)}):")
+            for connection in connections:
+                print(connection)
+
+            # Get the properties of the default connection of a particular "type", with credentials
+            connection = await project_client.connections.get_default(
+                connection_type=ConnectionType.AZURE_AI_SERVICES,
+                include_credentials=True,  # Optional. Defaults to "False"
+            )
+            print("====> Get default Azure AI Services connection:")
             print(connection)
 
-        # List the properties of all connections of a particular "type" (in this sample, Azure OpenAI connections)
-        connections = await project_client.connections.list(
-            connection_type=ConnectionType.AZURE_OPEN_AI,
-        )
-        print(f"====> Listing of all Azure Open AI connections (found {len(connections)}):")
-        for connection in connections:
+            # Get the properties of a connection by its connection name:
+            connection = await project_client.connections.get(
+                connection_name=connection_name, include_credentials=True  # Optional. Defaults to "False"
+            )
+            print("====> Get connection by name:")
             print(connection)
-
-        # Get the properties of the default connection of a particular "type", with credentials
-        connection = await project_client.connections.get_default(
-            connection_type=ConnectionType.AZURE_AI_SERVICES,
-            include_credentials=True,  # Optional. Defaults to "False"
-        )
-        print("====> Get default Azure AI Services connection:")
-        print(connection)
-
-        # Get the properties of a connection by its connection name:
-        connection = await project_client.connections.get(
-            connection_name=connection_name, include_credentials=True  # Optional. Defaults to "False"
-        )
-        print("====> Get connection by name:")
-        print(connection)
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_inference_client_from_connection_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_inference_client_from_connection_async.py
@@ -40,88 +40,88 @@ async def sample_inference_client_from_connection() -> None:
     connection_name = os.environ["CONNECTION_NAME"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
-    project_client = AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=project_connection_string,
-    )
+    async with DefaultAzureCredential() as credential:
 
-    async with project_client:
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=project_connection_string,
+        ) as project_client:
 
-        # Get the properties of a connection by its connection name:
-        connection = await project_client.connections.get(connection_name=connection_name, include_credentials=True)
-        print("====> Get connection by name (credentials printout redacted)):")
-        print(connection)
+            # Get the properties of a connection by its connection name:
+            connection = await project_client.connections.get(connection_name=connection_name, include_credentials=True)
+            print("====> Get connection by name (credentials printout redacted)):")
+            print(connection)
 
-    # Examples of how you would create an inference client
-    if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
+            # Examples of how you would create an inference client
+            if connection.connection_type == ConnectionType.AZURE_OPEN_AI:
 
-        from openai import AsyncAzureOpenAI
+                from openai import AsyncAzureOpenAI
 
-        if connection.authentication_type == AuthenticationType.API_KEY:
-            print("====> Creating AsyncAzureOpenAI client using API key authentication")
-            aoai_client = AsyncAzureOpenAI(
-                api_key=connection.key,
-                azure_endpoint=connection.endpoint_url,
-                api_version="2024-06-01",  # See "Data plane - inference" row in table https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
-            )
-        elif connection.authentication_type == AuthenticationType.ENTRA_ID:
-            print("====> Creating AsyncAzureOpenAI client using Entra ID authentication")
-            from azure.identity.aio import get_bearer_token_provider
-            from azure.core.credentials_async import AsyncTokenCredential
+                if connection.authentication_type == AuthenticationType.API_KEY:
+                    print("====> Creating AsyncAzureOpenAI client using API key authentication")
+                    aoai_client = AsyncAzureOpenAI(
+                        api_key=connection.key,
+                        azure_endpoint=connection.endpoint_url,
+                        api_version="2024-06-01",  # See "Data plane - inference" row in table https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+                    )
+                elif connection.authentication_type == AuthenticationType.ENTRA_ID:
+                    print("====> Creating AsyncAzureOpenAI client using Entra ID authentication")
+                    from azure.identity.aio import get_bearer_token_provider
+                    from azure.core.credentials_async import AsyncTokenCredential
 
-            aoai_client = AsyncAzureOpenAI(
-                # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider
-                azure_ad_token_provider=get_bearer_token_provider(
-                    cast(AsyncTokenCredential, connection.token_credential),
-                    "https://cognitiveservices.azure.com/.default",
-                ),
-                azure_endpoint=connection.endpoint_url,
-                api_version="2024-06-01",  # See "Data plane - inference" row in table https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
-            )
-        else:
-            raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
+                    aoai_client = AsyncAzureOpenAI(
+                        # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider
+                        azure_ad_token_provider=get_bearer_token_provider(
+                            cast(AsyncTokenCredential, connection.token_credential),
+                            "https://cognitiveservices.azure.com/.default",
+                        ),
+                        azure_endpoint=connection.endpoint_url,
+                        api_version="2024-06-01",  # See "Data plane - inference" row in table https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+                    )
+                else:
+                    raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-        aoai_response = await aoai_client.chat.completions.create(
-            model=model_deployment_name,
-            messages=[
-                {
-                    "role": "user",
-                    "content": "How many feet are in a mile?",
-                },
-            ],
-        )
-        await aoai_client.close()
-        print(aoai_response.choices[0].message.content)
+                aoai_response = await aoai_client.chat.completions.create(
+                    model=model_deployment_name,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": "How many feet are in a mile?",
+                        },
+                    ],
+                )
+                await aoai_client.close()
+                print(aoai_response.choices[0].message.content)
 
-    elif connection.connection_type == ConnectionType.AZURE_AI_SERVICES:
+            elif connection.connection_type == ConnectionType.AZURE_AI_SERVICES:
 
-        from azure.ai.inference.aio import ChatCompletionsClient
-        from azure.ai.inference.models import UserMessage
+                from azure.ai.inference.aio import ChatCompletionsClient
+                from azure.ai.inference.models import UserMessage
 
-        if connection.authentication_type == AuthenticationType.API_KEY:
-            print("====> Creating ChatCompletionsClient using API key authentication")
-            from azure.core.credentials import AzureKeyCredential
+                if connection.authentication_type == AuthenticationType.API_KEY:
+                    print("====> Creating ChatCompletionsClient using API key authentication")
+                    from azure.core.credentials import AzureKeyCredential
 
-            inference_client = ChatCompletionsClient(
-                endpoint=f"{connection.endpoint_url}/models", credential=AzureKeyCredential(connection.key or "")
-            )
-        elif connection.authentication_type == AuthenticationType.ENTRA_ID:
-            from azure.core.credentials_async import AsyncTokenCredential
+                    inference_client = ChatCompletionsClient(
+                        endpoint=f"{connection.endpoint_url}/models", credential=AzureKeyCredential(connection.key or "")
+                    )
+                elif connection.authentication_type == AuthenticationType.ENTRA_ID:
+                    from azure.core.credentials_async import AsyncTokenCredential
 
-            print("====> Creating ChatCompletionsClient using Entra ID authentication")
-            inference_client = ChatCompletionsClient(
-                endpoint=f"{connection.endpoint_url}/models",
-                credential=cast(AsyncTokenCredential, connection.token_credential),
-                credential_scopes=["https://cognitiveservices.azure.com/.default"],
-            )
-        else:
-            raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
+                    print("====> Creating ChatCompletionsClient using Entra ID authentication")
+                    inference_client = ChatCompletionsClient(
+                        endpoint=f"{connection.endpoint_url}/models",
+                        credential=cast(AsyncTokenCredential, connection.token_credential),
+                        credential_scopes=["https://cognitiveservices.azure.com/.default"],
+                    )
+                else:
+                    raise ValueError(f"Authentication type {connection.authentication_type} not supported.")
 
-        inference_response = await inference_client.complete(
-            model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
-        )
-        await inference_client.close()
-        print(inference_response.choices[0].message.content)
+                inference_response = await inference_client.complete(
+                    model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+                )
+                await inference_client.close()
+                print(inference_response.choices[0].message.content)
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_inference_client_from_connection_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/async_samples/sample_inference_client_from_connection_async.py
@@ -103,7 +103,8 @@ async def sample_inference_client_from_connection() -> None:
                     from azure.core.credentials import AzureKeyCredential
 
                     inference_client = ChatCompletionsClient(
-                        endpoint=f"{connection.endpoint_url}/models", credential=AzureKeyCredential(connection.key or "")
+                        endpoint=f"{connection.endpoint_url}/models",
+                        credential=AzureKeyCredential(connection.key or ""),
                     )
                 elif connection.authentication_type == AuthenticationType.ENTRA_ID:
                     from azure.core.credentials_async import AsyncTokenCredential

--- a/sdk/ai/azure-ai-projects/samples/evaluations/async_samples/sample_evaluations_async.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/async_samples/sample_evaluations_async.py
@@ -33,62 +33,64 @@ from azure.ai.evaluation import F1ScoreEvaluator, RelevanceEvaluator, ViolenceEv
 
 
 async def main():
-    project_client = AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=os.environ["PROJECT_CONNECTION_STRING"],
-    )
 
-    # Upload data for evaluation
-    data_id, _ = project_client.upload_file("./data/evaluate_test_data.jsonl")
+    async with DefaultAzureCredential() as credential:
 
-    default_connection = await project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=os.environ["PROJECT_CONNECTION_STRING"],
+        ) as project_client:
 
-    deployment_name = "<>"
-    api_version = "<>"
+            # Upload data for evaluation
+            data_id, _ = project_client.upload_file("./data/evaluate_test_data.jsonl")
 
-    # Create an evaluation
-    evaluation = Evaluation(
-        display_name="Remote Evaluation",
-        description="Evaluation of dataset",
-        data=Dataset(id=data_id),
-        evaluators={
-            "f1_score": EvaluatorConfiguration(
-                # id=F1ScoreEvaluator.id,
-                id="azureml://registries/azureml-staging/models/F1Score-Evaluator/versions/3",
-            ),
-            "relevance": EvaluatorConfiguration(
-                # id=RelevanceEvaluator.id,
-                id="azureml://registries/azureml-staging/models/Relevance-Evaluator/versions/3",
-                init_params={
-                    "model_config": default_connection.to_evaluator_model_config(
-                        deployment_name=deployment_name, api_version=api_version
-                    )
+            default_connection = await project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+
+            deployment_name = "<>"
+            api_version = "<>"
+
+            # Create an evaluation
+            evaluation = Evaluation(
+                display_name="Remote Evaluation",
+                description="Evaluation of dataset",
+                data=Dataset(id=data_id),
+                evaluators={
+                    "f1_score": EvaluatorConfiguration(
+                        # id=F1ScoreEvaluator.id,
+                        id="azureml://registries/azureml-staging/models/F1Score-Evaluator/versions/3",
+                    ),
+                    "relevance": EvaluatorConfiguration(
+                        # id=RelevanceEvaluator.id,
+                        id="azureml://registries/azureml-staging/models/Relevance-Evaluator/versions/3",
+                        init_params={
+                            "model_config": default_connection.to_evaluator_model_config(
+                                deployment_name=deployment_name, api_version=api_version
+                            )
+                        },
+                    ),
+                    "violence": EvaluatorConfiguration(
+                        # id=ViolenceEvaluator.id,
+                        id="azureml://registries/azureml-staging/models/Violent-Content-Evaluator/versions/3",
+                        init_params={"azure_ai_project": project_client.scope},
+                    ),
                 },
-            ),
-            "violence": EvaluatorConfiguration(
-                # id=ViolenceEvaluator.id,
-                id="azureml://registries/azureml-staging/models/Violent-Content-Evaluator/versions/3",
-                init_params={"azure_ai_project": project_client.scope},
-            ),
-        },
-    )
-
-    async with project_client:
-        # Create evaluation
-        evaluation_response = await project_client.evaluations.create(evaluation)
-
-        # Get evaluation
-        get_evaluation_response = await project_client.evaluations.get(evaluation_response.id)
-
-        print("----------------------------------------------------------------")
-        print("Created evaluation, evaluation ID: ", get_evaluation_response.id)
-        print("Evaluation status: ", get_evaluation_response.status)
-        if isinstance(get_evaluation_response.properties, dict):
-            print(
-                "AI Foundry URI: ",
-                get_evaluation_response.properties["AiStudioEvaluationUri"],
             )
-        print("----------------------------------------------------------------")
+
+            # Create evaluation
+            evaluation_response = await project_client.evaluations.create(evaluation)
+
+            # Get evaluation
+            get_evaluation_response = await project_client.evaluations.get(evaluation_response.id)
+
+            print("----------------------------------------------------------------")
+            print("Created evaluation, evaluation ID: ", get_evaluation_response.id)
+            print("Evaluation status: ", get_evaluation_response.status)
+            if isinstance(get_evaluation_response.properties, dict):
+                print(
+                    "AI Foundry URI: ",
+                    get_evaluation_response.properties["AiStudioEvaluationUri"],
+                )
+            print("----------------------------------------------------------------")
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/evaluations/async_samples/sample_evaluations_async.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/async_samples/sample_evaluations_async.py
@@ -44,7 +44,9 @@ async def main():
             # Upload data for evaluation
             data_id, _ = project_client.upload_file("./data/evaluate_test_data.jsonl")
 
-            default_connection = await project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+            default_connection = await project_client.connections.get_default(
+                connection_type=ConnectionType.AZURE_OPEN_AI
+            )
 
             deployment_name = "<>"
             api_version = "<>"

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
@@ -32,17 +32,19 @@ async def sample_get_chat_completions_client_async():
     project_connection_string = os.environ["PROJECT_CONNECTION_STRING"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
-    async with AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=project_connection_string,
-    ) as project_client:
+    async with DefaultAzureCredential() as credential:
 
-        async with await project_client.inference.get_chat_completions_client() as client:
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=project_connection_string,
+        ) as project_client:
 
-            response = await client.complete(
-                model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
-            )
-            print(response.choices[0].message.content)
+            async with await project_client.inference.get_chat_completions_client() as client:
+
+                response = await client.complete(
+                    model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+                )
+                print(response.choices[0].message.content)
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
@@ -33,25 +33,27 @@ async def sample_get_azure_openai_client_async():
     project_connection_string = os.environ["PROJECT_CONNECTION_STRING"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
-    async with AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=project_connection_string,
-    ) as project_client:
+    async with DefaultAzureCredential() as credential:
 
-        # Get an authenticated AsyncAzureOpenAI client for your default Azure OpenAI connection:
-        async with await project_client.inference.get_azure_openai_client(api_version="2024-06-01") as client:
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=project_connection_string,
+        ) as project_client:
 
-            response = await client.chat.completions.create(
-                model=model_deployment_name,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "How many feet are in a mile?",
-                    },
-                ],
-            )
+            # Get an authenticated AsyncAzureOpenAI client for your default Azure OpenAI connection:
+            async with await project_client.inference.get_azure_openai_client(api_version="2024-06-01") as client:
 
-            print(response.choices[0].message.content)
+                response = await client.chat.completions.create(
+                    model=model_deployment_name,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": "How many feet are in a mile?",
+                        },
+                    ],
+                )
+
+                print(response.choices[0].message.content)
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
@@ -31,24 +31,26 @@ async def sample_get_embeddings_client_async():
     project_connection_string = os.environ["PROJECT_CONNECTION_STRING"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
-    async with AIProjectClient.from_connection_string(
-        credential=DefaultAzureCredential(),
-        conn_str=project_connection_string,
-    ) as project_client:
+    async with DefaultAzureCredential() as credential:
 
-        # Get an authenticated async azure.ai.inference embeddings client for your default Serverless connection:
-        async with await project_client.inference.get_embeddings_client() as client:
+        async with AIProjectClient.from_connection_string(
+            credential=credential,
+            conn_str=project_connection_string,
+        ) as project_client:
 
-            response = await client.embed(
-                model=model_deployment_name, input=["first phrase", "second phrase", "third phrase"]
-            )
+            # Get an authenticated async azure.ai.inference embeddings client for your default Serverless connection:
+            async with await project_client.inference.get_embeddings_client() as client:
 
-            for item in response.data:
-                length = len(item.embedding)
-                print(
-                    f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
-                    f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                response = await client.embed(
+                    model=model_deployment_name, input=["first phrase", "second phrase", "third phrase"]
                 )
+
+                for item in response.data:
+                    length = len(item.embedding)
+                    print(
+                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
+                    )
 
 
 async def main():

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_operations_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_operations_async.py
@@ -206,10 +206,10 @@ class TestAgentsOperations:
     @pytest.mark.parametrize(
         "file_agent_1,file_agent_2",
         [
-            #("file_for_agent1", "file_for_agent2"),
+            # ("file_for_agent1", "file_for_agent2"),
             (None, "file_for_agent2"),
-            #("file_for_agent1", None),
-            #(None, None),
+            # ("file_for_agent1", None),
+            # (None, None),
         ],
     )
     async def test_multiple_agents_create(
@@ -251,7 +251,7 @@ class TestAgentsOperations:
                 toolset=toolset1,
             )
             self._assert_pipeline_and_reset(mock_pipeline._pipeline.run, tool_set=toolset1)
-            
+
             agent2 = await project_client.agents.create_agent(
                 model="gpt-4-1106-preview",
                 name="second",
@@ -262,7 +262,7 @@ class TestAgentsOperations:
             # Check that the new agents are called with correct tool sets.
             await project_client.agents.create_and_process_run(thread_id="some_thread_id", assistant_id=agent1.id)
             self._assert_tool_call(project_client.agents.submit_tool_outputs_to_run, "run123", toolset1)
-            
+
             await project_client.agents.create_and_process_run(thread_id="some_thread_id", assistant_id=agent2.id)
             self._assert_tool_call(project_client.agents.submit_tool_outputs_to_run, "run456", toolset2)
             # Check the contents of a toolset

--- a/sdk/ai/azure-ai-projects/tests/connections/test_connections.py
+++ b/sdk/ai/azure-ai-projects/tests/connections/test_connections.py
@@ -112,7 +112,7 @@ class TestConnections(ConnectionsTestBase):
                     expected_connection_type=ConnectionType.AZURE_AI_SERVICES,
                     expected_authentication_type=AuthenticationType.ENTRA_ID,
                 )
-                if (include_credentials):
+                if include_credentials:
                     ConnectionsTestBase.validate_inference(connection, chat_completions_model_deployment_name)
 
     @servicePreparerConnectionsTests()

--- a/sdk/ai/azure-ai-projects/tests/connections/test_connections_async.py
+++ b/sdk/ai/azure-ai-projects/tests/connections/test_connections_async.py
@@ -112,8 +112,10 @@ class TestConnectionsAsync(ConnectionsTestBase):
                     expected_connection_type=ConnectionType.AZURE_AI_SERVICES,
                     expected_authentication_type=AuthenticationType.ENTRA_ID,
                 )
-                if (include_credentials):
-                    await ConnectionsTestBase.validate_async_inference(connection, chat_completions_model_deployment_name)
+                if include_credentials:
+                    await ConnectionsTestBase.validate_async_inference(
+                        connection, chat_completions_model_deployment_name
+                    )
 
     @servicePreparerConnectionsTests()
     @recorded_by_proxy_async


### PR DESCRIPTION
# Description

No functional change in this PR.

Use "async with DefaultAzureCredential() as credential" in async .inference/.connections/.evaluation samples, to make sure we don't see the console spew like this at the end of the run: `Unclosed client session. client_session: <aiohttp.client.ClientSession object at 0x000001C7ECF4B800>` . This change has already been done in the Agents async samples.

Also run the tool `black --config ../../../eng/black-pyproject.toml .`

Also update CHANGELOG.md to prepare for the next release.
