### PR TITLE
Address 1ES warning on release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -38,11 +38,6 @@ stages:
                 inputs:
                   versionSpec: '3.12'
 
-              - script: |
-                  set -e
-                  python -m pip install -r eng/release_requirements.txt
-                displayName: Install Release Dependencies
-
               - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
               - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -99,6 +94,9 @@ stages:
                 isProduction: true
                 inputs:
                 - input: pipelineArtifact
+                  artifactName: release_artifacts
+                  targetPath: $(Pipeline.Workspace)/release_artifacts
+                - input: pipelineArtifact
                   artifactName: packages_extended
                   targetPath: $(Pipeline.Workspace)/packages_extended
 
@@ -111,28 +109,14 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      # - checkout: self
-
-# todo: re-enable by publishing the necessary scripts as a build artifact that can be downloaded
-                      # - download: current
-                      #   artifact:
-                      #   timeoutInMinutes: 5
 
                       - task: UsePythonVersion@0
                         inputs:
                           versionSpec: '3.9'
 
-                      # - script: |
-                      #     set -e
-                      #     python -m pip install -r eng/release_requirements.txt
-                      #   displayName: Install Release Dependencies
-
-                      # - task: PythonScript@0
-                      #   displayName: Verify Dependency Presence
-                      #   condition: and(succeeded(), ne(variables['Skip.VerifyDependencies'], 'true'))
-                      #   inputs:
-                      #     scriptPath: 'scripts/devops_tasks/verify_dependencies_present.py'
-                      #     arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+                      - script: |
+                          python -m pip install -r $(Pipeline.Workspace)/release_artifacts/release_requirements.txt
+                        displayName: Install Release Dependencies
 
                       - task: TwineAuthenticate@0
                         displayName: 'Authenticate to feed: ${{parameters.DevFeedName}}'

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -94,8 +94,8 @@ stages:
                 isProduction: true
                 inputs:
                 - input: pipelineArtifact
-                  artifactName: release_artifacts
-                  targetPath: $(Pipeline.Workspace)/release_artifacts
+                  artifactName: release_artifact
+                  targetPath: $(Pipeline.Workspace)/release_artifact
                 - input: pipelineArtifact
                   artifactName: packages_extended
                   targetPath: $(Pipeline.Workspace)/packages_extended
@@ -115,7 +115,7 @@ stages:
                           versionSpec: '3.9'
 
                       - script: |
-                          python -m pip install -r $(Pipeline.Workspace)/release_artifacts/release_requirements.txt
+                          python -m pip install -r $(Pipeline.Workspace)/release_artifact/release_requirements.txt
                         displayName: Install Release Dependencies
 
                       - task: TwineAuthenticate@0

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -18,81 +18,80 @@ stages:
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-python-pr'))
         jobs:
-          # - deployment: TagRepository
-          #   displayName: "Create release tag"
-          #   condition: ne(variables['Skip.TagRepository'], 'true')
-          #   environment: github
+          - job: TagRepository
+            displayName: "Create release tag"
+            condition: ne(variables['Skip.TagRepository'], 'true')
 
-          #   pool:
-          #     image: azsdk-pool-mms-ubuntu-2004-1espt
-          #     name: azsdk-pool-mms-ubuntu-2004-general
-          #     os: linux
+            pool:
+              image: azsdk-pool-mms-ubuntu-2004-1espt
+              name: azsdk-pool-mms-ubuntu-2004-general
+              os: linux
 
-          #   strategy:
-          #     runOnce:
-          #       deploy:
-          #         steps:
-          #           - checkout: self
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: self
 
-          #           - task: UsePythonVersion@0
-          #             inputs:
-          #               versionSpec: '3.12'
+                    - task: UsePythonVersion@0
+                      inputs:
+                        versionSpec: '3.12'
 
-          #           - script: |
-          #               set -e
-          #               python -m pip install -r eng/release_requirements.txt
-          #             displayName: Install Release Dependencies
+                    - script: |
+                        set -e
+                        python -m pip install -r eng/release_requirements.txt
+                      displayName: Install Release Dependencies
 
-          #           - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
-          #           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
-          #             parameters:
-          #               PackageName: "azure-template"
-          #               ServiceDirectory: "template"
-          #               TestPipeline: ${{ parameters.TestPipeline }}
+                    - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+                      parameters:
+                        PackageName: "azure-template"
+                        ServiceDirectory: "template"
+                        TestPipeline: ${{ parameters.TestPipeline }}
 
-          #           - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-          #             parameters:
-          #               PackageName: ${{artifact.name}}
-          #               ServiceName: ${{parameters.ServiceDirectory}}
-          #               ForRelease: true
+                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceName: ${{parameters.ServiceDirectory}}
+                        ForRelease: true
 
-          #           - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
-          #             parameters:
-          #               PackageName: ${{artifact.name}}
-          #               ServiceDirectory: ${{parameters.ServiceDirectory}}
-          #               ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceDirectory: ${{parameters.ServiceDirectory}}
+                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
 
