### PR TITLE
add tests for workspace REST to entity conversion

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
@@ -1,0 +1,47 @@
+{
+    "id": "/subscriptions/sub-id/test_workspace/providers/Microsoft.Storage/storageAccounts/storage-account-name",
+    "name": "test_workspace",
+    "location": "test_location",
+    "kind": "test_kind",
+    "sku": {
+        "name": "test_sku"
+    },
+    "tags": {
+        "test_tag": "test_value"
+    },
+    "properties": {
+        "description": "test_description",
+        "friendlyName": "test_friendly_name",
+        "discoveryUrl": "test_discovery_url",
+        "hbiWorkspace": true,
+        "storageAccount": "test_storage_account",
+        "containerRegistry": "test_container_registry",
+        "keyVault": "test_key_vault",
+        "applicationInsights": "test_application_insights",
+        "imageBuildCompute": "test_image_build_compute",
+        "publicNetworkAccess": "Enabled",
+        "enableDataIsolation": true,
+        "allowPublicAccessWhenBehindVnet": true,
+        "primaryUserAssignedIdentity": "test_primary_user_assigned_identity",
+        "encryption": {
+            "status": "Enabled",
+            "keyVaultProperties": {
+                "keyIdentifier": "key_identifier",
+                "keyVaultArmId": "key_vault_arm_id"
+            }
+        },
+        "hubResourceId": "hub_resource_id",
+        "workspaceId": "workspace_id",
+        "mlFlowTrackingUri": "ml_flow_tracking_uri",
+        "allowRoleAssignmentOnRG": true,
+        "systemDatastoresAuthMode": "AccessKey",
+        "managedNetwork": {},
+        "provisionNetworkNow": true,
+        "featureStoreSettings": {},
+        "serverlessComputeSettings": {},
+        "networkAcls": {}
+    },
+    "identity": {
+        "type": "ManagedServiceIdentityType"
+    }
+}

--- a/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
@@ -23,8 +23,8 @@
             "status": "Enabled",
             "keyVaultProperties": {
                 "keyIdentifier": "key_identifier",
-                "keyVaultArmId": "key_vault_arm_id",
-            },
+                "keyVaultArmId": "key_vault_arm_id"
+            }
         },
         "hubResourceId": "hub_resource_id",
         "workspaceId": "workspace_id",
@@ -35,7 +35,7 @@
         "provisionNetworkNow": true,
         "featureStoreSettings": {},
         "serverlessComputeSettings": {},
-        "networkAcls": {},
+        "networkAcls": {}
     },
-    "identity": {"type": "ManagedServiceIdentityType"},
+    "identity": {"type": "ManagedServiceIdentityType"}
 }

--- a/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_full_rest_response.json
@@ -3,12 +3,8 @@
     "name": "test_workspace",
     "location": "test_location",
     "kind": "test_kind",
-    "sku": {
-        "name": "test_sku"
-    },
-    "tags": {
-        "test_tag": "test_value"
-    },
+    "sku": {"name": "test_sku"},
+    "tags": {"test_tag": "test_value"},
     "properties": {
         "description": "test_description",
         "friendlyName": "test_friendly_name",
@@ -27,8 +23,8 @@
             "status": "Enabled",
             "keyVaultProperties": {
                 "keyIdentifier": "key_identifier",
-                "keyVaultArmId": "key_vault_arm_id"
-            }
+                "keyVaultArmId": "key_vault_arm_id",
+            },
         },
         "hubResourceId": "hub_resource_id",
         "workspaceId": "workspace_id",
@@ -39,9 +35,7 @@
         "provisionNetworkNow": true,
         "featureStoreSettings": {},
         "serverlessComputeSettings": {},
-        "networkAcls": {}
+        "networkAcls": {},
     },
-    "identity": {
-        "type": "ManagedServiceIdentityType"
-    }
+    "identity": {"type": "ManagedServiceIdentityType"},
 }

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
@@ -33,25 +33,16 @@ class TestWorkspaceEntity:
     def test_serverless_compute_settings_loaded_from_rest_object(
         self, settings: Optional[ServerlessComputeSettings]
     ) -> None:
-        workspace = Workspace(
-            name="test_workspace", location="test_location", serverless_compute=settings
-        )
+        workspace = Workspace(name="test_workspace", location="test_location", serverless_compute=settings)
         rest_object = workspace._to_rest_object()
         assert rest_object is not None
         if settings is None:
             assert rest_object.serverless_compute_settings is None
         else:
-            assert (
-                ServerlessComputeSettings._from_rest_object(
-                    rest_object.serverless_compute_settings
-                )
-                == settings
-            )
+            assert ServerlessComputeSettings._from_rest_object(rest_object.serverless_compute_settings) == settings
 
     def test_from_rest_object(self) -> None:
-        with open(
-            "./tests/test_configs/workspace/workspace_full_rest_response.json", "r"
-        ) as f:
+        with open("./tests/test_configs/workspace/workspace_full_rest_response.json", "r") as f:
             rest_object = RestWorkspace.deserialize(json.load(f))
 
         workspace = Workspace._from_rest_object(rest_object)
