### PR TITLE
Add support for OpenTelemetry SemConv SESSION_ID propagation to Application Insights

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Support for OpenTelemetry SemConv SESSION_ID propagation to Application Insights
+  ([#39630](https://github.com/Azure/azure-sdk-for-python/pull/39630))
 - Support AAD for sovereign clouds
   ([#39379](https://github.com/Azure/azure-sdk-for-python/pull/39379))
 - Support stable http semantic conventions for breeze exporter - REQUESTS

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -221,6 +221,8 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
     envelope.tags[ContextTagKeys.AI_OPERATION_ID] = "{:032x}".format(span.context.trace_id)
     if SpanAttributes.ENDUSER_ID in span.attributes:
         envelope.tags[ContextTagKeys.AI_USER_ID] = span.attributes[SpanAttributes.ENDUSER_ID]
+    if SpanAttributes.SESSION_ID in span.attributes:
+        envelope.tags[ContextTagKeys.AI_SESSION_ID] = span.attributes[SpanAttributes.SESSION_ID]
     if span.parent and span.parent.span_id:
         envelope.tags[ContextTagKeys.AI_OPERATION_PARENT_ID] = "{:016x}".format(span.parent.span_id)
     if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -14,6 +14,7 @@ from opentelemetry.semconv.attributes.http_attributes import (
 )
 from opentelemetry.semconv.trace import DbSystemValues, SpanAttributes
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from opentelemetry.semconv._incubating.attributes import session_attributes
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -221,8 +222,8 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
     envelope.tags[ContextTagKeys.AI_OPERATION_ID] = "{:032x}".format(span.context.trace_id)
     if SpanAttributes.ENDUSER_ID in span.attributes:
         envelope.tags[ContextTagKeys.AI_USER_ID] = span.attributes[SpanAttributes.ENDUSER_ID]
-    if SpanAttributes.SESSION_ID in span.attributes:
-        envelope.tags[ContextTagKeys.AI_SESSION_ID] = span.attributes[SpanAttributes.SESSION_ID]
+    if session_attributes.SESSION_ID in span.attributes:
+        envelope.tags[ContextTagKeys.AI_SESSION_ID] = span.attributes[session_attributes.SESSION_ID]
     if span.parent and span.parent.span_id:
         envelope.tags[ContextTagKeys.AI_OPERATION_PARENT_ID] = "{:016x}".format(span.parent.span_id)
     if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -272,7 +272,10 @@ class TestAzureTraceExporter(unittest.TestCase):
             name="test",
             context=context,
             resource=resource,
-            attributes={"enduser.id": "testId"},
+            attributes={
+                "enduser.id": "testUserId",
+                "session.id": "testSessionId",
+            },
             parent=context,
         )
         test_span.start()
@@ -303,7 +306,8 @@ class TestAzureTraceExporter(unittest.TestCase):
         self.assertEqual(envelope.tags.get(ContextTagKeys.AI_CLOUD_ROLE_INSTANCE), "testServiceInstanceId")
         self.assertEqual(envelope.tags.get(ContextTagKeys.AI_INTERNAL_NODE_NAME), "testServiceInstanceId")
         self.assertEqual(envelope.tags.get(ContextTagKeys.AI_OPERATION_ID), "{:032x}".format(context.trace_id))
-        self.assertEqual(envelope.tags.get(ContextTagKeys.AI_USER_ID), "testId")
+        self.assertEqual(envelope.tags.get(ContextTagKeys.AI_USER_ID), "testUserId")
+        self.assertEqual(envelope.tags.get(ContextTagKeys.AI_SESSION_ID), "testSessionId")
         self.assertEqual(envelope.tags.get(ContextTagKeys.AI_OPERATION_PARENT_ID), "{:016x}".format(context.span_id))
 
     def test_span_to_envelope_partA_default(self):


### PR DESCRIPTION
# Description

Fixes #39433

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.


Proof that it works:
<img width="477" alt="Screenshot 2025-02-07 at 23 04 16" src="https://github.com/user-attachments/assets/c470b18c-a83f-451b-988c-c393ccc8b3f3" />