-          #           - script: |
-          #               python -m pip install "./tools/azure-sdk-tools"
-          #             displayName: Install tool dependencies
+                    - script: |
+                        python -m pip install "./tools/azure-sdk-tools"
+                      displayName: Install tool dependencies
 
-          #           - task: PythonScript@0
-          #             displayName: Verify CI enabled
-          #             condition: succeeded()
-          #             inputs:
-          #               scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
-          #               arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+                    - task: PythonScript@0
+                      displayName: Verify CI enabled
+                      condition: succeeded()
+                      inputs:
+                        scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
+                        arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
 
-          #           - pwsh: |
-          #               Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-          #             workingDirectory: $(Pipeline.Workspace)
-          #             displayName: Output Visible Artifacts
+                    - pwsh: |
+                        Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+                      workingDirectory: $(Pipeline.Workspace)
+                      displayName: Output Visible Artifacts
 
-          #           - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-          #             parameters:
-          #               ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-          #               PackageRepository: PyPI
-          #               ReleaseSha: $(Build.SourceVersion)
-          #               RepoId: Azure/azure-sdk-for-python
-          #               WorkingDirectory: $(System.DefaultWorkingDirectory)
+                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+                        PackageRepository: PyPI
+                        ReleaseSha: $(Build.SourceVersion)
+                        RepoId: Azure/azure-sdk-for-python
+                        WorkingDirectory: $(System.DefaultWorkingDirectory)
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
               displayName: "Publish to PyPI"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
               environment: pypi
-              # dependsOn: TagRepository
+              dependsOn: TagRepository
 
               templateContext:
                 type: releaseJob

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -63,6 +63,13 @@ stages:
                 displayName: Install tool dependencies
 
               - task: PythonScript@0
+                displayName: Verify Dependency Presence
+                condition: and(succeeded(), ne(variables['Skip.VerifyDependencies'], 'true'))
+                inputs:
+                  scriptPath: 'scripts/devops_tasks/verify_dependencies_present.py'
+                  arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+
+              - task: PythonScript@0
                 displayName: Verify CI enabled
                 condition: succeeded()
                 inputs:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -166,136 +166,154 @@ stages:
                           echo "Uploaded sdist to devops feed"
                         displayName: 'Publish package to feed: ${{parameters.DevFeedName}}'
 
-                      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
-                        parameters:
-                          ArtifactPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
-                          Artifacts: ${{parameters.Artifacts}}
-                          ConfigFileDir: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo
-                          MarkPackageAsShipped: true
-                          ArtifactName: ${{parameters.ArtifactName}}
-                          PackageName: ${{artifact.name}}
+          - job: CreateApiView
+            displayName: "Create APIView"
+            dependsOn: PublishPackage
 
-          # - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
-          #   - deployment: PublishGitHubIODocs
-          #     displayName: Publish Docs to GitHubIO Blob Storage
-          #     condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-          #     environment: githubio
-          #     dependsOn: PublishPackage
+            pool:
+              image: azsdk-pool-mms-ubuntu-2004-1espt
+              name: azsdk-pool-mms-ubuntu-2004-general
+              os: linux
 
-          #     pool:
-          #       name: azsdk-pool-mms-win-2022-general
-          #       image: azsdk-pool-mms-win-2022-1espt
-          #       os: windows
+            steps:
+              - checkout: self
 
-          #     strategy:
-          #       runOnce:
-          #         deploy:
-          #           steps:
-          #             - checkout: self
+              - download: current
+                artifact: ${{parameters.ArtifactName}}
+                timeoutInMinutes: 5
 
-          #             - pwsh: |
-          #                 if (Test-Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}") {
-          #                   Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
-          #                 }
-          #                 else {
-          #                   New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
-          #                 }
-          #               workingDirectory: $(Pipeline.Workspace)
-          #               displayName: Output Visible Artifacts
+              - task: UsePythonVersion@0
+                inputs:
+                  versionSpec: '3.9'
 
-          #             - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
-          #               parameters:
-          #                 FolderForUpload: '$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}'
-          #                 TargetLanguage: 'python'
-          #                 ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
+              - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+                parameters:
+                  ArtifactPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+                  Artifacts: ${{parameters.Artifacts}}
+                  ConfigFileDir: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo
+                  MarkPackageAsShipped: true
+                  ArtifactName: ${{parameters.ArtifactName}}
+                  PackageName: ${{artifact.name}}
 
-          # - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
-          #       - deployment: PublishDocs
-          #         displayName: Docs.MS Release
-          #         condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-          #         environment: githubio
-          #         dependsOn: PublishPackage
+          - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
+            - job: PublishGitHubIODocs
+              displayName: Publish Docs to GitHubIO Blob Storage
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              dependsOn: PublishPackage
 
