### PR TITLE
Add support for chat completions message with "developer" role

### DIFF
--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_model_base.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_model_base.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines,arguments-differ,signature-differs,no-member
+# pylint: disable=too-many-lines
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -373,15 +373,34 @@ class _MyMutableMapping(MutableMapping[str, typing.Any]):  # pylint: disable=uns
         return not self.__eq__(other)
 
     def keys(self) -> typing.KeysView[str]:
+        """
+        :returns: a set-like object providing a view on D's keys
+        :rtype: ~typing.KeysView
+        """
         return self._data.keys()
 
     def values(self) -> typing.ValuesView[typing.Any]:
+        """
+        :returns: an object providing a view on D's values
+        :rtype: ~typing.ValuesView
+        """
         return self._data.values()
 
     def items(self) -> typing.ItemsView[str, typing.Any]:
+        """
+        :returns: set-like object providing a view on D's items
+        :rtype: ~typing.ItemsView
+        """
         return self._data.items()
 
     def get(self, key: str, default: typing.Any = None) -> typing.Any:
+        """
+        Get the value for key if key is in the dictionary, else default.
+        :param str key: The key to look up.
+        :param any default: The value to return if key is not in the dictionary. Defaults to None
+        :returns: D[k] if k in D, else d.
+        :rtype: any
+        """
         try:
             return self[key]
         except KeyError:
@@ -397,17 +416,38 @@ class _MyMutableMapping(MutableMapping[str, typing.Any]):  # pylint: disable=uns
     def pop(self, key: str, default: typing.Any) -> typing.Any: ...
 
     def pop(self, key: str, default: typing.Any = _UNSET) -> typing.Any:
+        """
+        Removes specified key and return the corresponding value.
+        :param str key: The key to pop.
+        :param any default: The value to return if key is not in the dictionary
+        :returns: The value corresponding to the key.
+        :rtype: any
+        :raises KeyError: If key is not found and default is not given.
+        """
         if default is _UNSET:
             return self._data.pop(key)
         return self._data.pop(key, default)
 
     def popitem(self) -> typing.Tuple[str, typing.Any]:
+        """
+        Removes and returns some (key, value) pair
+        :returns: The (key, value) pair.
+        :rtype: tuple
+        :raises KeyError: if D is empty.
+        """
         return self._data.popitem()
 
     def clear(self) -> None:
+        """
+        Remove all items from D.
+        """
         self._data.clear()
 
     def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """
+        Updates D from mapping/iterable E and F.
+        :param any args: Either a mapping object or an iterable of key-value pairs.
+        """
         self._data.update(*args, **kwargs)
 
     @typing.overload
@@ -417,6 +457,13 @@ class _MyMutableMapping(MutableMapping[str, typing.Any]):  # pylint: disable=uns
     def setdefault(self, key: str, default: typing.Any) -> typing.Any: ...
 
     def setdefault(self, key: str, default: typing.Any = _UNSET) -> typing.Any:
+        """
+        Same as calling D.get(k, d), and setting D[k]=d if k not found
+        :param str key: The key to look up.
+        :param any default: The value to set if key is not in the dictionary
+        :returns: D[k] if k in D, else d.
+        :rtype: any
+        """
         if default is _UNSET:
             return self._data.setdefault(key)
         return self._data.setdefault(key, default)
@@ -903,6 +950,19 @@ def _failsafe_deserialize(
 ) -> typing.Any:
     try:
         return _deserialize(deserializer, value, module, rf, format)
