### PR TITLE
[Storage] [Typing] [File Datalake] `_shared_access_signature.py`

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -6,7 +6,7 @@
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
 from typing import (
-    Any, Callable, Optional, Union,
+    Any, Callable, cast, Optional, Union,
     TYPE_CHECKING
 )
 from urllib.parse import parse_qs
@@ -18,6 +18,8 @@ from ._shared.shared_access_signature import QueryStringConstants
 
 
 if TYPE_CHECKING:
+    from azure.storage.blob import BlobSasPermissions, ContainerSasPermissions
+    from azure.storage.blob._shared.models import Services as BlobServices
     from datetime import datetime
     from ._models import (
         AccountSasPermissions,
@@ -93,7 +95,7 @@ def generate_account_sas(
         resource_types=resource_types,
         permission=permission,
         expiry=expiry,
-        services=services,  # type: ignore [arg-type]
+        services=cast(Union["BlobServices", str], services),
         sts_hook=sts_hook,
         **kwargs
     )
@@ -203,7 +205,7 @@ def generate_file_system_sas(
         container_name=file_system_name,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,  # type: ignore [arg-type]
+        permission=cast(Optional[Union["ContainerSasPermissions", str]], permission),
         expiry=expiry,
         sts_hook=sts_hook,
         **kwargs
@@ -319,7 +321,7 @@ def generate_directory_sas(
         blob_name=directory_name,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,  # type: ignore [arg-type]
+        permission=cast(Optional[Union["BlobSasPermissions", str]], permission),
         expiry=expiry,
         sdd=depth,
         is_directory=True,
@@ -443,7 +445,7 @@ def generate_file_sas(
         blob_name=path,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,  # type: ignore [arg-type]
+        permission=cast(Optional[Union["BlobSasPermissions", str]], permission),
         expiry=expiry,
         sts_hook=sts_hook,
         **kwargs

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -12,7 +12,7 @@ from typing import (
 from urllib.parse import parse_qs
 
 from azure.storage.blob import generate_account_sas as generate_blob_account_sas
-from azure.storage.blob import generate_container_sas, generate_blob_sas
+from azure.storage.blob import generate_blob_sas, generate_container_sas
 from ._shared.models import Services
 from ._shared.shared_access_signature import QueryStringConstants
 
@@ -75,6 +75,7 @@ def generate_account_sas(
     :keyword Union[Services, str] services:
         Specifies the services that the Shared Access Signature (sas) token will be able to be utilized with.
         Will default to only this package (i.e. blobs) if not provided.
+    :paramtype services: Services or str
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
     :keyword str encryption_scope:
@@ -82,7 +83,7 @@ def generate_account_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], None]]
+    :paramtype sts_hook: Callable[[str], None] or None
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -92,23 +93,22 @@ def generate_account_sas(
         resource_types=resource_types,
         permission=permission,
         expiry=expiry,
-        services=services,
+        services=services,  # type: ignore [arg-type]
         sts_hook=sts_hook,
         **kwargs
     )
 
 
 def generate_file_system_sas(
-    account_name,  # type: str
-    file_system_name,  # type: str
-    credential,  # type: Union[str, UserDelegationKey]
-    permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
-    expiry=None,  # type: Optional[Union[datetime, str]]
+    account_name: str,
+    file_system_name: str,
+    credential: Union[str, "UserDelegationKey"],
+    permission: Optional[Union["FileSystemSasPermissions", str]] = None,
+    expiry: Optional[Union["datetime", str]] = None,
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], None]]
-    **kwargs  # type: Any
-):
-    # type: (...) -> str
+    sts_hook: Optional[Callable[[str], None]] = None,
+    **kwargs: Any
+) -> str:
     """Generates a shared access signature for a file system.
 
     Use the returned signature with the credential parameter of any DataLakeServiceClient,
@@ -118,7 +118,7 @@ def generate_file_system_sas(
         The storage account name used to generate the shared access signature.
     :param str file_system_name:
         The name of the file system.
-    :param str credential:
+    :param credential:
         Credential could be either account key or user delegation key.
         If use account key is used as credential, then the credential type should be a str.
         Instead of an account key, the user could also pass in a user delegation key.
@@ -134,7 +134,7 @@ def generate_file_system_sas(
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.filedatalake.FileSystemSasPermissions
+    :type permission: str or ~azure.storage.filedatalake.FileSystemSasPermissions or None
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -142,7 +142,7 @@ def generate_file_system_sas(
         been specified in an associated stored access policy. Azure will always
         convert values to UTC. If a date is passed in without timezone info, it
         is assumed to be UTC.
-    :type expiry: datetime or str
+    :type expiry: datetime or str or None
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
@@ -194,7 +194,7 @@ def generate_file_system_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], None]]
+    :paramtype sts_hook: Callable[[str], None] or None
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -203,7 +203,7 @@ def generate_file_system_sas(
         container_name=file_system_name,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,
+        permission=permission,  # type: ignore [arg-type]
         expiry=expiry,
         sts_hook=sts_hook,
         **kwargs
@@ -211,17 +211,16 @@ def generate_file_system_sas(
 
 
 def generate_directory_sas(
-    account_name,  # type: str
-    file_system_name,  # type: str
-    directory_name,  # type: str
-    credential,  # type: Union[str, UserDelegationKey]
-    permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
-    expiry=None,  # type: Optional[Union[datetime, str]]
+    account_name: str,
+    file_system_name: str,
+    directory_name: str,
+    credential: Union[str, "UserDelegationKey"],
+    permission: Optional[Union["DirectorySasPermissions", str]] = None,
+    expiry: Optional[Union["datetime", str]] = None,
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], None]]
-    **kwargs  # type: Any
-):
-    # type: (...) -> str
+    sts_hook: Optional[Callable[[str], None]] = None,
+    **kwargs: Any
+) -> str:
     """Generates a shared access signature for a directory.
 
     Use the returned signature with the credential parameter of any DataLakeServiceClient,
