### PR TITLE
update sphinx to v8

### DIFF
--- a/doc/analyze_check_versions.md
+++ b/doc/analyze_check_versions.md
@@ -9,5 +9,5 @@ Pylint | 3.2.7 | 3.2.7 | 2025-04-14 |
 Pylint Guidelines Checker | 0.4.1 | 0.5.1 | 2025-04-14 |
 MyPy | 1.13.0 | 1.14.1 | 2025-04-14 |
 Pyright | 1.1.389 | 1.1.391 | 2025-04-14 |
-Sphinx | 7.3.7 | N/A | N/A |
+Sphinx | 8.2.0 | N/A | N/A |
 Black | 24.4.0 | N/A | N/A |

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -24,9 +24,9 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This variable is set from resolve-package-targeting.yml.
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.11'
+    displayName: 'Use Python 3.13'
     inputs:
-      versionSpec: '3.11'
+      versionSpec: '3.13'
 
   - pwsh: |
       if ("${{ parameters.ServiceDirectory }}" -ne "auto")

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -325,9 +325,9 @@ setenv =
   PROXY_URL=http://localhost:5007
 deps =
   {[base]deps}
-  sphinx==7.3.7
-  sphinx_rtd_theme==1.3.0
-  myst_parser==2.0.0
+  sphinx==8.2.0
+  sphinx_rtd_theme==3.0.2
+  myst_parser==4.0.1
   sphinxcontrib-jquery==4.1
 commands =
   python {repository_root}/eng/tox/create_package_and_install.py \


### PR DESCRIPTION
In this [PR](https://github.com/Azure/azure-sdk-for-python/pull/39823) we added a `next-sphinx` env to evaluate bumping sphinx to v8 and using python 3.13. We found that there are no new warnings/errors emitted with these versions so we should be able to safely bump them in the `sphinx` env as well.