### PR TITLE
Stream with event queue

### DIFF
--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0b5 (Unreleased)
+
+### Features Added
+
+### Bugs Fixed
+
+### Breaking Changes
+
 ## 1.0.0b4 (2024-12-20)
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_version.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0b4"
+VERSION = "1.0.0b5"

--- a/sdk/ai/azure-ai-projects/pyrightconfig.json
+++ b/sdk/ai/azure-ai-projects/pyrightconfig.json
@@ -12,5 +12,12 @@
   "**/sample_agents_code_interpreter_attachment_enterprise_search_async.py",
   "**/sample_agents_code_interpreter_attachment_enterprise_search_async.py",
   "**/sample_agents_code_interpreter_attachment_async.py"
+  ],
+  "extraPaths": [        
+    "./../../core/azure-core",
+    "./../../evaluation/azure-ai-evaluation",
+    "./../../identity/azure-identity",
+    "./../../monitor/azure-monitor-opentelemetry",
+    "./../azure-ai-inference"
   ]
 }

--- a/sdk/ai/azure-ai-projects/tests/README.md
+++ b/sdk/ai/azure-ai-projects/tests/README.md
@@ -15,9 +15,9 @@ The instructions below are for running tests locally, on a Windows machine, agai
     pip install wheel
     python setup.py bdist_wheel
     ```
-- Install the resulting wheel (update version `1.0.0b4` to the current one):
+- Install the resulting wheel (update version `1.0.0b5` to the current one):
     ```bash
-    pip install dist\azure_ai_projects-1.0.0b4-py3-none-any.whl --user --force-reinstall
+    pip install dist\azure_ai_projects-1.0.0b5-py3-none-any.whl --user --force-reinstall
     ```
 
 ## Log in to Azure


### PR DESCRIPTION
Added the _event_queue in stream handling because __anext__ is designed to produce only one event (or item) per iteration. If the response stream delivers multiple events within a single chunk of data, we would need to queue up all those events and then return them one-at-a-time in subsequent calls to __anext__. Otherwise, if we return the first parsed event and discard the rest in that same call leads to lost events.
