### PR TITLE
Fixed interrupt_call_media_operation issue in async play to all api.

### DIFF
--- a/sdk/communication/azure-communication-callautomation/CHANGELOG.md
+++ b/sdk/communication/azure-communication-callautomation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.3.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+Fixed interrupt_call_media_operation flag in play to all api.
+
+### Other Changes
+
 ## 1.3.0 (2024-11-22)
 
 ### Features Added

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
@@ -567,7 +567,8 @@ class CallConnectionClient:  # pylint: disable=too-many-public-methods
             play_sources=[play_source_single._to_generated()] if play_source_single else # pylint:disable=protected-access
             [source._to_generated() for source in play_sources] if play_sources else None, # pylint:disable=protected-access
             play_to=audience,
-            play_options=PlayOptions(loop=loop, interrupt_call_media_operation=interrupt_call_media_operation),
+            play_options=PlayOptions(loop=loop),
+            interrupt_call_media_operation=interrupt_call_media_operation,
             operation_context=operation_context,
             operation_callback_uri=operation_callback_url,
             **kwargs


### PR DESCRIPTION
# Description
Fixed interrupt_call_media_operation issue in async play to all api.

[Bug 3953398](https://skype.visualstudio.com/SPOOL/_workitems/edit/3953398): [GA4][Python][Async][Play Barg-in] Play interrupt isn't working with Async