### PR TITLE
Resolve the failed package lookup

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -19,6 +19,11 @@ steps:
       ServiceDirectory: "template"
       TestPipeline: ${{ parameters.TestPipeline }}
 
+  - ${{if eq(variables['System.TeamProject'], 'internal') }}:
+    - template: ../steps/auth-dev-feed.yml
+      parameters:
+        DevFeedName: ${{ parameters.DevFeedName }}
+
   - task: PythonScript@0
     displayName: 'Set Tox Environment Skips'
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -6,6 +6,7 @@ parameters:
   TestPipeline: false
   VerifyAutorest: false
   GenerateApiReviewForManualOnly: false
+  DevFeedName: 'public/azure-sdk-for-python'
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This variable is set from resolve-package-targeting.yml.
 steps:


### PR DESCRIPTION
Hey @LibbaLawrence this resolves the issue you pinged me last week about. Sorry for the delay this was **very** annoying to repro and find.

The issue became quite obvious once you see the change here. Our `analyze` nightly didn't have access to the dev feeds, so an alpha version of a dependency wasn't resolving.

[Here is a build with successful mypy run of azure-ai-inference](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4488633&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32) running the nightly build with this change.