### PR TITLE
Add trailing slash exclude paths

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -14,7 +14,7 @@ pr:
     # any excludes here. The reason being is that we can't access
     # pr->paths->exclude
     exclude:
-    - sdk/cosmos
+    - sdk/cosmos/
 
 parameters:
   - name: Service
@@ -31,4 +31,4 @@ extends:
     # See pr->paths->exclude comment above. Anything added/removed there
     # needs to be added/removed here.
     ExcludePaths:
-      - sdk/cosmos
+      - sdk/cosmos/

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -51,7 +51,7 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
   # The targetedFiles needs to filter out anything in the ExcludePaths
   # otherwise it'll end up processing things below that it shouldn't be.
   foreach ($excludePath in $diffObj.ExcludePaths) {
-    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath.TrimEnd("/") + "/") }
+    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath) }
   }
 
   if ($targetedFiles) {


### PR DESCRIPTION
This PR is in preparation for an upcoming change that'll allow us to exclude specific files. Right now, we were always adding a trailing "/" if one wasn't there and this was done to ensure that things didn't overmatch. For example, if you had sdk/foo and sdk/foobar with an exclude of sdk/foo, without the slash, it would overmatch sdk/foo and sdk/foobar. We were adding the trailing the slash to ensure that this didn't happen. Because always have a need to exclude specific files, adding the trailing slash won't allow this case to work.

This is the first change and it's a safe. Adding the trailing slash allows the removal of where we were doing this in Language-Settings.ps1. Note: There's still a place in eng/common Package-Properties.ps1 where this also has to be done before specific file excludes can be added.