### PR TITLE
Ensure that the `sbom` generation during our `analyze` doesn't time out

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -164,11 +164,11 @@ steps:
   # the pip authenticate task sets PIP_INDEX_URL value to the internal feed URL
   # we should reset it such that the next task uses public pypi
   - pwsh: |
-        if (Test-Path "~/.pypirc") {
-          Remove-Item "~/.pypirc"
-        }
+      if (Test-Path "~/.pypirc") {
+        Remove-Item "~/.pypirc"
+      }
 
-        Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL;]"
+      Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL;]"
     displayName: Reset PIP INDEX URL
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -161,6 +161,16 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
+  # the pip authenticate task sets PIP_INDEX_URL value to the internal feed URL
+  # we should reset it such that the next task uses public pypi
+  - pwsh: |
+        if (Test-Path "~/.pypirc") {
+          Remove-Item "~/.pypirc"
+        }
+
+        Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL;]"
+    displayName: Reset PIP INDEX URL
+
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)/reports'


### PR DESCRIPTION
[Example long run failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4513282&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=dffc7ffa-72af-5cf4-68af-7a52ba211152)

CC @benbp 