### PR TITLE
Add regression tests (unit tests) for parsing streaming response

### DIFF
--- a/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/_patch.py
@@ -142,8 +142,10 @@ def load_client(
         try:
             model_info = client.get_model_info()  # type: ignore
         except ResourceNotFoundError as error:
-            error.message = "`load_client` function does not work on this endpoint (`/info` route not supported). " \
-                            "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            error.message = (
+                "`load_client` function does not work on this endpoint (`/info` route not supported). "
+                "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            )
             raise error
 
     _LOGGER.info("model_info=%s", model_info)
@@ -756,7 +758,7 @@ class ChatCompletionsClient(ChatCompletionsClientGenerated):  # pylint: disable=
             try:
                 self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info
@@ -1057,7 +1059,7 @@ class EmbeddingsClient(EmbeddingsClientGenerated):
             try:
                 self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info
@@ -1358,7 +1360,7 @@ class ImageEmbeddingsClient(ImageEmbeddingsClientGenerated):
             try:
                 self._model_info = self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/aio/_patch.py
@@ -81,8 +81,10 @@ async def load_client(
         try:
             model_info = await client.get_model_info()  # type: ignore
         except ResourceNotFoundError as error:
-            error.message = "`load_client` function does not work on this endpoint (`/info` route not supported). " \
-                            "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            error.message = (
+                "`load_client` function does not work on this endpoint (`/info` route not supported). "
+                "Please construct one of the clients (e.g. `ChatCompletionsClient`) directly."
+            )
             raise error
 
     _LOGGER.info("model_info=%s", model_info)
@@ -692,9 +694,11 @@ class ChatCompletionsClient(ChatCompletionsClientGenerated):  # pylint: disable=
         """
         if not self._model_info:
             try:
-                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+                self._model_info = await self._get_model_info(
+                    **kwargs
+                )  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info
@@ -993,9 +997,11 @@ class EmbeddingsClient(EmbeddingsClientGenerated):
         """
         if not self._model_info:
             try:
-                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+                self._model_info = await self._get_model_info(
+                    **kwargs
+                )  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info
@@ -1294,9 +1300,11 @@ class ImageEmbeddingsClient(ImageEmbeddingsClientGenerated):
         """
         if not self._model_info:
             try:
-                self._model_info = await self._get_model_info(**kwargs)  # pylint: disable=attribute-defined-outside-init
+                self._model_info = await self._get_model_info(
+                    **kwargs
+                )  # pylint: disable=attribute-defined-outside-init
             except ResourceNotFoundError as error:
-                error.message="Model information is not available on this endpoint (`/info` route not supported)."
+                error.message = "Model information is not available on this endpoint (`/info` route not supported)."
                 raise error
 
         return self._model_info

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/models/_patch.py
@@ -370,7 +370,11 @@ class BaseStreamingChatCompletions:
         self._incomplete_json = ""
         self._done = False  # Will be set to True when reading 'data: [DONE]' line
 
+    # See https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
     def _deserialize_and_add_to_queue(self, element: bytes) -> bool:
+
+        if self._ENABLE_CLASS_LOGS:
+            logger.debug("[Original element] %s", repr(element))
 
         # Clear the queue of StreamingChatCompletionsUpdate before processing the next block
         self._queue.queue.clear()

--- a/sdk/ai/azure-ai-inference/tests/model_inference_test_base.py
+++ b/sdk/ai/azure-ai-inference/tests/model_inference_test_base.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import List, Optional, Union, Dict, Any
 from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader
 from azure.core.credentials import AzureKeyCredential
+from azure.core.rest import HttpResponse, AsyncHttpResponse
 
 # Set to True to enable SDK logging
 LOGGING_ENABLED = True
@@ -280,9 +281,16 @@ class ModelClientTestBase(AzureRecordedTestCase):
         return sdk.load_client(endpoint=endpoint, credential=credential, logging_enable=LOGGING_ENABLED)
 
     def _load_chat_client_on_aoai_endpoint(self, *, bad_key: bool = False, **kwargs) -> sdk.ChatCompletionsClient:
-        endpoint, credential, credential_scopes, api_version = self._load_aoai_chat_credentials(key_auth=True, bad_key=False, **kwargs)
-        return sdk.load_client(endpoint=endpoint, credential=credential, credential_scopes=credential_scopes,
-            api_version=api_version, logging_enable=LOGGING_ENABLED)
+        endpoint, credential, credential_scopes, api_version = self._load_aoai_chat_credentials(
+            key_auth=True, bad_key=False, **kwargs
+        )
+        return sdk.load_client(
+            endpoint=endpoint,
+            credential=credential,
+            credential_scopes=credential_scopes,
+            api_version=api_version,
+            logging_enable=LOGGING_ENABLED,
+        )
 
     async def _load_async_embeddings_client(self, *, bad_key: bool = False, **kwargs) -> async_sdk.EmbeddingsClient:
         endpoint, credential = self._load_embeddings_credentials_api_key(bad_key=bad_key, **kwargs)
@@ -754,3 +762,168 @@ class ModelClientTestBase(AzureRecordedTestCase):
         """
         with Path(__file__).with_name(file_name).open("r") as f:
             return io.BytesIO(f.read().encode("utf-8"))
+
+
+# **********************************************************************************
+#
+#                         OTHER HELPER CLASSES
+#
+# **********************************************************************************
+
+
+class HttpResponseForUnitTests(HttpResponse):
+
+    def __init__(self, response_bytes: list[bytes]):
+        self._response_bytes = response_bytes
+
+    # Required to support context management
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    # Implementation of HttpResponse abstract base class methods.
+    # Only the first one requires an implementation for this test to work.
+    def iter_bytes(self):
+        for response_byte in self._response_bytes:
+            yield response_byte
+
+    def close(self):
+        pass
+
+    def iter_raw(self):
+        pass
+
+    def json(self):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    def text(self):
+        pass
+
+    def read(self):
+        pass
+
+    # Implementation of HttpResponse abstract base class properties
+    # None of these are used by test code.
+    @property
+    def content(self):
+        pass
+
+    @property
+    def content_type(self):
+        pass
+
+    @property
+    def encoding(self):
+        pass
+
+    @property
+    def headers(self):
+        pass
+
+    @property
+    def is_closed(self):
+        pass
+
+    @property
+    def is_stream_consumed(self):
+        pass
+
+    @property
+    def reason(self):
+        pass
+
+    @property
+    def request(self):
+        pass
+
+    @property
+    def status_code(self):
+        pass
+
+    @property
+    def url(self):
+        pass
+
+
+class AsyncHttpResponseForUnitTests(AsyncHttpResponse):
+
+    def __init__(self, response_bytes: list[bytes]):
+        self._response_bytes = response_bytes
+
+    # Required to support context management
+    def __aenter__(self):
+        return self
+
+    def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    # Implementation of HttpResponse abstract base class methods.
+    # Only the first one requires an implementation for this test to work.
+    async def iter_bytes(self):
+        for response_byte in self._response_bytes:
+            yield response_byte
+
+    async def close(self):
+        pass
+
+    async def iter_raw(self):
+        pass
+
+    async def json(self):
+        pass
+
+    async def raise_for_status(self):
+        pass
+
+    async def text(self):
+        pass
+
+    async def read(self):
+        pass
+
+    # Implementation of HttpResponse abstract base class properties
+    # None of these are used by test code.
+    @property
+    def content(self):
+        pass
+
+    @property
+    def content_type(self):
+        pass
+
+    @property
+    def encoding(self):
+        pass
+
+    @property
+    def headers(self):
+        pass
+
+    @property
+    def is_closed(self):
+        pass
+
+    @property
+    def is_stream_consumed(self):
+        pass
+
+    @property
+    def reason(self):
+        pass
+
+    @property
+    def request(self):
+        pass
+
+    @property
+    def status_code(self):
+        pass
+
+    @property
+    def url(self):
+        pass

--- a/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
+++ b/sdk/ai/azure-ai-inference/tests/test_chat_completions_client.py
@@ -656,4 +656,3 @@ class TestChatCompletionsClient(ModelClientTestBase):
                 assert "model information is not available on this endpoint" in e.message.lower()
 
             assert exception_caught
-

--- a/sdk/ai/azure-ai-inference/tests/test_unit_tests.py
+++ b/sdk/ai/azure-ai-inference/tests/test_unit_tests.py
@@ -6,7 +6,7 @@ import os
 import json
 import azure.ai.inference as sdk
 
-from model_inference_test_base import ModelClientTestBase
+from model_inference_test_base import ModelClientTestBase, HttpResponseForUnitTests, AsyncHttpResponseForUnitTests
 
 
 # The test class name needs to start with "Test" to get collected by pytest
@@ -291,3 +291,91 @@ class TestUnitTests(ModelClientTestBase):
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAAApCAYAAAB9ctS7AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAB0CSURBVGhDRZpZzK33ddbXnufh2"
         )
         assert image_embedding_input.text == "some text"
