### PR TITLE
Fix registry model mdc bug

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -655,7 +655,7 @@ class MLClient:
         self._operation_container.add(AzureMLResourceType.ONLINE_DEPLOYMENT, self._online_deployments)
         self._operation_container.add(AzureMLResourceType.BATCH_DEPLOYMENT, self._batch_deployments)
         self._data = DataOperations(
-            self._operation_scope,
+            self._ws_operation_scope if registry_reference else self._operation_scope,
             self._operation_config,
             (self._service_client_10_2021_dataplanepreview if registry_name else self._service_client_04_2023_preview),
             self._service_client_01_2024_preview,


### PR DESCRIPTION
# Description

This fixes an ICM where cx had a registry model and a deployment yml with model data collection enabled. The data collection API was picking the wrong resource group (registry's). Note that registry_reference is only set when a registry model is used. Verified that with the changes, the deployment works in both registry model and workspace model scenarios.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
