### PR TITLE
Descriptive exception error message when `load_client` function or `get_model_info` method fails to run

### DIFF
--- a/sdk/ai/azure-ai-inference/CHANGELOG.md
+++ b/sdk/ai/azure-ai-inference/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added support for chat completion messages with `developer` role.
 * Updated package document with an example of how to set custom HTTP request headers,
 and an example of providing chat completion "messages" as an array of Python `dicts`.
+* Add a descriptive exception error message message when `load_client` function or
+`get_model_info` methods run on an endpoint that does not support the `/info` route.
 
 ## 1.0.0b8 (2025-01-29)
 

--- a/sdk/ai/azure-ai-inference/CHANGELOG.md
+++ b/sdk/ai/azure-ai-inference/CHANGELOG.md
@@ -7,8 +7,8 @@
 * Added support for chat completion messages with `developer` role.
 * Updated package document with an example of how to set custom HTTP request headers,
 and an example of providing chat completion "messages" as an array of Python `dicts`.
-* Add a descriptive exception error message message when `load_client` function or
-`get_model_info` methods run on an endpoint that does not support the `/info` route.
+* Add a descriptive exception error message when `load_client` function or
+`get_model_info` method fails to run on an endpoint that does not support the `/info` route.
 
 ## 1.0.0b8 (2025-01-29)
 

--- a/sdk/ai/azure-ai-inference/assets.json
+++ b/sdk/ai/azure-ai-inference/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ai/azure-ai-inference",
-  "Tag": "python/ai/azure-ai-inference_bc7c5bd581"
+  "Tag": "python/ai/azure-ai-inference_3f06cee8a7"
 }

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
@@ -1057,9 +1057,8 @@ class EmbeddingsClient(EmbeddingsClientGenerated):
             try:
                 self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                raise ResourceNotFoundError(
-                    message="Model information is not available on this endpoint (`/info` route not supported)."
-                ) from error
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
 
         return self._model_info
 
