### PR TITLE
Add unit tests for notification entity

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_batch_job.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_batch_job.py
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
 import pytest
 
 from azure.ai.ml.entities import BatchJob

--- a/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_model_batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_model_batch_deployment.py
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
 import pytest
 from azure.ai.ml.entities import ModelBatchDeployment
 from azure.ai.ml.entities._load_functions import load_model_batch_deployment

--- a/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_pipeline_component_bach_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_pipeline_component_bach_deployment.py
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
 import pytest
 import json
 from azure.ai.ml.entities._deployment.pipeline_component_batch_deployment import (

--- a/sdk/ml/azure-ai-ml/tests/feature_set/unittests/test_feature_set_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/feature_set/unittests/test_feature_set_entity.py
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import pytest
+import json
+
+from azure.ai.ml.entities._assets._artifacts.feature_set import FeatureSet
+from azure.ai.ml.entities._load_functions import load_feature_set
+from azure.ai.ml._restclient.v2023_10_01.models import (
+    FeaturesetContainer,
+    FeaturesetContainerProperties,
+    FeaturesetVersion,
+    FeaturesetVersionProperties,
+)
+
+@pytest.mark.unittest
+class TestFeatureSetEntity:
+    FEATURE_SET = "./tests/test_configs/feature_set/feature_set_full.yaml"
+    FEATURE_SET_REST = "./tests/test_configs/feature_set/feature_set_full_rest.json"
+    FEATURE_SET_CONTAINER_REST = "./tests/test_configs/feature_set/feature_set_container_rest.json"
+    
+    def test_to_rest_object(self) -> None:
+        feature_set = load_feature_set(self.FEATURE_SET)
+
+        feature_set_rest = feature_set._to_rest_object()
+        assert feature_set_rest.properties.description == feature_set.description
+        assert feature_set_rest.properties.tags == feature_set.tags
+        assert feature_set_rest.properties.entities == feature_set.entities
+        assert feature_set_rest.properties.specification.path == feature_set.specification.path
+        assert feature_set_rest.properties.stage == feature_set.stage
+        assert str(feature_set_rest.properties.materialization_settings.store_type) == 'MaterializationStoreType.OFFLINE'
+        assert feature_set_rest.properties.materialization_settings.schedule.frequency == feature_set.materialization_settings.schedule.frequency
+        assert feature_set_rest.properties.materialization_settings.schedule.interval == feature_set.materialization_settings.schedule.interval
+        assert feature_set_rest.properties.materialization_settings.spark_configuration == feature_set.materialization_settings.spark_configuration
+        assert feature_set_rest.properties.materialization_settings.resource.instance_type == feature_set.materialization_settings.resource.instance_type
+        assert feature_set_rest.properties.materialization_settings.notification.email_on == feature_set.materialization_settings.notification.email_on
+        assert feature_set_rest.properties.materialization_settings.notification.emails == feature_set.materialization_settings.notification.emails
+    
+    def test_from_rest_object(self) -> None:
+        with open(self.FEATURE_SET_REST, "r") as f:
+            feature_set_rest = FeaturesetVersion.deserialize(json.load(f))
+            feature_set = FeatureSet._from_rest_object(featureset_rest_object=feature_set_rest)
+            assert feature_set.name == feature_set_rest.name
+            assert feature_set.description == feature_set_rest.properties.description
+            assert feature_set.tags == feature_set_rest.properties.tags
+            assert feature_set.entities == feature_set_rest.properties.entities
+            assert feature_set.specification.path == feature_set_rest.properties.specification.path
+            assert feature_set.stage == feature_set_rest.properties.stage
+            assert feature_set.materialization_settings.schedule.frequency == feature_set_rest.properties.materialization_settings.schedule.frequency.lower()
+            assert feature_set.materialization_settings.schedule.interval == feature_set_rest.properties.materialization_settings.schedule.interval
+            assert feature_set.materialization_settings.spark_configuration == feature_set_rest.properties.materialization_settings.spark_configuration
+            assert feature_set.materialization_settings.resource.instance_type == feature_set_rest.properties.materialization_settings.resource.instance_type
+            assert feature_set.materialization_settings.notification.email_on == feature_set_rest.properties.materialization_settings.notification.email_on
+            assert feature_set.materialization_settings.notification.emails == feature_set_rest.properties.materialization_settings.notification.emails
+     
+    def test_from_container_rest_object(self)->None:
+        with open(self.FEATURE_SET_CONTAINER_REST, "r") as f:
+            featureset_container_rest = FeaturesetContainer.deserialize(json.load(f))
+            feature_set = FeatureSet._from_container_rest_object(featureset_container_rest)
+            assert feature_set.name == featureset_container_rest.name
+            assert feature_set.description == featureset_container_rest.properties.description
+            assert feature_set.tags == featureset_container_rest.properties.tags
+            assert feature_set.entities == []
+            assert feature_set.specification.path == None
+            assert feature_set.version == ""
+            assert feature_set.latest_version == featureset_container_rest.properties.latest_version

--- a/sdk/ml/azure-ai-ml/tests/feature_set/unittests/test_feature_set_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/feature_set/unittests/test_feature_set_entity.py
@@ -14,12 +14,13 @@ from azure.ai.ml._restclient.v2023_10_01.models import (
     FeaturesetVersionProperties,
 )
 
+
 @pytest.mark.unittest
 class TestFeatureSetEntity:
     FEATURE_SET = "./tests/test_configs/feature_set/feature_set_full.yaml"
     FEATURE_SET_REST = "./tests/test_configs/feature_set/feature_set_full_rest.json"
     FEATURE_SET_CONTAINER_REST = "./tests/test_configs/feature_set/feature_set_container_rest.json"
-    
+
     def test_to_rest_object(self) -> None:
         feature_set = load_feature_set(self.FEATURE_SET)
 
@@ -29,14 +30,34 @@ class TestFeatureSetEntity:
         assert feature_set_rest.properties.entities == feature_set.entities
         assert feature_set_rest.properties.specification.path == feature_set.specification.path
         assert feature_set_rest.properties.stage == feature_set.stage
-        assert str(feature_set_rest.properties.materialization_settings.store_type) == 'MaterializationStoreType.OFFLINE'
-        assert feature_set_rest.properties.materialization_settings.schedule.frequency == feature_set.materialization_settings.schedule.frequency
-        assert feature_set_rest.properties.materialization_settings.schedule.interval == feature_set.materialization_settings.schedule.interval
-        assert feature_set_rest.properties.materialization_settings.spark_configuration == feature_set.materialization_settings.spark_configuration
-        assert feature_set_rest.properties.materialization_settings.resource.instance_type == feature_set.materialization_settings.resource.instance_type
-        assert feature_set_rest.properties.materialization_settings.notification.email_on == feature_set.materialization_settings.notification.email_on
-        assert feature_set_rest.properties.materialization_settings.notification.emails == feature_set.materialization_settings.notification.emails
-    
+        assert (
+            str(feature_set_rest.properties.materialization_settings.store_type) == "MaterializationStoreType.OFFLINE"
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.schedule.frequency
+            == feature_set.materialization_settings.schedule.frequency
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.schedule.interval
+            == feature_set.materialization_settings.schedule.interval
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.spark_configuration
+            == feature_set.materialization_settings.spark_configuration
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.resource.instance_type
+            == feature_set.materialization_settings.resource.instance_type
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.notification.email_on
+            == feature_set.materialization_settings.notification.email_on
+        )
+        assert (
+            feature_set_rest.properties.materialization_settings.notification.emails
+            == feature_set.materialization_settings.notification.emails
+        )
+
     def test_from_rest_object(self) -> None:
         with open(self.FEATURE_SET_REST, "r") as f:
             feature_set_rest = FeaturesetVersion.deserialize(json.load(f))
@@ -47,14 +68,32 @@ class TestFeatureSetEntity:
             assert feature_set.entities == feature_set_rest.properties.entities
             assert feature_set.specification.path == feature_set_rest.properties.specification.path
             assert feature_set.stage == feature_set_rest.properties.stage
-            assert feature_set.materialization_settings.schedule.frequency == feature_set_rest.properties.materialization_settings.schedule.frequency.lower()
-            assert feature_set.materialization_settings.schedule.interval == feature_set_rest.properties.materialization_settings.schedule.interval
-            assert feature_set.materialization_settings.spark_configuration == feature_set_rest.properties.materialization_settings.spark_configuration
-            assert feature_set.materialization_settings.resource.instance_type == feature_set_rest.properties.materialization_settings.resource.instance_type
-            assert feature_set.materialization_settings.notification.email_on == feature_set_rest.properties.materialization_settings.notification.email_on
-            assert feature_set.materialization_settings.notification.emails == feature_set_rest.properties.materialization_settings.notification.emails
-     
-    def test_from_container_rest_object(self)->None:
+            assert (
+                feature_set.materialization_settings.schedule.frequency
+                == feature_set_rest.properties.materialization_settings.schedule.frequency.lower()
+            )
+            assert (
+                feature_set.materialization_settings.schedule.interval
+                == feature_set_rest.properties.materialization_settings.schedule.interval
+            )
+            assert (
+                feature_set.materialization_settings.spark_configuration
+                == feature_set_rest.properties.materialization_settings.spark_configuration
+            )
+            assert (
+                feature_set.materialization_settings.resource.instance_type
+                == feature_set_rest.properties.materialization_settings.resource.instance_type
+            )
+            assert (
+                feature_set.materialization_settings.notification.email_on
+                == feature_set_rest.properties.materialization_settings.notification.email_on
+            )
+            assert (
+                feature_set.materialization_settings.notification.emails
+                == feature_set_rest.properties.materialization_settings.notification.emails
+            )
+
+    def test_from_container_rest_object(self) -> None:
         with open(self.FEATURE_SET_CONTAINER_REST, "r") as f:
             featureset_container_rest = FeaturesetContainer.deserialize(json.load(f))
             feature_set = FeatureSet._from_container_rest_object(featureset_container_rest)

--- a/sdk/ml/azure-ai-ml/tests/test_configs/feature_set/feature_set_container_rest.json
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/feature_set/feature_set_container_rest.json
@@ -1,0 +1,15 @@
+{
+    "name": "feature_set_full_rest",
+    "id": "/subscriptions/sub-id/resourceGroups/some-rg/providers/Microsoft.MachineLearningServices/workspaces/some-ws/feature_set/feature_set_full_rest/versions/1",
+    "properties": {
+        "description": "Feature set for testing",
+        "provisioningState": "Succeeded",
+        "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+        },
+        "isArchived": false,
+        "latestVersion": "1",
+        "nextVersion": "2"
+    }
+}

--- a/sdk/ml/azure-ai-ml/tests/test_configs/feature_set/feature_set_full_rest.json
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/feature_set/feature_set_full_rest.json
@@ -1,0 +1,58 @@
+{
+    "name": "feature_set_full_rest",
+    "id": "/subscriptions/sub-id/resourceGroups/some-rg/providers/Microsoft.MachineLearningServices/workspaces/some-ws/feature_set/feature_set_full_rest/versions/1",
+    "properties": {
+        "description": "Feature set for testing",
+        "entities": [
+            "azureml:test:1",
+            "azureml:test:2"
+        ],
+        "provisioningState": "Succeeded",
+        "specification": {
+            "path": "./tests/test_configs/feature_set"
+        },
+        "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+        },
+        "stage": "Production",
+        "materializationSettings": {
+            "notification": {
+                "emailOn": [
+                    "JobCompleted",
+                    "JobFailed"
+                ],
+                "email": [
+                    "fake@email.com",
+                    "test@email.com"
+                ]
+            },
+            "resource": {
+                "instanceType": "standard_e8s_v3"
+            },
+            "schedule": {
+                "frequency": "Minute",
+                "interval": 5,
+                "schedule": {
+                    "hours": [
+                        12
+                    ],
+                    "minutes": [
+                        5
+                    ],
+                    "weekDays": [
+                        "Sunday"
+                    ]
+                }
+            },
+            "sparkConfiguration": {
+                "spark.executor.instances": 2,
+                "spark.executor.memory": "4g",
+                "spark.executor.cores": 2,
+                "spark.driver.memory": "4g",
+                "spark.driver.cores": 2
+            },
+            "storeType": "Offline"
+        }
+    }
+}


### PR DESCRIPTION
# Description

Add unit tests for notifications entity. Notification entity is used in FeatureSet entity thats why the file test_feature_set is used

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
