### PR TITLE
PR to deprecate azure-mgmt-networkanalytics

### DIFF
--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/CHANGELOG.md
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0 (2024-01-26)
 
+### Other Changes
+
+- This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
+
 ### Features Added
 
   - Model DataProduct has a new parameter properties

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
@@ -1,6 +1,3 @@
-# Microsoft Azure SDK for Python
-
-# Microsoft Azure SDK for Python
 
 **NOTE**: This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
 

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
@@ -1,3 +1,4 @@
+# Microsoft Azure SDK for Python
 
 **NOTE**: This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
 

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
@@ -1,5 +1,9 @@
 # Microsoft Azure SDK for Python
 
+# Microsoft Azure SDK for Python
+
+This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
+
 This is the Microsoft Azure Networkanalytics Management Client Library.
 This package has been tested with Python 3.8+.
 For a more complete view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/README.md
@@ -2,7 +2,7 @@
 
 # Microsoft Azure SDK for Python
 
-This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
+**NOTE**: This package has been deprecated and will no longer be maintained after 03-14-2025. This package will only receive security fixes until 03-14-2025.
 
 This is the Microsoft Azure Networkanalytics Management Client Library.
 This package has been tested with Python 3.8+.

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/pyproject.toml
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/pyproject.toml
@@ -4,3 +4,4 @@ mypy = false
 pyright = false
 type_check_samples = false
 verifytypes = false
+ci_enabled = false

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/pyproject.toml
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/pyproject.toml
@@ -4,4 +4,3 @@ mypy = false
 pyright = false
 type_check_samples = false
 verifytypes = false
-ci_enabled = false

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/sdk_packaging.toml
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/sdk_packaging.toml
@@ -10,3 +10,4 @@ need_azuremgmtcore = true
 sample_link = ""
 exclude_folders = ""
 title = "NetworkAnalyticsMgmtClient"
+auto_update = false

--- a/sdk/networkanalytics/azure-mgmt-networkanalytics/setup.py
+++ b/sdk/networkanalytics/azure-mgmt-networkanalytics/setup.py
@@ -49,7 +49,7 @@ setup(
     url="https://github.com/Azure/azure-sdk-for-python",
     keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
# Description

Underlying service for this package is retired and the associated package is no longer supported. Please help us in bringing this down from the package manager. Also raised PR for deprecation of the azure-SDK.

All the resources associated to this service is removed and also removed public facing rest-api-specs. This is the last step remaining for us.

Also, no customer exists for using these packages.