### PR TITLE
[Identity] Update behavior of MI Service Fabric

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Previously, if a `client_id` or `identity_config` was specified in `ManagedIdentityCredential` for Service Fabric managed identity, which is not supported, the `client_id` (or `resource_id`/`object_id` specified `identity_config`) would be silently ignored. Now, an exception will be raised during a token request if a `client_id` or `identity_config` is specified for Service Fabric managed identity.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
@@ -6,15 +6,36 @@ import functools
 import os
 from typing import Dict, Optional, Any
 
+from azure.core.credentials import AccessToken, AccessTokenInfo, TokenRequestOptions
+from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.transport import HttpRequest
 
 from .._constants import EnvironmentVariables
 from .._internal.msal_managed_identity_client import MsalManagedIdentityClient
 
 
+SERVICE_FABRIC_ERROR_MESSAGE = (
+    "Specifying a client_id or identity_config is not supported by the Service Fabric managed identity environment. "
+    "The managed identity configuration is determined by the Service Fabric cluster resource configuration. "
+    "See https://aka.ms/servicefabricmi for more information."
+)
+
+
 class ServiceFabricCredential(MsalManagedIdentityClient):
     def get_unavailable_message(self, desc: str = "") -> str:
         return f"Service Fabric managed identity configuration not found in environment. {desc}"
+
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
+        if self._settings.get("client_id") or self._settings.get("identity_config"):
+            raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
+        return super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+
+    def get_token_info(self, *scopes: str, options: Optional[TokenRequestOptions] = None) -> AccessTokenInfo:
+        if self._settings.get("client_id") or self._settings.get("identity_config"):
+            raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
+        return super().get_token_info(*scopes, options=options)
 
 
 def _get_client_args(**kwargs: Any) -> Optional[Dict]:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -4,9 +4,13 @@
 # ------------------------------------
 from typing import Optional, Any
 
+from azure.core.credentials import AccessToken, AccessTokenInfo, TokenRequestOptions
+from azure.core.exceptions import ClientAuthenticationError
+
 from .._internal.managed_identity_base import AsyncManagedIdentityBase
 from .._internal.managed_identity_client import AsyncManagedIdentityClient
-from ..._credentials.service_fabric import _get_client_args
+from ..._credentials.service_fabric import _get_client_args, SERVICE_FABRIC_ERROR_MESSAGE
+from ... import CredentialUnavailableError
 
 
 class ServiceFabricCredential(AsyncManagedIdentityBase):
@@ -18,3 +22,19 @@ class ServiceFabricCredential(AsyncManagedIdentityBase):
 
     def get_unavailable_message(self, desc: str = "") -> str:
         return f"Service Fabric managed identity configuration not found in environment. {desc}"
+
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
+        if not self._client:
+            raise CredentialUnavailableError(message=self.get_unavailable_message())
+        if self._client._identity_config:  # pylint:disable=protected-access
+            raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+
+    async def get_token_info(self, *scopes: str, options: Optional[TokenRequestOptions] = None) -> AccessTokenInfo:
+        if not self._client:
+            raise CredentialUnavailableError(message=self.get_unavailable_message())
+        if self._client._identity_config:  # pylint:disable=protected-access
+            raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
+        return await super().get_token_info(*scopes, options=options)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -26,15 +26,12 @@ class ServiceFabricCredential(AsyncManagedIdentityBase):
     async def get_token(
         self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
-        if not self._client:
-            raise CredentialUnavailableError(message=self.get_unavailable_message())
-        if self._client._identity_config:  # pylint:disable=protected-access
+        if self._client and self._client._identity_config:  # pylint:disable=protected-access
             raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
         return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     async def get_token_info(self, *scopes: str, options: Optional[TokenRequestOptions] = None) -> AccessTokenInfo:
-        if not self._client:
-            raise CredentialUnavailableError(message=self.get_unavailable_message())
-        if self._client._identity_config:  # pylint:disable=protected-access
+
+        if self._client and self._client._identity_config:  # pylint:disable=protected-access
             raise ClientAuthenticationError(message=SERVICE_FABRIC_ERROR_MESSAGE)
         return await super().get_token_info(*scopes, options=options)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -10,7 +10,6 @@ from azure.core.exceptions import ClientAuthenticationError
 from .._internal.managed_identity_base import AsyncManagedIdentityBase
 from .._internal.managed_identity_client import AsyncManagedIdentityClient
 from ..._credentials.service_fabric import _get_client_args, SERVICE_FABRIC_ERROR_MESSAGE
-from ... import CredentialUnavailableError
 
 
 class ServiceFabricCredential(AsyncManagedIdentityBase):

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -860,6 +860,29 @@ async def test_service_fabric_tenant_id(get_token_method):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)
+async def test_service_fabric_with_client_id_error(get_token_method):
+    """ManagedIdentityCredential should raise an error if a user identity is provided."""
+    endpoint = "http://localhost:42"
+    with mock.patch(
+        "os.environ",
+        {
+            EnvironmentVariables.IDENTITY_ENDPOINT: endpoint,
+            EnvironmentVariables.IDENTITY_HEADER: "secret",
+            EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT: "thumbprint",
+        },
+    ):
+
+        cred = ManagedIdentityCredential(client_id="client_id")
+        with pytest.raises(ClientAuthenticationError):
+            await getattr(cred, get_token_method)("scope")
+
+        cred = ManagedIdentityCredential(identity_config={"resource_id": "resource_id"})
+        with pytest.raises(ClientAuthenticationError):
+            await getattr(cred, get_token_method)("scope")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)
 async def test_azure_arc(tmpdir, get_token_method):
     """Azure Arc 2020-06-01"""
     access_token = "****"


### PR DESCRIPTION
Previously, if a `client_id` or `identity_config` was specified in `ManagedIdentityCredential` for Service Fabric managed identity, which is not supported, the `client_id` (or `resource_id`/`object_id` specified `identity_config`) would be silently ignored. Now, an exception will be raised if a `client_id` or `identity_config` is specified for Service Fabric managed identity.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/38015