-          #         pool:
-          #           image: azsdk-pool-mms-ubuntu-2004-1espt
-          #           name: azsdk-pool-mms-ubuntu-2004-general
-          #           os: linux
+              pool:
+                name: azsdk-pool-mms-win-2022-general
+                image: azsdk-pool-mms-win-2022-1espt
+                os: windows
 
-          #         strategy:
-          #           runOnce:
-          #             deploy:
-          #               steps:
-          #                 - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          #                   parameters:
-          #                     Paths:
-          #                       - sdk/**/*.md
-          #                       - .github/CODEOWNERS
-          #                 - download: current
+              steps:
+                - checkout: self
 
-          #                 # py2docfx requires Python >= 3.11
-          #                 - task: UsePythonVersion@0
-          #                   displayName: 'Use Python 3.11'
-          #                   inputs:
-          #                     versionSpec: '3.11'
+                - download: current
+                  artifact: ${{parameters.ArtifactName}}
+                  timeoutInMinutes: 5
 
-          #                 - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
+                - download: current
+                  artifact: ${{parameters.DocArtifact}}
+                  timeoutInMinutes: 5
 
-          #                 - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
-          #                   parameters:
-          #                     PackageInfoLocations:
-          #                       - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
-          #                     WorkingDirectory: $(System.DefaultWorkingDirectory)
-          #                     TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-          #                     TargetDocRepoName: ${{parameters.TargetDocRepoName}}
-          #                     Language: 'python'
-          #                     SparseCheckoutPaths:
-          #                       - docs-ref-services/
-          #                       - metadata/
-          #                     PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+                - pwsh: |
+                    if (Test-Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}") {
+                      Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+                    }
+                    else {
+                      New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+                    }
+                  workingDirectory: $(Pipeline.Workspace)
+                  displayName: Output Visible Artifacts
 
-          # - deployment: UpdatePackageVersion
-          #   displayName: "Update Package Version"
-          #   condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-          #   environment: github
-          #   dependsOn: PublishPackage
+                - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
+                  parameters:
+                    FolderForUpload: '$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}'
+                    TargetLanguage: 'python'
+                    ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
 
-          #   pool:
-          #     image: azsdk-pool-mms-ubuntu-2004-1espt
-          #     name: azsdk-pool-mms-ubuntu-2004-general
-          #     os: linux
+          - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
+                - job: PublishDocs
+                  displayName: Docs.MS Release
+                  condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+                  dependsOn: PublishPackage
 
-          #   strategy:
-          #     runOnce:
-          #       deploy:
-          #         steps:
-          #           - checkout: self
-          #           - task: UsePythonVersion@0
-          #           - script: |
-          #               python -m pip install "./tools/azure-sdk-tools[build]"
-          #             displayName: Install versioning tool dependencies
+                  pool:
+                    image: azsdk-pool-mms-ubuntu-2004-1espt
+                    name: azsdk-pool-mms-ubuntu-2004-general
+                    os: linux
 
-          #           - pwsh: |
-          #               sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
-          #               if (Test-Path component-detection-pip-report.json) {
-          #                 Write-Host "Deleting component-detection-pip-report.json"
-          #                 rm component-detection-pip-report.json
-          #               }
-          #             displayName: Increment package version
+                  steps:
+                    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                      parameters:
+                        Paths:
+                          - sdk/**/*.md
+                          - .github/CODEOWNERS
 
-          #           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-          #             parameters:
-          #               RepoName: azure-sdk-for-python
-          #               PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
-          #               CommitMsg: "Increment package version after release of ${{ artifact.name }}"
-          #               PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-          #               CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+                    - download: current
 
-          # - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-          #   - template: /eng/pipelines/templates/jobs/smoke.tests.yml
-          #     parameters:
-          #       Daily: false
-          #       ArtifactName: ${{ parameters.ArtifactName }}
-          #       Artifact: ${{ artifact }}
+                    # py2docfx requires Python >= 3.11
+                    - task: UsePythonVersion@0
+                      displayName: 'Use Python 3.11'
+                      inputs:
+                        versionSpec: '3.11'
+
+                    - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
+
+                    - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+                      parameters:
+                        PackageInfoLocations:
+                          - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+                        WorkingDirectory: $(System.DefaultWorkingDirectory)
+                        TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+                        TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+                        Language: 'python'
+                        SparseCheckoutPaths:
+                          - docs-ref-services/
+                          - metadata/
+                        PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+
+          - deployment: UpdatePackageVersion
+            displayName: "Update Package Version"
+            condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+            environment: github
+            dependsOn: PublishPackage
+
+            pool:
+              image: azsdk-pool-mms-ubuntu-2004-1espt
+              name: azsdk-pool-mms-ubuntu-2004-general
+              os: linux
+
+            steps:
+              - checkout: self
+              - task: UsePythonVersion@0
+              - script: |
+                  python -m pip install "./tools/azure-sdk-tools[build]"
+                displayName: Install versioning tool dependencies
+
+              - pwsh: |
+                  sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
+                  if (Test-Path component-detection-pip-report.json) {
+                    Write-Host "Deleting component-detection-pip-report.json"
+                    rm component-detection-pip-report.json
+                  }
+                displayName: Increment package version
+
+              - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                parameters:
+                  RepoName: azure-sdk-for-python
+                  PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                  CommitMsg: "Increment package version after release of ${{ artifact.name }}"
+                  PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                  CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+
+          - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+            - template: /eng/pipelines/templates/jobs/smoke.tests.yml
+              parameters:
+                Daily: false
+                ArtifactName: ${{ parameters.ArtifactName }}
+                Artifact: ${{ artifact }}
 
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - stage: Integration

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -27,64 +27,61 @@ stages:
               name: azsdk-pool-mms-ubuntu-2004-general
               os: linux
 
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
+            steps:
+              - checkout: self
 
