### PR TITLE
[Corehttp] Implement tracing capabilities

### DIFF
--- a/sdk/core/corehttp/CHANGELOG.md
+++ b/sdk/core/corehttp/CHANGELOG.md
@@ -4,11 +4,22 @@
 
 ### Features Added
 
+- Native tracing support was added. [#39172](https://github.com/Azure/azure-sdk-for-python/pull/39172)
+  - The `OpenTelemetryTracer` class was added to the `corehttp.instrumentation.tracing.opentelemetry` module. This is a wrapper around the OpenTelemetry tracer that is used to create spans for SDK operations.
+  - Added a `get_tracer` method to the new `corehttp.instrumentation` module. This method returns an instance of the `OpenTelemetryTracer` class if OpenTelemetry is available.
+  - A `TracingOptions` TypedDict class was added to define the options that SDK users can use to configure tracing per-operation. These options include the ability to enable or disable tracing and set additional attributes on spans.
+    - Example usage: `client.method(tracing_options={"enabled": True, "attributes": {"foo": "bar"}})`
+  - `DistributedHttpTracingPolicy` and `distributed_trace`/`distributed_trace_async` decorators were added to support OpenTelemetry tracing for SDK operations.
+    - SDK clients can define an `_instrumentation_config` class variable to configure the OpenTelemetry tracer used in method span creation. Possible configuration options are `library_name`, `library_version`, `schema_url`, and `attributes`.
+- Added a global settings object, `corehttp.settings`, to the `corehttp` package. This object can be used to set global settings for the `corehttp` package. Currently the only setting is `tracing_enabled` for enabling/disabling tracing. [#39172](https://github.com/Azure/azure-sdk-for-python/pull/39172)
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Added `opentelemetry-api` as an optional dependency for tracing. [#39172](https://github.com/Azure/azure-sdk-for-python/pull/39172)
 
 ## 1.0.0b6 (2025-03-27)
 

--- a/sdk/core/corehttp/corehttp/instrumentation/__init__.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/__init__.py
@@ -1,0 +1,9 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from .tracing._tracer import get_tracer
+
+__all__ = [
+    "get_tracer",
+]

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/__init__.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/__init__.py
@@ -1,0 +1,14 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from ._models import SpanKind, Link, TracingOptions
+from ._decorator import distributed_trace, distributed_trace_async
+
+__all__ = [
+    "Link",
+    "SpanKind",
+    "TracingOptions",
+    "distributed_trace",
+    "distributed_trace_async",
+]

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/_decorator.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/_decorator.py
@@ -1,0 +1,189 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""The decorator to apply if you want the given method traced."""
+from contextvars import ContextVar
+import functools
+from typing import Awaitable, Any, TypeVar, overload, Optional, Callable, TYPE_CHECKING
+from typing_extensions import ParamSpec
+
+from ._models import SpanKind
+from ._tracer import get_tracer
+from ...settings import settings
+
+if TYPE_CHECKING:
+    from ._models import TracingOptions
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+# This context variable is used to determine if we are already in the span context of a decorated function.
+_in_span_context = ContextVar("in_span_context", default=False)
+
+
+@overload
+def distributed_trace(__func: Callable[P, T]) -> Callable[P, T]:
+    pass
+
+
+@overload
+def distributed_trace(**kwargs: Any) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    pass
+
+
+def distributed_trace(__func: Optional[Callable[P, T]] = None, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
+    """Decorator to apply to an SDK method to have it traced automatically.
+
+    Span will use the method's qualified name.
+
+    Note: This decorator SHOULD NOT be used by application developers. It's intended to be called by client
+    libraries only. Application developers should use OpenTelemetry directly to instrument their applications.
+
+    :param callable __func: A function to decorate
+
+    :return: The decorated function
+    :rtype: Any
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+
+        @functools.wraps(func)
+        def wrapper_use_tracer(*args: Any, **kwargs: Any) -> T:
+            # If we are already in the span context of a decorated function, don't trace.
+            if _in_span_context.get():
+                return func(*args, **kwargs)
+
+            # This will be popped in the pipeline or transport runner.
+            tracing_options: TracingOptions = kwargs.get("tracing_options", {})
+
+            # User can explicitly disable tracing for this call
+            user_enabled = tracing_options.get("enabled")
+            if user_enabled is False:
+                return func(*args, **kwargs)
+
+            # If tracing is disabled globally and user didn't explicitly enable it, don't trace.
+            if not settings.tracing_enabled and user_enabled is None:
+                return func(*args, **kwargs)
+
+            config = {}
+            if args and hasattr(args[0], "_instrumentation_config"):
+                config = args[0]._instrumentation_config  # pylint: disable=protected-access
+
+            method_tracer = get_tracer(
+                library_name=config.get("library_name"),
+                library_version=config.get("library_version"),
+                schema_url=config.get("schema_url"),
+                attributes=config.get("attributes"),
+            )
+            if not method_tracer:
+                return func(*args, **kwargs)
+
+            name = func.__qualname__
+            span_suppression_token = _in_span_context.set(True)
+            try:
+                with method_tracer.start_as_current_span(
+                    name=name,
+                    kind=SpanKind.INTERNAL,
+                    attributes=tracing_options.get("attributes"),
+                ) as span:
+                    try:
+                        return func(*args, **kwargs)
+                    except Exception as err:  # pylint: disable=broad-except
+                        ex_type = type(err)
+                        module = ex_type.__module__ if ex_type.__module__ != "builtins" else ""
+                        error_type = f"{module}.{ex_type.__qualname__}" if module else ex_type.__qualname__
+                        span.set_attribute("error.type", error_type)
+                        raise
+            finally:
+                _in_span_context.reset(span_suppression_token)
+
+        return wrapper_use_tracer
+
+    return decorator if __func is None else decorator(__func)
+
+
+@overload
+def distributed_trace_async(__func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    pass
+
+
+@overload
+def distributed_trace_async(**kwargs: Any) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    pass
+
+
+def distributed_trace_async(  # pylint: disable=unused-argument
+    __func: Optional[Callable[P, Awaitable[T]]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Decorator to apply to an SDK method to have it traced automatically.
+
+    Span will use the method's qualified name.
+
+    Note: This decorator SHOULD NOT be used by application developers. It's intended to be called by client
+    libraries only. Application developers should use OpenTelemetry directly to instrument their applications.
+
+    :param callable __func: A function to decorate
+
+    :return: The decorated function
+    :rtype: Any
+    """
+
+    def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+
+        @functools.wraps(func)
+        async def wrapper_use_tracer(*args: Any, **kwargs: Any) -> T:
+            # If we are already in the span context of a decorated function, don't trace.
+            if _in_span_context.get():
+                return await func(*args, **kwargs)
+
+            # This will be popped in the pipeline or transport runner.
+            tracing_options: TracingOptions = kwargs.get("tracing_options", {})
+
+            # User can explicitly disable tracing for this call
+            user_enabled = tracing_options.get("enabled")
+            if user_enabled is False:
+                return await func(*args, **kwargs)
+
+            # If tracing is disabled globally and user didn't explicitly enable it, don't trace.
+            if not settings.tracing_enabled and user_enabled is None:
+                return await func(*args, **kwargs)
+
+            config = {}
+            if args and hasattr(args[0], "_instrumentation_config"):
+                config = args[0]._instrumentation_config  # pylint: disable=protected-access
+
+            method_tracer = get_tracer(
+                library_name=config.get("library_name"),
+                library_version=config.get("library_version"),
+                schema_url=config.get("schema_url"),
+                attributes=config.get("attributes"),
+            )
+            if not method_tracer:
+                return await func(*args, **kwargs)
+
+            name = func.__qualname__
+            span_suppression_token = _in_span_context.set(True)
+            try:
+                with method_tracer.start_as_current_span(
+                    name=name,
+                    kind=SpanKind.INTERNAL,
+                    attributes=tracing_options.get("attributes"),
+                ) as span:
+                    try:
+                        return await func(*args, **kwargs)
+                    except Exception as err:  # pylint: disable=broad-except
+                        ex_type = type(err)
+                        module = ex_type.__module__ if ex_type.__module__ != "builtins" else ""
+                        error_type = f"{module}.{ex_type.__qualname__}" if module else ex_type.__qualname__
+                        span.set_attribute("error.type", error_type)
+                        raise
+            finally:
+                _in_span_context.reset(span_suppression_token)
+
+        return wrapper_use_tracer
+
+    return decorator if __func is None else decorator(__func)

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/_models.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/_models.py
@@ -1,0 +1,72 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from __future__ import annotations
+from enum import Enum
+from typing import Dict, Mapping, Optional, Union, Sequence, TypedDict
+
+from ...utils import CaseInsensitiveEnumMeta
+
+
+AttributeValue = Union[
+    str,
+    bool,
+    int,
+    float,
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+]
+Attributes = Mapping[str, AttributeValue]
+
+
+class SpanKind(Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Describes the role or kind of a span within a distributed trace.
+
+    This helps to categorize spans based on their relationship to other spans and the type
+    of operation they represent.
+    """
+
+    UNSPECIFIED = 1
+    """Unspecified span kind."""
+
+    SERVER = 2
+    """Indicates that the span describes an operation that handles a remote request."""
+
+    CLIENT = 3
+    """Indicates that the span describes a request to some remote service."""
+
+    PRODUCER = 4
+    """Indicates that the span describes the initiation or scheduling of a local or remote operation."""
+
+    CONSUMER = 5
+    """Indicates that the span represents the processing of an operation initiated by a producer."""
+
+    INTERNAL = 6
+    """Indicates that the span is used internally in the application."""
+
+
+class Link:
+    """Represents a reference from one span to another span.
+
+    :param headers: A dictionary of the request header as key value pairs.
+    :type headers: dict
+    :param attributes: Any additional attributes that should be added to link
+    :type attributes: dict
+    """
+
+    def __init__(self, headers: Dict[str, str], attributes: Optional[Attributes] = None) -> None:
+        self.headers = headers
+        self.attributes = attributes
+
+
+class TracingOptions(TypedDict, total=False):
+    """Options to configure tracing behavior for operations."""
+
+    enabled: bool
+    """Whether tracing is enabled for the operation. By default, if the global setting is enabled, tracing is
+    enabled for all operations. This option can be used to override the global setting for a specific operation."""
+    attributes: Attributes
+    """Attributes to include in the spans emitted for the operation."""

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/_tracer.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/_tracer.py
@@ -1,0 +1,69 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from typing import Optional, Union, Mapping, TYPE_CHECKING
+from functools import lru_cache
+
+if TYPE_CHECKING:
+    try:
+        from .opentelemetry import OpenTelemetryTracer
+    except ImportError:
+        pass
+
+
+def _get_tracer_impl():
+    # Check if OpenTelemetry is available/installed.
+    try:
+        from .opentelemetry import OpenTelemetryTracer
+
+        return OpenTelemetryTracer
+    except ImportError:
+        return None
+
+
+@lru_cache
+def _get_tracer_cached(
+    library_name: Optional[str],
+    library_version: Optional[str],
+    schema_url: Optional[str],
+    attributes_key: Optional[frozenset],
+) -> Optional["OpenTelemetryTracer"]:
+    tracer_impl = _get_tracer_impl()
+    if tracer_impl:
+        # Convert attributes_key back to dict if needed
+        attributes = dict(attributes_key) if attributes_key else None
+        return tracer_impl(
+            library_name=library_name,
+            library_version=library_version,
+            schema_url=schema_url,
+            attributes=attributes,
+        )
+    return None
+
+
+def get_tracer(
+    *,
+    library_name: Optional[str] = None,
+    library_version: Optional[str] = None,
+    schema_url: Optional[str] = None,
+    attributes: Optional[Mapping[str, Union[str, bool, int, float]]] = None,
+) -> Optional["OpenTelemetryTracer"]:
+    """Get the OpenTelemetry tracer instance if available.
+
+    If OpenTelemetry is not available, this method will return None. This method caches
+    the tracer instance for each unique set of parameters.
+
+    :keyword library_name: The name of the library to use in the tracer.
+    :paramtype library_name: str
+    :keyword library_version: The version of the library to use in the tracer.
+    :paramtype library_version: str
+    :keyword schema_url: Specifies the Schema URL of the emitted spans.
+    :paramtype schema_url: str
+    :keyword attributes: Attributes to add to the emitted spans.
+    :paramtype attributes: Mapping[str, Union[str, bool, int, float]]
+    :return: The OpenTelemetry tracer instance if available.
+    :rtype: Optional[~corehttp.instrumentation.tracing.opentelemetry.OpenTelemetryTracer]
+    """
+    attributes_key = frozenset(attributes.items()) if attributes else None
+    return _get_tracer_cached(library_name, library_version, schema_url, attributes_key)

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/opentelemetry.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/opentelemetry.py
@@ -1,0 +1,244 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from __future__ import annotations
+from contextlib import contextmanager
+from contextvars import Token
+from typing import Optional, Dict, Sequence, cast, Callable, Iterator, TYPE_CHECKING
+
+from opentelemetry import context as otel_context_module, trace
+from opentelemetry.trace import (
+    Span,
+    SpanKind as OpenTelemetrySpanKind,
+    Link as OpenTelemetryLink,
+)
+from opentelemetry.trace.propagation import get_current_span as get_current_span_otel
+from opentelemetry.propagate import extract, inject
+
+try:
+    from opentelemetry.context import _SUPPRESS_HTTP_INSTRUMENTATION_KEY  # type: ignore[attr-defined]
+except ImportError:
+    _SUPPRESS_HTTP_INSTRUMENTATION_KEY = "suppress_http_instrumentation"
+
+from ..._version import VERSION
+from ._models import (
+    Attributes,
+    SpanKind as _SpanKind,
+    Link as _Link,
+)
+
+if TYPE_CHECKING:
+    from corehttp.instrumentation.tracing import Link, SpanKind
+
+
+_DEFAULT_SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1"
+_DEFAULT_MODULE_NAME = "corehttp"
+
+_KIND_MAPPINGS = {
+    _SpanKind.CLIENT: OpenTelemetrySpanKind.CLIENT,
+    _SpanKind.CONSUMER: OpenTelemetrySpanKind.CONSUMER,
+    _SpanKind.PRODUCER: OpenTelemetrySpanKind.PRODUCER,
+    _SpanKind.SERVER: OpenTelemetrySpanKind.SERVER,
+    _SpanKind.INTERNAL: OpenTelemetrySpanKind.INTERNAL,
+    _SpanKind.UNSPECIFIED: OpenTelemetrySpanKind.INTERNAL,
+}
+
+
+class OpenTelemetryTracer:
+    """A tracer that uses OpenTelemetry to trace operations.
+
+    :keyword library_name: The name of the library to use in the tracer.
+    :paramtype library_name: str
+    :keyword library_version: The version of the library to use in the tracer.
+    :paramtype library_version: str
+    :keyword schema_url: Specifies the Schema URL of the emitted spans. Defaults to
+        "https://opentelemetry.io/schemas/1.23.1".
+    :paramtype schema_url: str
+    :keyword attributes: Attributes to add to the emitted spans.
+    """
+
+    def __init__(
+        self,
+        *,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        schema_url: Optional[str] = None,
+        attributes: Optional[Attributes] = None,
+    ) -> None:
+        self._tracer = trace.get_tracer(
+            instrumenting_module_name=library_name or _DEFAULT_MODULE_NAME,
+            instrumenting_library_version=library_version or VERSION,
+            schema_url=schema_url or _DEFAULT_SCHEMA_URL,
+            attributes=attributes,
+        )
+
+    def start_span(
+        self,
+        name: str,
+        *,
+        kind: SpanKind = _SpanKind.INTERNAL,
+        attributes: Optional[Attributes] = None,
+        links: Optional[Sequence[Link]] = None,
+    ) -> Span:
+        """Starts a span without setting it as the current span in the context.
+
+        :param name: The name of the span
+        :type name: str
+        :keyword kind: The kind of the span. INTERNAL by default.
+        :paramtype kind: ~corehttp.instrumentation.tracing.SpanKind
+        :keyword attributes: Attributes to add to the span.
+        :paramtype attributes: Mapping[str, AttributeValue]
+        :keyword links: Links to add to the span.
+        :paramtype links: list[~corehttp.instrumentation.tracing.Link]
+        :return: The span that was started
+        :rtype: ~opentelemetry.trace.Span
+        """
+        otel_kind = _KIND_MAPPINGS.get(kind, OpenTelemetrySpanKind.INTERNAL)
+        otel_links = self._parse_links(links)
+
+        otel_span = self._tracer.start_span(
+            name,
+            kind=otel_kind,
+            attributes=attributes,
+            links=otel_links,
+        )
+
+        return otel_span
+
+    @contextmanager
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        kind: SpanKind = _SpanKind.INTERNAL,
+        attributes: Optional[Attributes] = None,
+        links: Optional[Sequence[Link]] = None,
+        end_on_exit: bool = True,
+    ) -> Iterator[Span]:
+        """Context manager that starts a span and sets it as the current span in the context.
+
+        Exiting the context manager will call the span's end method.
+
+        .. code:: python
+
+            with tracer.start_as_current_span("span_name") as span:
+                # Do something with the span
+                span.set_attribute("key", "value")
+
+        :param name: The name of the span
+        :type name: str
+        :keyword kind: The kind of the span. INTERNAL by default.
+        :paramtype kind: ~corehttp.instrumentation.tracing.SpanKind
+        :keyword attributes: Attributes to add to the span.
+        :paramtype attributes: Optional[Attributes]
+        :keyword links: Links to add to the span.
+        :paramtype links: Optional[Sequence[Link]]
+        :keyword end_on_exit: Whether to end the span when exiting the context manager. Defaults to True.
+        :paramtype end_on_exit: bool
+        :return: The span that was started
+        :rtype: ~opentelemetry.trace.Span
+        """
+        span = self.start_span(name, kind=kind, attributes=attributes, links=links)
+        with trace.use_span(  # pylint: disable=not-context-manager
+            span, record_exception=False, end_on_exit=end_on_exit
+        ) as span:
+            yield span
+
+    @classmethod
+    @contextmanager
+    def use_span(cls, span: Span, *, end_on_exit: bool = True) -> Iterator[Span]:
+        """Context manager that takes a non-active span and activates it in the current context.
+
+        :param span: The span to set as the current span
+        :type span: ~opentelemetry.trace.Span
+        :keyword end_on_exit: Whether to end the span when exiting the context manager. Defaults to True.
+        :paramtype end_on_exit: bool
+        :return: The span that was activated.
+        :rtype: Iterator[~opentelemetry.trace.Span]
+        """
+        with trace.use_span(  # pylint: disable=not-context-manager
+            span, record_exception=False, end_on_exit=end_on_exit
+        ) as active_span:
+            yield active_span
+
+    def _parse_links(self, links: Optional[Sequence[Link]]) -> Optional[Sequence[OpenTelemetryLink]]:
+        if not links:
+            return None
+
+        try:
+            otel_links = []
+            for link in links:
+                ctx = extract(link.headers)
+                span_ctx = get_current_span_otel(ctx).get_span_context()
+                otel_links.append(OpenTelemetryLink(span_ctx, link.attributes))
+            return otel_links
+        except AttributeError:
+            # We will just send the links as is if it's not ~corehttp.instrumentation.tracing.Link without
+            # any validation assuming the user knows what they are doing.
+            return cast(Sequence[OpenTelemetryLink], links)
+
+    @classmethod
+    def get_current_span(cls) -> Span:
+        """Returns the current span in the context.
+
+        :return: The current span
+        :rtype: ~opentelemetry.trace.Span
+        """
+        return get_current_span_otel()
+
+    @classmethod
+    def with_current_context(cls, func: Callable) -> Callable:
+        """Passes the current spans to the new context the function will be run in.
+
+        :param func: The function that will be run in the new context
+        :type func: callable
+        :return: The wrapped function
+        :rtype: callable
+        """
+        current_context = otel_context_module.get_current()
+
+        def call_with_current_context(*args, **kwargs):
+            token = None
+            try:
+                token = otel_context_module.attach(current_context)
+                return func(*args, **kwargs)
+            finally:
+                if token is not None:
+                    otel_context_module.detach(token)
+
+        return call_with_current_context
+
+    @classmethod
+    def get_trace_context(cls) -> Dict[str, str]:
+        """Returns the Trace Context header values associated with the current span.
+
+        These are generally the W3C Trace Context headers (i.e. "traceparent" and "tracestate").
+        :return: A key value pair dictionary
+        :rtype: dict[str, str]
+        """
+        trace_context: Dict[str, str] = {}
+        inject(trace_context)
+        return trace_context
+
+    @classmethod
+    def _suppress_auto_http_instrumentation(cls) -> Token:
+        """Enabled automatic HTTP instrumentation suppression.
+
+        Since corehttp already instruments HTTP calls, we need to suppress any automatic HTTP
+        instrumentation provided by other libraries to prevent duplicate spans. This has no effect if no
+        automatic HTTP instrumentation libraries are being used.
+
+        :return: A token that can be used to detach the suppression key from the context
+        :rtype: ~contextvars.Token
+        """
+        return otel_context_module.attach(otel_context_module.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True))
+
+    @classmethod
+    def _detach_from_context(cls, token: Token) -> None:
+        """Detach a token from the context.
+
+        :param token: The token to detach
+        :type token: ~contextvars.Token
+        """
+        otel_context_module.detach(token)

--- a/sdk/core/corehttp/corehttp/instrumentation/tracing/utils.py
+++ b/sdk/core/corehttp/corehttp/instrumentation/tracing/utils.py
@@ -1,0 +1,31 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Common tracing functionality for SDK libraries."""
+from typing import Any, Callable
+
+from ._tracer import get_tracer
+from ...settings import settings
+
+
+__all__ = [
+    "with_current_context",
+]
+
+
+def with_current_context(func: Callable) -> Any:
+    """Passes the current spans to the new context the function will be run in.
+
+    :param func: The function that will be run in the new context
+    :type func: callable
+    :return: The func wrapped with correct context
+    :rtype: callable
+    """
+    if not settings.tracing_enabled:
+        return func
+
+    tracer = get_tracer()
+    if not tracer:
+        return func
+    return tracer.with_current_context(func)

--- a/sdk/core/corehttp/corehttp/runtime/pipeline/_base.py
+++ b/sdk/core/corehttp/corehttp/runtime/pipeline/_base.py
@@ -34,7 +34,7 @@ from . import (
     PipelineContext,
 )
 from ..policies import HTTPPolicy, SansIOHTTPPolicy
-from ._tools import await_result as _await_result
+from ._tools import sanitize_transport_options, await_result as _await_result
 from ...transport import HttpTransport
 
 HTTPResponseType = TypeVar("HTTPResponseType")
@@ -103,6 +103,7 @@ class _TransportRunner(HTTPPolicy[HTTPRequestType, HTTPResponseType]):
         :return: The PipelineResponse object.
         :rtype: ~corehttp.runtime.pipeline.PipelineResponse
         """
+        sanitize_transport_options(request.context.options)
         return PipelineResponse(
             request.http_request,
             self._sender.send(request.http_request, **request.context.options),

--- a/sdk/core/corehttp/corehttp/runtime/pipeline/_base_async.py
+++ b/sdk/core/corehttp/corehttp/runtime/pipeline/_base_async.py
@@ -33,6 +33,7 @@ from . import PipelineRequest, PipelineResponse, PipelineContext
 from ..policies import AsyncHTTPPolicy, SansIOHTTPPolicy
 from ..pipeline._base import is_sansio_http_policy
 from ._tools_async import await_result as _await_result
+from ._tools import sanitize_transport_options
 from ...transport import AsyncHttpTransport
 
 AsyncHTTPResponseType = TypeVar("AsyncHTTPResponseType")
@@ -97,6 +98,7 @@ class _AsyncTransportRunner(AsyncHTTPPolicy[HTTPRequestType, AsyncHTTPResponseTy
         :return: The PipelineResponse object.
         :rtype: ~corehttp.runtime.pipeline.PipelineResponse
         """
+        sanitize_transport_options(request.context.options)
         return PipelineResponse(
             request.http_request,
             await self._sender.send(request.http_request, **request.context.options),

--- a/sdk/core/corehttp/corehttp/runtime/pipeline/_tools.py
+++ b/sdk/core/corehttp/corehttp/runtime/pipeline/_tools.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, Dict
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
@@ -45,3 +45,19 @@ def await_result(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
     if hasattr(result, "__await__"):
         raise TypeError("Policy {} returned awaitable object in non-async pipeline.".format(func))
     return result
+
+
+def sanitize_transport_options(options: Dict[str, str]) -> None:
+    """Remove options that could potentially make it to the transport layer.
+
+    - "tracing_options" is used in the DistributedHttpTracingPolicy and tracing decorators
+
+    :param options: The options.
+    :type options: dict
+    """
+    if not options:
+        return
+
+    options_to_remove = ["tracing_options"]
+    for key in options_to_remove:
+        options.pop(key, None)

--- a/sdk/core/corehttp/corehttp/runtime/policies/__init__.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/__init__.py
@@ -29,6 +29,7 @@ from ._authentication import (
     BearerTokenCredentialPolicy,
     ServiceKeyCredentialPolicy,
 )
+from ._distributed_tracing import DistributedHttpTracingPolicy
 from ._retry import RetryPolicy, RetryMode
 from ._universal import (
     HeadersPolicy,
@@ -57,4 +58,5 @@ __all__ = [
     "AsyncHTTPPolicy",
     "AsyncBearerTokenCredentialPolicy",
     "AsyncRetryPolicy",
+    "DistributedHttpTracingPolicy",
 ]

--- a/sdk/core/corehttp/corehttp/runtime/policies/_distributed_tracing.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_distributed_tracing.py
@@ -1,0 +1,156 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from __future__ import annotations
+import logging
+import urllib.parse
+from typing import Any, Optional, Tuple, Union, Type, Mapping, Dict, TYPE_CHECKING
+from types import TracebackType
+
+from ...rest import HttpRequest
+from ...rest._rest_py3 import _HttpResponseBase as SansIOHttpResponse
+from ._base import SansIOHTTPPolicy
+from ...settings import settings
+from ...instrumentation.tracing._models import SpanKind, TracingOptions
+from ...instrumentation.tracing._tracer import get_tracer
+
+if TYPE_CHECKING:
+    from ..pipeline import PipelineRequest, PipelineResponse
+    from opentelemetry.trace import Span
+
+
+ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
+OptExcInfo = Union[ExcInfo, Tuple[None, None, None]]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DistributedHttpTracingPolicy(SansIOHTTPPolicy[HttpRequest, SansIOHttpResponse]):
+    """The policy to create tracing spans for API calls.
+
+    :keyword instrumentation_config: Configuration for the instrumentation providers.
+    :type instrumentation_config: dict[str, Any]
+    """
+
+    TRACING_CONTEXT = "TRACING_CONTEXT"
+    _SUPPRESSION_TOKEN = "SUPPRESSION_TOKEN"
+
+    # Attribute names
+    _HTTP_RESEND_COUNT = "http.request.resend_count"
+    _USER_AGENT_ORIGINAL = "user_agent.original"
+    _HTTP_REQUEST_METHOD = "http.request.method"
+    _URL_FULL = "url.full"
+    _HTTP_RESPONSE_STATUS_CODE = "http.response.status_code"
+    _SERVER_ADDRESS = "server.address"
+    _SERVER_PORT = "server.port"
+    _ERROR_TYPE = "error.type"
+
+    def __init__(  # pylint: disable=unused-argument
+        self,
+        *,
+        instrumentation_config: Optional[Mapping[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._instrumentation_config = instrumentation_config
+
+    def on_request(self, request: PipelineRequest[HttpRequest]) -> None:
+        ctxt = request.context.options
+        try:
+            tracing_options: TracingOptions = ctxt.pop("tracing_options", {})
+
+            # User can explicitly disable tracing for this request.
+            user_enabled = tracing_options.get("enabled")
+            if user_enabled is False:
+                return
+
+            # If tracing is disabled globally and user didn't explicitly enable it, don't trace.
+            if not settings.tracing_enabled and user_enabled is None:
+                return
+
+            config = self._instrumentation_config or {}
+            tracer = get_tracer(
+                library_name=config.get("library_name"),
+                library_version=config.get("library_version"),
+                attributes=config.get("attributes"),
+            )
+            if not tracer:
+                _LOGGER.warning(
+                    "Tracing is enabled, but not able to get an OpenTelemetry tracer. "
+                    "Please ensure that `opentelemetry-api` is installed."
+                )
+                return
+
+            span_name = request.http_request.method
+            span = tracer.start_span(
+                name=span_name,
+                kind=SpanKind.CLIENT,
+                attributes=tracing_options.get("attributes"),
+            )
+
+            with tracer.use_span(span, end_on_exit=False):
+                trace_context_headers = tracer.get_trace_context()
+                request.http_request.headers.update(trace_context_headers)
+
+            request.context[self.TRACING_CONTEXT] = span
+            token = tracer._suppress_auto_http_instrumentation()  # pylint: disable=protected-access
+            request.context[self._SUPPRESSION_TOKEN] = token
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning("Unable to start HTTP span: %s", err)
+
+    def on_response(
+        self,
+        request: PipelineRequest[HttpRequest],
+        response: PipelineResponse[HttpRequest, SansIOHttpResponse],
+    ) -> None:
+        if self.TRACING_CONTEXT not in request.context:
+            return
+
+        span: Optional["Span"] = request.context[self.TRACING_CONTEXT]
+        http_request = request.http_request
+        if span:
+            self._set_http_client_span_attributes(span, http_request, response=response.http_response)
+            if request.context.get("retry_count"):
+                span.set_attribute(self._HTTP_RESEND_COUNT, request.context["retry_count"])
+            span.end()
+
+        suppression_token = request.context.get(self._SUPPRESSION_TOKEN)
+        if suppression_token:
+            tracer = get_tracer()
+            if tracer:
+                tracer._detach_from_context(suppression_token)  # pylint: disable=protected-access
+
+    def _set_http_client_span_attributes(
+        self,
+        span: "Span",
+        request: HttpRequest,
+        response: Optional[SansIOHttpResponse] = None,
+    ) -> None:
+        """Add attributes to an HTTP client span.
+        :param span: The span to add attributes to.
+        :type span: ~opentelemetry.trace.Span
+        :param request: The request made
+        :type request: ~corehttp.rest.HttpRequest
+        :param response: The response received from the server. Is None if no response received.
+        :type response: ~corehttp.rest.HttpResponse
+        """
+        attributes: Dict[str, Any] = {
+            self._HTTP_REQUEST_METHOD: request.method,
+            self._URL_FULL: request.url,
+        }
+
+        parsed_url = urllib.parse.urlparse(request.url)
+        if parsed_url.hostname:
+            attributes[self._SERVER_ADDRESS] = parsed_url.hostname
+        if parsed_url.port:
+            attributes[self._SERVER_PORT] = parsed_url.port
+
+        user_agent = request.headers.get("User-Agent")
+        if user_agent:
+            attributes[self._USER_AGENT_ORIGINAL] = user_agent
+        if response and response.status_code:
+            attributes[self._HTTP_RESPONSE_STATUS_CODE] = response.status_code
+            if response.status_code >= 400:
+                attributes[self._ERROR_TYPE] = str(response.status_code)
+
+        span.set_attributes(attributes)

--- a/sdk/core/corehttp/corehttp/runtime/policies/_retry.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_retry.py
@@ -505,6 +505,7 @@ class RetryPolicy(RetryPolicyBase, HTTPPolicy[HttpRequest, HttpResponse]):
             )
             try:
                 self._configure_timeout(request, absolute_timeout, is_response_error)
+                request.context["retry_count"] = len(retry_settings["history"])
                 response = self.next.send(request)
                 if self.is_retry(retry_settings, response):
                     retry_active = self.increment(retry_settings, response=response)

--- a/sdk/core/corehttp/corehttp/runtime/policies/_retry_async.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_retry_async.py
@@ -162,6 +162,7 @@ class AsyncRetryPolicy(RetryPolicyBase, AsyncHTTPPolicy[HttpRequest, AsyncHttpRe
             )
             try:
                 self._configure_timeout(request, absolute_timeout, is_response_error)
+                request.context["retry_count"] = len(retry_settings["history"])
                 response = await self.next.send(request)
                 if self.is_retry(retry_settings, response):
                     retry_active = self.increment(retry_settings, response=response)

--- a/sdk/core/corehttp/corehttp/settings.py
+++ b/sdk/core/corehttp/corehttp/settings.py
@@ -1,0 +1,59 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+from typing import Union
+
+
+def _convert_bool(value: Union[str, bool]) -> bool:
+    """Convert a string to True or False
+
+    If a boolean is passed in, it is returned as-is. Otherwise the function
+    maps the following strings, ignoring case:
+
+    * "yes", "1", "on" -> True
+    * "no", "0", "off" -> False
+
+    :param value: the value to convert
+    :type value: str or bool
+    :returns: A boolean value matching the intent of the input
+    :rtype: bool
+    :raises ValueError: If conversion to bool fails
+
+    """
+    if isinstance(value, bool):
+        return value
+    val = value.lower()
+    if val in ["yes", "1", "on", "true", "True"]:
+        return True
+    if val in ["no", "0", "off", "false", "False"]:
+        return False
+    raise ValueError("Cannot convert {} to boolean value".format(value))
+
+
+class Settings:
+    """Global settings for the SDK."""
+
+    def __init__(self) -> None:
+        self._tracing_enabled: bool = _convert_bool(os.environ.get("SDK_TRACING_ENABLED", False))
+
+    @property
+    def tracing_enabled(self) -> bool:
+        """Whether tracing for SDKs is enabled.
+
+        :return: True if tracing is enabled, False otherwise.
+        :rtype: bool
+        """
+        return self._tracing_enabled
+
+    @tracing_enabled.setter
+    def tracing_enabled(self, value: bool):
+        self._tracing_enabled = _convert_bool(value)
+
+
+settings: Settings = Settings()
+"""The settings global instance.
+
+:type settings: Settings
+"""

--- a/sdk/core/corehttp/dev_requirements.txt
+++ b/sdk/core/corehttp/dev_requirements.txt
@@ -9,3 +9,5 @@ httpx>=0.25.0
 azure-storage-blob
 azure-data-tables
 azure-identity
+opentelemetry-sdk~=1.26
+opentelemetry-instrumentation-requests>=0.50b0

--- a/sdk/core/corehttp/samples/sample_tracing.py
+++ b/sdk/core/corehttp/samples/sample_tracing.py
@@ -1,0 +1,97 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""
+FILE: sample_tracing.py
+
+DESCRIPTION:
+    This sample demonstrates how to trace a client method.
+
+    Note: This sample requires the opentelemetry-sdk library to be installed.
+
+USAGE:
+    python sample_tracing.py
+"""
+from typing import Iterable, Union, Any
+from functools import partial
+
+from corehttp.instrumentation import get_tracer
+from corehttp.instrumentation.tracing import distributed_trace
+from corehttp.runtime import PipelineClient
+from corehttp.rest import HttpRequest, HttpResponse
+from corehttp.runtime.policies import (
+    HTTPPolicy,
+    SansIOHTTPPolicy,
+    HeadersPolicy,
+    UserAgentPolicy,
+    RetryPolicy,
+    DistributedHttpTracingPolicy,
+)
+
+
+class SampleClient:
+    """Sample client to demonstrate how an SDK developer would add tracing to their client."""
+
+    _instrumentation_config = {
+        "library_name": "my-library",
+        "library_version": "1.0.0",
+        "attributes": {"namespace": "Sample.Namespace"},
+    }
+
+    def __init__(self, endpoint: str) -> None:
+        policies: Iterable[Union[HTTPPolicy, SansIOHTTPPolicy]] = [
+            HeadersPolicy(),
+            UserAgentPolicy("myuseragent"),
+            RetryPolicy(),
+            DistributedHttpTracingPolicy(instrumentation_config=self._instrumentation_config),
+        ]
+
+        self._client: PipelineClient[HttpRequest, HttpResponse] = PipelineClient(endpoint, policies=policies)
+
+    @distributed_trace()
+    def sample_method(self, **kwargs: Any) -> HttpResponse:
+        request = HttpRequest("GET", "https://bing.com")
+        response = self._client.send_request(request, **kwargs)
+        return response
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "SampleClient":
+        self._client.__enter__()
+        return self
+
+    def __exit__(self, *exc_details: Any) -> None:
+        self._client.__exit__(*exc_details)
+
+
+def sample_user():
+    """Sample showing how an end user would enable tracing and configure OpenTelemetry."""
+    from corehttp.settings import settings
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    tracer_provider = TracerProvider()
+    exporter = ConsoleSpanExporter()
+    span_processor = SimpleSpanProcessor(exporter)
+
+    tracer_provider.add_span_processor(span_processor)
+    trace.set_tracer_provider(tracer_provider)
+    tracer = tracer_provider.get_tracer("my-application")
+
+    settings.tracing_enabled = True
+
+    endpoint = "https://bing.com"
+    with SampleClient(endpoint) as client:
+        with tracer.start_as_current_span(name="MyApplication"):  # type: ignore
+            response = client.sample_method(tracing_options={"attributes": {"custom_key": "custom_value"}})
+            print(f"Response: {response}")
+
+
+if __name__ == "__main__":
+    sample_user()

--- a/sdk/core/corehttp/setup.py
+++ b/sdk/core/corehttp/setup.py
@@ -79,5 +79,8 @@ setup(
         "httpx": [
             "httpx>=0.25.0",
         ],
+        "tracing": [
+            "opentelemetry-api~=1.26",
+        ],
     },
 )

--- a/sdk/core/corehttp/tests/async_tests/test_tracing_decorator_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_tracing_decorator_async.py
@@ -1,0 +1,131 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the distributed_trace_async policy."""
+import asyncio
+import pytest
+
+from corehttp.settings import settings
+from corehttp.instrumentation.tracing import distributed_trace_async
+
+from opentelemetry.trace import StatusCode as OtelStatusCode
+
+
+class MockClient:
+
+    _instrumentation_config = {
+        "library_name": "mylibrary",
+        "library_version": "1.0.0",
+        "schema_url": "https://test.schema",
+        "attributes": {"namespace": "Sample.Namespace"},
+    }
+
+    @distributed_trace_async
+    async def nested_calls(self):
+        await asyncio.sleep(0.001)
+        await self.get_foo()
+        await self.method_with_kwargs()
+
+    @distributed_trace_async
+    async def get_foo(self):
+        await asyncio.sleep(0.001)
+        return 5
+
+    @distributed_trace_async
+    async def raising_exception(self, **kwargs):
+        raise ValueError("Something went horribly wrong here")
+
+    @distributed_trace_async
+    async def method_with_kwargs(self, **kwargs):
+        await asyncio.sleep(0.001)
+
+
+@pytest.mark.asyncio
+async def test_decorator_raise_exception(tracing_helper):
+    """Test that an exception is recorded as an error event."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        try:
+            await client.raising_exception()
+        except ValueError:
+            pass
+        await client.get_foo()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 2
+        assert finished_spans[0].name == "MockClient.raising_exception"
+        assert finished_spans[0].status.status_code == OtelStatusCode.ERROR
+        assert "Something went horribly wrong here" in finished_spans[0].status.description
+        assert finished_spans[0].attributes.get("error.type") == "ValueError"
+
+        assert finished_spans[1].name == "MockClient.get_foo"
+        assert finished_spans[1].status.status_code == OtelStatusCode.UNSET
+
+
+@pytest.mark.asyncio
+async def test_decorator_nested_calls(tracing_helper):
+    """Test that only a span corresponding to the outermost method is created."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        await client.nested_calls()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.nested_calls"
+
+
+@pytest.mark.asyncio
+async def test_decorator_instrumentation_config(tracing_helper):
+    """Test that the instrumentation config is respected."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        await client.get_foo()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.get_foo"
+        assert finished_spans[0].instrumentation_scope.schema_url == "https://test.schema"
+        assert finished_spans[0].instrumentation_scope.name == "mylibrary"
+        assert finished_spans[0].instrumentation_scope.version == "1.0.0"
+        assert finished_spans[0].instrumentation_scope.attributes.get("namespace") == "Sample.Namespace"
+
+
+@pytest.mark.asyncio
+async def test_decorated_method_with_tracing_options(tracing_helper):
+    """Test that a decorated method can respect tracing options."""
+    client = MockClient()
+    settings.tracing_enabled = False
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        await client.method_with_kwargs(tracing_options={"enabled": True, "attributes": {"custom_key": "custom_value"}})
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.method_with_kwargs"
+        assert finished_spans[0].attributes.get("custom_key") == "custom_value"
+
+
+@pytest.mark.asyncio
+async def test_decorated_method_with_tracing_disabled(tracing_helper):
+    """Test that a decorated method isn't traced if tracing is disabled on a per-operation basis."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        await client.method_with_kwargs(
+            tracing_options={"enabled": False, "attributes": {"custom_key": "custom_value"}}
+        )
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 0
+
+
+@pytest.mark.asyncio
+async def test_decorated_method_with_tracing_disabled_globally(tracing_helper):
+    """Test that a decorated method isn't traced if tracing is disabled globally."""
+    client = MockClient()
+    settings.tracing_enabled = False
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        await client.method_with_kwargs()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 0

--- a/sdk/core/corehttp/tests/async_tests/test_tracing_policy_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_tracing_policy_async.py
@@ -1,0 +1,68 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the distributed tracing policy."""
+import pytest
+
+from corehttp.rest import HttpRequest
+from corehttp.runtime.policies import (
+    DistributedHttpTracingPolicy,
+    AsyncRetryPolicy,
+)
+from corehttp.runtime.pipeline import AsyncPipeline
+from corehttp.transport import AsyncHttpTransport
+
+from utils import HTTP_RESPONSES, create_http_response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+async def test_span_retry_attributes(tracing_helper, http_response):
+    """Test that the retry count is added to the span attributes."""
+
+    class MockTransport(AsyncHttpTransport):
+        def __init__(self):
+            self._count = 0
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        async def close(self):
+            pass
+
+        async def open(self):
+            pass
+
+        async def send(self, request, **kwargs):
+            self._count += 1
+            response = create_http_response(http_response, request, None, status_code=429)
+            return response
+
+    http_request = HttpRequest("GET", "http://localhost/")
+    retry_policy = AsyncRetryPolicy(retry_total=2)
+    distributed_tracing_policy = DistributedHttpTracingPolicy()
+    transport = MockTransport()
+
+    with tracing_helper.tracer.start_as_current_span("Root") as root_span:
+        policies = [retry_policy, distributed_tracing_policy]
+        pipeline = AsyncPipeline(transport, policies=policies)
+        await pipeline.run(http_request)
+
+    assert transport._count == 3
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    parent_context = root_span.get_span_context()
+    assert len(finished_spans) == 4
+    assert finished_spans[0].parent == parent_context
+    assert finished_spans[0].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) is None
+    assert finished_spans[0].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"
+
+    assert finished_spans[1].parent == parent_context
+    assert finished_spans[1].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) == 1
+    assert finished_spans[1].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"
+
+    assert finished_spans[2].parent == parent_context
+    assert finished_spans[2].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) == 2
+    assert finished_spans[2].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"

--- a/sdk/core/corehttp/tests/test_settings.py
+++ b/sdk/core/corehttp/tests/test_settings.py
@@ -1,0 +1,43 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the global settings."""
+from unittest import mock
+
+import pytest
+
+from corehttp.settings import Settings, settings, convert_bool
+
+
+def test_global_settings_default():
+    assert settings.tracing_enabled is False
+
+
+def test_global_settings_set():
+    settings.tracing_enabled = True
+    assert settings.tracing_enabled is True
+
+    settings.tracing_enabled = False
+    assert settings.tracing_enabled is False
+
+
+def test_environment_settings():
+    with mock.patch.dict("os.environ", {"SDK_TRACING_ENABLED": "True"}):
+        test_settings = Settings()
+        assert test_settings.tracing_enabled is True
+
+    with mock.patch.dict("os.environ", {"SDK_TRACING_ENABLED": "False"}):
+        test_settings = Settings()
+        assert test_settings.tracing_enabled is False
+
+
+@pytest.mark.parametrize("value", ["Yes", "YES", "yes", "1", "ON", "on", "true", "True", True])
+def test_convert_bool(value):
+    assert convert_bool(value)
+
+
+@pytest.mark.parametrize("value", ["No", "NO", "no", "0", "OFF", "off", "false", "False", False])
+def test_convert_bool_false(value):
+    assert not convert_bool(value)

--- a/sdk/core/corehttp/tests/test_settings.py
+++ b/sdk/core/corehttp/tests/test_settings.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from corehttp.settings import Settings, settings, convert_bool
+from corehttp.settings import Settings, settings, _convert_bool
 
 
 def test_global_settings_default():
@@ -35,9 +35,9 @@ def test_environment_settings():
 
 @pytest.mark.parametrize("value", ["Yes", "YES", "yes", "1", "ON", "on", "true", "True", True])
 def test_convert_bool(value):
-    assert convert_bool(value)
+    assert _convert_bool(value)
 
 
 @pytest.mark.parametrize("value", ["No", "NO", "no", "0", "OFF", "off", "false", "False", False])
 def test_convert_bool_false(value):
-    assert not convert_bool(value)
+    assert not _convert_bool(value)

--- a/sdk/core/corehttp/tests/test_tracer_otel.py
+++ b/sdk/core/corehttp/tests/test_tracer_otel.py
@@ -1,0 +1,367 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the OpenTelemetry tracer and span classes."""
+from concurrent.futures import ThreadPoolExecutor, wait
+import sys
+import threading
+
+from corehttp.instrumentation import get_tracer
+from corehttp.instrumentation.tracing._models import SpanKind, Link
+from corehttp.instrumentation.tracing.opentelemetry import OpenTelemetryTracer
+from corehttp.instrumentation.tracing.utils import with_current_context
+from corehttp.settings import settings
+
+from opentelemetry.trace import (
+    Tracer as OtelTracer,
+    Span as OtelSpan,
+    StatusCode as OtelStatusCode,
+    NonRecordingSpan,
+    format_span_id,
+    format_trace_id,
+)
+import pytest
+
+
+def test_tracer(tracing_helper):
+    """Test basic usage of a Instrumentation."""
+    tracer = get_tracer(
+        library_name="my-library",
+        library_version="1.0.0",
+        schema_url="https://test.schema",
+        attributes={"namespace": "Sample.Namespace"},
+    )
+
+    assert isinstance(tracer, OpenTelemetryTracer)
+    assert isinstance(tracer._tracer, OtelTracer)
+
+    with tracer.start_as_current_span("test_span") as span:
+        assert isinstance(span, OtelSpan)
+        span.set_attribute("foo", "bar")
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].name == "test_span"
+    assert finished_spans[0].attributes["foo"] == "bar"
+    assert finished_spans[0].status.status_code == OtelStatusCode.UNSET
+    assert finished_spans[0].instrumentation_scope.schema_url == "https://test.schema"
+    assert finished_spans[0].instrumentation_scope.name == "my-library"
+    assert finished_spans[0].instrumentation_scope.version == "1.0.0"
+    assert finished_spans[0].instrumentation_scope.attributes.get("namespace") == "Sample.Namespace"
+
+
+def test_default_instrumentation():
+    """Test that the default tracer manager returns an OpenTelemetryTracer."""
+    tracer = get_tracer()
+
+    assert isinstance(tracer, OpenTelemetryTracer)
+    assert isinstance(tracer._tracer, OtelTracer)
+
+
+def test_start_span_with_links(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    trace_context_headers = {}
+    with tracer.start_as_current_span(name="foo-span") as span:
+        trace_context_headers = tracer.get_trace_context()
+
+    link = Link(headers=trace_context_headers, attributes={"foo": "bar"})
+
+    with tracer.start_as_current_span(name="bar-span", links=[link]) as span:
+        pass
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+    assert finished_spans[0].name == "foo-span"
+    assert finished_spans[1].name == "bar-span"
+    assert finished_spans[1].links[0].context.trace_id == finished_spans[0].context.trace_id
+    assert finished_spans[1].links[0].context.span_id == finished_spans[0].context.span_id
+    assert finished_spans[1].links[0].attributes["foo"] == "bar"
+
+
+def test_start_span_with_attributes(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    with tracer.start_as_current_span(name="foo-span", attributes={"foo": "bar", "biz": 123}) as span:
+        pass
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].attributes["foo"] == "bar"
+    assert finished_spans[0].attributes["biz"] == 123
+
+
+def test_start_as_current_span_no_exit(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    with tracer.start_as_current_span(name="foo-span", kind=SpanKind.INTERNAL, end_on_exit=False) as span:
+        assert span.is_recording()
+        assert tracer.get_current_span() == span
+
+    assert span.is_recording()
+    span.end()
+    assert not span.is_recording()
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+
+
+def test_tracer_get_current_span():
+    """Test that the tracer can get the current OpenTelemetry span instance."""
+    tracer = get_tracer()
+    assert tracer
+
+    with tracer.start_as_current_span("test_span") as span:
+        with tracer.start_as_current_span("test_span2", kind=SpanKind.CLIENT) as span2:
+            current_span = tracer.get_current_span()
+            assert current_span == span2
+
+        current_span = tracer.get_current_span()
+        assert current_span == span
+
+    current_span = tracer.get_current_span()
+    assert isinstance(current_span, NonRecordingSpan)
+
+
+def test_end_span(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    span = tracer.start_span(name="foo-span", kind=SpanKind.INTERNAL)
+    assert span.is_recording()
+    assert span.start_time is not None
+    assert span.end_time is None
+
+    span.end()
+    assert not span.is_recording()
+    assert span.end_time is not None
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].name == "foo-span"
+
+
+def test_use_span(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    assert isinstance(tracer.get_current_span(), NonRecordingSpan)
+    with tracer.start_as_current_span(name="root", kind=SpanKind.INTERNAL) as root:
+        span = tracer.start_span(name="foo-span", kind=SpanKind.INTERNAL)
+        assert span.is_recording()
+        assert tracer.get_current_span() == root
+
+        with tracer.use_span(span):
+            assert tracer.get_current_span() == span
+
+        assert not span.is_recording()
+
+        span2 = tracer.start_span(name="bar-span", kind=SpanKind.INTERNAL)
+        assert span2.is_recording()
+        assert tracer.get_current_span() == root
+        with tracer.use_span(span2, end_on_exit=False):
+            assert tracer.get_current_span() == span2
+            assert span2.is_recording()
+
+        assert span2.is_recording()
+        span2.end()
+        assert not span2.is_recording()
+        assert tracer.get_current_span() == root
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 3
+
+
+def test_get_trace_context():
+    """Test that the tracer can get the trace context and it contains the traceparent header."""
+    tracer = get_tracer()
+    assert tracer
+
+    assert not tracer.get_trace_context()
+
+    with tracer.start_as_current_span(name="foo-span") as span:
+        trace_context = tracer.get_trace_context()
+        span_context = span.get_span_context()
+        assert "traceparent" in trace_context
+        assert trace_context["traceparent"].startswith("00-")
+
+        assert trace_context["traceparent"].split("-")[1] == format_trace_id(span_context.trace_id)
+        assert trace_context["traceparent"].split("-")[2] == format_span_id(span_context.span_id)
+
+
+def test_with_current_context_util_function(tracing_helper):
+
+    settings.tracing_enabled = True
+    result = []
+    tracer = get_tracer()
+    assert tracer
+
+    def get_span_from_thread(output):
+        current_span = tracer.get_current_span()
+        output.append(current_span)
+
+    with tracing_helper.tracer.start_as_current_span(name="TestSpan") as span:
+
+        thread = threading.Thread(target=with_current_context(get_span_from_thread), args=(result,))
+        thread.start()
+        thread.join()
+
+        assert span is result[0]
+
+
+def test_nest_span_with_thread_pool_executor(tracing_helper):
+    tracer = get_tracer(
+        library_name="my-library",
+        library_version="1.0.0",
+        schema_url="https://test.schema",
+        attributes={"namespace": "Sample.Namespace"},
+    )
+    assert tracer
+
+    def nest_spans():
+        with tracer.start_as_current_span(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
+            with tracer.start_as_current_span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:
+                assert isinstance(inner_span, OtelSpan)
+                assert tracer.get_current_span() == inner_span
+
+    futures = []
+    with ThreadPoolExecutor() as executor:
+        for _ in range(3):
+            futures.append(executor.submit(tracer.with_current_context(nest_spans)))
+    wait(futures)
+
+    # Each thread should produce 2 spans, so we should have 6 spans.
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 6
+    for span in finished_spans:
+        assert "-span" in span.name
+        assert span.instrumentation_scope.schema_url == "https://test.schema"
+        assert span.instrumentation_scope.name == "my-library"
+        assert span.instrumentation_scope.version == "1.0.0"
+        assert span.instrumentation_scope.attributes.get("namespace") == "Sample.Namespace"
+
+
+def test_set_span_status(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    with tracer.start_as_current_span(name="foo-span") as span:
+        span.set_status(OtelStatusCode.OK)
+
+    with tracer.start_as_current_span(name="bar-span") as span:
+        span.set_status(OtelStatusCode.ERROR, "This is an error")
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+    assert finished_spans[0].status.status_code == OtelStatusCode.OK
+    assert finished_spans[0].status.description is None
+
+    assert finished_spans[1].status.status_code == OtelStatusCode.ERROR
+    assert finished_spans[1].status.description == "This is an error"
+
+
+def test_add_event(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    with tracer.start_as_current_span(name="foo-span") as span:
+        span.add_event("test-event", attributes={"foo": "bar"})
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert len(finished_spans[0].events) == 1
+    assert finished_spans[0].events[0].name == "test-event"
+    assert finished_spans[0].events[0].attributes["foo"] == "bar"
+
+
+def test_span_exception(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    with pytest.raises(ValueError):
+        with tracer.start_as_current_span(name="foo-span") as span:
+            raise ValueError("This is an error")
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+
+    assert len(finished_spans) == 1
+    assert finished_spans[0].status.status_code == OtelStatusCode.ERROR
+
+
+def test_span_exception_without_current_context(tracing_helper):
+    tracer = get_tracer()
+    assert tracer
+
+    span = tracer.start_span(name="foo-span")
+    assert span.is_recording()
+
+    with pytest.raises(ValueError):
+        with span:
+            raise ValueError("This is an error")
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert len(finished_spans[0].events) == 1
+    assert finished_spans[0].events[0].name == "exception"
+    assert finished_spans[0].events[0].attributes["exception.type"] == "ValueError"
+    assert finished_spans[0].events[0].attributes["exception.message"] == "This is an error"
+    assert finished_spans[0].status.status_code == OtelStatusCode.ERROR
+
+
+def test_span_exception_exit(tracing_helper):
+
+    tracer = get_tracer()
+    assert tracer
+
+    span = tracer.start_span(name="foo-span")
+    assert span.is_recording()
+    try:
+        raise ValueError("This is an error")
+    except ValueError as e:
+        exc_info = sys.exc_info()
+        span.__exit__(*exc_info)
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+
+    assert len(finished_spans) == 1
+    assert len(finished_spans[0].events) == 1
+    assert finished_spans[0].events[0].name == "exception"
+    assert finished_spans[0].events[0].attributes["exception.type"] == "ValueError"
+    assert finished_spans[0].events[0].attributes["exception.message"] == "This is an error"
+    assert finished_spans[0].status.status_code == OtelStatusCode.ERROR
+
+
+def test_tracer_caching():
+    """Test that get_tracer caches the OpenTelemetryTracer."""
+    tracer1 = get_tracer()
+    tracer2 = get_tracer()
+
+    assert tracer1 is tracer2
+
+
+def test_tracer_caching_different_args():
+    """Test that get_tracer caches the OpenTelemetryTracer."""
+    tracer1 = get_tracer(
+        library_name="my-library",
+        library_version="1.0.0",
+        schema_url="https://test.schema",
+        attributes={"namespace": "Sample.Namespace"},
+    )
+    tracer2 = get_tracer(
+        library_name="my-library",
+        library_version="1.0.0",
+        schema_url="https://test.schema",
+        attributes={"namespace": "Sample.Namespace"},
+    )
+    tracer3 = get_tracer(
+        library_name="my-library-2",
+        library_version="2.0.0",
+        schema_url="https://test.schema",
+        attributes={"namespace": "Sample.Namespace"},
+    )
+
+    assert tracer1 is tracer2
+    assert tracer1 is not tracer3

--- a/sdk/core/corehttp/tests/test_tracing_decorator.py
+++ b/sdk/core/corehttp/tests/test_tracing_decorator.py
@@ -1,0 +1,122 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the distributed_trace decorator."""
+import time
+
+from corehttp.settings import settings
+from corehttp.instrumentation.tracing import distributed_trace
+
+from opentelemetry.trace import StatusCode as OtelStatusCode
+
+
+class MockClient:
+
+    _instrumentation_config = {
+        "library_name": "mylibrary",
+        "library_version": "1.0.0",
+        "schema_url": "https://test.schema",
+        "attributes": {"namespace": "Sample.Namespace"},
+    }
+
+    @distributed_trace
+    def nested_calls(self):
+        time.sleep(0.001)
+        self.get_foo()
+        self.method_with_kwargs()
+
+    @distributed_trace
+    def get_foo(self):
+        time.sleep(0.001)
+        return 5
+
+    @distributed_trace
+    def raising_exception(self, **kwargs):
+        raise ValueError("Something went horribly wrong here")
+
+    @distributed_trace
+    def method_with_kwargs(self, **kwargs):
+        time.sleep(0.001)
+
+
+def test_decorator_raise_exception(tracing_helper):
+    """Test that an exception is recorded as an error event."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        try:
+            client.raising_exception()
+        except ValueError:
+            pass
+        client.get_foo()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 2
+        assert finished_spans[0].name == "MockClient.raising_exception"
+        assert finished_spans[0].status.status_code == OtelStatusCode.ERROR
+        assert "Something went horribly wrong here" in finished_spans[0].status.description
+        assert finished_spans[0].attributes.get("error.type") == "ValueError"
+
+        assert finished_spans[1].name == "MockClient.get_foo"
+        assert finished_spans[1].status.status_code == OtelStatusCode.UNSET
+
+
+def test_decorator_nested_calls(tracing_helper):
+    """Test that only a span corresponding to the outermost method is created."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        client.nested_calls()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.nested_calls"
+
+
+def test_decorator_instrumentation_config(tracing_helper):
+    """Test that the instrumentation config is respected."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        client.get_foo()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.get_foo"
+        assert finished_spans[0].instrumentation_scope.schema_url == "https://test.schema"
+        assert finished_spans[0].instrumentation_scope.name == "mylibrary"
+        assert finished_spans[0].instrumentation_scope.version == "1.0.0"
+        assert finished_spans[0].instrumentation_scope.attributes.get("namespace") == "Sample.Namespace"
+
+
+def test_decorated_method_with_tracing_options(tracing_helper):
+    """Test that a decorated method can respect tracing options."""
+    client = MockClient()
+    settings.tracing_enabled = False
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        client.method_with_kwargs(tracing_options={"enabled": True, "attributes": {"custom_key": "custom_value"}})
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+        assert finished_spans[0].name == "MockClient.method_with_kwargs"
+        assert finished_spans[0].attributes.get("custom_key") == "custom_value"
+
+
+def test_decorated_method_with_tracing_disabled(tracing_helper):
+    """Test that a decorated method isn't traced if tracing is disabled on a per-operation basis."""
+    client = MockClient()
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        client.method_with_kwargs(tracing_options={"enabled": False, "attributes": {"custom_key": "custom_value"}})
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 0
+
+
+def test_decorated_method_with_tracing_disabled_globally(tracing_helper):
+    """Test that a decorated method isn't traced if tracing is disabled globally."""
+    client = MockClient()
+    settings.tracing_enabled = False
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        client.method_with_kwargs()
+
+        finished_spans = tracing_helper.exporter.get_finished_spans()
+        assert len(finished_spans) == 0

--- a/sdk/core/corehttp/tests/test_tracing_policy.py
+++ b/sdk/core/corehttp/tests/test_tracing_policy.py
@@ -1,0 +1,270 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""Tests for the distributed tracing policy."""
+from unittest import mock
+import pytest
+
+from corehttp.rest import HttpRequest
+from corehttp.runtime.policies import (
+    DistributedHttpTracingPolicy,
+    UserAgentPolicy,
+    RetryPolicy,
+)
+from corehttp.settings import settings
+from corehttp.runtime.pipeline import PipelineRequest, PipelineContext, PipelineResponse, Pipeline
+from corehttp.transport import HttpTransport
+from corehttp.transport.requests import RequestsTransport
+from opentelemetry.trace import format_span_id, format_trace_id
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+from utils import HTTP_RESPONSES, create_http_response
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy(tracing_helper, http_response):
+    """Test policy when the HTTP response corresponds to a success."""
+    with tracing_helper.tracer.start_as_current_span("Root") as root_span:
+        policy = DistributedHttpTracingPolicy()
+
+        request = HttpRequest("GET", "http://localhost/temp?query=query")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+        policy.on_request(pipeline_request)
+
+        response = create_http_response(http_response, request, None, headers=request.headers, status_code=202)
+
+        traceparent = request.headers.get("traceparent")
+        assert traceparent is not None
+        assert traceparent.startswith("00-")
+
+        policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+    assert finished_spans[0].name == "GET"
+    assert finished_spans[0].parent is root_span.get_span_context()
+
+    span_context = finished_spans[0].get_span_context()
+    assert traceparent.split("-")[1] == format_trace_id(span_context.trace_id)
+    assert traceparent.split("-")[2] == format_span_id(span_context.span_id)
+
+    assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
+    assert finished_spans[0].attributes.get(policy._URL_FULL) == "http://localhost/temp?query=query"
+    assert finished_spans[0].attributes.get(policy._SERVER_ADDRESS) == "localhost"
+    assert finished_spans[0].attributes.get(policy._USER_AGENT_ORIGINAL) is None
+    assert finished_spans[0].attributes.get(policy._HTTP_RESPONSE_STATUS_CODE) == 202
+    assert finished_spans[1].name == "Root"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy_error_response(tracing_helper, http_response):
+    """Test policy when the HTTP response corresponds to an error."""
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        policy = DistributedHttpTracingPolicy()
+
+        request = HttpRequest("GET", "http://localhost/temp?query=query")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+        policy.on_request(pipeline_request)
+
+        response = create_http_response(http_response, request, None, headers=request.headers, status_code=403)
+
+        policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert finished_spans[0].name == "GET"
+    assert finished_spans[0].attributes.get("error.type") == "403"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy_custom_instrumentation_config(tracing_helper, http_response):
+    """Test policy when a custom instrumentation config is provided."""
+    instrumentation_config = {
+        "library_name": "mylibrary",
+        "library_version": "1.0.0",
+        "attributes": {"namespace": "Sample.Namespace"},
+    }
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        policy = DistributedHttpTracingPolicy(instrumentation_config=instrumentation_config)
+
+        request = HttpRequest("GET", "http://localhost/temp?query=query")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+        policy.on_request(pipeline_request)
+
+        response = create_http_response(http_response, request, None, headers=request.headers, status_code=403)
+
+        policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert finished_spans[0].name == "GET"
+    assert finished_spans[0].attributes.get(policy._ERROR_TYPE) == "403"
+    assert finished_spans[0].instrumentation_scope.name == "mylibrary"
+    assert finished_spans[0].instrumentation_scope.version == "1.0.0"
+    assert finished_spans[0].instrumentation_scope.attributes.get("namespace") == "Sample.Namespace"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy_with_user_agent_policy(tracing_helper, http_response):
+    """Test policy when used with the UserAgentPolicy."""
+    with mock.patch.dict("os.environ", {"CORE_HTTP_USER_AGENT": "test-user-agent"}):
+        with tracing_helper.tracer.start_as_current_span("Root") as root_span:
+            policy = DistributedHttpTracingPolicy()
+            user_agent_policy = UserAgentPolicy()
+
+            request = HttpRequest("GET", "http://localhost/temp?query=query")
+            pipeline_request = PipelineRequest(request, PipelineContext(None))
+            user_agent_policy.on_request(pipeline_request)
+            policy.on_request(pipeline_request)
+
+            response = create_http_response(http_response, request, None, headers=request.headers, status_code=202)
+
+            traceparent = request.headers.get("traceparent")
+            assert traceparent is not None
+            assert traceparent.startswith("00-")
+
+            pipeline_response = PipelineResponse(request, response, PipelineContext(None))
+
+            policy.on_response(pipeline_request, pipeline_response)
+            user_agent_policy.on_response(pipeline_request, pipeline_response)
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+    assert finished_spans[0].name == "GET"
+    assert finished_spans[0].parent is root_span.get_span_context()
+
+    span_context = finished_spans[0].get_span_context()
+    assert traceparent.split("-")[1] == format_trace_id(span_context.trace_id)
+    assert traceparent.split("-")[2] == format_span_id(span_context.span_id)
+
+    assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
+    assert finished_spans[0].attributes.get(policy._URL_FULL) == "http://localhost/temp?query=query"
+    assert finished_spans[0].attributes.get(policy._SERVER_ADDRESS) == "localhost"
+    assert finished_spans[0].attributes.get(policy._USER_AGENT_ORIGINAL) is not None
+    assert finished_spans[0].attributes.get(policy._USER_AGENT_ORIGINAL).endswith("test-user-agent")
+    assert finished_spans[0].attributes.get(policy._HTTP_RESPONSE_STATUS_CODE) == 202
+    assert finished_spans[1].name == "Root"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_span_retry_attributes(tracing_helper, http_response):
+    """Test that the retry count is added to the span attributes."""
+
+    class MockTransport(HttpTransport):
+        def __init__(self):
+            self._count = 0
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def close(self):
+            pass
+
+        def open(self):
+            pass
+
+        def send(self, request, **kwargs):
+            self._count += 1
+            response = create_http_response(http_response, request, None, status_code=429)
+            return response
+
+    http_request = HttpRequest("GET", "http://localhost/")
+    retry_policy = RetryPolicy(retry_total=2)
+    distributed_tracing_policy = DistributedHttpTracingPolicy()
+    transport = MockTransport()
+
+    with tracing_helper.tracer.start_as_current_span("Root") as root_span:
+        policies = [retry_policy, distributed_tracing_policy]
+        pipeline = Pipeline(transport, policies=policies)
+        pipeline.run(http_request)
+
+    assert transport._count == 3
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    parent_context = root_span.get_span_context()
+    assert len(finished_spans) == 4
+    assert finished_spans[0].parent == parent_context
+    assert finished_spans[0].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) is None
+    assert finished_spans[0].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"
+
+    assert finished_spans[1].parent == parent_context
+    assert finished_spans[1].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) == 1
+    assert finished_spans[1].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"
+
+    assert finished_spans[2].parent == parent_context
+    assert finished_spans[2].attributes.get(distributed_tracing_policy._HTTP_RESEND_COUNT) == 2
+    assert finished_spans[2].attributes.get(distributed_tracing_policy._URL_FULL) == "http://localhost/"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy_with_tracing_options(tracing_helper, http_response):
+    """Test policy when tracing options are provided."""
+    settings.tracing_enabled = False
+    with tracing_helper.tracer.start_as_current_span("Root") as root_span:
+        policy = DistributedHttpTracingPolicy()
+
+        request = HttpRequest("GET", "http://localhost/temp?query=query")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+        pipeline_request.context.options["tracing_options"] = {
+            "enabled": True,
+            "attributes": {"custom_key": "custom_value"},
+        }
+
+        policy.on_request(pipeline_request)
+        response = create_http_response(http_response, request, None, headers=request.headers, status_code=202)
+        policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+
+    assert finished_spans[0].name == "GET"
+    assert finished_spans[0].parent is root_span.get_span_context()
+
+    assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
+    assert finished_spans[0].attributes.get(policy._URL_FULL) == "http://localhost/temp?query=query"
+    assert finished_spans[0].attributes.get(policy._SERVER_ADDRESS) == "localhost"
+    assert finished_spans[0].attributes.get(policy._USER_AGENT_ORIGINAL) is None
+    assert finished_spans[0].attributes.get(policy._HTTP_RESPONSE_STATUS_CODE) == 202
+    assert finished_spans[0].attributes.get("custom_key") == "custom_value"
+
+
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_distributed_tracing_policy_disabled(tracing_helper, http_response):
+    """Test policy when tracing is enabled globally but disabled on the operation."""
+    with tracing_helper.tracer.start_as_current_span("Root"):
+        policy = DistributedHttpTracingPolicy()
+
+        request = HttpRequest("GET", "http://localhost/temp?query=query")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+        pipeline_request.context.options["tracing_options"] = {
+            "enabled": False,
+        }
+        policy.on_request(pipeline_request)
+        response = create_http_response(http_response, request, None, headers=request.headers)
+        policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].name == "Root"
+
+
+def test_suppress_http_auto_instrumentation(port, tracing_helper):
+    """Test that automatic HTTP instrumentation is suppressed when a request is made through the pipeline."""
+    # Enable auto-instrumentation for requests.
+    requests_instrumentor = RequestsInstrumentor()
+    requests_instrumentor.instrument()
+    policy = DistributedHttpTracingPolicy()
+    transport = RequestsTransport()
+
+    request = HttpRequest("GET", f"http://localhost:{port}/basic/string")
+    with Pipeline(transport, policies=[policy]) as pipeline:
+        pipeline.run(request)
+
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
+    assert finished_spans[0].attributes.get(policy._URL_FULL) == f"http://localhost:{port}/basic/string"
+    assert finished_spans[0].attributes.get(policy._SERVER_ADDRESS) == "localhost"
+    assert finished_spans[0].attributes.get(policy._HTTP_RESPONSE_STATUS_CODE) == 200
+
+    requests_instrumentor.uninstrument()


### PR DESCRIPTION
- `DistributedHttpTracingPolicy` and `distributed_trace`/`distributed_trace_async` decorators are added.
- `opentelemetry-api` is added as an optional dependency, and is needed to enable tracing
- Added a `settings` global object for enabling tracing via `settings.tracing_enabled = True`
- Tracing related code is currently placed in the `corehttp.instrumentation.tracing` namespace.

The native tracing logic implemented in this PR follows what was done in azure-core in https://github.com/Azure/azure-sdk-for-python/pull/39563. It's simpler here because we don't have to worry about the tracing plugin support in corehttp.
