### PR TITLE
[Storage] Change content iterating in `_download_async.py`, add decompression live tests against compressed dataset

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -46,8 +46,11 @@ T = TypeVar('T', bytes, str)
 async def process_content(data: Any, start_offset: int, end_offset: int, encryption: Dict[str, Any]) -> bytes:
     if data is None:
         raise ValueError("Response cannot be None.")
-    await data.response.load_body()
-    content = cast(bytes, data.response.body())
+    if not data.response.is_stream_consumed:
+        content = b"".join([d async for d in data])
+    else:
+        await data.response.read()
+        content = cast(bytes, data.response.content)
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:
             return decrypt_blob(

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3531,4 +3531,27 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         result = blob.download_blob().readall()
         assert result == data[:length]
 
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    def test_download_blob_compressed_data_with_decompress(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        self._setup(storage_account_name, storage_account_key)
+        blob_name = self._get_blob_reference()
+        blob = self.bsc.get_blob_client(self.container_name, blob_name)
+        compressed_data = b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xcaH\xcd\xc9\xc9WH+\xca\xcfUH\xaf\xca,\x00\x00\x00\x00\xff\xff\x03\x00d\xaa\x8e\xb5\x0f\x00\x00\x00'
+        decompressed_data = b"hello from gzip"
+        content_settings = ContentSettings(content_encoding='gzip')
+
+        # Act / Assert
+        blob.upload_blob(data=compressed_data, content_settings=content_settings, overwrite=True)
+
+        result = blob.download_blob(decompress=True).readall()
+        assert result == decompressed_data
+
+        result = blob.download_blob(decompress=False).readall()
+        assert result == compressed_data
+
     # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -3510,4 +3510,29 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         blob_data = await (await blob_client.download_blob(validate_content=True)).read()
         assert blob_data == b"Hello Async World!"  # data is fixed by mock transport
+
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    async def test_download_blob_compressed_data_with_decompress(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        # Arrange
+        await self._setup(storage_account_name, storage_account_key)
+        blob_name = self._get_blob_reference()
+        blob = self.bsc.get_blob_client(self.container_name, blob_name)
+        compressed_data = b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xcaH\xcd\xc9\xc9WH+\xca\xcfUH\xaf\xca,\x00\x00\x00\x00\xff\xff\x03\x00d\xaa\x8e\xb5\x0f\x00\x00\x00'
+        decompressed_data = b"hello from gzip"
+        content_settings = ContentSettings(content_encoding='gzip')
+
+        # Act / Assert
+        await blob.upload_blob(data=compressed_data, content_settings=content_settings, overwrite=True)
+
+        downloaded = await blob.download_blob(decompress=True)
+        result = await downloaded.readall()
+        assert result == decompressed_data
+
+        downloaded = await blob.download_blob(decompress=False)
+        result = await downloaded.readall()
+        assert result == compressed_data
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Change from `response.load_body()` and `response.body()` in `_download_async.py` to access content, as this method does not respect the `decompress` param passed to `download_blob` API
  - This was resolved by using the iterator directly.
  - An `if-else` block was added to handle the general hotpath and the `validate_content=True` path (where the body would have been loaded previously for MD5 check)
- Test cases were added for both sync and async for the compressed data + `decompress=T/F` scenario.