@@ -249,7 +248,7 @@ def generate_directory_sas(
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.filedatalake.DirectorySasPermissions
+    :type permission: str or ~azure.storage.filedatalake.DirectorySasPermissions or None
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -257,7 +256,7 @@ def generate_directory_sas(
         been specified in an associated stored access policy. Azure will always
         convert values to UTC. If a date is passed in without timezone info, it
         is assumed to be UTC.
-    :type expiry: ~datetime.datetime or str
+    :type expiry: ~datetime.datetime or str or None
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
@@ -309,7 +308,7 @@ def generate_directory_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], None]]
+    :paramtype sts_hook: Callable[[str], None] or None
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -320,7 +319,7 @@ def generate_directory_sas(
         blob_name=directory_name,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,
+        permission=permission,  # type: ignore [arg-type]
         expiry=expiry,
         sdd=depth,
         is_directory=True,
@@ -330,18 +329,17 @@ def generate_directory_sas(
 
 
 def generate_file_sas(
-    account_name,  # type: str
-    file_system_name,  # type: str
-    directory_name,  # type: str
-    file_name,  # type: str
-    credential,  # type: Union[str, UserDelegationKey]
-    permission=None,  # type: Optional[Union[FileSasPermissions, str]]
-    expiry=None,  # type: Optional[Union[datetime, str]]
+    account_name: str,
+    file_system_name: str,
+    directory_name: str,
+    file_name: str,
+    credential: Union[str, "UserDelegationKey"],
+    permission: Optional[Union["FileSasPermissions", str]] = None,
+    expiry: Optional[Union["datetime", str]] = None,
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], None]]
-    **kwargs  # type: Any
-):
-    # type: (...) -> str
+    sts_hook: Optional[Callable[[str], None]] = None,
+    **kwargs: Any
+) -> str:
     """Generates a shared access signature for a file.
 
     Use the returned signature with the credential parameter of any BDataLakeServiceClient,
@@ -371,7 +369,7 @@ def generate_file_sas(
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.filedatalake.FileSasPermissions
+    :type permission: str or ~azure.storage.filedatalake.FileSasPermissions or None
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -379,7 +377,7 @@ def generate_file_sas(
         been specified in an associated stored access policy. Azure will always
         convert values to UTC. If a date is passed in without timezone info, it
         is assumed to be UTC.
-    :type expiry: ~datetime.datetime or str
+    :type expiry: ~datetime.datetime or str or None
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
@@ -431,7 +429,7 @@ def generate_file_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], None]]
+    :paramtype sts_hook: Callable[[str], None] or None
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -445,7 +443,7 @@ def generate_file_sas(
         blob_name=path,
         account_key=credential if isinstance(credential, str) else None,
         user_delegation_key=credential if not isinstance(credential, str) else None,
-        permission=permission,
+        permission=permission,  # type: ignore [arg-type]
         expiry=expiry,
         sts_hook=sts_hook,
         **kwargs


### PR DESCRIPTION
As usual, this typing PR includes:

- Reordering of imports
- Updated docstring type annotations to match current style
- Typed function parameters and return types
- Removed unnecessary # type: ignore statements

For `permission` and `services` parameters, `mypy` wants the blob version and not the datalake version. It does not seem to figure out how to implicitly cast to the blob version - this is because some variables present in blob's version of permission is not present in datalake, and vice-versa.

I have put a `# type: ignore [arg-type]` for now, and I'll look for other ways to perhaps modify models to make this work.

:shipit: