### PR TITLE
Update _patch.py

### DIFF
--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
@@ -338,7 +338,7 @@ class BaseStreamingChatCompletions:
 
         # Convert `bytes` to string and split the string by newline, while keeping the new line char.
         # the last may be a partial "line" that does not contain a newline char at the end.
-        line_list: List[str] = re.split(r"(?<=\n)", element.decode("utf-8"))
+        line_list: List[str] = re.split(r"(?<=\n)", element.decode("utf-8", errors="replace"))  # or errors="ignore"
         for index, line in enumerate(line_list):
 
             if self._ENABLE_CLASS_LOGS:


### PR DESCRIPTION
The current implementation of the line splitting logic in the code does not handle non-ASCII characters properly. Specifically, the following line: line_list: List[str] = re.split(r"(?<=\n)", element.decode("utf-8")) This line attempts to decode the element byte string using UTF-8 encoding. If the element contains non-ASCII characters that cannot be decoded, it will raise a UnicodeDecodeError.

To address this issue, we should add an error handling mechanism to the decode method. There are several options available:

errors="replace": Replace undecodable characters with a replacement character (usually �). errors="ignore": Ignore undecodable characters.
errors="backslashreplace": Replace undecodable characters with \x escape sequences. errors="surrogateescape": Save undecodable characters as surrogate characters for later recovery. For this pull request, I propose using errors="replace" or errors="ignore".