-                    - task: UsePythonVersion@0
-                      inputs:
-                        versionSpec: '3.12'
+              - task: UsePythonVersion@0
+                inputs:
+                  versionSpec: '3.12'
 
-                    - script: |
-                        set -e
-                        python -m pip install -r eng/release_requirements.txt
-                      displayName: Install Release Dependencies
+              - script: |
+                  set -e
+                  python -m pip install -r eng/release_requirements.txt
+                displayName: Install Release Dependencies
 
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
+              - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
-                    - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
-                      parameters:
-                        PackageName: "azure-template"
-                        ServiceDirectory: "template"
-                        TestPipeline: ${{ parameters.TestPipeline }}
+              - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+                parameters:
+                  PackageName: "azure-template"
+                  ServiceDirectory: "template"
+                  TestPipeline: ${{ parameters.TestPipeline }}
 
-                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceName: ${{parameters.ServiceDirectory}}
-                        ForRelease: true
+              - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                parameters:
+                  PackageName: ${{artifact.name}}
+                  ServiceName: ${{parameters.ServiceDirectory}}
+                  ForRelease: true
 
-                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceDirectory: ${{parameters.ServiceDirectory}}
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+              - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+                parameters:
+                  PackageName: ${{artifact.name}}
+                  ServiceDirectory: ${{parameters.ServiceDirectory}}
+                  ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
 
-                    - script: |
-                        python -m pip install "./tools/azure-sdk-tools"
-                      displayName: Install tool dependencies
+              - script: |
+                  python -m pip install "./tools/azure-sdk-tools"
+                displayName: Install tool dependencies
 
-                    - task: PythonScript@0
-                      displayName: Verify CI enabled
-                      condition: succeeded()
-                      inputs:
-                        scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
-                        arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+              - task: PythonScript@0
+                displayName: Verify CI enabled
+                condition: succeeded()
+                inputs:
+                  scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
+                  arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
 
-                    - pwsh: |
-                        Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                      workingDirectory: $(Pipeline.Workspace)
-                      displayName: Output Visible Artifacts
+              - pwsh: |
+                  Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+                workingDirectory: $(Pipeline.Workspace)
+                displayName: Output Visible Artifacts
 
-                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                      parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                        PackageRepository: PyPI
-                        ReleaseSha: $(Build.SourceVersion)
-                        RepoId: Azure/azure-sdk-for-python
-                        WorkingDirectory: $(System.DefaultWorkingDirectory)
+              - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                parameters:
+                  ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+                  PackageRepository: PyPI
+                  ReleaseSha: $(Build.SourceVersion)
+                  RepoId: Azure/azure-sdk-for-python
+                  WorkingDirectory: $(System.DefaultWorkingDirectory)
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -93,7 +93,7 @@ stages:
             - deployment: PublishPackage
               displayName: "Publish to PyPI"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-              environment: pypi
+              environment: package-publish
               dependsOn: TagRepository
 
               templateContext:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -94,6 +94,13 @@ stages:
               environment: pypi
               dependsOn: TagRepository
 
+              templateContext:
+                type: releaseJob
+                isProduction: true
+                inputs:
+                - input: pipelineArtifact
+                  artifactName: ${{parameters.ArtifactName}}
+
               pool:
                 image: azsdk-pool-mms-ubuntu-2004-1espt
                 name: azsdk-pool-mms-ubuntu-2004-general
@@ -105,25 +112,26 @@ stages:
                     steps:
                       - checkout: self
 
-                      - download: current
-                        artifact: ${{parameters.ArtifactName}}
-                        timeoutInMinutes: 5
+# todo: re-enable by publishing the necessary scripts as a build artifact that can be downloaded
+                      # - download: current
+                      #   artifact:
+                      #   timeoutInMinutes: 5
 
                       - task: UsePythonVersion@0
                         inputs:
                           versionSpec: '3.9'
 
-                      - script: |
-                          set -e
-                          python -m pip install -r eng/release_requirements.txt
-                        displayName: Install Release Dependencies
+                      # - script: |
+                      #     set -e
+                      #     python -m pip install -r eng/release_requirements.txt
+                      #   displayName: Install Release Dependencies
 
