### PR TITLE
Move pullrequest.yml location to eng

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -1,0 +1,34 @@
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+    - restapi*
+    - pipelinev3*
+  paths:
+    include:
+    - "*"
+    # Note: The ExcludePaths template below needs to duplicate
+    # any excludes here. The reason being is that we can't access
+    # pr->paths->exclude
+    exclude:
+    - sdk/cosmos
+
+parameters:
+  - name: Service
+    type: string
+    default: auto
+
+extends:
+  template: ../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: ${{ parameters.Service }}
+    BuildTargetingString: "*"
+    TestProxy: true
+    TestTimeOutInMinutes: 180
+    # See pr->paths->exclude comment above. Anything added/removed there
+    # needs to be added/removed here.
+    ExcludePaths:
+      - sdk/cosmos


### PR DESCRIPTION
Proposing this as a change, some thoughts/discussion below. If we like it I can do the same for js.

From a conversation with @scbedd 

>> I'm only just now realizing that pullrequest.yml is in sdk/. I'm curious why it needed to be there vs. eng? @scbedd

> I was thinking that it makes sense to be there because it applies to all the services equally. Like a ci.yml applies to a specific service, so it exists in the service folder.

I would say that our CI pipeline definitions in eng apply to all services equally as well. I think `eng/pipelines/pullrequest.yml` is a more logical place. It's also hard to find the file since it gets sorted all the way down below every sdk directory.