### PR TITLE
Howie/overload test

### DIFF
--- a/sdk/ai/azure-ai-projects/tests/agents/overload_assert_utils.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/overload_assert_utils.py
@@ -1,0 +1,186 @@
+import io
+import json
+import unittest
+from typing import Any, Dict, IO, Union
+from unittest.mock import Mock, MagicMock, AsyncMock
+from requests.structures import CaseInsensitiveDict
+import inspect
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.aio import AIProjectClient as AsyncAIProjectClient
+from azure.ai.projects._model_base import SdkJSONEncoder
+
+
+def dict_to_io_bytes(input: Dict[str, Any]) -> io.BytesIO:
+    input_string = json.dumps(input, cls=SdkJSONEncoder, exclude_readonly=True)
+    return io.BytesIO(input_string.encode("utf-8"))
+
+
+class OverloadAssertion:
+    def __init__(self, mock: Mock, async_mock: AsyncMock, **args):
+        self.mock = mock
+        self.async_mock = async_mock
+
+    def _to_dict(self, input: Union[None, str, IO[bytes]]) -> Dict[str, Any]:
+        json_string = ""
+        if isinstance(input, io.BytesIO):
+            json_string = input.getvalue().decode("utf-8")
+        elif isinstance(input, str):
+            json_string = input
+        else:
+            json_string = "{}"
+        return json.loads(json_string)
+
+    def assert_deep_equal_header_except_content_length(
+        self, header1: CaseInsensitiveDict, header2: CaseInsensitiveDict, msg: str
+    ):
+        """
+        Compare two HTTP headers for deep equality, except for the Content-Length header.
+        Because it seems only created by HttpRequest class automatically when the type is bytes
+        """
+        header1 = header1.copy()
+        header2 = header2.copy()
+        header1.pop("Content-Length", None)
+        header2.pop("Content-Length", None)
+        unittest.TestCase().assertDictEqual(dict(header1), dict(header2), msg)
+
+    def _assert_same_http_request(self, call1: Any, call2: Any, index1: int, index2: int):
+        """
+        Compare two HTTP request objects for deep equality.
+        """
+
+        # Compare method, URL, headers, body, and other relevant attributes
+        req1 = call1.args[0]
+        req2 = call2.args[0]
+        req1_body = self._to_dict(req1.body)
+        req2_body = self._to_dict(req2.body)
+        unittest.TestCase().assertEqual(
+            req1.method,
+            req2.method,
+            f"call[{index1}] method is {req1.method}, but call[{index2}] method is {req2.method}",
+        )
+        unittest.TestCase().assertEqual(
+            req1.url, req2.url, f"call[{index1}] url is {req1.url}, but call[{index2}] url is {req2.url}"
+        )
+        unittest.TestCase().assertDictEqual(
+            req1_body,
+            req2_body,
+            f"call[{index1}] body is {json.dumps(req1_body, sort_keys=True)}, but call[{index2}] body is {json.dumps(req2_body, sort_keys=True)}",
+        )
+        self.assert_deep_equal_header_except_content_length(
+            req1.headers,
+            req2.headers,
+            f"call[{index1}] headers are {req1.headers}, but call[{index2}] headers are {req2.headers}",
+        )
+        unittest.TestCase().assertDictEqual(
+            call1.kwargs,
+            call2.kwargs,
+            f"call[{index1}] kwargs are {call1.kwargs}, but call[{index2}] kwargs are {call2.kwargs}",
+        )
+
+    def same_http_requests_from(self, *, operation_count: int, api_per_operation_count: int):
+        all_calls = self.mock.call_args_list + self.async_mock.call_args_list
+        assert len(all_calls) == operation_count * api_per_operation_count
+
+        # Compare first followed by second followed by third call etc of each operations,
+        # Assert they have the same http request
+        template = all_calls[:api_per_operation_count]
+        for j in range(api_per_operation_count, len(all_calls), api_per_operation_count):
+            for i, (api_one, api_other) in enumerate(zip(template, all_calls[j : j + api_per_operation_count])):
+                self._assert_same_http_request(api_one, api_other, i, i + j)
+
+
+def assert_same_http_requests(test_func):
+    """
+    Decorator to mock pipeline responses and call the test function with the mock clients and assertion.
+
+    :param test_func: The test function to be decorated.
+    :return: The wrapper function.
+    """
+
+    def _get_mock_client() -> AIProjectClient:
+        """Return the fake project client"""
+        client = AIProjectClient(
+            endpoint="www.bcac95dd-a1eb-11ef-978f-8c1645fec84b.com",
+            subscription_id="00000000-0000-0000-0000-000000000000",
+            resource_group_name="non-existing-rg",
+            project_name="non-existing-project",
+            credential=MagicMock(),
+        )
+        client.agents.submit_tool_outputs_to_run = MagicMock()
+        client.agents.submit_tool_outputs_to_stream = MagicMock()
+        return client
+
+    def _get_async_mock_client() -> AsyncAIProjectClient:
+        """Return the fake project client"""
+        client = AsyncAIProjectClient(
+            endpoint="www.bcac95dd-a1eb-11ef-978f-8c1645fec84b.com",
+            subscription_id="00000000-0000-0000-0000-000000000000",
+            resource_group_name="non-existing-rg",
+            project_name="non-existing-project",
+            credential=AsyncMock(),
+        )
+        client.agents.submit_tool_outputs_to_run = AsyncMock()
+        client.agents.submit_tool_outputs_to_stream = AsyncMock()
+        return client
+
+    async def wrapper(self, *args, **kwargs):
+        """
+        Wrapper function to set up mocks and call the test function.
+
+        :param self: The test class instance.
+        :param args: Positional arguments to pass to the test function.
+        :param kwargs: Keyword arguments to pass to the test function.
+        """
+        if not test_func:
+            return
+
+        # Mock the pipeline response
+        pipeline_response_mock_return = Mock()
+        http_response = Mock()
+        http_response_json = Mock()
+        iter_bytes = Mock()
+
+        # Set up the mock HTTP response
+        http_response_json.return_value = {}
+        http_response.status_code = 200
+        http_response.json = http_response_json
+        http_response.iter_bytes = iter_bytes
+
+        # Set up the pipeline response mock
+        pipeline_response_mock = Mock()
+        pipeline_response_mock_async = AsyncMock()
+        pipeline_response_mock.return_value = pipeline_response_mock_return
+        pipeline_response_mock_async.return_value = pipeline_response_mock_return
+        pipeline_response_mock_return.http_response = http_response
+
+        # Get the mock clients
+        client = _get_mock_client()
+        async_client = _get_async_mock_client()
+
+        async with async_client:
+            with client:
+                # Assign the pipeline mock to the client's agent
+                client.agents._client._pipeline.run = pipeline_response_mock
+                async_client.agents._client._pipeline.run = pipeline_response_mock_async
+
+                # Create an assertion object with the call arguments list
+                assertion = OverloadAssertion(pipeline_response_mock, pipeline_response_mock_async)
+
+                # Call the test function with the mock clients and assertion
+                await test_func(self, client.agents, async_client.agents, assertion, *args, **kwargs)
+
+    return wrapper
+
+
+def get_mock_fn(fn, return_val):
+    def mock_func(*args, **kwargs):
+        fn(*args, **kwargs)
+        return return_val
+
+    async def mock_func_async(*args, **kwargs):
+        await fn(*args, **kwargs)
+        return return_val
+
+    if inspect.iscoroutinefunction(fn):
+        return mock_func_async
+    return mock_func

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_operation_overloads.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_operation_overloads.py
@@ -1,0 +1,139 @@
+from unittest.mock import patch
+
+import pytest
+from azure.ai.projects.operations import AgentsOperations
+from azure.ai.projects.aio.operations import AgentsOperations as AsyncAgentsOperations
+from typing import List, Dict, MutableMapping, Any
+
+from overload_assert_utils import (
+    assert_same_http_requests,
+    OverloadAssertion,
+    dict_to_io_bytes,
+    get_mock_fn,
+)
+
+from azure.ai.projects.models import ThreadMessageOptions, ToolResources, VectorStore
+
+
+JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
+
+
+class TestSignatures:
+
+    @pytest.mark.asyncio
+    @assert_same_http_requests
+    async def test_create_agent(
+        self, agent: AgentsOperations, async_agent: AsyncAgentsOperations, assertion: OverloadAssertion
+    ):
+        model = "gpt-4-1106-preview"
+        name = "first"
+        instructions = "You are a helpful assistant"
+        body = {"model": model, "name": name, "instructions": instructions}
+
+        agent.create_agent(model=model, name=name, instructions=instructions)
+        agent.create_agent(body=body)
+        agent.create_agent(body=dict_to_io_bytes(body))
+
+        await async_agent.create_agent(model=model, name=name, instructions=instructions)
+        await async_agent.create_agent(body=body)
+        await async_agent.create_agent(body=dict_to_io_bytes(body))
+
+        assertion.same_http_requests_from(operation_count=6, api_per_operation_count=1)
+
+    @pytest.mark.asyncio
+    @assert_same_http_requests
+    async def test_create_vector_store_and_poll(
+        self, agent: AgentsOperations, async_agent: AsyncAgentsOperations, assertion: OverloadAssertion
+    ):
+        file_ids = ["file_id"]
+        body = {"file_ids": file_ids}
+
+        with patch(
+            "azure.ai.projects.operations._operations.AgentsOperations.create_vector_store",
+            wraps=get_mock_fn(
+                agent.create_vector_store, return_val=VectorStore({"id": "store_1", "status": "in_progress"})
+            ),
+        ), patch(
+            "azure.ai.projects.operations._operations.AgentsOperations.get_vector_store",
+            wraps=get_mock_fn(agent.get_vector_store, return_val=VectorStore({"id": "store_1", "status": "completed"})),
+        ):
+
+            agent.create_vector_store_and_poll(file_ids=file_ids, sleep_interval=0)
+            agent.create_vector_store_and_poll(body=body, sleep_interval=0)
+            agent.create_vector_store_and_poll(body=dict_to_io_bytes(body), sleep_interval=0)
+
+        with patch(
+            "azure.ai.projects.aio.operations._operations.AgentsOperations.create_vector_store",
+            wraps=get_mock_fn(
+                async_agent.create_vector_store, return_val=VectorStore({"id": "store_1", "status": "in_progress"})
+            ),
+        ), patch(
+            "azure.ai.projects.aio.operations._operations.AgentsOperations.get_vector_store",
+            wraps=get_mock_fn(
+                async_agent.get_vector_store, return_val=VectorStore({"id": "store_1", "status": "completed"})
+            ),
+        ):
+            await async_agent.create_vector_store_and_poll(file_ids=file_ids, sleep_interval=0)
+            await async_agent.create_vector_store_and_poll(body=body, sleep_interval=0)
+            await async_agent.create_vector_store_and_poll(body=dict_to_io_bytes(body), sleep_interval=0)
+        assertion.same_http_requests_from(operation_count=6, api_per_operation_count=2)
+
+    @pytest.mark.asyncio
+    @assert_same_http_requests
+    async def test_create_thread(
+        self, agent: AgentsOperations, async_agent: AsyncAgentsOperations, assertion: OverloadAssertion
+    ):
+        messages: List[ThreadMessageOptions] = []
+        tool_resources: ToolResources = ToolResources()
+        metadata: Dict[str, str] = {}
+        body = {"messages": messages, "tool_resources": tool_resources, "metadata": metadata}
+
+        agent.create_thread(messages=messages, tool_resources=tool_resources, metadata=metadata)
+        agent.create_thread(body=body)
+        agent.create_thread(body=dict_to_io_bytes(body))
+
+        await async_agent.create_thread(messages=messages, tool_resources=tool_resources, metadata=metadata)
+        await async_agent.create_thread(body=body)
+        await async_agent.create_thread(body=dict_to_io_bytes(body))
+
+        assertion.same_http_requests_from(operation_count=6, api_per_operation_count=1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip("Defect: during body as JSON and IO Bytes don't, backend not called with stream=False")
+    @assert_same_http_requests
+    async def test_create_run(
+        self, agent: AgentsOperations, async_agent: AsyncAgentsOperations, assertion: OverloadAssertion
+    ):
+        thread_id = "thread_id"
+        agent_id = "agent_id"
+        body = {"agent_id": agent_id}
+
+        agent.create_run(thread_id, agent_id=agent_id)
+        agent.create_run(thread_id, body=body)
+        agent.create_run(thread_id, body=dict_to_io_bytes(body))
+
+        await async_agent.create_run(thread_id, agent_id=agent_id)
+        await async_agent.create_run(thread_id, body=body)
+        await async_agent.create_run(thread_id, body=dict_to_io_bytes(body))
+
+        assertion.same_http_requests_from(operation_count=6, api_per_operation_count=1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip("Defect: during body as JSON and IO Bytes don't, backend not called with stream=True")
+    @assert_same_http_requests
+    async def test_create_stream(
+        self, agent: AgentsOperations, async_agent: AsyncAgentsOperations, assertion: OverloadAssertion
+    ):
+        thread_id = "thread_id"
+        agent_id = "agent_id"
+        body = {"agent_id": agent_id}
+
+        agent.create_stream(thread_id, agent_id=agent_id)
+        agent.create_stream(thread_id, body=body)
+        agent.create_stream(thread_id, body=dict_to_io_bytes(body))
+
+        await async_agent.create_stream(thread_id, agent_id=agent_id)
+        await async_agent.create_stream(thread_id, body=body)
+        await async_agent.create_stream(thread_id, body=dict_to_io_bytes(body))
+
+        assertion.same_http_requests_from(operation_count=6, api_per_operation_count=1)

--- a/sdk/ai/azure-ai-projects/tests/agents/test_overload_assert.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_overload_assert.py
@@ -1,0 +1,25 @@
+import unittest
+import pytest
+from azure.ai.projects.operations import AgentsOperations
+from azure.ai.projects.aio.operations import AgentsOperations as AsyncAgentsOperations
+from overload_assert_utils import OverloadAssertion, assert_same_http_requests
+
+
+class TestDeclarator(unittest.TestCase):
+
+    @pytest.mark.asyncio
+    @assert_same_http_requests
+    async def test_assert_errors(self, agent: AgentsOperations, _: AsyncAgentsOperations, assertion: OverloadAssertion):
+        # This is a special test case tested verified the decorator assert name field presents in one call but not another
+        model = "gpt-4-1106-preview"
+        name = "first"
+        instructions = "You are a helpful assistant"
+        body = {"model": model, "name": name, "instructions": instructions}
+
+        agent.create_agent(model=model, instructions=instructions)
+        agent.create_agent(body=body)
+
+        # Expect failure because the name field is missing in the second call
+        # If it doesn't assert, it means the decorator is not working and the test is failing here
+        with pytest.raises(AssertionError):
+            assertion.same_http_requests_from(operation_count=2, api_per_operation_count=1)


### PR DESCRIPTION
New decorator to sample tests that verify if you call the same operator function with similar values but different overload signature, it will generate the same http request.

Check the bottom first to see the real tests.

And create_vector_store_and_poll calls 2 apis, POST and GET.    Since I call this function with 6 different signature, I verify that call number, 0, 2, 4, 6, 8, 10, 12 are the same which is the POST api.   and call number 1, 3, 5 7, 9, 11  are the same which is GET API