-                      - task: PythonScript@0
-                        displayName: Verify Dependency Presence
-                        condition: and(succeeded(), ne(variables['Skip.VerifyDependencies'], 'true'))
-                        inputs:
-                          scriptPath: 'scripts/devops_tasks/verify_dependencies_present.py'
-                          arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+                      # - task: PythonScript@0
+                      #   displayName: Verify Dependency Presence
+                      #   condition: and(succeeded(), ne(variables['Skip.VerifyDependencies'], 'true'))
+                      #   inputs:
+                      #     scriptPath: 'scripts/devops_tasks/verify_dependencies_present.py'
+                      #     arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
 
                       - task: TwineAuthenticate@0
                         displayName: 'Authenticate to feed: ${{parameters.DevFeedName}}'
@@ -175,127 +183,127 @@ stages:
                           ArtifactName: ${{parameters.ArtifactName}}
                           PackageName: ${{artifact.name}}
 
-          - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
-            - deployment: PublishGitHubIODocs
-              displayName: Publish Docs to GitHubIO Blob Storage
-              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-              environment: githubio
-              dependsOn: PublishPackage
+          # - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
+          #   - deployment: PublishGitHubIODocs
+          #     displayName: Publish Docs to GitHubIO Blob Storage
+          #     condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+          #     environment: githubio
+          #     dependsOn: PublishPackage
 
-              pool:
-                name: azsdk-pool-mms-win-2022-general
-                image: azsdk-pool-mms-win-2022-1espt
-                os: windows
+          #     pool:
+          #       name: azsdk-pool-mms-win-2022-general
+          #       image: azsdk-pool-mms-win-2022-1espt
+          #       os: windows
 
-              strategy:
-                runOnce:
-                  deploy:
-                    steps:
-                      - checkout: self
+          #     strategy:
+          #       runOnce:
+          #         deploy:
+          #           steps:
+          #             - checkout: self
 
-                      - pwsh: |
-                          if (Test-Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}") {
-                            Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
-                          }
-                          else {
-                            New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
-                          }
-                        workingDirectory: $(Pipeline.Workspace)
-                        displayName: Output Visible Artifacts
+          #             - pwsh: |
+          #                 if (Test-Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}") {
+          #                   Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+          #                 }
+          #                 else {
+          #                   New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+          #                 }
+          #               workingDirectory: $(Pipeline.Workspace)
+          #               displayName: Output Visible Artifacts
 
-                      - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
-                        parameters:
-                          FolderForUpload: '$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}'
-                          TargetLanguage: 'python'
-                          ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
+          #             - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
+          #               parameters:
+          #                 FolderForUpload: '$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}'
+          #                 TargetLanguage: 'python'
+          #                 ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
 
-          - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
-                - deployment: PublishDocs
-                  displayName: Docs.MS Release
-                  condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                  environment: githubio
-                  dependsOn: PublishPackage
+          # - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
+          #       - deployment: PublishDocs
+          #         displayName: Docs.MS Release
+          #         condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+          #         environment: githubio
+          #         dependsOn: PublishPackage
 
-                  pool:
-                    image: azsdk-pool-mms-ubuntu-2004-1espt
-                    name: azsdk-pool-mms-ubuntu-2004-general
-                    os: linux
+          #         pool:
+          #           image: azsdk-pool-mms-ubuntu-2004-1espt
+          #           name: azsdk-pool-mms-ubuntu-2004-general
+          #           os: linux
 
-                  strategy:
-                    runOnce:
-                      deploy:
-                        steps:
-                          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-                            parameters:
-                              Paths:
-                                - sdk/**/*.md
-                                - .github/CODEOWNERS
-                          - download: current
+          #         strategy:
+          #           runOnce:
+          #             deploy:
+          #               steps:
+          #                 - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          #                   parameters:
+          #                     Paths:
+          #                       - sdk/**/*.md
+          #                       - .github/CODEOWNERS
+          #                 - download: current
 
-                          # py2docfx requires Python >= 3.11
-                          - task: UsePythonVersion@0
-                            displayName: 'Use Python 3.11'
-                            inputs:
-                              versionSpec: '3.11'
+          #                 # py2docfx requires Python >= 3.11
+          #                 - task: UsePythonVersion@0
+          #                   displayName: 'Use Python 3.11'
+          #                   inputs:
+          #                     versionSpec: '3.11'
 
-                          - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
+          #                 - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
 
-                          - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
-                            parameters:
-                              PackageInfoLocations:
-                                - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
-                              WorkingDirectory: $(System.DefaultWorkingDirectory)
-                              TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-                              TargetDocRepoName: ${{parameters.TargetDocRepoName}}
-                              Language: 'python'
-                              SparseCheckoutPaths:
-                                - docs-ref-services/
-                                - metadata/
-                              PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+          #                 - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+          #                   parameters:
+          #                     PackageInfoLocations:
+          #                       - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+          #                     WorkingDirectory: $(System.DefaultWorkingDirectory)
+          #                     TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+          #                     TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+          #                     Language: 'python'
+          #                     SparseCheckoutPaths:
+          #                       - docs-ref-services/
+          #                       - metadata/
+          #                     PackageSourceOverride: ${{parameters.PackageSourceOverride}}
 
