### PR TITLE
[Storage] [STG 98] Added support for `x-ms-file-request-intent` for Blob Copy APIs

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_b11831f46e"
+  "Tag": "python/storage/azure-storage-blob_72ab806004"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1756,6 +1756,15 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
             .. versionadded:: 12.9.0
 
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :keyword str encryption_scope:
             A predefined encryption scope used to encrypt the data on the sync copied blob. An encryption
             scope can be created using the Management API and referenced here by name. If a default
@@ -1780,7 +1789,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             source_url=source_url,
             metadata=metadata,
             incremental_copy=incremental_copy,
-            **kwargs)
+            **kwargs
+        )
         try:
             if incremental_copy:
                 return cast(Dict[str, Union[str, datetime]], self._client.page_blob.copy_incremental(**options))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -422,6 +422,15 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Blob-updated property Dict (Etag and last modified)
         :rtype: Dict[str, Any]
         """
@@ -430,7 +439,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         options = _upload_blob_from_url_options(
             source_url=source_url,
             metadata=metadata,
-            **kwargs)
+            **kwargs
+        )
         try:
             return cast(Dict[str, Any], self._client.block_blob.put_blob_from_url(**options))
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -3241,6 +3241,15 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Result after appending a new block.
         :rtype: Dict[str, Union[str, datetime, int]]
         """

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -2056,6 +2056,15 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Blob property dict.
         :rtype: dict[str, Any]
         """
@@ -2067,7 +2076,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             source_offset=source_offset,
             source_length=source_length,
             source_content_md5=source_content_md5,
-            **kwargs)
+            **kwargs
+        )
         try:
             return cast(Dict[str, Any], self._client.block_blob.stage_block_from_url(**options))
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -2949,6 +2949,15 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Response after uploading pages from specified URL.
         :rtype: Dict[str, Any]
         """

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -1162,6 +1162,7 @@ def _append_block_from_url_options(
             append_position=appendpos_condition
         )
     source_authorization = kwargs.pop('source_authorization', None)
+    source_token_intent = kwargs.pop('source_token_intent', None)
     access_conditions = get_access_conditions(kwargs.pop('lease', None))
     mod_conditions = get_modify_conditions(kwargs)
     source_mod_conditions = get_source_conditions(kwargs)
