### PR TITLE
Handle PR changes in the root of the repository

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -62,8 +62,11 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
         $changedServices += $pathComponents[1]
       }
 
-      # handle any changes under sdk/<file>.<extension>
-      if ($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") {
+      # handle any changes under sdk/<file>.<extension> as well as any
+      # changes to the root of the repository. Changes to the root of
+      # repository is the case where pathComponents.Lenght -eq 1
+      if (($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") -or
+          ($pathComponents.Length -eq 1)) {
         $changedServices += "template"
       }
     }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -70,6 +70,9 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
         $changedServices += "template"
       }
     }
+
+    # dedupe the changed service list before processing
+    $changedServices = $changedServices | Get-Unique
     foreach ($changedService in $changedServices) {
       $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
 
@@ -93,8 +96,6 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
     $engChanged = $targetedFiles | Where-Object { $_.StartsWith("eng")}
     $othersChanged = $targetedFiles | Where-Object { isOther($_) }
   }
-
-  $changedServices = $changedServices | Get-Unique
 
   if ($toolChanged) {
     $additionalPackages = @(


### PR DESCRIPTION
This was the [test PR where I found the issue](https://github.com/Azure/azure-sdk-for-python/pull/39748) and this was the [python - pullrequest run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4566648&view=results). The PR just changed a file in the root of the directory, and this is the resulting diff.json
```
{
  "ChangedFiles": "README.md",
  "ChangedServices": [],
  "ExcludePaths": [
    "sdk/cosmos"
  ],
  "DeletedFiles": [],
  "PRNumber": "39748"
}
```
When splitting on the directory separator for a file in the repo root, `$pathComponents.Length -eq 1`. I've got the same change in Java, I've tested this exact piece of code in there and things work just fine.

There was one other change I'd pushed up in the second commit. The changedServices should have been deduped prior to processing it.