-          - deployment: UpdatePackageVersion
-            displayName: "Update Package Version"
-            condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-            environment: github
-            dependsOn: PublishPackage
+          # - deployment: UpdatePackageVersion
+          #   displayName: "Update Package Version"
+          #   condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+          #   environment: github
+          #   dependsOn: PublishPackage
 
-            pool:
-              image: azsdk-pool-mms-ubuntu-2004-1espt
-              name: azsdk-pool-mms-ubuntu-2004-general
-              os: linux
+          #   pool:
+          #     image: azsdk-pool-mms-ubuntu-2004-1espt
+          #     name: azsdk-pool-mms-ubuntu-2004-general
+          #     os: linux
 
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
-                    - task: UsePythonVersion@0
-                    - script: |
-                        python -m pip install "./tools/azure-sdk-tools[build]"
-                      displayName: Install versioning tool dependencies
+          #   strategy:
+          #     runOnce:
+          #       deploy:
+          #         steps:
+          #           - checkout: self
+          #           - task: UsePythonVersion@0
+          #           - script: |
+          #               python -m pip install "./tools/azure-sdk-tools[build]"
+          #             displayName: Install versioning tool dependencies
 
-                    - pwsh: |
-                        sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
-                        if (Test-Path component-detection-pip-report.json) {
-                          Write-Host "Deleting component-detection-pip-report.json"
-                          rm component-detection-pip-report.json
-                        }
-                      displayName: Increment package version
+          #           - pwsh: |
+          #               sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
+          #               if (Test-Path component-detection-pip-report.json) {
+          #                 Write-Host "Deleting component-detection-pip-report.json"
+          #                 rm component-detection-pip-report.json
+          #               }
+          #             displayName: Increment package version
 
-                    - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                      parameters:
-                        RepoName: azure-sdk-for-python
-                        PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
-                        CommitMsg: "Increment package version after release of ${{ artifact.name }}"
-                        PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-                        CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+          #           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+          #             parameters:
+          #               RepoName: azure-sdk-for-python
+          #               PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+          #               CommitMsg: "Increment package version after release of ${{ artifact.name }}"
+          #               PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+          #               CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
-          - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-            - template: /eng/pipelines/templates/jobs/smoke.tests.yml
-              parameters:
-                Daily: false
-                ArtifactName: ${{ parameters.ArtifactName }}
-                Artifact: ${{ artifact }}
+          # - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+          #   - template: /eng/pipelines/templates/jobs/smoke.tests.yml
+          #     parameters:
+          #       Daily: false
+          #       ArtifactName: ${{ parameters.ArtifactName }}
+          #       Artifact: ${{ artifact }}
 
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - stage: Integration

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -30,6 +30,10 @@ stages:
             steps:
               - checkout: self
 
+              - download: current
+                artifact: ${{parameters.ArtifactName}}
+                timeoutInMinutes: 5
+
               - task: UsePythonVersion@0
                 inputs:
                   versionSpec: '3.12'

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -110,7 +110,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: self
+                      # - checkout: self
 
 # todo: re-enable by publishing the necessary scripts as a build artifact that can be downloaded
                       # - download: current

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -234,50 +234,49 @@ stages:
                     ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
 
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
-                - job: PublishDocs
-                  displayName: Docs.MS Release
-                  condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                  dependsOn: PublishPackage
+            - job: PublishDocs
+              displayName: Docs.MS Release
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              dependsOn: PublishPackage
 
-                  pool:
-                    image: azsdk-pool-mms-ubuntu-2004-1espt
-                    name: azsdk-pool-mms-ubuntu-2004-general
-                    os: linux
+              pool:
+                image: azsdk-pool-mms-ubuntu-2004-1espt
+                name: azsdk-pool-mms-ubuntu-2004-general
+                os: linux
 
-                  steps:
-                    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-                      parameters:
-                        Paths:
-                          - sdk/**/*.md
-                          - .github/CODEOWNERS
+              steps:
+                - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                  parameters:
+                    Paths:
+                      - sdk/**/*.md
+                      - .github/CODEOWNERS
 
-                    - download: current
+                - download: current
 
-                    # py2docfx requires Python >= 3.11
-                    - task: UsePythonVersion@0
-                      displayName: 'Use Python 3.11'
-                      inputs:
-                        versionSpec: '3.11'
+                # py2docfx requires Python >= 3.11
+                - task: UsePythonVersion@0
+                  displayName: 'Use Python 3.11'
+                  inputs:
+                    versionSpec: '3.11'
 
-                    - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
+                - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
 
