### PR TITLE
Filter out ExcludePaths from PR files before processing

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -48,6 +48,12 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
     $targetedFiles += $diff.DeletedFiles
   }
 
+  # The targetedFiles needs to filter out anything in the ExcludePaths
+  # otherwise it'll end up processing things below that it shouldn't be.
+  foreach ($excludePath in $diffObj.ExcludePaths) {
+    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath) }
+  }
+
   if ($targetedFiles) {
     foreach($file in $targetedFiles) {
       $pathComponents = $file -split "/"


### PR DESCRIPTION
I ran into this while doing testing for Java's function. The problem I saw was that `sdk/cosmos` is excluded in the [pullrequest.yml](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/pipelines/pullrequest.yml#L17) file but if something were changed in the root of `sdk/cosmos` [this line of code in the Language-Settings.ps1](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/scripts/Language-Settings.ps1#L55) would still end up adding cosmos libraries if something were changed in the root of sdk/cosmos.

The solution was simple, remove any entries that start with any exclude paths from the targetedFiles list.

This was the [test PR where I verified the issue](https://github.com/Azure/azure-sdk-for-python/pull/39665) and changing something within the root of sdk/cosmos was causing the additional packages for validation to return azure-cosmos, azure-mgmt-cosmosdb and azure-mgmt-documentdb. The [python - pullrequest run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4554271&view=results) had failures because of this.

@scbedd the other languages you've implemented PR pipelines for will also need this change.