### PR TITLE
Update logging preferences, handle coverage `NoDataError`

### DIFF
--- a/eng/tox/run_coverage.py
+++ b/eng/tox/run_coverage.py
@@ -3,18 +3,27 @@ import argparse
 import os
 import json
 import datetime
+import logging
+
+from typing import Optional
 
 from ci_tools.parsing import ParsedSetup
 from ci_tools.variables import in_ci
 from ci_tools.environment_exclusions import is_check_enabled
+from coverage.exceptions import NoDataError
 
-def get_total_coverage(coverage_file: str) -> float:
+def get_total_coverage(coverage_file: str) -> Optional[float]:
     cov = coverage.Coverage(data_file=coverage_file)
     cov.load()
-    report = cov.report()
-
-    return report
-
+    try:
+        report = cov.report()
+        return report
+    except NoDataError as e:
+        logging.warning(f"This package did not generate any coverage output: {e}")
+        return None
+    except Exception as e:
+        logging.error(f"An error occurred while generating the coverage report: {e}")
+        return None
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -36,16 +45,20 @@ if __name__ == "__main__":
 
     if os.path.exists(possible_coverage_file):
         total_coverage = get_total_coverage(possible_coverage_file)
-        print(f"Total coverage for {pkg_details.name} is {total_coverage:.2f}%")
+        if total_coverage is not None:
+            logging.info(f"Total coverage for {pkg_details.name} is {total_coverage:.2f}%")
 
-        if in_ci():
-            metric_obj = {}
-            metric_obj["value"] = total_coverage / 100
-            metric_obj["name"] = "test_coverage_ratio"
-            metric_obj["labels"] = { "package": pkg_details.name }
-            metric_obj["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
-            print(f'logmetric: {json.dumps(metric_obj)}')
+            if in_ci():
+                metric_obj = {}
+                metric_obj["value"] = total_coverage / 100
+                metric_obj["name"] = "test_coverage_ratio"
+                metric_obj["labels"] = { "package": pkg_details.name }
+                metric_obj["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+                # normally we logging.info anywhere we need to output, but these logmetric statements
+                # need to be the sole value on the line, as the logmetric log parsing doesn't allow prefixes
+                # before the 'logmetric' start string.
+                print(f'logmetric: {json.dumps(metric_obj)}')
 
     if is_check_enabled(args.target_package, "cov_enforcement", False):
-        print("Coverage enforcement is enabled for this package.")
+        logging.info("Coverage enforcement is enabled for this package.")
 


### PR DESCRIPTION
We need to handle this case. @jalauzon-msft has `azure-storage-extensions` package crashing on run because extension packages don't generate coverage.

Also update logging preferences to align with the rest of the scripts in the repo.