-                    - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
-                      parameters:
-                        PackageInfoLocations:
-                          - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
-                        WorkingDirectory: $(System.DefaultWorkingDirectory)
-                        TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-                        TargetDocRepoName: ${{parameters.TargetDocRepoName}}
-                        Language: 'python'
-                        SparseCheckoutPaths:
-                          - docs-ref-services/
-                          - metadata/
-                        PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+                - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+                  parameters:
+                    PackageInfoLocations:
+                      - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+                    WorkingDirectory: $(System.DefaultWorkingDirectory)
+                    TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+                    TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+                    Language: 'python'
+                    SparseCheckoutPaths:
+                      - docs-ref-services/
+                      - metadata/
+                    PackageSourceOverride: ${{parameters.PackageSourceOverride}}
 
-          - deployment: UpdatePackageVersion
+          - job: UpdatePackageVersion
             displayName: "Update Package Version"
             condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-            environment: github
             dependsOn: PublishPackage
 
             pool:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -18,88 +18,89 @@ stages:
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-python-pr'))
         jobs:
-          - deployment: TagRepository
-            displayName: "Create release tag"
-            condition: ne(variables['Skip.TagRepository'], 'true')
-            environment: github
+          # - deployment: TagRepository
+          #   displayName: "Create release tag"
+          #   condition: ne(variables['Skip.TagRepository'], 'true')
+          #   environment: github
 
-            pool:
-              image: azsdk-pool-mms-ubuntu-2004-1espt
-              name: azsdk-pool-mms-ubuntu-2004-general
-              os: linux
+          #   pool:
+          #     image: azsdk-pool-mms-ubuntu-2004-1espt
+          #     name: azsdk-pool-mms-ubuntu-2004-general
+          #     os: linux
 
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
+          #   strategy:
+          #     runOnce:
+          #       deploy:
+          #         steps:
+          #           - checkout: self
 
-                    - task: UsePythonVersion@0
-                      inputs:
-                        versionSpec: '3.12'
+          #           - task: UsePythonVersion@0
+          #             inputs:
+          #               versionSpec: '3.12'
 
-                    - script: |
-                        set -e
-                        python -m pip install -r eng/release_requirements.txt
-                      displayName: Install Release Dependencies
+          #           - script: |
+          #               set -e
+          #               python -m pip install -r eng/release_requirements.txt
+          #             displayName: Install Release Dependencies
 
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
+          #           - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
-                    - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
-                      parameters:
-                        PackageName: "azure-template"
-                        ServiceDirectory: "template"
-                        TestPipeline: ${{ parameters.TestPipeline }}
+          #           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+          #             parameters:
+          #               PackageName: "azure-template"
+          #               ServiceDirectory: "template"
+          #               TestPipeline: ${{ parameters.TestPipeline }}
 
-                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceName: ${{parameters.ServiceDirectory}}
-                        ForRelease: true
+          #           - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+          #             parameters:
+          #               PackageName: ${{artifact.name}}
+          #               ServiceName: ${{parameters.ServiceDirectory}}
+          #               ForRelease: true
 
-                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceDirectory: ${{parameters.ServiceDirectory}}
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+          #           - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+          #             parameters:
+          #               PackageName: ${{artifact.name}}
+          #               ServiceDirectory: ${{parameters.ServiceDirectory}}
+          #               ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
 
-                    - script: |
-                        python -m pip install "./tools/azure-sdk-tools"
-                      displayName: Install tool dependencies
+          #           - script: |
+          #               python -m pip install "./tools/azure-sdk-tools"
+          #             displayName: Install tool dependencies
 
-                    - task: PythonScript@0
-                      displayName: Verify CI enabled
-                      condition: succeeded()
-                      inputs:
-                        scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
-                        arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
+          #           - task: PythonScript@0
+          #             displayName: Verify CI enabled
+          #             condition: succeeded()
+          #             inputs:
+          #               scriptPath: 'scripts/devops_tasks/verify_ci_enabled.py'
+          #               arguments: '--package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}'
 
-                    - pwsh: |
-                        Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                      workingDirectory: $(Pipeline.Workspace)
-                      displayName: Output Visible Artifacts
+          #           - pwsh: |
+          #               Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+          #             workingDirectory: $(Pipeline.Workspace)
+          #             displayName: Output Visible Artifacts
 
-                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                      parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                        PackageRepository: PyPI
-                        ReleaseSha: $(Build.SourceVersion)
-                        RepoId: Azure/azure-sdk-for-python
-                        WorkingDirectory: $(System.DefaultWorkingDirectory)
+          #           - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+          #             parameters:
+          #               ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+          #               PackageRepository: PyPI
+          #               ReleaseSha: $(Build.SourceVersion)
+          #               RepoId: Azure/azure-sdk-for-python
+          #               WorkingDirectory: $(System.DefaultWorkingDirectory)
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
               displayName: "Publish to PyPI"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
               environment: pypi
-              dependsOn: TagRepository
+              # dependsOn: TagRepository
 
               templateContext:
                 type: releaseJob
                 isProduction: true
                 inputs:
                 - input: pipelineArtifact
