### PR TITLE
Fixed partition_key filter for change_feed

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed `partition_key` filter for `query_items_change_feed` API. See [PR 39426](https://github.com/Azure/azure-sdk-for-python/pull/39426)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_change_feed/change_feed_state.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_change_feed/change_feed_state.py
@@ -260,6 +260,7 @@ class ChangeFeedStateV2(ChangeFeedState):
             # the current token feed range spans less than single physical partition
             # for this case, need to set both the partition key range id and epk filter headers
             request_headers[http_constants.HttpHeaders.PartitionKeyRangeID] = over_lapping_ranges[0]["id"]
+            request_headers[http_constants.HttpHeaders.ReadFeedKeyType] = "EffectivePartitionKeyRange"
             request_headers[http_constants.HttpHeaders.StartEpkString] = self._continuation.current_token.feed_range.min
             request_headers[http_constants.HttpHeaders.EndEpkString] = self._continuation.current_token.feed_range.max
 


### PR DESCRIPTION
# Description
For `query_items_change_feed` API, there was a bug with `partition_key` filter. It was only returning the filtered results for `Physical partition` level, not all the way to `partition_key` level.

This fix will correctly filter the results at the `partition_key` level.
Also, all related tests and examples were added in this PR.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