@@ -1359,9 +1358,8 @@ class ImageEmbeddingsClient(ImageEmbeddingsClientGenerated):
             try:
                 self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                raise ResourceNotFoundError(
-                    message="Model information is not available on this endpoint (`/info` route not supported)."
-                ) from error
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
 
         return self._model_info
 

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
@@ -139,7 +139,12 @@ def load_client(
     with ChatCompletionsClient(
         endpoint, credential, **kwargs
     ) as client:  # Pick any of the clients, it does not matter.
-        model_info = client.get_model_info()  # type: ignore
+        try:
+            model_info = client.get_model_info()  # type: ignore
+        except ResourceNotFoundError as error:
+            error.message = "`load_client` function does not work on this endpoint (`/info` route not supported). " \
+                            "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            raise error
 
     _LOGGER.info("model_info=%s", model_info)
     if not model_info.model_type:
@@ -748,7 +753,12 @@ class ChatCompletionsClient(ChatCompletionsClientGenerated):  # pylint: disable=
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
+
         return self._model_info
 
     def __str__(self) -> str:
@@ -1044,7 +1054,13 @@ class EmbeddingsClient(EmbeddingsClientGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                raise ResourceNotFoundError(
+                    message="Model information is not available on this endpoint (`/info` route not supported)."
+                ) from error
+
         return self._model_info
 
     def __str__(self) -> str:
@@ -1340,7 +1356,13 @@ class ImageEmbeddingsClient(ImageEmbeddingsClientGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                raise ResourceNotFoundError(
+                    message="Model information is not available on this endpoint (`/info` route not supported)."
+                ) from error
+
         return self._model_info
 
     def __str__(self) -> str:

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_patch.py
@@ -78,7 +78,12 @@ async def load_client(
     async with ChatCompletionsClient(
         endpoint, credential, **kwargs
     ) as client:  # Pick any of the clients, it does not matter.
-        model_info = await client.get_model_info()  # type: ignore
+        try:
+            model_info = await client.get_model_info()  # type: ignore
+        except ResourceNotFoundError as error:
+            error.message = "`load_client` function does not work on this endpoint (`/info` route not supported). " \
+                            "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            raise error
 
     _LOGGER.info("model_info=%s", model_info)
     if not model_info.model_type:
@@ -686,7 +691,12 @@ class ChatCompletionsClient(ChatCompletionsClientGenerated):  # pylint: disable=
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
+
         return self._model_info
 
     def __str__(self) -> str:
@@ -982,7 +992,12 @@ class EmbeddingsClient(EmbeddingsClientGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
+
         return self._model_info
 
     def __str__(self) -> str:
@@ -1278,7 +1293,12 @@ class ImageEmbeddingsClient(ImageEmbeddingsClientGenerated):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         if not self._model_info:
-            self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            try:
+                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+            except ResourceNotFoundError as error:
+                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                raise error
+
         return self._model_info
 
     def __str__(self) -> str:

--- a/sdk/ai/azure-ai-inference/tests/model_inference_test_base.py
+++ b/sdk/ai/azure-ai-inference/tests/model_inference_test_base.py
@@ -279,6 +279,11 @@ class ModelClientTestBase(AzureRecordedTestCase):
         endpoint, credential = self._load_chat_credentials_api_key(bad_key=bad_key, **kwargs)
         return sdk.load_client(endpoint=endpoint, credential=credential, logging_enable=LOGGING_ENABLED)
 
+    def _load_chat_client_on_aoai_endpoint(self, *, bad_key: bool = False, **kwargs) -> sdk.ChatCompletionsClient:
+        endpoint, credential, credential_scopes, api_version = self._load_aoai_chat_credentials(key_auth=True, bad_key=False, **kwargs)
+        return sdk.load_client(endpoint=endpoint, credential=credential, credential_scopes=credential_scopes,
+            api_version=api_version, logging_enable=LOGGING_ENABLED)
+
     async def _load_async_embeddings_client(self, *, bad_key: bool = False, **kwargs) -> async_sdk.EmbeddingsClient:
         endpoint, credential = self._load_embeddings_credentials_api_key(bad_key=bad_key, **kwargs)
         return await async_sdk.load_client(endpoint=endpoint, credential=credential, logging_enable=LOGGING_ENABLED)

--- a/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
+++ b/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
@@ -13,7 +13,7 @@ from model_inference_test_base import (
 )
 
 from devtools_testutils import recorded_by_proxy
-from azure.core.exceptions import AzureError, ServiceRequestError
+from azure.core.exceptions import AzureError, ServiceRequestError, ResourceNotFoundError
 from azure.core.credentials import AzureKeyCredential
 
 
@@ -628,3 +628,33 @@ class TestChatCompletionsClient(ModelClientTestBase):
             assert "not found" in e.message.lower() or "not allowed" in e.message.lower()
         client.close()
         assert exception_caught
+
+    @ServicePreparerAOAIChatCompletions()
+    @recorded_by_proxy
+    def test_load_client_on_aoai_endpoint(self, **kwargs):
+
+        exception_caught = False
+        try:
+            _ = self._load_chat_client_on_aoai_endpoint(**kwargs)
+        except ResourceNotFoundError as e:
+            exception_caught = True
+            print(e)
+            assert "`load_client` function does not work on this endpoint" in e.message.lower()
+        assert exception_caught
+
+    @ServicePreparerAOAIChatCompletions()
+    @recorded_by_proxy
+    def test_get_model_info_on_aoai_endpoint(self, **kwargs):
+
+        with self._create_aoai_chat_client(**kwargs) as client:
+
+            exception_caught = False
+            try:
+                _ = client.get_model_info()
+            except ResourceNotFoundError as e:
+                exception_caught = True
+                print(e)
+                assert "model information is not available on this endpoint" in e.message.lower()
+
+            assert exception_caught
+


### PR DESCRIPTION
This fix is to address a GitHub issue, where a customer tried to run "load_client" on an AOAI endpoint, which does not support the /info route. The exception error was not informative.

Add a more descriptive exception error message when `load_client` function or`get_model_info` method fails to run on an endpoint that does not support the `/info` route.