### PR TITLE
fix: handle URL-safe base64 decoding for JWT

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -45,9 +45,7 @@ def log_get_token(fn):
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except
-                    _LOGGER.debug(
-                        "Failed to log the account information: %s", ex, exc_info=True
-                    )
+                    _LOGGER.debug("Failed to log the account information: %s", ex, exc_info=True)
             return token
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.log(
@@ -78,9 +76,7 @@ def wrap_exceptions(fn):
         except ClientAuthenticationError:
             raise
         except Exception as ex:  # pylint:disable=broad-except
-            auth_error = ClientAuthenticationError(
-                message="Authentication failed: {}".format(ex)
-            )
+            auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
             raise auth_error from ex
 
     return wrapper

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -26,8 +26,11 @@ def log_get_token(fn):
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
-                    base64_meta_data = token.token.split(".")[1].encode("utf-8") + b"=="
-                    json_bytes = base64.decodebytes(base64_meta_data)
+                    base64_meta_data = token.token.split(".")[1]
+                    padding_needed = 4 - (len(base64_meta_data) % 4)
+                    if padding_needed:
+                        base64_meta_data += "=" * padding_needed
+                    json_bytes = base64.urlsafe_b64decode(base64_meta_data)
                     json_string = json_bytes.decode("utf-8")
                     json_dict = json.loads(json_string)
                     upn = json_dict.get("upn", "unavailableUpn")

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -22,12 +22,14 @@ def log_get_token(fn):
         try:
             token = fn(*args, **kwargs)
             _LOGGER.log(
-                logging.DEBUG if within_credential_chain.get() else logging.INFO, "%s succeeded", fn.__qualname__
+                logging.DEBUG if within_credential_chain.get() else logging.INFO,
+                "%s succeeded",
+                fn.__qualname__,
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
                     base64_meta_data = token.token.split(".")[1]
-                    padding_needed = - (len(base64_meta_data) % 4)
+                    padding_needed = -(len(base64_meta_data) % 4)
                     if padding_needed:
                         base64_meta_data += "=" * padding_needed
                     json_bytes = base64.urlsafe_b64decode(base64_meta_data)
@@ -43,7 +45,9 @@ def log_get_token(fn):
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except
-                    _LOGGER.debug("Failed to log the account information: %s", ex, exc_info=True)
+                    _LOGGER.debug(
+                        "Failed to log the account information: %s", ex, exc_info=True
+                    )
             return token
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.log(
@@ -74,7 +78,9 @@ def wrap_exceptions(fn):
         except ClientAuthenticationError:
             raise
         except Exception as ex:  # pylint:disable=broad-except
-            auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
+            auth_error = ClientAuthenticationError(
+                message="Authentication failed: {}".format(ex)
+            )
             raise auth_error from ex
 
     return wrapper

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -27,7 +27,7 @@ def log_get_token(fn):
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
                     base64_meta_data = token.token.split(".")[1]
-                    padding_needed = 4 - (len(base64_meta_data) % 4)
+                    padding_needed = - (len(base64_meta_data) % 4)
                     if padding_needed:
                         base64_meta_data += "=" * padding_needed
                     json_bytes = base64.urlsafe_b64decode(base64_meta_data)

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -29,7 +29,7 @@ def log_get_token(fn):
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
                     base64_meta_data = token.token.split(".")[1]
-                    padding_needed = -(len(base64_meta_data) % 4)
+                    padding_needed = -len(base64_meta_data) % 4
                     if padding_needed:
                         base64_meta_data += "=" * padding_needed
                     json_bytes = base64.urlsafe_b64decode(base64_meta_data)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
@@ -25,8 +25,11 @@ def log_get_token_async(fn):
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
-                    base64_meta_data = token.token.split(".")[1].encode("utf-8") + b"=="
-                    json_bytes = base64.decodebytes(base64_meta_data)
+                    base64_meta_data = token.token.split(".")[1]
+                    padding_needed = - (len(base64_meta_data) % 4)
+                    if padding_needed:
+                        base64_meta_data += "=" * padding_needed
+                    json_bytes = base64.urlsafe_b64decode(base64_meta_data)
                     json_string = json_bytes.decode("utf-8")
                     json_dict = json.loads(json_string)
                     upn = json_dict.get("upn", "unavailableUpn")

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
@@ -28,7 +28,7 @@ def log_get_token_async(fn):
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
                     base64_meta_data = token.token.split(".")[1]
-                    padding_needed = -(len(base64_meta_data) % 4)
+                    padding_needed = -len(base64_meta_data) % 4
                     if padding_needed:
                         base64_meta_data += "=" * padding_needed
                     json_bytes = base64.urlsafe_b64decode(base64_meta_data)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
@@ -21,12 +21,14 @@ def log_get_token_async(fn):
         try:
             token = await fn(*args, **kwargs)
             _LOGGER.log(
-                logging.DEBUG if within_credential_chain.get() else logging.INFO, "%s succeeded", fn.__qualname__
+                logging.DEBUG if within_credential_chain.get() else logging.INFO,
+                "%s succeeded",
+                fn.__qualname__,
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
                     base64_meta_data = token.token.split(".")[1]
-                    padding_needed = - (len(base64_meta_data) % 4)
+                    padding_needed = -(len(base64_meta_data) % 4)
                     if padding_needed:
                         base64_meta_data += "=" * padding_needed
                     json_bytes = base64.urlsafe_b64decode(base64_meta_data)
@@ -42,7 +44,9 @@ def log_get_token_async(fn):
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except
-                    _LOGGER.debug("Failed to log the account information: %s", ex, exc_info=True)
+                    _LOGGER.debug(
+                        "Failed to log the account information: %s", ex, exc_info=True
+                    )
             return token
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.log(
@@ -74,7 +78,9 @@ def wrap_exceptions(fn):
         except ClientAuthenticationError:
             raise
         except Exception as ex:  # pylint:disable=broad-except
-            auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
+            auth_error = ClientAuthenticationError(
+                message="Authentication failed: {}".format(ex)
+            )
             raise auth_error from ex
 
     return wrapper

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/decorators.py
@@ -44,9 +44,7 @@ def log_get_token_async(fn):
                     )
                     _LOGGER.debug(log_string)
                 except Exception as ex:  # pylint: disable=broad-except
-                    _LOGGER.debug(
-                        "Failed to log the account information: %s", ex, exc_info=True
-                    )
+                    _LOGGER.debug("Failed to log the account information: %s", ex, exc_info=True)
             return token
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.log(
@@ -78,9 +76,7 @@ def wrap_exceptions(fn):
         except ClientAuthenticationError:
             raise
         except Exception as ex:  # pylint:disable=broad-except
-            auth_error = ClientAuthenticationError(
-                message="Authentication failed: {}".format(ex)
-            )
+            auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
             raise auth_error from ex
 
     return wrapper


### PR DESCRIPTION
# Description

This pull request addresses an issue with JWT decoding where URL-safe base64 decoding was not being used, leading to UTF-8 decoding errors. The changes ensure that the base64 encoded string is properly padded and decoded using URL-safe base64 decoding.

[RFC4648](https://www.rfc-editor.org/rfc/rfc4648)

## Changes:
- Replaced `base64.decodebytes` with `base64.urlsafe_b64decode`.
- Added logic to calculate and append necessary padding to the base64 string.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
