### PR TITLE
More parallelism in jobs

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -259,6 +259,7 @@ jobs:
           - "**/*matrix*.json"
         EnablePRGeneration: true
         PRMatrixSetting: "TargetingString"
+        PRJobBatchSize: 5
         PreGenerationSteps:
           - task: UsePythonVersion@0
             inputs:


### PR DESCRIPTION
Batching by 5 packages instead of 10. In worst case we do _way_ better on agent usage than the old world of multiple CI builds.