### PR TITLE
[SDK generation pipeline] fix for changelog generation

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -67,7 +67,10 @@ def change_log_generate(
     # try new changelog tool
     if prefolder and not is_multiapi:
         try:
-            return change_log_new(str(Path(prefolder) / package_name), not (last_stable_release and tag_is_stable))
+            return (
+                change_log_new(str(Path(prefolder) / package_name), not (last_stable_release and tag_is_stable)),
+                last_version,
+            )
         except Exception as e:
             _LOGGER.warning(f"Failed to generate changelog with breaking_change_detector: {e}")
 


### PR DESCRIPTION
fix for https://github.com/Azure/azure-sdk-for-python/pull/39309 which forgets to return `last_version` when new tool succeeds.