+
+    # **********************************************************************************
+    #
+    #            UNIT TESTS (REGRESSION TESTS) FOR STREAMING RESPONSE PARSING
+    #
+    # **********************************************************************************
+
+    # Recorded from real chat completions streaming response
+    # - Using sample code `samples\sample_chat_completions_streaming.py`,
+    # - With SSE logging turned on (_ENABLE_CLASS_LOGS = True`),
+    # - With Mistral Large model, with user message "how many feet are in a mile?", with content safety turned on.
+    # - The bytes below are from the log output of `[Original element]`.
+    STREAMING_RESPONSE_BYTES: list[bytes] = [
+        b'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+        b'data: {"choices":[{"delta":{"content":"There"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" are"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" "},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"5"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":","},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"2"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"8"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"0"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" feet"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" in"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" a"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" mile"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"."},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" This"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+        b'data: {"choices":[{"delta":{"content":" is"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" a"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" standard"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" measurement"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" used"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" in"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" the"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" United"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" States"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" and"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" a"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" few"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" other"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" countries"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"."},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" If"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" you"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" need"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" help"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.',
+        b'chunk"}\n\ndata: {"choices":[{"delta":{"content":" conver"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"ting"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" other"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" units"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" of"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" measurement"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":","},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" feel"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" free"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" to"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":" ask"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+        b'data: {"choices":[{"delta":{"content":"!"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":""},"finish_reason":"stop","index":0,"logprobs":null}],"created":1739300519,"id":"f9a9e06e5c844339aee30ecb9f61ca8b","model":"mistral-large","object":"chat.completion.chunk","usage":{"completion_tokens":45,"prompt_tokens":19,"total_tokens":64}}\n\ndata: [DONE]\n\n',
+    ]
+    EXPECTED_STREAMING_RESPONSE = "There are 5,280 feet in a mile. This is a standard measurement used in the United States and a few other countries. If you need help converting other units of measurement, feel free to ask!"
+
+    # To test the case where a chinese chars are broken between two lines.
+    # See GitHub issue https://github.com/Azure/azure-sdk-for-python/issues/39565
+    # Recorded from real chat completions streaming response
+    # - Using sample code `samples\sample_chat_completions_streaming.py`,
+    # - With SSE logging turned on (_ENABLE_CLASS_LOGS = True`),
+    # - With Mistral Large model, with user message "Translate 'the sky is blue' to Chinese. Don't add any extra text before or after the Chinese translation. Just give the translation.", with content safety turned on.
+    # - The bytes below are from the log output of `[Original element]`.
+    # This was the original response:
+    # STREAMING_RESPONSE_BYTES_SPLIT_CHINISE_CHAR: list[bytes] = [
+    #     b'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+    #     b'data: {"choices":[{"delta":{"content":"\xe5\xa4\xa9"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+    #     b'data: {"choices":[{"delta":{"content":"\xe7\xa9\xba"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe6\x98\xaf"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe8\x93\x9d"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe8\x89\xb2"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe7\x9a\x84"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":""},"finish_reason":"stop","index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk","usage":{"completion_tokens":7,"prompt_tokens":41,"total_tokens":48}}\n\ndata: [DONE]\n\n'
+    # ]
+    # This is the manually modifed response, after splitting the 2nd line into two lines, in the middle of the 3-byte Chinese charcater. This is an
+    # attempt to repro what was reported in the GitHub issue, since I don't have a model and that actually generated such a response. The existing code
+    # works fine in this case, and I don't get the `decode("utf-8")` exception.
+    # If I add `\n` at the end of the 2nd line below (per inline comment), I do get the exception, but I don't think that's a valid SSE syntex. If this is the behaviour seen by the customer,
+    # I belive the service code for streaming needs to be fixed.
+    STREAMING_RESPONSE_BYTES_SPLIT_CHINISE_CHAR: list[bytes] = [
+        b'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+        b'data: {"choices":[{"delta":{"content":"\xe5\xa4'  # If you add \n at the end, parsing will fail, but I don't think that's a valid SSE syntax.
+        b'\xa9"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\n',
+        b'data: {"choices":[{"delta":{"content":"\xe7\xa9\xba"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe6\x98\xaf"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe8\x93\x9d"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe8\x89\xb2"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":"\xe7\x9a\x84"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk"}\n\ndata: {"choices":[{"delta":{"content":""},"finish_reason":"stop","index":0,"logprobs":null}],"created":1739388793,"id":"97f3900d75c94c028984e58bef2a2584","model":"mistral-large","object":"chat.completion.chunk","usage":{"completion_tokens":7,"prompt_tokens":41,"total_tokens":48}}\n\ndata: [DONE]\n\n',
+    ]
+    EXPECTED_STREAMING_RESPONSE_SPLIT_CHINESE_CHAR = "天空是蓝色的"  # "The sky is blue" in Chinese
+
+    # Regression test for the implementation of StreamingChatCompletions class,
+    # which does the SSE parsing for streaming response
+    def test_streaming_response_parsing(self, **kwargs):
+
+        http_response = HttpResponseForUnitTests(TestUnitTests.STREAMING_RESPONSE_BYTES)
+        response = sdk.models.StreamingChatCompletions(response=http_response)
+
+        actual_response: str = ""
+        for update in response:
+            print(update.choices[0].delta.content or "", end="", flush=True)
+            actual_response += update.choices[0].delta.content or ""
+
+        assert actual_response == TestUnitTests.EXPECTED_STREAMING_RESPONSE
+
+    # Regression test for the implementation of AsyncStreamingChatCompletions class,
+    # which does the async SSE parsing for streaming response
+    async def test_streaming_response_parsing_async(self, **kwargs):
+
+        async_http_response = AsyncHttpResponseForUnitTests(TestUnitTests.STREAMING_RESPONSE_BYTES)
+        response = sdk.models.AsyncStreamingChatCompletions(response=async_http_response)
+
+        actual_response: str = ""
+        async for update in response:
+            print(update.choices[0].delta.content or "", end="", flush=True)
+            actual_response += update.choices[0].delta.content or ""
+
+        assert actual_response == TestUnitTests.EXPECTED_STREAMING_RESPONSE
+
+    # Regression test for the implementation of StreamingChatCompletions class,
+    # which does the SSE parsing for streaming response
+    def test_streaming_response_parsing_split_chinese_char(self, **kwargs):
+
+        http_response = HttpResponseForUnitTests(TestUnitTests.STREAMING_RESPONSE_BYTES_SPLIT_CHINISE_CHAR)
+        response = sdk.models.StreamingChatCompletions(response=http_response)
+
+        actual_response: str = ""
+        for update in response:
+            print(update.choices[0].delta.content or "", end="", flush=True)
+            actual_response += update.choices[0].delta.content or ""
+
+        assert actual_response == TestUnitTests.EXPECTED_STREAMING_RESPONSE_SPLIT_CHINESE_CHAR


### PR DESCRIPTION
Add regression tests for the classes that parse the chat completions streaming response.

With regards to this GitHub issue: https://github.com/Azure/azure-sdk-for-python/issues/39565, I'm still waiting for the customer to respond with information indicating which AI Model they used, as I cannot get a repro of this. I wrote an additional unit-test which uses Chinese characters, allowing me to manually split SSE lines in different ways trying to guess what caused the exception thrown from `element.decode("utf-8")` as reported by the customer. There is one split I can do, that results in that exception, however as far as I know that is not a valid SSE format.  So, we may have a service bug in the streaming code of some AI model that needs to be investigated. Therefore, at the moment I'm not making any SDK changes. This PR just adds regression tests.

There are some SDK changes as a result of running the black tool (`black --config ../../../eng/black-pyproject.toml .`), unrelated to the above. You can focus your code review only on the 3 files under the `/tests` folder.