### PR TITLE
Azure Identity: AzureCliCredentials and AzureDeveloperCliCredential handle stderr may be None when executing subprocess

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- A bug in the error handling for AzureCliCredentials and AzureDeveloperCliCredential which would result in the unexpected error `'NoneType' object has no attribute 'startswith'` has been fixed ([#39176](https://github.com/Azure/azure-sdk-for-python/pull/39176))
+
 ### Other Changes
 
 ## 1.19.0 (2024-10-08)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -261,9 +261,11 @@ def _run_command(command: str, timeout: int) -> str:
     except subprocess.CalledProcessError as ex:
         # non-zero return from shell
         # Fallback check in case the executable is not found while executing subprocess.
-        if ex.returncode == 127 or ex.stderr.startswith("'azd' is not recognized"):
+        if ex.returncode == 127 or (ex.stderr is not None and ex.stderr.startswith("'azd' is not recognized")):
             raise CredentialUnavailableError(message=CLI_NOT_FOUND) from ex
-        if "not logged in, run `azd auth login` to login" in ex.stderr and "AADSTS" not in ex.stderr:
+        if ex.stderr is not None and (
+            "not logged in, run `azd auth login` to login" in ex.stderr and "AADSTS" not in ex.stderr
+        ):
             raise CredentialUnavailableError(message=NOT_LOGGED_IN) from ex
 
         # return code is from the CLI -> propagate its output

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -252,9 +252,11 @@ def _run_command(command: str, timeout: int) -> str:
     except subprocess.CalledProcessError as ex:
         # non-zero return from shell
         # Fallback check in case the executable is not found while executing subprocess.
-        if ex.returncode == 127 or ex.stderr.startswith("'az' is not recognized"):
+        if ex.returncode == 127 or (ex.stderr is not None and ex.stderr.startswith("'az' is not recognized")):
             raise CredentialUnavailableError(message=CLI_NOT_FOUND) from ex
-        if ("az login" in ex.stderr or "az account set" in ex.stderr) and "AADSTS" not in ex.stderr:
+        if ex.stderr is not None and (
+            ("az login" in ex.stderr or "az account set" in ex.stderr) and "AADSTS" not in ex.stderr
+        ):
             raise CredentialUnavailableError(message=NOT_LOGGED_IN) from ex
 
         # return code is from the CLI -> propagate its output

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
@@ -147,6 +147,17 @@ def test_unexpected_error(get_token_method):
                 getattr(AzureDeveloperCliCredential(), get_token_method)("scope")
 
 
+@pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)
+def test_unexpected_error_no_strerr(get_token_method):
+    """When the CLI returns an unexpected error with no stderr captured, the credential should raise an error with a str output"""
+    stderr = None
+    default_message = "Failed to invoke Azure Developer CLI"
+    with mock.patch("shutil.which", return_value="azd"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, stderr=stderr)):
+            with pytest.raises(ClientAuthenticationError, match=default_message):
+                getattr(AzureDeveloperCliCredential(), get_token_method)("scope")
+
+
 @pytest.mark.parametrize("output", TEST_ERROR_OUTPUTS)
 @pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)
 def test_parsing_error_does_not_expose_token(output, get_token_method):

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -230,6 +230,18 @@ def test_unexpected_error(get_token_method):
                 getattr(AzureCliCredential(), get_token_method)("scope")
 
 
+@pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)
+def test_unexpected_error_no_stderr(get_token_method):
+    """When the CLI returns an unexpected error with no stderr captured, the credential should raise an error with a str output"""
+
+    stderr = None
+    default_message = "Failed to invoke Azure CLI"
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, stderr=stderr)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                getattr(AzureCliCredential(), get_token_method)("scope")
+
+
 @pytest.mark.parametrize("output,get_token_method", product(TEST_ERROR_OUTPUTS, GET_TOKEN_METHODS))
 def test_parsing_error_does_not_expose_token(output, get_token_method):
     """Errors during CLI output parsing shouldn't expose access tokens in that output"""


### PR DESCRIPTION
# Description

According to the docs
CredentialUnavailableError.stderr may be None
if no output is captured.

```
Stderr output of the child process if it was
captured by run(). Otherwise, None.
```
https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError

In AzureCliCredential._run_command (and similar in AzureDeveloperCliCredential) this is
handled when propagating the error
but was overlooked in other parts of the code.
This pr fixes the code to ensure that the None
case is handled before checking for str content.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