@@ -78,10 +69,7 @@ class TestWorkspaceEntity:
         assert workspace.image_build_compute == "test_image_build_compute"
         assert workspace.discovery_url == "test_discovery_url"
         assert workspace.mlflow_tracking_uri == "ml_flow_tracking_uri"
-        assert (
-            workspace.primary_user_assigned_identity
-            == "test_primary_user_assigned_identity"
-        )
+        assert workspace.primary_user_assigned_identity == "test_primary_user_assigned_identity"
         assert workspace.system_datastores_auth_mode == "AccessKey"
         assert workspace.enable_data_isolation == True
         assert workspace.allow_roleassignment_on_rg == True
@@ -97,9 +85,7 @@ class TestWorkspaceEntity:
         assert workspace.network_acls is not None
 
     def test_from_rest_object_for_attributes_none(self) -> None:
-        with open(
-            "./tests/test_configs/workspace/workspace_full_rest_response.json", "r"
-        ) as f:
+        with open("./tests/test_configs/workspace/workspace_full_rest_response.json", "r") as f:
             rest_json = json.load(f)
             del rest_json["properties"]["managedNetwork"]
             del rest_json["properties"]["encryption"]
@@ -130,10 +116,7 @@ class TestWorkspaceEntity:
         assert workspace.image_build_compute == "test_image_build_compute"
         assert workspace.discovery_url == "test_discovery_url"
         assert workspace.mlflow_tracking_uri == "ml_flow_tracking_uri"
-        assert (
-            workspace.primary_user_assigned_identity
-            == "test_primary_user_assigned_identity"
-        )
+        assert workspace.primary_user_assigned_identity == "test_primary_user_assigned_identity"
         assert workspace.system_datastores_auth_mode == "AccessKey"
         assert workspace.enable_data_isolation == True
         assert workspace.allow_roleassignment_on_rg == True
@@ -172,9 +155,7 @@ class TestWorkspaceEntity:
             ),
         ],
     )
