### PR TITLE
[Identity] Improve DAC debugging with workload identity

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -158,6 +158,13 @@ class DefaultAzureCredential(ChainedTokenCredential):
                         **kwargs
                     )
                 )
+            else:
+                unset_variables = [v for v in EnvironmentVariables.WORKLOAD_IDENTITY_VARS if not os.environ.get(v)]
+                _LOGGER.info(
+                    "WorkloadIdentityCredential unavailable. Not all required environment variables are set: %s",
+                    ", ".join(unset_variables),
+                )
+
         if not exclude_managed_identity_credential:
             credentials.append(
                 ManagedIdentityCredential(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -149,6 +149,13 @@ class DefaultAzureCredential(ChainedTokenCredential):
                         **kwargs
                     )
                 )
+            else:
+                unset_variables = [v for v in EnvironmentVariables.WORKLOAD_IDENTITY_VARS if not os.environ.get(v)]
+                _LOGGER.info(
+                    "WorkloadIdentityCredential unavailable. Not all required environment variables are set: %s",
+                    ", ".join(unset_variables),
+                )
+
         if not exclude_managed_identity_credential:
             credentials.append(
                 ManagedIdentityCredential(


### PR DESCRIPTION
Sometimes when people expect `WorkloadIdentityCredential` to be used with `DefaultAzureCredential`, it's not clear why it's not working. This adds a log statement to help convey what environmental configuration is missing.