### PR TITLE
Downgrade checker version for next-pylint tests

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -116,7 +116,7 @@ deps =
   PyGitHub>=1.59.0
 commands =
     python -m pip install pylint=={[testenv:next-pylint]pylint_version}
-    python -m pip install azure-pylint-guidelines-checker==0.5.0 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+    python -m pip install azure-pylint-guidelines-checker==0.4.1 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \
       -p {tox_root} \


### PR DESCRIPTION
# Description

The newer version(`0.5.01`) of `azure-pylint-guidelines-checker` caused the following error. Downgrading back to `0.4.1` to fix the issue. 

```
Exception on node <Call l.122 at 0x10683eae0> in file '/Users/kyunghwankim/Documents/GitHub/azure-sdk-for-python/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py'Traceback (most recent call last):  File "/Users/kyunghwankim/Documents/GitHub/azure-sdk-for-python/sdk/cosmos/azure-cosmos/.tox/next-pylint/lib/python3.12/site-packages/pylint/utils/ast_walker.py", line 91, in walk    callback(astroid)  File "/Users/kyunghwankim/Documents/GitHub/azure-sdk-for-python/sdk/cosmos/azure-cosmos/.tox/next-pylint/lib/python3.12/site-packages/pylint_guidelines_checker.py", line 3031, in visit_call    if type(keyword.value.value) == bool:            ^^^^^^^^^^^^^^^^^^^AttributeError: 'Call' object has no attribute 'value' 
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