@@ -1174,6 +1175,7 @@ def _append_block_from_url_options(
 
     options = {
         'copy_source_authorization': source_authorization,
+        'file_request_intent': source_token_intent,
         'source_url': copy_source_url,
         'content_length': 0,
         'source_range': source_range,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -609,6 +609,7 @@ def _start_copy_from_url_options(  # pylint:disable=too-many-statements
     requires_sync = kwargs.pop('requires_sync', None)
     encryption_scope_str = kwargs.pop('encryption_scope', None)
     source_authorization = kwargs.pop('source_authorization', None)
+    source_token_intent = kwargs.pop('source_token_intent', None)
     # If tags is a str, interpret that as copy_source_tags
     copy_source_tags = isinstance(tags, str)
 
@@ -628,6 +629,8 @@ def _start_copy_from_url_options(  # pylint:disable=too-many-statements
             headers['x-ms-encryption-scope'] = encryption_scope_str
         if source_authorization:
             headers['x-ms-copy-source-authorization'] = source_authorization
+        if source_token_intent:
+            headers['x-ms-file-request-intent'] = source_token_intent
         if copy_source_tags:
             headers['x-ms-copy-source-tag-option'] = tags
     else:
@@ -637,6 +640,9 @@ def _start_copy_from_url_options(  # pylint:disable=too-many-statements
         if source_authorization:
             raise ValueError(
                 "Source authorization tokens are only supported for sync copy, please specify requires_sync=True")
+        if source_token_intent:
+            raise ValueError(
+                "Source token intent is only supported for sync copy, please specify requires_sync=True")
         if copy_source_tags:
             raise ValueError(
                 "Copying source tags is only supported for sync copy, please specify requires_sync=True")

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -731,6 +731,7 @@ def _stage_block_from_url_options(
 ) -> Dict[str, Any]:
     source_url = _encode_source_url(source_url=source_url)
     source_authorization = kwargs.pop('source_authorization', None)
+    source_token_intent = kwargs.pop('source_token_intent', None)
     if source_length is not None and source_offset is None:
         raise ValueError("Source offset value must not be None if length is set.")
     if source_length is not None and source_offset is not None:
@@ -749,6 +750,7 @@ def _stage_block_from_url_options(
                             encryption_algorithm=cpk.algorithm)
     options = {
         'copy_source_authorization': source_authorization,
+        'file_request_intent': source_token_intent,
         'block_id': block_id,
         'content_length': 0,
         'source_url': source_url,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -197,6 +197,7 @@ def _upload_blob_from_url_options(source_url: str, **kwargs: Any) -> Dict[str, A
     overwrite = kwargs.pop('overwrite', False)
     content_settings = kwargs.pop('content_settings', None)
     source_authorization = kwargs.pop('source_authorization', None)
+    source_token_intent = kwargs.pop('source_token_intent', None)
     if content_settings:
         kwargs['blob_http_headers'] = BlobHTTPHeaders(
             blob_cache_control=content_settings.cache_control,
@@ -214,6 +215,7 @@ def _upload_blob_from_url_options(source_url: str, **kwargs: Any) -> Dict[str, A
 
     options = {
         'copy_source_authorization': source_authorization,
+        'file_request_intent': source_token_intent,
         'content_length': 0,
         'copy_source_blob_properties': kwargs.pop('include_source_blob_properties', True),
         'source_content_md5': kwargs.pop('source_content_md5', None),

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -1020,6 +1020,7 @@ def _upload_pages_from_url_options(
         if_sequence_number_equal_to=kwargs.pop('if_sequence_number_eq', None)
     )
     source_authorization = kwargs.pop('source_authorization', None)
+    source_token_intent = kwargs.pop('source_token_intent', None)
     access_conditions = get_access_conditions(kwargs.pop('lease', None))
     mod_conditions = get_modify_conditions(kwargs)
     source_mod_conditions = get_source_conditions(kwargs)
@@ -1033,6 +1034,7 @@ def _upload_pages_from_url_options(
 
     options = {
         'copy_source_authorization': source_authorization,
+        'file_request_intent': source_token_intent,
         'source_url': source_url,
         'content_length': 0,
         'source_range': source_range,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -1954,6 +1954,15 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Blob property dict.
         :rtype: Dict[str, Any]
         """

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -2849,6 +2849,15 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Response after uploading pages from specified URL.
         :rtype: Dict[str, Any]
         """

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -1660,6 +1660,15 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
 
             .. versionadded:: 12.9.0
 
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :keyword str encryption_scope:
             A predefined encryption scope used to encrypt the data on the sync copied blob. An encryption
             scope can be created using the Management API and referenced here by name. If a default
@@ -1684,7 +1693,8 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             source_url=source_url,
             metadata=metadata,
             incremental_copy=incremental_copy,
-            **kwargs)
+            **kwargs
+        )
         try:
             if incremental_copy:
                 return cast(Dict[str, Union[str, datetime]], await self._client.page_blob.copy_incremental(**options))
@@ -1974,7 +1984,8 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
             source_offset=source_offset,
             source_length=source_length,
             source_content_md5=source_content_md5,
-            **kwargs)
+            **kwargs
+        )
         try:
             return cast(Dict[str, Any], await self._client.block_blob.stage_block_from_url(**options))
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -412,6 +412,15 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Response from creating a new block blob for a given URL.
         :rtype: Dict[str, Any]
         """
@@ -420,7 +429,8 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
         options = _upload_blob_from_url_options(
             source_url=source_url,
             metadata=metadata,
-            **kwargs)
+            **kwargs
+        )
         try:
             return cast(Dict[str, Any], await self._client.block_blob.put_blob_from_url(**options))
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -3142,6 +3142,15 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
         :keyword str source_authorization:
             Authenticate as a service principal using a client secret to access a source blob. Ensure "bearer " is
             the prefix of the source_authorization string.
+        :keyword source_token_intent:
+            Required when source is Azure Storage Files and using `TokenCredential` for authentication.
+            This is ignored for other forms of authentication.
+            Specifies the intent for all requests when using `TokenCredential` authentication. Possible values are:
+
+            backup - Specifies requests are intended for backup/admin type operations, meaning that all file/directory
+                 ACLs are bypassed and full permissions are granted. User must also have required RBAC permission.
+
+        :paramtype source_token_intent: Literal['backup']
         :returns: Result after appending a new block.
         :rtype: Dict[str, Union[str, datetime, int]]
         """

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -3,3 +3,4 @@
 -e ../../identity/azure-identity
 azure-mgmt-storage==20.1.0
 aiohttp>=3.0
+azure-storage-file-share>=12.20.1

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -88,7 +88,6 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
         self, storage_account_name: str,
         data: bytes
     ) -> Tuple[ShareServiceClient, ShareClient, ShareFileClient]:
-
         share_name = self.get_resource_name('utshare')
         file_name = self.get_resource_name('file')
         share_token = self.get_credential(ShareServiceClient)

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -25,7 +25,7 @@ from azure.storage.blob import (
     StandardBlobTier,
 )
 from azure.storage.blob._shared.policies import StorageContentValidation
-from azure.storage.fileshare import ShareClient, ShareServiceClient, ShareFileClient
+from azure.storage.fileshare import ShareClient, ShareFileClient, ShareServiceClient
 
 from devtools_testutils import recorded_by_proxy
 from devtools_testutils.storage import StorageRecordedTestCase
@@ -88,16 +88,13 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
         self, storage_account_name: str,
         data: bytes
     ) -> Tuple[ShareServiceClient, ShareClient, ShareFileClient]:
-        share_name = self.get_resource_name('utshare')
-        file_name = self.get_resource_name('file')
-        share_token = self.get_credential(ShareServiceClient)
         share_service_client = ShareServiceClient(
             account_url=self.account_url(storage_account_name, "file"),
-            credential=share_token,
+            credential=self.get_credential(ShareServiceClient),
             token_intent='backup'
         )
-        share_client = share_service_client.create_share(share_name)
-        file_client = share_client.get_file_client(file_name)
+        share_client = share_service_client.create_share(self.get_resource_name('utshare'))
+        file_client = share_client.get_file_client(self.get_resource_name('file'))
         file_client.upload_file(data)
         return share_service_client, share_client, file_client
 

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -84,7 +84,7 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
     ) -> str:
         return prefix + f"{self.get_credential(BlobServiceClient).get_token(url).token}"
 
-    def _create_file_share(
+    def _create_file_share_oauth(
         self, storage_account_name: str,
         data: bytes
     ) -> Tuple[ShareServiceClient, ShareClient, ShareFileClient]:
@@ -139,7 +139,7 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
 
         # Set up source file share with random data
         source_data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        share_service_client, share_client, source_file_client = self._create_file_share(
+        share_service_client, share_client, source_file_client = self._create_file_share_oauth(
             storage_account_name,
             source_data
         )

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -287,6 +287,53 @@ class TestStorageBlockBlobAsync(AsyncStorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy_async
+    async def test_append_block_from_file_to_blob_with_oauth(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        await self._setup(storage_account_name, storage_account_key)
+
+        # Set up source file share with random data
+        source_data = self.get_random_bytes(LARGE_BLOB_SIZE)
+        share_service_client, share_client, source_file_client = await self._create_file_share_oauth(
+            storage_account_name,
+            source_data
+        )
+
+        # Set up destination blob without data
+        account_url = self.account_url(storage_account_name, "blob")
+        blob_service_client = BlobServiceClient(
+            account_url=account_url,
+            credential=storage_account_key
+        )
+        destination_blob_client = BlobClient(
+            account_url=account_url,
+            container_name=self.source_container_name,
+            blob_name=self.get_resource_name(TEST_BLOB_PREFIX + "1"),
+            credential=storage_account_key
+        )
+        await destination_blob_client.create_append_blob()
+
+        try:
+            # Act
+            token = await self._get_bearer_token_string()
+            await destination_blob_client.append_block_from_url(
+                copy_source_url=source_file_client.url,
+                source_authorization=token,
+                source_token_intent='backup'
+            )
+            destination_blob = await destination_blob_client.download_blob()
+            destination_blob_data = await destination_blob.readall()
+
+            # Assert
+            assert destination_blob_data == source_data
+        finally:
+            await share_service_client.delete_share(share_client.share_name)
+            await blob_service_client.delete_container(self.source_container_name)
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
     async def test_upload_blob_with_and_without_overwrite(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -236,6 +236,57 @@ class TestStorageBlockBlobAsync(AsyncStorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy_async
+    async def test_copy_from_file_to_blob_with_oauth(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        await self._setup(storage_account_name, storage_account_key)
+
+        # Set up source file share with random data
+        source_data = self.get_random_bytes(LARGE_BLOB_SIZE)
+        share_service_client, share_client, source_file_client = await self._create_file_share_oauth(
+            storage_account_name,
+            source_data
+        )
+
+        # Set up destination blob without data
+        blob_service_client = BlobServiceClient(
+            account_url=self.account_url(storage_account_name, "blob"),
+            credential=storage_account_key
+        )
+        destination_blob_client = blob_service_client.get_blob_client(
+            container=self.source_container_name,
+            blob=self.get_resource_name(TEST_BLOB_PREFIX + "1")
+        )
+
+        try:
+            # Act
+            token = await self._get_bearer_token_string()
+            with pytest.raises(ValueError):
+                await destination_blob_client.start_copy_from_url(
+                    source_url=source_file_client.url,
+                    source_authorization=token,
+                    source_token_intent='backup',
+                    requires_sync=False
+                )
+            await destination_blob_client.start_copy_from_url(
+                source_url=source_file_client.url,
+                source_authorization=token,
+                source_token_intent='backup',
+                requires_sync=True
+            )
+            destination_blob = await destination_blob_client.download_blob()
+            destination_blob_data = await destination_blob.readall()
+
+            # Assert
+            assert destination_blob_data == source_data
+        finally:
+            await share_service_client.delete_share(share_client.share_name)
+            await blob_service_client.delete_container(self.source_container_name)
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
     async def test_upload_blob_with_and_without_overwrite(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import uuid
 from datetime import datetime, timedelta
+from typing import Tuple
 
 import pytest
 from azure.core import MatchConditions
@@ -24,6 +25,7 @@ from azure.storage.blob import (
     SequenceNumberAction,
     generate_blob_sas)
 from azure.storage.blob._shared.policies import StorageContentValidation
+from azure.storage.fileshare import ShareClient, ShareFileClient, ShareServiceClient
 
 from devtools_testutils import recorded_by_proxy
 from devtools_testutils.storage import StorageRecordedTestCase
@@ -100,6 +102,26 @@ class TestStoragePageBlob(StorageRecordedTestCase):
         blob_client.upload_page(data, offset=range_start, length=len(data))
 
         return blob_client
+
+    def _get_bearer_token_string(
+        self, prefix: str = "Bearer ",
+        url: str = "https://storage.azure.com/.default"
+    ) -> str:
+        return prefix + f"{self.get_credential(BlobServiceClient).get_token(url).token}"
+
+    def _create_file_share_oauth(
+        self, storage_account_name: str,
+        data: bytes
+    ) -> Tuple[ShareServiceClient, ShareClient, ShareFileClient]:
+        share_service_client = ShareServiceClient(
+            account_url=self.account_url(storage_account_name, "file"),
+            credential=self.get_credential(ShareServiceClient),
+            token_intent='backup'
+        )
+        share_client = share_service_client.create_share(self.get_resource_name('utshare'))
+        file_client = share_client.get_file_client(self.get_resource_name('file'))
+        file_client.upload_file(data)
+        return share_service_client, share_client, file_client
 
     def assertBlobEqual(self, container_name, blob_name, expected_data, bsc):
         blob = bsc.get_blob_client(container_name, blob_name)
@@ -585,7 +607,7 @@ class TestStoragePageBlob(StorageRecordedTestCase):
 
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=storage_account_key, max_page_size=4 * 1024)
         self._setup(bsc)
-        token = "Bearer {}".format(self.get_credential(BlobServiceClient).get_token("https://storage.azure.com/.default").token)
+        token = self._get_bearer_token_string()
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(bsc, source_blob_data, 0, SOURCE_BLOB_SIZE)
         destination_blob_client = self._create_blob(bsc, length=SOURCE_BLOB_SIZE)
@@ -2370,3 +2392,49 @@ class TestStoragePageBlob(StorageRecordedTestCase):
 
         # Assert
         progress.assert_complete()
+
+    @BlobPreparer()
+    @recorded_by_proxy
+    def test_upload_from_file_to_page_blob_with_oauth(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        blob_service_client = BlobServiceClient(
+            self.account_url(storage_account_name, "blob"),
+            credential=storage_account_key,
+            max_page_size=4 * 1024
+        )
+        self._setup(blob_service_client)
+
+        # Set up source file share with random data
+        source_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
+        share_service_client, share_client, source_file_client = self._create_file_share_oauth(
+            storage_account_name,
+            source_data
+        )
+
+        # Set up destination blob without any data
+        destination_blob_client = blob_service_client.get_blob_client(
+            container=self.source_container_name,
+            blob=self.get_resource_name(TEST_BLOB_PREFIX + "1")
+        )
+        destination_blob_client.create_page_blob(SOURCE_BLOB_SIZE)
+
+        try:
+            # Act
+            destination_blob_client.upload_pages_from_url(
+                source_url=source_file_client.url,
+                offset=0,
+                length=SOURCE_BLOB_SIZE,
+                source_offset=0,
+                source_authorization=self._get_bearer_token_string(),
+                source_token_intent='backup'
+            )
+            destination_blob_data = destination_blob_client.download_blob().readall()
+
+            # Assert
+            assert destination_blob_data == source_data
+        finally:
+            share_service_client.delete_share(share_client.share_name)
+            blob_service_client.delete_container(self.source_container_name)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import uuid
 from datetime import datetime, timedelta
+from typing import Tuple
 
 import pytest
 from azure.core import MatchConditions
@@ -24,6 +25,7 @@ from azure.storage.blob import (
     generate_blob_sas)
 from azure.storage.blob.aio import BlobClient, BlobServiceClient
 from azure.storage.blob._shared.policies import StorageContentValidation
+from azure.storage.fileshare.aio import ShareClient, ShareFileClient, ShareServiceClient
 
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
@@ -95,6 +97,27 @@ class TestStoragePageBlobAsync(AsyncStorageRecordedTestCase):
             self.sleep(6)
             props = await blob.get_blob_properties()
         return props
+
+    async def _get_bearer_token_string(
+        self, prefix: str = "Bearer ",
+        url: str = "https://storage.azure.com/.default"
+    ) -> str:
+        access_token = await self.get_credential(BlobServiceClient, is_async=True).get_token(url)
+        return prefix + access_token.token
+
+    async def _create_file_share_oauth(
+        self, storage_account_name: str,
+        data: bytes
+    ) -> Tuple[ShareServiceClient, ShareClient, ShareFileClient]:
+        share_service_client = ShareServiceClient(
+            account_url=self.account_url(storage_account_name, "file"),
+            credential=self.get_credential(ShareServiceClient, is_async=True),
+            token_intent='backup'
+        )
+        share_client = await share_service_client.create_share(self.get_resource_name('utshare'))
+        file_client = share_client.get_file_client(self.get_resource_name('file'))
+        await file_client.upload_file(data)
+        return share_service_client, share_client, file_client
 
     async def assertBlobEqual(self, container_name, blob_name, expected_data, bsc):
         blob = bsc.get_blob_client(container_name, blob_name)
@@ -2339,5 +2362,53 @@ class TestStoragePageBlobAsync(AsyncStorageRecordedTestCase):
 
         # Assert
         progress.assert_complete()
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
+    async def test_upload_from_file_to_page_blob_with_oauth(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        blob_service_client = BlobServiceClient(
+            self.account_url(storage_account_name, "blob"),
+            credential=storage_account_key,
+            max_page_size=4 * 1024
+        )
+        await self._setup(blob_service_client)
+
+        # Set up source file share with random data
+        source_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
+        share_service_client, share_client, source_file_client = await self._create_file_share_oauth(
+            storage_account_name,
+            source_data
+        )
+
+        # Set up destination blob without any data
+        destination_blob_client = blob_service_client.get_blob_client(
+            container=self.source_container_name,
+            blob=self.get_resource_name(TEST_BLOB_PREFIX + "1")
+        )
+        await destination_blob_client.create_page_blob(SOURCE_BLOB_SIZE)
+
+        try:
+            # Act
+            token = await self._get_bearer_token_string()
+            await destination_blob_client.upload_pages_from_url(
+                source_url=source_file_client.url,
+                offset=0,
+                length=SOURCE_BLOB_SIZE,
+                source_offset=0,
+                source_authorization=token,
+                source_token_intent='backup'
+            )
+            destination_blob = await destination_blob_client.download_blob()
+            destination_blob_data = await destination_blob.readall()
+
+            # Assert
+            assert destination_blob_data == source_data
+        finally:
+            await share_service_client.delete_share(share_client.share_name)
+            await blob_service_client.delete_container(self.source_container_name)
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains the following changes:
1. Created helper functions (sync and async) to manage bearer token credential strings
2. Created helper functions to manage creating source files with OAuth
3. Added `azure-storage-file-share>=12.20.1` to `dev_requirements.txt`, the latest GA File Share release, for testing compatibility
4. Added kwargs for `source_token_intent` to send `x-ms-file-request-intent` and the appropriate validation for async copy (which is not a part of the feature)
5. Misc. fixes like moving closing parentheses to a new line

As of the first iteration, only the `upload_blob_from_url` tests has been recorded to check if `dev_requirements.txt` dependency is scaffolded properly. In addition, I've grouped `append_block_from_url` tests with `test_block_blob.py` and `test_block_blob_async.py` because they're all block blobs to reduce code duplication. I'm open to moving this to `test_append_blob.py` and `test_append_blob_async.py` respectively, after the naming, features, and testing structures have been reviewed. Thanks!

:shipit: 