### PR TITLE
[SB] Fix Peek Last Sequence ID Capture

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
@@ -52,9 +52,12 @@ def peek_op(  # pylint: disable=inconsistent-return-statements
 ):
     condition = message.application_properties.get(MGMT_RESPONSE_MESSAGE_ERROR_CONDITION)
     if status_code == 200:
-        return amqp_transport.parse_received_message(
+        parsed_messages = amqp_transport.parse_received_message(
             message, message_type=ServiceBusReceivedMessage, receiver=receiver, is_peeked_message=True
         )
+        if parsed_messages:
+            receiver._last_received_sequenced_number = parsed_messages[-1].sequence_number # pylint: disable=protected-access
+        return parsed_messages
     if status_code in [202, 204]:
         return []
     amqp_transport.handle_amqp_mgmt_error(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
@@ -52,13 +52,11 @@ def peek_op(  # pylint: disable=inconsistent-return-statements
 ):
     condition = message.application_properties.get(MGMT_RESPONSE_MESSAGE_ERROR_CONDITION)
     if status_code == 200:
-        parsed_messages = amqp_transport.parse_received_message(
+        return amqp_transport.parse_received_message(
             message, message_type=ServiceBusReceivedMessage, receiver=receiver, is_peeked_message=True
         )
-        receiver._last_received_sequenced_number = parsed_messages[-1].sequence_number # pylint: disable=protected-access
     if status_code in [202, 204]:
         return []
-
     amqp_transport.handle_amqp_mgmt_error(
         _LOGGER, "Message peek failed.", condition, description, status_code
     )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
@@ -52,9 +52,10 @@ def peek_op(  # pylint: disable=inconsistent-return-statements
 ):
     condition = message.application_properties.get(MGMT_RESPONSE_MESSAGE_ERROR_CONDITION)
     if status_code == 200:
-        return amqp_transport.parse_received_message(
+        parsed_messages = amqp_transport.parse_received_message(
             message, message_type=ServiceBusReceivedMessage, receiver=receiver, is_peeked_message=True
         )
+        receiver._last_received_sequenced_number = parsed_messages[-1].sequence_number # pylint: disable=protected-access
     if status_code in [202, 204]:
         return []
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -790,8 +790,6 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin): # pylint: disable=too-many
             REQUEST_RESPONSE_PEEK_OPERATION, message, handler, timeout=timeout
         )
         links = get_receive_links(messages)
-        if messages:
-            self._last_received_sequenced_number = messages[-1].sequence_number # pylint: disable=attribute-defined-outside-init
         with receive_trace_context_manager(self, span_name=SPAN_NAME_PEEK, links=links, start_time=start_time):
             return messages
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class ServiceBusReceiver(BaseHandler, ReceiverMixin):
+class ServiceBusReceiver(BaseHandler, ReceiverMixin): # pylint: disable=too-many-instance-attributes
     """The ServiceBusReceiver class defines a high level interface for
     receiving messages from the Azure Service Bus Queue or Topic Subscription.
 
@@ -791,7 +791,7 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):
         )
         links = get_receive_links(messages)
         if messages:
-            self._last_received_sequenced_number = messages[-1].sequence_number
+            self._last_received_sequenced_number = messages[-1].sequence_number # pylint: disable=attribute-defined-outside-init
         with receive_trace_context_manager(self, span_name=SPAN_NAME_PEEK, links=links, start_time=start_time):
             return messages
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -769,7 +769,11 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
         if not sequence_number:
-            sequence_number = self._last_received_sequenced_number or 1
+            sequence_number = (
+                self._last_received_sequenced_number + 1
+                if self._last_received_sequenced_number
+                else 1
+            )
         if int(max_message_count) < 0:
             raise ValueError("max_message_count must be 1 or greater.")
 
@@ -786,6 +790,8 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):
             REQUEST_RESPONSE_PEEK_OPERATION, message, handler, timeout=timeout
         )
         links = get_receive_links(messages)
+        if messages:
+            self._last_received_sequenced_number = messages[-1].sequence_number
         with receive_trace_context_manager(self, span_name=SPAN_NAME_PEEK, links=links, start_time=start_time):
             return messages
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -748,7 +748,11 @@ class ServiceBusReceiver(AsyncIterator, BaseHandler, ReceiverMixin):
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
         if not sequence_number:
-            sequence_number = self._last_received_sequenced_number or 1
+            sequence_number = (
+                self._last_received_sequenced_number + 1
+                if self._last_received_sequenced_number
+                else 1
+            )
         if int(max_message_count) < 0:
             raise ValueError("max_message_count must be 1 or greater.")
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -3643,7 +3643,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
         ) as sb_client:
 
             sender = sb_client.get_queue_sender(servicebus_queue.name)
-            with sender:
+            async with sender:
                 messages = []
                 for i in range(3):
                     message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -3637,7 +3637,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
         self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
     ):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
+        credential = get_credential(is_async=True)
         async with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
         ) as sb_client:

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -3654,8 +3654,87 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
             async with receiver:
                 peek_message = await receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 0
+                assert peek_message[0].sequence_number == 1
                 peek_message = await receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 1
+                assert peek_message[0].sequence_number == 2
                 peek_message = await receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 2
-       
+                assert peek_message[0].sequence_number == 3
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix="servicebustest")
+    @CachedServiceBusNamespacePreparer(name_prefix="servicebustest")
+    @ServiceBusQueuePreparer(name_prefix="servicebustest", dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_by_queue_client_peek_auto_increment_multiple(
+        self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
+    ):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                messages = []
+                for i in range(4):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})
+                    messages.append(message)
+                await sender.send_messages(messages)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            async with receiver:
+                peek_message = await receiver.peek_messages(max_message_count=2)
+                assert len(peek_message) == 2
+                assert peek_message[0].application_properties[b"index"] == 0
+                assert peek_message[0].sequence_number == 1
+                assert peek_message[1].application_properties[b"index"] == 1
+                assert peek_message[1].sequence_number == 2
+                peek_message = await receiver.peek_messages(max_message_count=2)
+                assert len(peek_message) == 2
+                assert peek_message[0].application_properties[b"index"] == 2
+                assert peek_message[0].sequence_number == 3
+                assert peek_message[1].application_properties[b"index"] == 3
+                assert peek_message[1].sequence_number == 4
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix="servicebustest")
+    @CachedServiceBusNamespacePreparer(name_prefix="servicebustest")
+    @ServiceBusQueuePreparer(name_prefix="servicebustest", dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_by_queue_client_peek_and_receive(
+        self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
+    ):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                messages = []
+                for i in range(4):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})
+                    messages.append(message)
+                await sender.send_messages(messages)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            async with receiver:
+                peeked_messages = await receiver.peek_messages(max_message_count=2)
+
+                messages = await receiver.receive_messages(max_message_count=3)
+                last_received_sequnece_number = messages[-1].sequence_number
+                for message in messages:
+                    await receiver.complete_message(message)
+
+                peeked_messages = await receiver.peek_messages(max_message_count=2)
+                assert peeked_messages[0].sequence_number == last_received_sequnece_number + 1

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -3652,10 +3652,10 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
 
             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
             async with receiver:
-                peek_message = await receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 0
-                peek_message = await receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 1
-                peek_message = await receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 2
+                peek_message = await receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 0
+                peek_message = await receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 1
+                peek_message = await receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 2
        

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3642,10 +3642,10 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
 
             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
             with receiver:
-                peek_message = receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 0
-                peek_message = receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 1
-                peek_message = receiver.peek_message()
-                assert peek_message.application_properties[b"index"] == 2
+                peek_message = receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 0
+                peek_message = receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 1
+                peek_message = receiver.peek_messages()
+                assert peek_message[0].application_properties[b"index"] == 2
                 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3644,8 +3644,89 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             with receiver:
                 peek_message = receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 0
+                assert peek_message[0].sequence_number == 1
                 peek_message = receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 1
+                assert peek_message[0].sequence_number == 2
                 peek_message = receiver.peek_messages()
                 assert peek_message[0].application_properties[b"index"] == 2
+                assert peek_message[0].sequence_number == 3
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix="servicebustest")
+    @CachedServiceBusNamespacePreparer(name_prefix="servicebustest")
+    @ServiceBusQueuePreparer(name_prefix="servicebustest", dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_peek_auto_increment_multiple(
+        self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
+    ):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            with sender:
+                messages = []
+                for i in range(4):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})
+                    messages.append(message)
+                sender.send_messages(messages)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            with receiver:
+                peek_message = receiver.peek_messages(max_message_count=2)
+                assert len(peek_message) == 2
+                assert peek_message[0].application_properties[b"index"] == 0
+                assert peek_message[1].sequence_number == 1
+                assert peek_message[1].application_properties[b"index"] == 1
+                assert peek_message[1].sequence_number == 2
+                peek_message = receiver.peek_messages(max_message_count=2)
+                assert len(peek_message) == 2
+                assert peek_message[0].application_properties[b"index"] == 2
+                assert peek_message[0].sequence_number == 3
+                assert peek_message[1].application_properties[b"index"] == 3
+                assert peek_message[1].sequence_number == 4
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix="servicebustest")
+    @CachedServiceBusNamespacePreparer(name_prefix="servicebustest")
+    @ServiceBusQueuePreparer(name_prefix="servicebustest", dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_peek_and_receive(
+        self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
+    ):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            with sender:
+                messages = []
+                for i in range(4):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})
+                    messages.append(message)
+                sender.send_messages(messages)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            with receiver:
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+                with receiver:
+                    peeked_messages = receiver.peek_messages(max_message_count=2)
+
+                messages = receiver.receive_messages(max_message_count=3)
+                last_received_sequnece_number = messages[-1].sequence_number
+                for message in messages:
+                    receiver.complete_message(message)
+
+                peeked_messages = receiver.peek_messages(max_message_count=2)
+                assert peeked_messages[0].sequence_number == last_received_sequnece_number + 1
+
                 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3615,3 +3615,37 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                 messages_in_queue = receiver1.peek_messages()
 
                 assert len(messages_in_queue) == 0
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix="servicebustest")
+    @CachedServiceBusNamespacePreparer(name_prefix="servicebustest")
+    @ServiceBusQueuePreparer(name_prefix="servicebustest", dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_peek_auto_increment(
+        self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs
+    ):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            with sender:
+                messages = []
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), application_properties={"index": i})
+                    messages.append(message)
+                sender.send_messages(messages)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            with receiver:
+                peek_message = receiver.peek_message()
+                assert peek_message.application_properties[b"index"] == 0
+                peek_message = receiver.peek_message()
+                assert peek_message.application_properties[b"index"] == 1
+                peek_message = receiver.peek_message()
+                assert peek_message.application_properties[b"index"] == 2
+                

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3681,7 +3681,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                 peek_message = receiver.peek_messages(max_message_count=2)
                 assert len(peek_message) == 2
                 assert peek_message[0].application_properties[b"index"] == 0
-                assert peek_message[1].sequence_number == 1
+                assert peek_message[0].sequence_number == 1
                 assert peek_message[1].application_properties[b"index"] == 1
                 assert peek_message[1].sequence_number == 2
                 peek_message = receiver.peek_messages(max_message_count=2)
@@ -3718,8 +3718,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
             with receiver:
                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-                with receiver:
-                    peeked_messages = receiver.peek_messages(max_message_count=2)
+                peeked_messages = receiver.peek_messages(max_message_count=2)
 
                 messages = receiver.receive_messages(max_message_count=3)
                 last_received_sequnece_number = messages[-1].sequence_number


### PR DESCRIPTION
This fixes a bug in `peek_messages` where the `last_sequence_id` on the receiver was not being set, so subsequent calls to `peek_message` would continue to bring back the same messages defaulting to sequence id 0. 