### PR TITLE
[SDK generation pipeline] fix for changelog generation for first release

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -62,7 +62,7 @@ def change_log_generate(
         else:
             last_version[-1] = str(last_release)
     except:
-        return "### Other Changes\n\n  - Initial version"
+        return ("### Other Changes\n\n  - Initial version", last_version)
 
     # try new changelog tool
     if prefolder and not is_multiapi:


### PR DESCRIPTION
fix for https://github.com/Azure/azure-sdk-for-python/pull/39309 which forgets to return last_version for first release.