### PR TITLE
Remove post processing step from tox generate environment

### DIFF
--- a/sdk/ai/azure-ai-inference/pyproject.toml
+++ b/sdk/ai/azure-ai-inference/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.generate]
-autorest-post-process = true

--- a/sdk/documentintelligence/azure-ai-documentintelligence/pyproject.toml
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/pyproject.toml
@@ -1,5 +1,3 @@
 [tool.azure-sdk-build]
 pyright = false
 
-[tool.generate]
-autorest-post-process = true

--- a/sdk/face/azure-ai-vision-face/pyproject.toml
+++ b/sdk/face/azure-ai-vision-face/pyproject.toml
@@ -1,3 +1,2 @@
-
 [tool.azure-sdk-build]
 verifytypes = false

--- a/sdk/face/azure-ai-vision-face/pyproject.toml
+++ b/sdk/face/azure-ai-vision-face/pyproject.toml
@@ -1,4 +1,3 @@
-[tool.generate]
-autorest-post-process = true
+
 [tool.azure-sdk-build]
 verifytypes = false

--- a/sdk/monitor/azure-monitor-ingestion/pyproject.toml
+++ b/sdk/monitor/azure-monitor-ingestion/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.generate]
-autorest-post-process = true

--- a/sdk/translation/azure-ai-translation-document/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-document/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.azure-sdk-build]
 pyright = false
 
-[tool.generate]
-autorest-post-process = true
+

--- a/sdk/translation/azure-ai-translation-text/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-text/pyproject.toml
@@ -4,5 +4,4 @@ type_check_samples = true
 verifytypes = true
 pyright = true
 
-[tool.generate]
-autorest-post-process = true
+

--- a/sdk/vision/azure-ai-vision-imageanalysis/pyproject.toml
+++ b/sdk/vision/azure-ai-vision-imageanalysis/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.generate]
-autorest-post-process = true

--- a/tools/azure-sdk-tools/packaging_tools/generate_client.py
+++ b/tools/azure-sdk-tools/packaging_tools/generate_client.py
@@ -7,28 +7,6 @@ import tomli
 _LOGGER = logging.getLogger(__name__)
 
 
-CONF_NAME = "pyproject.toml"
-
-def check_post_process(folder: Path) -> bool:
-    conf_path = folder / CONF_NAME
-    if not conf_path.exists():
-        return False
-
-    with open(conf_path, "rb") as fd:
-        toml_dict = tomli.load(fd)
-        if toml_dict.get("tool", None) is not None:
-            if toml_dict["tool"].get("generate", None) is not None:
-                if toml_dict["tool"]["generate"].get("autorest-post-process", None) is not None:
-                    return toml_dict["tool"]["generate"]["autorest-post-process"]
-    return False
-
-def run_post_process(folder: Path) -> None:
-    completed_process = run(f"autorest --postprocess --output-folder={folder} --perform-load=false --python", cwd=folder, shell=True)
-
-    if completed_process.returncode != 0:
-        raise ValueError("Something happened during autorest post processing: " + str(completed_process))
-    _LOGGER.info("Autorest post processing done")
-
 def generate_autorest(folder: Path) -> None:
 
     readme_path = folder / "swagger" / "README.md"
@@ -67,9 +45,6 @@ def generate(folder: Path = Path(".")) -> None:
         generate_typespec(folder)
     else:
         raise ValueError("Didn't find swagger/README.md nor tsp_location.yaml")
-
-    if check_post_process(folder):
-        run_post_process(folder)
 
 def generate_main() -> None:
     """Main method"""


### PR DESCRIPTION
We dont need to run the post-processing step anymore in the tox generate environment since it's done as part of code generation now. Also, cleaning up pyproject.toml files that set `autorest-post-process`.