### PR TITLE
[Storage] Fix Create Hard Link Error Test

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_ed248ab97a"
+  "Tag": "python/storage/azure-storage-file-share_28d3d8db00"
 }

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_4047c4afa8"
+  "Tag": "python/storage/azure-storage-file-share_ed248ab97a"
 }

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs.py
@@ -262,13 +262,13 @@ class TestStorageFileNFS(StorageRecordedTestCase):
 
         share_client = self.fsc.get_share_client(self.share_name)
         directory_name = self._get_directory_name()
-        directory_client = share_client.create_directory(directory_name)
-        source_file_name = self._get_file_name()
+        directory_client = share_client.get_directory_client(directory_name)
+        source_file_name = self._get_file_name('file1')
         source_file_client = directory_client.get_file_client(source_file_name)
-        hard_link_file_name = self._get_file_name()
+        hard_link_file_name = self._get_file_name('file2')
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
         with pytest.raises(ResourceNotFoundError) as e:
-            hard_link_file_client.create_hard_link(target=source_file_client.url)
+            hard_link_file_client.create_hard_link(target=f"{directory_name}/{source_file_name}")
 
         assert 'ParentNotFound' in e.value.args[0]

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
@@ -274,13 +274,13 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
 
         share_client = self.fsc.get_share_client(self.share_name)
         directory_name = self._get_directory_name()
-        directory_client = await share_client.create_directory(directory_name)
-        source_file_name = self._get_file_name()
+        directory_client = share_client.get_directory_client(directory_name)
+        source_file_name = self._get_file_name('file1')
         source_file_client = directory_client.get_file_client(source_file_name)
-        hard_link_file_name = self._get_file_name()
+        hard_link_file_name = self._get_file_name('file2')
         hard_link_file_client = directory_client.get_file_client(hard_link_file_name)
 
         with pytest.raises(ResourceNotFoundError) as e:
-            await hard_link_file_client.create_hard_link(target=source_file_client.url)
+            await hard_link_file_client.create_hard_link(target=f"{directory_name}/{source_file_name}")
 
         assert 'ParentNotFound' in e.value.args[0]


### PR DESCRIPTION
Fixed Create Hard Link Error Test as part of NFS over REST 97, which was causing live tests failures.