### PR TITLE
[monitor] fix: Loosen psutil version requirement

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -88,7 +88,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api~=1.26",
         "opentelemetry-sdk~=1.26",
-        "psutil~=5.9",
+        "psutil>=5.9,<7",
     ],
     entry_points={
         "opentelemetry_traces_exporter": [


### PR DESCRIPTION


# Description

This pull request fixes an issue where an overly restrictive version requirement on `psutils~=5.9` causes newer versions of `azure-monitor-opentelemetry-exporter` and `azure-monitor-opentelemetry` to be uninstallable in certain scenarios.

# Background

`psutil~=5.9` (which is equivalent to `psutil>=5.9,==5.*`) restricts `azure-monitor opentelemetry-exporter` to ONLY be compatible with the `5.9.X` patch versions of `psutil`.

By transitivity, the same restriction applies to `azure-monitor-opentelemetry`. In the event you need to install both `azure-monitor-opentelemetry` and `psutil>=6`, the version resolution is forced to backtrack `azure-monitor-opentelemetry` all the way back to 1.4.2 which predates an apparent fix for the deprecation of `pkg_resources`.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
