### PR TITLE
[Storage] update perf tests core baseline

### DIFF
--- a/sdk/storage/azure-storage-blob/perf-tests.yml
+++ b/sdk/storage/azure-storage-blob/perf-tests.yml
@@ -5,7 +5,7 @@ Project: sdk/storage/azure-storage-blob
 PrimaryPackage: azure-storage-blob
 
 PackageVersions:
-- azure-core: 1.29.5
+- azure-core: 1.31.0
   azure-storage-blob: 12.18.3
 - azure-core: source
   azure-storage-blob: source

--- a/sdk/storage/azure-storage-file-datalake/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-datalake/perf-tests.yml
@@ -6,7 +6,7 @@ PrimaryPackage: azure-storage-file-datalake
 
 PackageVersions:
 - azure-core: 1.31.0
-  azure-storage-file-datalake: 12.13.2
+  azure-storage-file-datalake: 12.18.0
 - azure-core: source
   azure-storage-file-datalake: source
 

--- a/sdk/storage/azure-storage-file-datalake/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-datalake/perf-tests.yml
@@ -5,7 +5,7 @@ Project: sdk/storage/azure-storage-file-datalake
 PrimaryPackage: azure-storage-file-datalake
 
 PackageVersions:
-- azure-core: 1.29.5
+- azure-core: 1.31.0
   azure-storage-file-datalake: 12.13.2
 - azure-core: source
   azure-storage-file-datalake: source

--- a/sdk/storage/azure-storage-file-share/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-share/perf-tests.yml
@@ -6,7 +6,7 @@ PrimaryPackage: azure-storage-file-share
 
 PackageVersions:
 - azure-core: 1.31.0
-  azure-storage-file-share: 12.14.2
+  azure-storage-file-share: 12.20.0
 - azure-core: source
   azure-storage-file-share: source
 

--- a/sdk/storage/azure-storage-file-share/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-share/perf-tests.yml
@@ -5,7 +5,7 @@ Project: sdk/storage/azure-storage-file-share
 PrimaryPackage: azure-storage-file-share
 
 PackageVersions:
-- azure-core: 1.29.5
+- azure-core: 1.31.0
   azure-storage-file-share: 12.14.2
 - azure-core: source
   azure-storage-file-share: source


### PR DESCRIPTION
Updating azure-core baseline dependency in perf tests to avoid dependency conflict with identity and mgmt-core.