-    def test_workspace_load_override_serverless(
-        self, settings: ServerlessComputeSettings
-    ) -> None:
+    def test_workspace_load_override_serverless(self, settings: ServerlessComputeSettings) -> None:
         params_override = [
             {
                 "serverless_compute": {
@@ -191,15 +172,10 @@ class TestWorkspaceEntity:
         assert workspace_override.serverless_compute == settings
 
     def test_workspace_load_yamls_to_test_outbound_rule_load(self):
-        workspace = load_workspace(
-            "./tests/test_configs/workspace/workspace_many_ob_rules.yaml"
-        )
+        workspace = load_workspace("./tests/test_configs/workspace/workspace_many_ob_rules.yaml")
 
         assert workspace.managed_network is not None
-        assert (
-            workspace.managed_network.isolation_mode
-            == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
-        )
+        assert workspace.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
 
         rules = workspace.managed_network.outbound_rules
         assert rules[0].name == "microsoft"
@@ -220,15 +196,10 @@ class TestWorkspaceEntity:
         assert "10.0.0.0/24" in rules[2].address_prefixes
 
     def test_workspace_load_yamls_to_test_firewallsku_load(self):
-        workspace = load_workspace(
-            "./tests/test_configs/workspace/workspace_mvnet_with_firewallsku.yaml"
-        )
+        workspace = load_workspace("./tests/test_configs/workspace/workspace_mvnet_with_firewallsku.yaml")
 
         assert workspace.managed_network is not None
-        assert (
-            workspace.managed_network.isolation_mode
-            == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
-        )
+        assert workspace.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
         rules = workspace.managed_network.outbound_rules
 
         assert workspace.managed_network.firewall_sku == "Basic"
@@ -247,9 +218,7 @@ class TestWorkspaceEntity:
         assert rules[2].destination == "*.pytorch.org"
 
     def test_workspace_load_yaml_to_test_network_acls_load(self):
-        workspace = load_workspace(
-            "./tests/test_configs/workspace/ai_workspaces/workspacehub_with_networkacls.yaml"
-        )
+        workspace = load_workspace("./tests/test_configs/workspace/ai_workspaces/workspacehub_with_networkacls.yaml")
 
         assert workspace.network_acls is not None
         assert len(workspace.network_acls.ip_rules) == 2

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
@@ -1,10 +1,21 @@
 from typing import Optional
 
 import pytest
+import json
 from marshmallow.exceptions import ValidationError
 
 from azure.ai.ml import load_workspace
-from azure.ai.ml._restclient.v2024_10_01_preview.models import Workspace
+from azure.ai.ml._restclient.v2024_10_01_preview.models import (
+    EncryptionProperty,
+    ManagedServiceIdentity,
+    ManagedNetworkSettings,
+    KeyVaultProperties,
+    FeatureStoreSettings,
+    NetworkAcls,
+    ServerlessComputeSettings as RestServerlessComputeSettings,
+    Sku,
+    Workspace as RestWorkspace,
+)
 from azure.ai.ml.constants._workspace import FirewallSku, IsolationMode
 from azure.ai.ml.entities import ServerlessComputeSettings, Workspace
 
@@ -37,6 +48,93 @@ class TestWorkspaceEntity:
             assert rest_object.serverless_compute_settings is None
         else:
             assert ServerlessComputeSettings._from_rest_object(rest_object.serverless_compute_settings) == settings
+
+    def test_from_rest_object(self) -> None:
+        with open("./tests/test_configs/workspace/workspace_full_rest_response.json", "r") as f:
+            rest_object = RestWorkspace.deserialize(json.load(f))
+
+        workspace = Workspace._from_rest_object(rest_object)
+
+        assert workspace.id == "/subscriptions/sub-id/test_workspace/providers/Microsoft.Storage/storageAccounts/storage-account-name"
+        assert workspace.name == "test_workspace"
+        assert workspace.location == "test_location"
+        assert workspace.description == "test_description"
+        assert workspace.tags == {"test_tag": "test_value"}
+        assert workspace.display_name == "test_friendly_name"
+        assert workspace.discovery_url == "test_discovery_url"
+        assert workspace.resource_group == "providers"
+        assert workspace.storage_account == "test_storage_account"
+        assert workspace.key_vault == "test_key_vault"
+        assert workspace.application_insights == "test_application_insights"
+        assert workspace.container_registry == "test_container_registry"
+        assert workspace.customer_managed_key.key_uri == "key_identifier"
+        assert workspace.customer_managed_key.key_vault == "key_vault_arm_id"
+        assert workspace.hbi_workspace is True
+        assert workspace.public_network_access == "Enabled"
+        assert workspace.image_build_compute == "test_image_build_compute"
+        assert workspace.discovery_url == "test_discovery_url"
+        assert workspace.mlflow_tracking_uri == "ml_flow_tracking_uri"
+        assert workspace.primary_user_assigned_identity == "test_primary_user_assigned_identity"
+        assert workspace.system_datastores_auth_mode == "AccessKey"
+        assert workspace.enable_data_isolation == True
+        assert workspace.allow_roleassignment_on_rg == True
+        assert workspace._hub_id == "hub_resource_id"
+        assert workspace._kind == "project"
+        assert workspace._workspace_id == "workspace_id"
+        assert workspace.identity is not None
+        assert workspace.managed_network is not None
+        assert workspace._feature_store_settings is not None
+        assert workspace.network_acls is not None
+        assert workspace.provision_network_now == True
+        assert workspace.serverless_compute is not None
+        assert workspace.network_acls is not None
+
+
+    def test_from_rest_object_for_attributes_none(self) -> None:
+        with open("./tests/test_configs/workspace/workspace_full_rest_response.json", "r") as f:
+            rest_json = json.load(f)
+            del rest_json["properties"]["managedNetwork"]
+            del rest_json["properties"]["encryption"]
+            rest_json["id"] = "/subscriptions/sub-id"
+            del rest_json["identity"]
+            del rest_json["properties"]["featureStoreSettings"]
+            del rest_json["properties"]["serverlessComputeSettings"]
+            del rest_json["properties"]["networkAcls"]
+            rest_object = RestWorkspace.deserialize(rest_json)
+
+        workspace = Workspace._from_rest_object(rest_object)
+
+        assert workspace.id == "/subscriptions/sub-id"
+        assert workspace.name == "test_workspace"
+        assert workspace.location == "test_location"
+        assert workspace.description == "test_description"
+        assert workspace.tags == {"test_tag": "test_value"}
+        assert workspace.display_name == "test_friendly_name"
+        assert workspace.discovery_url == "test_discovery_url"
+        assert workspace.resource_group is None
+        assert workspace.storage_account == "test_storage_account"
+        assert workspace.key_vault == "test_key_vault"
+        assert workspace.application_insights == "test_application_insights"
+        assert workspace.container_registry == "test_container_registry"
+        assert workspace.customer_managed_key is None
+        assert workspace.hbi_workspace is True
+        assert workspace.public_network_access == "Enabled"
+        assert workspace.image_build_compute == "test_image_build_compute"
+        assert workspace.discovery_url == "test_discovery_url"
+        assert workspace.mlflow_tracking_uri == "ml_flow_tracking_uri"
+        assert workspace.primary_user_assigned_identity == "test_primary_user_assigned_identity"
+        assert workspace.system_datastores_auth_mode == "AccessKey"
+        assert workspace.enable_data_isolation == True
+        assert workspace.allow_roleassignment_on_rg == True
+        assert workspace._hub_id == "hub_resource_id"
+        assert workspace._kind == "project"
+        assert workspace._workspace_id == "workspace_id"
+        assert workspace.identity is None
+        assert workspace.managed_network is None
+        assert workspace._feature_store_settings is None
+        assert workspace.network_acls is None
+        assert workspace.provision_network_now == True
+        assert workspace.serverless_compute is None
 
     def test_serverless_compute_settings_subnet_name_must_be_an_arm_id(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
# Description

Added unit tests for workspace rest to entity conversion.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
