### PR TITLE
Fixed a typo in the CHANGELOG.md

### DIFF
--- a/sdk/ai/azure-ai-inference/CHANGELOG.md
+++ b/sdk/ai/azure-ai-inference/CHANGELOG.md
@@ -14,7 +14,7 @@ as "structured output". See new samples `sample_chat_completions_with_structured
 
 ### Breaking Changes
 
-* If you previously configured your `ChatCompletionClient.complete()` call to output JSON format without a scheme, you have this in your code: `response_format=ChatCompletionsResponseFormatJSON()`. To maintain the same functionality, replace this with `response_format="json-object"`. We however recommend that you now switch to output JSON format with a provided schema if your AI model supports it: `response_format=JsonSchemaFormat(...)`.
+* If you previously configured your `ChatCompletionClient.complete()` call to output JSON format without a scheme, you have this in your code: `response_format=ChatCompletionsResponseFormatJSON()`. To maintain the same functionality, replace this with `response_format="json_object"`. We however recommend that you now switch to output JSON format with a provided schema if your AI model supports it: `response_format=JsonSchemaFormat(...)`.
 
 ### Bugs Fixed
 


### PR DESCRIPTION
# Description
The document mentions `json-object`, however the code shows that `json_object` is the  correct value for the discriminator

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
