### PR TITLE
update user agent to align with azure standards

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (unreleased)
+## 1.3.0 (2025-02-11)
 
 ### Features Added
 

--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 1.3.0 (unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+ - Improved user agent used in logging to align with azure standards.
+
 ## 1.2.0 (2025-01-27)
 
 ### Features Added

--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.3.0 (2025-02-11)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.0 (Unreleased)
 
 ### Other Changes
  - Improved user agent used in logging to align with azure standards.

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -483,8 +483,10 @@ def _apply_target_to_data(
     run_summary = batch_client.get_run_summary(run)
 
     if run_summary["completed_lines"] == 0:
-        msg = (f"Evaluation target failed to produce any results."
-               f" Please check the logs at {run_summary['log_path']} for more details about cause of failure.")
+        msg = (
+            f"Evaluation target failed to produce any results."
+            f" Please check the logs at {run_summary['log_path']} for more details about cause of failure."
+        )
         raise EvaluationException(
             message=msg,
             target=ErrorTarget.EVALUATE,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_user_agent.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_user_agent.py
@@ -1,6 +1,11 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+from azure.core.pipeline.policies import UserAgentPolicy
 from azure.ai.evaluation._version import VERSION
+import platform
 
-USER_AGENT = "{}/{}".format("azure-ai-evaluation", VERSION)
+# Format is "azsdk-python-this-package/version language/version (platform info)"
+
+#USER_AGENT = "azsdk-python-evaluation/{} Python/{} ({})".format(VERSION, platform.python_version(), platform.platform())
+USER_AGENT = UserAgentPolicy(sdk_moniker="{}/{}".format("azure-ai-evaluation", VERSION)).user_agent

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_user_agent.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_user_agent.py
@@ -7,5 +7,5 @@ import platform
 
 # Format is "azsdk-python-this-package/version language/version (platform info)"
 
-#USER_AGENT = "azsdk-python-evaluation/{} Python/{} ({})".format(VERSION, platform.python_version(), platform.platform())
+# USER_AGENT = "azsdk-python-evaluation/{} Python/{} ({})".format(VERSION, platform.python_version(), platform.platform())
 USER_AGENT = UserAgentPolicy(sdk_moniker="{}/{}".format("azure-ai-evaluation", VERSION)).user_agent

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_version.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.2.0"
+VERSION = "1.3.0"

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_version.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.3.0"
+VERSION = "1.2.0"

--- a/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
@@ -600,6 +600,7 @@ def pytest_sessionfinish() -> None:
 
     stop_promptflow_service()
 
+
 @pytest.fixture
 def run_from_temp_dir(tmp_path):
     original_cwd = os.getcwd()

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_evaluate.py
@@ -34,6 +34,7 @@ def questions_file():
     data_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data")
     return os.path.join(data_path, "questions.jsonl")
 
+
 def answer_evaluator(response):
     return {"length": len(response)}
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -118,8 +118,10 @@ def _target_fn2(query):
     response["query"] = f"The query is as follows: {query}"
     return response
 
+
 def _target_that_fails(query):
     raise Exception("I am failing")
+
 
 def _new_answer_target():
     return {"response": "new response"}


### PR DESCRIPTION
Changed our user agent definition to leverage the azure core standard `UserAgentPolicy` class. The USER_AGENT field used throughout our SDK will now look something like this:

`azsdk-python-azure-ai-evaluation/1.2.0 Python/3.10.8 (Linux-#####-<system details>)'

Also added 1.3.0 to the changelog and a few nit changes imposed by the black style checker.