### PR TITLE
[EH/SB] pyAMQP retries

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -208,7 +208,9 @@ class PyamqpTransport(AmqpTransport):  # pylint: disable=too-many-public-methods
 
         """
         return errors.RetryPolicy(
-            retry_total=config.max_retries,
+            # hardcoding to 0 to avoid double retries and
+            # 8 seconds of wait time when retrying compared to uamqp
+            retry_total=0,
             retry_backoff_factor=config.backoff_factor,
             retry_backoff_max=config.backoff_max,
             retry_mode=config.retry_mode,

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_reconnect_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_reconnect_async.py
@@ -172,9 +172,6 @@ async def test_send_connection_idle_timeout_and_reconnect_async(
             with pytest.raises(error.AMQPConnectionError):
                 await sender._send_event_data()
 
-    with pytest.raises(error.AMQPConnectionError):
-        receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
-
 
 @pytest.mark.liveTest
 @pytest.mark.asyncio

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_reconnect_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_reconnect_async.py
@@ -169,18 +169,11 @@ async def test_send_connection_idle_timeout_and_reconnect_async(
             await asyncio.sleep(11)
             ed = transform_outbound_single_message(ed, EventData, amqp_transport.to_outgoing_amqp_message)
             sender._unsent_events = [ed._message]
-            await sender._send_event_data()
+            with pytest.raises(error.AMQPConnectionError):
+                await sender._send_event_data()
 
-    retry = 0
-    while retry < 3:
-        try:
-            messages = receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
-            if messages:
-                received_ed1 = EventData._from_message(messages[0])
-                assert received_ed1.body_as_str() == "data"
-                break
-        except timeout_exc:
-            retry += 1
+    with pytest.raises(error.AMQPConnectionError):
+        receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
@@ -157,18 +157,11 @@ def test_send_connection_idle_timeout_and_reconnect_sync(auth_credential_receive
             time.sleep(11)
             ed = transform_outbound_single_message(ed, EventData, amqp_transport.to_outgoing_amqp_message)
             sender._unsent_events = [ed._message]
-            sender._send_event_data()
+            with pytest.raises(error.AMQPConnectionError):
+                sender._send_event_data()
 
-    retry = 0
-    while retry < 3:
-        try:
-            messages = receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
-            if messages:
-                received_ed1 = EventData._from_message(messages[0])
-                assert received_ed1.body_as_str() == "data"
-                break
-        except timeout_exc:
-            retry += 1
+        with pytest.raises(error.AMQPConnectionError):
+            receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
@@ -160,10 +160,6 @@ def test_send_connection_idle_timeout_and_reconnect_sync(auth_credential_receive
             with pytest.raises(error.AMQPConnectionError):
                 sender._send_event_data()
 
-        with pytest.raises(error.AMQPConnectionError):
-            receivers[0].receive_message_batch(max_batch_size=10, timeout=10 * timeout_factor)
-
-
 @pytest.mark.liveTest
 def test_receive_connection_idle_timeout_and_reconnect_sync(auth_credential_senders, uamqp_transport):
     fully_qualified_namespace, eventhub_name, credential, senders = auth_credential_senders

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -412,7 +412,7 @@ class PyamqpTransport(AmqpTransport):  # pylint: disable=too-many-public-methods
         # TODO: What's the retry overlap between servicebus and pyamqp?
         return _ServiceBusErrorPolicy(
             is_session=is_session,
-            retry_total=config.retry_total,
+            retry_total=0, # hardcoding to 0 to avoid double retries, 8 seconds of wait time when retrying compared to uamqp
             retry_backoff_factor=config.retry_backoff_factor,
             retry_backoff_max=config.retry_backoff_max,
             retry_mode=config.retry_mode,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -412,7 +412,9 @@ class PyamqpTransport(AmqpTransport):  # pylint: disable=too-many-public-methods
         # TODO: What's the retry overlap between servicebus and pyamqp?
         return _ServiceBusErrorPolicy(
             is_session=is_session,
-            retry_total=0, # hardcoding to 0 to avoid double retries, 8 seconds of wait time when retrying compared to uamqp
+            # hardcoding to 0 to avoid double retries and
+            # 8 seconds of wait time when retrying compared to uamqp
+            retry_total=0,
             retry_backoff_factor=config.retry_backoff_factor,
             retry_backoff_max=config.retry_backoff_max,
             retry_mode=config.retry_mode,


### PR DESCRIPTION
set retries to 0 to reduce time lag between pyAMQP and uAMQP retries, sdk should still retry 3 times


- [x] tests passing
- [x] stress tests


- [ ] Go: a detach gets to the sdk level, which after investigating the error then chooses to retry (reattach link) or not
- [ ] .NET: a detach is treated in an on-demand context, if the detach happens outside of an operation call it will be retried at the amqp stack level on demand, elsewise it will be handled by the sdk for reattaching/retrying in the context of the operation

In python our send_messages in client.py is wrapped in an amqp level do_retryable_operation. On the other hand our receive operations are not, they only have the capability to be retried at the sdk level. Due to this we at this time cannot implement link-reattach (it would only work for send) without refactoring more code and extensively testing. Creating an issue [here](https://github.com/Azure/azure-sdk-for-python/issues/39201) to track this.

