### PR TITLE
Fix next-pylint issue

### DIFF
--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
@@ -463,6 +463,9 @@ class StreamingChatCompletions(BaseStreamingChatCompletions):
             return True
         return self._deserialize_and_add_to_queue(element)
 
+    def __enter__(self):
+        return self
+
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:  # type: ignore
         self.close()
 
@@ -501,6 +504,9 @@ class AsyncStreamingChatCompletions(BaseStreamingChatCompletions):
             await self.aclose()
             return True
         return self._deserialize_and_add_to_queue(element)
+
+    async def __aenter__(self):
+        return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:  # type: ignore
         await self.aclose()

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
@@ -6,7 +6,6 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-import asyncio
 import base64
 import json
 import logging
@@ -503,8 +502,8 @@ class AsyncStreamingChatCompletions(BaseStreamingChatCompletions):
             return True
         return self._deserialize_and_add_to_queue(element)
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:  # type: ignore
-        asyncio.run(self.aclose())
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:  # type: ignore
+        await self.aclose()
 
     async def aclose(self) -> None:
         await self._response.close()

--- a/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
+++ b/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
@@ -389,16 +389,15 @@ class TestChatCompletionsClient(ModelClientTestBase):
     @ServicePreparerChatCompletions()
     @recorded_by_proxy
     def test_chat_completions_streaming(self, **kwargs):
-        client = self._create_chat_client(**kwargs)
-        response = client.complete(
-            stream=True,
-            messages=[
-                sdk.models.SystemMessage("You are a helpful assistant."),
-                sdk.models.UserMessage("Give me 3 good reasons why I should exercise every day."),
-            ],
-        )
-        self._validate_chat_completions_streaming_result(response)
-        client.close()
+        with self._create_chat_client(**kwargs) as client:
+            with client.complete(
+                stream=True,
+                messages=[
+                    sdk.models.SystemMessage("You are a helpful assistant."),
+                    sdk.models.UserMessage("Give me 3 good reasons why I should exercise every day."),
+                ],
+            ) as response:
+                self._validate_chat_completions_streaming_result(response)
 
     @ServicePreparerChatCompletions()
     @recorded_by_proxy

--- a/sdk/ai/azure-ai-inference/tests/test_chat_completions_client_async.py
+++ b/sdk/ai/azure-ai-inference/tests/test_chat_completions_client_async.py
@@ -371,16 +371,15 @@ class TestChatCompletionsClientAsync(ModelClientTestBase):
     @ServicePreparerChatCompletions()
     @recorded_by_proxy_async
     async def test_async_chat_completions_streaming(self, **kwargs):
-        client = self._create_async_chat_client(Sync=False, **kwargs)
-        response = await client.complete(
-            stream=True,
-            messages=[
-                sdk.models.SystemMessage(content="You are a helpful assistant."),
-                sdk.models.UserMessage(content="Give me 3 good reasons why I should exercise every day."),
-            ],
-        )
-        await self._validate_async_chat_completions_streaming_result(response)
-        await client.close()
+        async with self._create_async_chat_client(Sync=False, **kwargs) as client:
+            async with await client.complete(
+                stream=True,
+                messages=[
+                    sdk.models.SystemMessage(content="You are a helpful assistant."),
+                    sdk.models.UserMessage(content="Give me 3 good reasons why I should exercise every day."),
+                ],
+            ) as response:
+                await self._validate_async_chat_completions_streaming_result(response)
 
     @ServicePreparerChatCompletions()
     @recorded_by_proxy_async


### PR DESCRIPTION
Fix for GitHub issue "azure-ai-inference needs linting updates for pylint version 3.2.7" (https://github.com/Azure/azure-sdk-for-python/issues/39270)

Running
```
>pip install "tox<5"
>tox run -e next-pylint -c ../../../eng/tox/tox.ini --root .
```
Resulted in this error:
```
************* Module azure.ai.inference.models._patch
azure\ai\inference\models\_patch.py:506: [C4763(do-not-import-asyncio), AsyncStreamingChatCompletions.__exit__] Do not import the asyncio package directly in your library
```

The fix is to make sure the async iterator class has the proper async exit method (`__aexit__`). I also made sure the "with context" pattern works with the streaming response object, by updating some of the streaming tests.