+    except DeserializationError:
+        _LOGGER.warning(
+            "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
+        )
+        return None
+
+
+def _failsafe_deserialize_xml(
+    deserializer: typing.Any,
+    value: typing.Any,
+) -> typing.Any:
+    try:
+        return _deserialize_xml(deserializer, value)
     except DeserializationError:
         _LOGGER.warning(
             "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_model_base.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_model_base.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,arguments-differ,signature-differs,no-member
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_operations/_operations.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_operations/_operations.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-locals
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -184,15 +183,6 @@ class ChatCompletionsClientOperationsMixin(ChatCompletionsClientMixinABC):
     @overload
     def _complete(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.ChatCompletions: ...
-    @overload
-    def _complete(
-        self,
         *,
         messages: List[_models._models.ChatRequestMessage],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -211,6 +201,15 @@ class ChatCompletionsClientOperationsMixin(ChatCompletionsClientMixinABC):
         ] = None,
         seed: Optional[int] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.ChatCompletions: ...
+    @overload
+    def _complete(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.ChatCompletions: ...
     @overload
@@ -488,15 +487,6 @@ class EmbeddingsClientOperationsMixin(EmbeddingsClientMixinABC):
     @overload
     def _embed(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.EmbeddingsResult: ...
-    @overload
-    def _embed(
-        self,
         *,
         input: List[str],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -505,6 +495,15 @@ class EmbeddingsClientOperationsMixin(EmbeddingsClientMixinABC):
         encoding_format: Optional[Union[str, _models.EmbeddingEncodingFormat]] = None,
         input_type: Optional[Union[str, _models.EmbeddingInputType]] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.EmbeddingsResult: ...
+    @overload
+    def _embed(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.EmbeddingsResult: ...
     @overload
@@ -701,15 +700,6 @@ class ImageEmbeddingsClientOperationsMixin(ImageEmbeddingsClientMixinABC):
     @overload
     def _embed(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.EmbeddingsResult: ...
-    @overload
-    def _embed(
-        self,
         *,
         input: List[_models.ImageEmbeddingInput],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -718,6 +708,15 @@ class ImageEmbeddingsClientOperationsMixin(ImageEmbeddingsClientMixinABC):
         encoding_format: Optional[Union[str, _models.EmbeddingEncodingFormat]] = None,
         input_type: Optional[Union[str, _models.EmbeddingInputType]] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.EmbeddingsResult: ...
+    @overload
+    def _embed(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.EmbeddingsResult: ...
     @overload

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_operations/_operations.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_operations/_operations.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-locals
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
@@ -20,7 +20,7 @@ Why do we patch auto-generated code? Below is a summary of the changes made in a
    JsonSchemaFormat object, instead of using auto-generated base/derived classes named
    ChatCompletionsResponseFormatXxxInternal.
 10. Allow UserMessage("my message") in addition to UserMessage(content="my message"). Same applies to 
-AssistantMessage, SystemMessage and ToolMessage.
+AssistantMessage, SystemMessage, DeveloperMessage and ToolMessage.
 
 """
 import json

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_serialization.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_serialization.py
@@ -48,9 +48,7 @@ from typing import (
     IO,
     Mapping,
     Callable,
-    TypeVar,
     MutableMapping,
-    Type,
     List,
 )
 
@@ -61,13 +59,13 @@ except ImportError:
 import xml.etree.ElementTree as ET
 
 import isodate  # type: ignore
+from typing_extensions import Self
 
 from azure.core.exceptions import DeserializationError, SerializationError
 from azure.core.serialization import NULL as CoreNull
 
 _BOM = codecs.BOM_UTF8.decode(encoding="utf-8")
 
-ModelType = TypeVar("ModelType", bound="Model")
 JSON = MutableMapping[str, Any]
 
 
@@ -384,25 +382,25 @@ class Model:
         return client_models
 
     @classmethod
-    def deserialize(cls: Type[ModelType], data: Any, content_type: Optional[str] = None) -> ModelType:
+    def deserialize(cls, data: Any, content_type: Optional[str] = None) -> Self:
         """Parse a str using the RestAPI syntax and return a model.
 
         :param str data: A str using RestAPI structure. JSON by default.
         :param str content_type: JSON by default, set application/xml if XML.
         :returns: An instance of this model
-        :raises: DeserializationError if something went wrong
-        :rtype: ModelType
+        :raises DeserializationError: if something went wrong
+        :rtype: Self
         """
         deserializer = Deserializer(cls._infer_class_models())
         return deserializer(cls.__name__, data, content_type=content_type)  # type: ignore
 
     @classmethod
     def from_dict(
-        cls: Type[ModelType],
+        cls,
         data: Any,
         key_extractors: Optional[Callable[[str, Dict[str, Any], Any], Any]] = None,
         content_type: Optional[str] = None,
-    ) -> ModelType:
+    ) -> Self:
         """Parse a dict using given key extractor return a model.
 
         By default consider key
@@ -414,7 +412,7 @@ class Model:
         :param str content_type: JSON by default, set application/xml if XML.
         :returns: An instance of this model
         :raises: DeserializationError if something went wrong
-        :rtype: ModelType
+        :rtype: Self
         """
         deserializer = Deserializer(cls._infer_class_models())
         deserializer.key_extractors = (  # type: ignore
@@ -560,7 +558,7 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param object target_obj: The data to be serialized.
         :param str data_type: The type to be serialized from.
         :rtype: str, dict
-        :raises: SerializationError if serialization fails.
+        :raises SerializationError: if serialization fails.
         :returns: The serialized data.
         """
         key_transformer = kwargs.get("key_transformer", self.key_transformer)
@@ -670,8 +668,8 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param object data: The data to be serialized.
         :param str data_type: The type to be serialized from.
         :rtype: dict
-        :raises: SerializationError if serialization fails.
-        :raises: ValueError if data is None
+        :raises SerializationError: if serialization fails.
+        :raises ValueError: if data is None
         :returns: The serialized request body
         """
 
@@ -715,8 +713,8 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param str data_type: The type to be serialized from.
         :rtype: str
         :returns: The serialized URL path
-        :raises: TypeError if serialization fails.
-        :raises: ValueError if data is None
+        :raises TypeError: if serialization fails.
+        :raises ValueError: if data is None
         """
         try:
             output = self.serialize_data(data, data_type, **kwargs)
@@ -739,8 +737,8 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param object data: The data to be serialized.
         :param str data_type: The type to be serialized from.
         :rtype: str, list
-        :raises: TypeError if serialization fails.
-        :raises: ValueError if data is None
+        :raises TypeError: if serialization fails.
+        :raises ValueError: if data is None
         :returns: The serialized query parameter
         """
         try:
@@ -769,8 +767,8 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param object data: The data to be serialized.
         :param str data_type: The type to be serialized from.
         :rtype: str
-        :raises: TypeError if serialization fails.
-        :raises: ValueError if data is None
+        :raises TypeError: if serialization fails.
+        :raises ValueError: if data is None
         :returns: The serialized header
         """
         try:
@@ -789,9 +787,9 @@ class Serializer:  # pylint: disable=too-many-public-methods
 
         :param object data: The data to be serialized.
         :param str data_type: The type to be serialized from.
-        :raises: AttributeError if required data is None.
-        :raises: ValueError if data is None
-        :raises: SerializationError if serialization fails.
+        :raises AttributeError: if required data is None.
+        :raises ValueError: if data is None
+        :raises SerializationError: if serialization fails.
         :returns: The serialized data.
         :rtype: str, int, float, bool, dict, list
         """
@@ -1126,7 +1124,7 @@ class Serializer:  # pylint: disable=too-many-public-methods
 
         :param Datetime attr: Object to be serialized.
         :rtype: str
-        :raises: TypeError if format invalid.
+        :raises TypeError: if format invalid.
         :return: serialized rfc
         """
         try:
@@ -1152,7 +1150,7 @@ class Serializer:  # pylint: disable=too-many-public-methods
 
         :param Datetime attr: Object to be serialized.
         :rtype: str
-        :raises: SerializationError if format invalid.
+        :raises SerializationError: if format invalid.
         :return: serialized iso
         """
         if isinstance(attr, str):
@@ -1185,7 +1183,7 @@ class Serializer:  # pylint: disable=too-many-public-methods
 
         :param Datetime attr: Object to be serialized.
         :rtype: int
-        :raises: SerializationError if format invalid
+        :raises SerializationError: if format invalid
         :return: serialied unix
         """
         if isinstance(attr, int):
@@ -1422,7 +1420,7 @@ class Deserializer:
         :param str target_obj: Target data type to deserialize to.
         :param requests.Response response_data: REST response object.
         :param str content_type: Swagger "produces" if available.
-        :raises: DeserializationError if deserialization fails.
+        :raises DeserializationError: if deserialization fails.
         :return: Deserialized object.
         :rtype: object
         """
@@ -1436,7 +1434,7 @@ class Deserializer:
 
         :param str target_obj: Target data type to deserialize to.
         :param object data: Object to deserialize.
-        :raises: DeserializationError if deserialization fails.
+        :raises DeserializationError: if deserialization fails.
         :return: Deserialized object.
         :rtype: object
         """
@@ -1651,7 +1649,7 @@ class Deserializer:
 
         :param str data: The response string to be deserialized.
         :param str data_type: The type to deserialize to.
-        :raises: DeserializationError if deserialization fails.
+        :raises DeserializationError: if deserialization fails.
         :return: Deserialized object.
         :rtype: object
         """
@@ -1733,7 +1731,7 @@ class Deserializer:
         :param dict attr: Dictionary to be deserialized.
         :return: Deserialized object.
         :rtype: dict
-        :raises: TypeError if non-builtin datatype encountered.
+        :raises TypeError: if non-builtin datatype encountered.
         """
         if attr is None:
             return None
@@ -1779,7 +1777,7 @@ class Deserializer:
         :param str data_type: deserialization data type.
         :return: Deserialized basic type.
         :rtype: str, int, float or bool
-        :raises: TypeError if string format is not valid.
+        :raises TypeError: if string format is not valid.
         """
         # If we're here, data is supposed to be a basic type.
         # If it's still an XML node, take the text
@@ -1870,7 +1868,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized bytearray
         :rtype: bytearray
-        :raises: TypeError if string format invalid.
+        :raises TypeError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1883,7 +1881,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized base64 string
         :rtype: bytearray
-        :raises: TypeError if string format invalid.
+        :raises TypeError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1898,7 +1896,7 @@ class Deserializer:
 
         :param str attr: response string to be deserialized.
         :return: Deserialized decimal
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         :rtype: decimal
         """
         if isinstance(attr, ET.Element):
@@ -1916,7 +1914,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized int
         :rtype: long or int
-        :raises: ValueError if string format invalid.
+        :raises ValueError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1929,7 +1927,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized duration
         :rtype: TimeDelta
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1947,7 +1945,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized date
         :rtype: Date
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1963,7 +1961,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized time
         :rtype: datetime.time
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -1978,7 +1976,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized RFC datetime
         :rtype: Datetime
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -2001,7 +1999,7 @@ class Deserializer:
         :param str attr: response string to be deserialized.
         :return: Deserialized ISO datetime
         :rtype: Datetime
-        :raises: DeserializationError if string format invalid.
+        :raises DeserializationError: if string format invalid.
         """
         if isinstance(attr, ET.Element):
             attr = attr.text
@@ -2039,7 +2037,7 @@ class Deserializer:
         :param int attr: Object to be serialized.
         :return: Deserialized datetime
         :rtype: Datetime
-        :raises: DeserializationError if format invalid
+        :raises DeserializationError: if format invalid
         """
         if isinstance(attr, ET.Element):
             attr = int(attr.text)  # type: ignore

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_operations/_operations.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_operations/_operations.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-locals
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -53,15 +52,6 @@ class ChatCompletionsClientOperationsMixin(ChatCompletionsClientMixinABC):
     @overload
     async def _complete(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.ChatCompletions: ...
-    @overload
-    async def _complete(
-        self,
         *,
         messages: List[_models._models.ChatRequestMessage],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -80,6 +70,15 @@ class ChatCompletionsClientOperationsMixin(ChatCompletionsClientMixinABC):
         ] = None,
         seed: Optional[int] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.ChatCompletions: ...
+    @overload
+    async def _complete(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.ChatCompletions: ...
     @overload
@@ -357,15 +356,6 @@ class EmbeddingsClientOperationsMixin(EmbeddingsClientMixinABC):
     @overload
     async def _embed(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.EmbeddingsResult: ...
-    @overload
-    async def _embed(
-        self,
         *,
         input: List[str],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -374,6 +364,15 @@ class EmbeddingsClientOperationsMixin(EmbeddingsClientMixinABC):
         encoding_format: Optional[Union[str, _models.EmbeddingEncodingFormat]] = None,
         input_type: Optional[Union[str, _models.EmbeddingInputType]] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.EmbeddingsResult: ...
+    @overload
+    async def _embed(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.EmbeddingsResult: ...
     @overload
@@ -570,15 +569,6 @@ class ImageEmbeddingsClientOperationsMixin(ImageEmbeddingsClientMixinABC):
     @overload
     async def _embed(
         self,
-        body: JSON,
-        *,
-        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> _models.EmbeddingsResult: ...
-    @overload
-    async def _embed(
-        self,
         *,
         input: List[_models.ImageEmbeddingInput],
         extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
@@ -587,6 +577,15 @@ class ImageEmbeddingsClientOperationsMixin(ImageEmbeddingsClientMixinABC):
         encoding_format: Optional[Union[str, _models.EmbeddingEncodingFormat]] = None,
         input_type: Optional[Union[str, _models.EmbeddingInputType]] = None,
         model: Optional[str] = None,
+        **kwargs: Any
+    ) -> _models.EmbeddingsResult: ...
+    @overload
+    async def _embed(
+        self,
+        body: JSON,
+        *,
+        extra_params: Optional[Union[str, _models._enums.ExtraParameters]] = None,
+        content_type: str = "application/json",
         **kwargs: Any
     ) -> _models.EmbeddingsResult: ...
     @overload

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_operations/_operations.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_operations/_operations.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-locals
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_enums.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_enums.py
@@ -46,6 +46,9 @@ class ChatRole(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """The role that provides responses to system-instructed, user-prompted input."""
     TOOL = "tool"
     """The role that represents extension tool activity within a chat completions operation."""
+    DEVELOPER = "developer"
+    """The role that instructs or sets the behavior of the assistant. Some AI models support this role
+    instead of the 'system' role."""
 
 
 class CompletionsFinishReason(str, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_models.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_models.py
@@ -194,8 +194,6 @@ class ChatCompletionsNamedToolChoice(_model_base.Model):
     """A tool selection of a specific, named function tool that will limit chat completions to using
     the named function.
 
-    Readonly variables are only populated by the server, and will be ignored when sending a request.
-
     :ivar type: The type of the tool. Currently, only ``function`` is supported. Required. Default
      value is "function".
     :vartype type: str
@@ -394,9 +392,6 @@ class ChatCompletionsResponseFormatText(ChatCompletionsResponseFormat, discrimin
 class ChatCompletionsToolCall(_model_base.Model):
     """A function tool call requested by the AI model.
 
-    Readonly variables are only populated by the server, and will be ignored when sending a request.
-
-
     :ivar id: The ID of the tool call. Required.
     :vartype id: str
     :ivar type: The type of tool call. Currently, only ``function`` is supported. Required. Default
@@ -437,8 +432,6 @@ class ChatCompletionsToolCall(_model_base.Model):
 class ChatCompletionsToolDefinition(_model_base.Model):
     """The definition of a chat completions tool that can call a function.
 
-    Readonly variables are only populated by the server, and will be ignored when sending a request.
-
     :ivar type: The type of the tool. Currently, only ``function`` is supported. Required. Default
      value is "function".
     :vartype type: str
@@ -475,18 +468,18 @@ class ChatRequestMessage(_model_base.Model):
     """An abstract representation of a chat message as provided in a request.
 
     You probably want to use the sub-classes and not this class directly. Known sub-classes are:
-    ChatRequestAssistantMessage, ChatRequestSystemMessage, ChatRequestToolMessage,
-    ChatRequestUserMessage
+    ChatRequestAssistantMessage, ChatRequestDeveloperMessage, ChatRequestSystemMessage,
+    ChatRequestToolMessage, ChatRequestUserMessage
 
     :ivar role: The chat role associated with this message. Required. Known values are: "system",
-     "user", "assistant", and "tool".
+     "user", "assistant", "tool", and "developer".
     :vartype role: str or ~azure.ai.inference.models.ChatRole
     """
 
     __mapping__: Dict[str, _model_base.Model] = {}
     role: str = rest_discriminator(name="role")
     """The chat role associated with this message. Required. Known values are: \"system\", \"user\",
-     \"assistant\", and \"tool\"."""
+     \"assistant\", \"tool\", and \"developer\"."""
 
     @overload
     def __init__(
@@ -548,6 +541,44 @@ class ChatRequestAssistantMessage(ChatRequestMessage, discriminator="assistant")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, role=ChatRole.ASSISTANT, **kwargs)
+
+
+class ChatRequestDeveloperMessage(ChatRequestMessage, discriminator="developer"):
+    """A request chat message containing system instructions that influence how the model will
+    generate a chat completions
+    response. Some AI models support a developer message instead of a system message.
+
+    :ivar role: The chat role associated with this message, which is always 'developer' for
+     developer messages. Required. The role that instructs or sets the behavior of the assistant.
+     Some AI models support this role instead of the 'system' role.
+    :vartype role: str or ~azure.ai.inference.models.DEVELOPER
+    :ivar content: The contents of the developer message. Required.
+    :vartype content: str
+    """
+
+    role: Literal[ChatRole.DEVELOPER] = rest_discriminator(name="role")  # type: ignore
+    """The chat role associated with this message, which is always 'developer' for developer messages.
+     Required. The role that instructs or sets the behavior of the assistant. Some AI models support
+     this role instead of the 'system' role."""
+    content: str = rest_field()
+    """The contents of the developer message. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        content: str,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, role=ChatRole.DEVELOPER, **kwargs)
 
 
 class ChatRequestSystemMessage(ChatRequestMessage, discriminator="system"):
@@ -667,7 +698,7 @@ class ChatResponseMessage(_model_base.Model):
 
 
     :ivar role: The chat role associated with the message. Required. Known values are: "system",
-     "user", "assistant", and "tool".
+     "user", "assistant", "tool", and "developer".
     :vartype role: str or ~azure.ai.inference.models.ChatRole
     :ivar content: The content of the message. Required.
     :vartype content: str
@@ -679,7 +710,7 @@ class ChatResponseMessage(_model_base.Model):
 
     role: Union[str, "_models.ChatRole"] = rest_field()
     """The chat role associated with the message. Required. Known values are: \"system\", \"user\",
-     \"assistant\", and \"tool\"."""
+     \"assistant\", \"tool\", and \"developer\"."""
     content: str = rest_field()
     """The content of the message. Required."""
     tool_calls: Optional[List["_models.ChatCompletionsToolCall"]] = rest_field()
@@ -1319,7 +1350,7 @@ class StreamingChatResponseMessageUpdate(_model_base.Model):
     """A representation of a chat message update as received in a streaming response.
 
     :ivar role: The chat role associated with the message. If present, should always be
-     'assistant'. Known values are: "system", "user", "assistant", and "tool".
+     'assistant'. Known values are: "system", "user", "assistant", "tool", and "developer".
     :vartype role: str or ~azure.ai.inference.models.ChatRole
     :ivar content: The content of the message.
     :vartype content: str
@@ -1331,7 +1362,7 @@ class StreamingChatResponseMessageUpdate(_model_base.Model):
 
     role: Optional[Union[str, "_models.ChatRole"]] = rest_field()
     """The chat role associated with the message. If present, should always be 'assistant'. Known
-     values are: \"system\", \"user\", \"assistant\", and \"tool\"."""
+     values are: \"system\", \"user\", \"assistant\", \"tool\", and \"developer\"."""
     content: Optional[str] = rest_field()
     """The content of the message."""
     tool_calls: Optional[List["_models.StreamingChatResponseToolCallUpdate"]] = rest_field()

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
@@ -76,11 +76,10 @@ class UserMessage(ChatRequestMessage, discriminator="user"):
 
 class SystemMessage(ChatRequestMessage, discriminator="system"):
     """A request chat message containing system instructions that influence how the model will
-    generate a chat completions
-    response.
+    generate a chat completions response.
 
     :ivar role: The chat role associated with this message, which is always 'system' for system
-     messages. Required. The role that instructs or sets the behavior of the assistant.
+     messages. Required.
     :vartype role: str or ~azure.ai.inference.models.SYSTEM
     :ivar content: The contents of the system message. Required.
     :vartype content: str
@@ -88,7 +87,7 @@ class SystemMessage(ChatRequestMessage, discriminator="system"):
 
     role: Literal[ChatRole.SYSTEM] = rest_discriminator(name="role")  # type: ignore
     """The chat role associated with this message, which is always 'system' for system messages.
-     Required. The role that instructs or sets the behavior of the assistant."""
+     Required."""
     content: str = rest_field()
     """The contents of the system message. Required."""
 
@@ -112,6 +111,46 @@ class SystemMessage(ChatRequestMessage, discriminator="system"):
             kwargs["content"] = args[0]
             args = tuple()
         super().__init__(*args, role=ChatRole.SYSTEM, **kwargs)
+
+
+class DeveloperMessage(ChatRequestMessage, discriminator="developer"):
+    """A request chat message containing developer instructions that influence how the model will
+    generate a chat completions response. Some AI models support developer messages instead
+    of system messages.
+
+    :ivar role: The chat role associated with this message, which is always 'developer' for developer
+     messages. Required.
+    :vartype role: str or ~azure.ai.inference.models.DEVELOPER
+    :ivar content: The contents of the developer message. Required.
+    :vartype content: str
+    """
+
+    role: Literal[ChatRole.DEVELOPER] = rest_discriminator(name="role")  # type: ignore
+    """The chat role associated with this message, which is always 'developer' for developer messages.
+     Required."""
+    content: str = rest_field()
+    """The contents of the developer message. Required."""
+
+    @overload
+    def __init__(
+        self,
+        content: str,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if len(args) == 1 and isinstance(args[0], str):
+            if kwargs.get("content") is not None:
+                raise ValueError("content cannot be provided as positional and keyword arguments")
+            kwargs["content"] = args[0]
+            args = tuple()
+        super().__init__(*args, role=ChatRole.DEVELOPER, **kwargs)
 
 
 class AssistantMessage(ChatRequestMessage, discriminator="assistant"):
@@ -511,6 +550,7 @@ __all__: List[str] = [
     "SystemMessage",
     "ToolMessage",
     "UserMessage",
+    "DeveloperMessage",
 ]  # Add all objects you want publicly available to users at this package level
 
 

--- a/sdk/ai/azure-ai-inference/tests/test_unit_tests.py
+++ b/sdk/ai/azure-ai-inference/tests/test_unit_tests.py
@@ -90,6 +90,25 @@ class TestUnitTests(ModelClientTestBase):
         except ValueError as e:
             assert str(e) == "content cannot be provided as positional and keyword arguments"
 
+    # Test custom class DeveloperMessage(), which allow specifying "content" as a positional argument
+    def test_developer_message(self, **kwargs):
+
+        # Verify that all these objects get serialized into the same dictionary
+        messages = [
+            sdk.models.DeveloperMessage(content="some content"),
+            sdk.models.DeveloperMessage("some content"),
+            sdk.models.DeveloperMessage({"role": "developer", "content": "some content"}),
+        ]
+        for message in messages:
+            assert message.as_dict() == {"role": "developer", "content": "some content"}
+
+        # Test invalid input arguments
+        try:
+            _ = (sdk.models.DeveloperMessage("some content", content="some content"),)
+            assert False
+        except ValueError as e:
+            assert str(e) == "content cannot be provided as positional and keyword arguments"
+
     # Test custom class AssistantMessage(), which allow specifying "content" as a positional argument
     def test_assistant_message(self, **kwargs):
 

--- a/sdk/ai/azure-ai-inference/tsp-location.yaml
+++ b/sdk/ai/azure-ai-inference/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/ModelClient
-commit: 46ddc411f22c02d678b63d8fe63e4b312d938977
+commit: a7a977a1666ad293769bc17fb80309be390b2ba9
 repo: Azure/azure-rest-api-specs
 additionalDirectories:


### PR DESCRIPTION
Manually tested end-to-end using o1 model.

Added unit-test to verify correct serialization of hand-written `DeveloperMessage` class.

Since this SDK was re-emited from TypeSpec, there are some unrelated changes due to emitter tool update.

Note: CHANGELOG.md was already updated in the feature branch to mention this added support. See PR https://github.com/Azure/azure-sdk-for-python/pull/39579.