### PR TITLE
Save package properties before setting daily dev version

### DIFF
--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -56,6 +56,13 @@ steps:
       }
     displayName: Set Component Governance Path
 
+  # Create package properties file before updating the version to daily dev build
+  # This is required to set the package version in info file before it's updated.
+  - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      ExcludePaths: ${{ parameters.ExcludePaths }}
+
   # set dev build calls SavePackageProperties with dev version if necessary. this will never happen in a PR build
   # however, it will set the variable SetDevVersion as appropriate for normal nightly runs
   - template: set-dev-build.yml


### PR DESCRIPTION
# Description

Save package properties in package info file before SDK version is updated to daily dev version so that all other tools that refer package info will have actual version and not the daily dev version.