### PR TITLE
remove disable black filter for mgmt

### DIFF
--- a/eng/pipelines/templates/steps/run_black.yml
+++ b/eng/pipelines/templates/steps/run_black.yml
@@ -24,7 +24,6 @@ steps:
         --mark_arg="${{ parameters.TestMarkArgument }}"
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="black"
-        --filter-type="Omit_management"
         ${{ parameters.AdditionalTestArgs }}
     env: ${{ parameters.EnvVars }}
     condition: and(succeededOrFailed(), ne(variables['Skip.Black'],'true'))


### PR DESCRIPTION
black runs after every generation so no need to globally skip the check here