-                  artifactName: ${{parameters.ArtifactName}}
+                  artifactName: packages_extended
+                  targetPath: $(Pipeline.Workspace)/packages_extended
 
               pool:
                 image: azsdk-pool-mms-ubuntu-2004-1espt

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -131,7 +131,7 @@ steps:
     displayName: Clean up repo
     condition: and(succeeded(), ne(variables['ENABLE_EXTENSION_BUILD'], 'true'), ne('${{ parameters.ArtifactSuffix }}', 'linux'))
 
-  # we need to only publish this if runnning on linux. we only need one for the whole build
+  # we need to only publish this if running on linux. we only need one for all stages
   - pwsh: |
       New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/release_artifact"
       Copy-Item -Path "$(Build.SourcesDirectory)/eng/release_requirements.txt" -Destination "$(Build.ArtifactStagingDirectory)/release_artifact/release_requirements.txt"

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -134,7 +134,7 @@ steps:
   # we need to only publish this if runnning on linux. we only need one for the whole build
   - pwsh: |
       New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/release_artifact"
-      Copy-Item -Path "$(Build.ArtifactStagingDirectory)/eng/release_requirements.txt" -Destination "$(Build.ArtifactStagingDirectory)/release_artifact/release_requirements.txt
+      Copy-Item -Path "$(Build.SourcesDirectory)/eng/release_requirements.txt" -Destination "$(Build.ArtifactStagingDirectory)/release_artifact/release_requirements.txt"
     displayName: 'Assemble Static Files for Release Stage'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -141,8 +141,8 @@ steps:
   - ${{ if eq(parameters.ArtifactSuffix, 'linux') }}:
     - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
       parameters:
-        ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-        ArtifactName: 'release_artifacts'
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)/release_artifact'
+        ArtifactName: 'release_artifact'
 
   - ${{ if eq(parameters.ArtifactSuffix, '') }}:
     - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -88,6 +88,9 @@ steps:
       $(VENV_ACTIVATION_SCRIPT)
       which python
       python -m pip install --force -r eng/ci_tools.txt
+      if $(env:AGENT_OS -eq "Linux") {
+        python -m pip install -r eng/release_requirements.txt
+      }
       python -m pip freeze --all
     displayName: 'Prep Environment'
     condition: and(succeeded(), or(eq(variables['ENABLE_EXTENSION_BUILD'], 'true'), eq('${{ parameters.ArtifactSuffix }}', 'linux')))
@@ -109,8 +112,8 @@ steps:
     env:
       CIBW_BUILD_VERBOSITY: 3
 
-  - script: |
-      python -m pip install -r eng/release_requirements.txt
+  - pwsh: |
+      $(VENV_ACTIVATION_SCRIPT)
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
       twine check $(Build.ArtifactStagingDirectory)/**/*.tar.gz
     displayName: 'Verify Readme'
@@ -126,6 +129,19 @@ steps:
         | Remove-Item -Force -Recurse
     displayName: Clean up repo
     condition: and(succeeded(), ne(variables['ENABLE_EXTENSION_BUILD'], 'true'), ne('${{ parameters.ArtifactSuffix }}', 'linux'))
+
+  # we need to only publish this if runnning on linux. we only need one for the whole build
+  - pwsh: |
+      New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/release_artifact"
+      Copy-Item -Path "$(Build.ArtifactStagingDirectory)/eng/release_requirements.txt" -Destination "$(Build.ArtifactStagingDirectory)/release_artifact/release_requirements.txt
+    displayName: 'Assemble Static Files for Release Stage'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+  - ${{ if eq(parameters.ArtifactSuffix, 'linux') }}:
+    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      parameters:
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'release_artifacts'
 
   - ${{ if eq(parameters.ArtifactSuffix, '') }}:
     - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -88,7 +88,8 @@ steps:
       $(VENV_ACTIVATION_SCRIPT)
       which python
       python -m pip install --force -r eng/ci_tools.txt
-      if $(env:AGENT_OS -eq "Linux") {
+      if ($env:AGENT_OS -eq "Linux") {
+        Write-Host "Installing release reqs"
         python -m pip install -r eng/release_requirements.txt
       }
       python -m pip freeze --all

--- a/eng/release_requirements.txt
+++ b/eng/release_requirements.txt
@@ -1,2 +1,1 @@
 twine==5.1.1
-tools/azure-sdk-tools


### PR DESCRIPTION
This PR will eliminate this error from release pipelines. I have a queued `template release` from `main` [that should demonstrate the error/warning we are addressing.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4520287&view=results)

[Successful build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4520166&view=logs&j=9f2af9ef-e951-5d42-1c6b-ef9735132d1d) Notice lack of warning from 1es.

![image](https://github.com/user-attachments/assets/9de23f0e-85d1-4e5c-a3ce-6a78882908f1)

- [x] We still wait for approval: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4520241&view=results
- [x] Run a [previous build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4520287&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=5ff8903e-121c-5085-301a-a582e2e6f029&l=83) to highlight the error we're resolving. 