### PR TITLE
Update index metrics to v2 for Cosmos Python SDK

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
@@ -24,7 +24,7 @@
 
 import platform
 import re
-import base64
+import urllib.parse
 import json
 from typing import Any, Dict, Optional
 
@@ -55,14 +55,13 @@ def safe_user_agent_header(s: Optional[str]) -> str:
     return s
 
 
-def get_index_metrics_info(delimited_string: Optional[str]) -> Dict[str, Any]:
-    if delimited_string is None:
+def get_index_metrics_info(url_encoded_string: Optional[str]) -> Dict[str, Any]:
+    if url_encoded_string is None:
         return {}
+
     try:
-        # Decode the base64 string to bytes
-        bytes_string = base64.b64decode(delimited_string)
-        # Decode the bytes to a string using UTF-8 encoding
-        decoded_string = bytes_string.decode('utf-8')
+        # Decode the URL-encoded string
+        decoded_string = urllib.parse.unquote(url_encoded_string, encoding='utf-8')
 
         # Python's json.loads method is used for deserialization
         result = json.loads(decoded_string) or {}

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
@@ -130,7 +130,7 @@ class HttpHeaders:
     ContentPath = "x-ms-content-path"
     IsContinuationExpected = "x-ms-documentdb-query-iscontinuationexpected"
     PopulateQueryMetrics = "x-ms-documentdb-populatequerymetrics"
-    PopulateIndexMetrics = "x-ms-cosmos-populateindexmetrics"
+    PopulateIndexMetrics = "x-ms-cosmos-populateindexmetrics-V2"
     ResourceQuota = "x-ms-resource-quota"
     ResourceUsage = "x-ms-resource-usage"
     IntendedCollectionRID = "x-ms-cosmos-intended-collection-rid"

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -102,11 +102,11 @@ class TestQuery(unittest.TestCase):
         self.assertTrue(INDEX_HEADER_NAME in created_collection.client_connection.last_response_headers)
         index_metrics = created_collection.client_connection.last_response_headers[INDEX_HEADER_NAME]
         self.assertIsNotNone(index_metrics)
-        expected_index_metrics = {'UtilizedSingleIndexes': [{'FilterExpression': '', 'IndexSpec': '/pk/?',
-                                                             'FilterPreciseSet': True, 'IndexPreciseSet': True,
-                                                             'IndexImpactScore': 'High'}],
-                                  'PotentialSingleIndexes': [], 'UtilizedCompositeIndexes': [],
-                                  'PotentialCompositeIndexes': []}
+        expected_index_metrics = {'PotentialIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': []},
+                                  'UtilizedIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': [{'IndexSpec': '/pk/?'}]}
+                                  }
         self.assertDictEqual(expected_index_metrics, index_metrics)
         self.created_db.delete_container(created_collection.id)
 
@@ -630,7 +630,6 @@ class TestQuery(unittest.TestCase):
             retry_utility.ExecuteFunction = self.OriginalExecuteFunction
         retry_utility.ExecuteFunction = self.OriginalExecuteFunction
         self.created_db.delete_container(created_collection.id)
-
 
     def _MockExecuteFunctionSessionRetry(self, function, *args, **kwargs):
         if args:

--- a/sdk/cosmos/azure-cosmos/test/test_query_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_async.py
@@ -119,11 +119,11 @@ class TestQueryAsync(unittest.IsolatedAsyncioTestCase):
         assert index_header_name in created_collection.client_connection.last_response_headers
         index_metrics = created_collection.client_connection.last_response_headers[index_header_name]
         assert index_metrics != {}
-        expected_index_metrics = {'UtilizedSingleIndexes': [{'FilterExpression': '', 'IndexSpec': '/pk/?',
-                                                             'FilterPreciseSet': True, 'IndexPreciseSet': True,
-                                                             'IndexImpactScore': 'High'}],
-                                  'PotentialSingleIndexes': [], 'UtilizedCompositeIndexes': [],
-                                  'PotentialCompositeIndexes': []}
+        expected_index_metrics = {'PotentialIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': []},
+                                  'UtilizedIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': [{'IndexSpec': '/pk/?'}]}
+                                  }
         assert expected_index_metrics == index_metrics
 
         await self.created_db.delete_container(created_collection.id)

--- a/sdk/cosmos/azure-cosmos/test/test_query_cross_partition.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_cross_partition.py
@@ -217,11 +217,11 @@ class TestCrossPartitionQuery(unittest.TestCase):
         self.assertTrue(INDEX_HEADER_NAME in self.created_container.client_connection.last_response_headers)
         index_metrics = self.created_container.client_connection.last_response_headers[INDEX_HEADER_NAME]
         self.assertIsNotNone(index_metrics)
-        expected_index_metrics = {'UtilizedSingleIndexes': [{'FilterExpression': '', 'IndexSpec': '/pk/?',
-                                                             'FilterPreciseSet': True, 'IndexPreciseSet': True,
-                                                             'IndexImpactScore': 'High'}],
-                                  'PotentialSingleIndexes': [], 'UtilizedCompositeIndexes': [],
-                                  'PotentialCompositeIndexes': []}
+        expected_index_metrics = {'PotentialIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': []},
+                                  'UtilizedIndexes':
+                                      {'CompositeIndexes': [], 'SingleIndexes': [{'IndexSpec': '/pk/?'}]}
+                                  }
         self.assertDictEqual(expected_index_metrics, index_metrics)
 
     def test_get_query_plan_through_gateway(self):


### PR DESCRIPTION
# Description
This PR upgrades the index metrics to v2 for the python sdk. 
Index Metrics from v1 looked like this:
{'UtilizedSingleIndexes': [{'FilterExpression': '', 'IndexSpec': '/pk/?', 'FilterPreciseSet': True, 'IndexPreciseSet': True,'IndexImpactScore': 'High'}],
 'PotentialSingleIndexes': [], 'UtilizedCompositeIndexes': [],'PotentialCompositeIndexes': []}
 
 Index metrics for v2 look like this:
 {
'PotentialIndexes':
                    {'CompositeIndexes': [], 'SingleIndexes': []},
'UtilizedIndexes':
                    {'CompositeIndexes': [], 'SingleIndexes': [{'IndexSpec': '/pk/?'}]}
}