### PR TITLE
[SDK generation pipeline] Fix logic to judge preview or stable for generated SDK code

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -216,8 +216,8 @@ def judge_tag_preview(path: str, package_name: str) -> bool:
         for line in list_in:
             if "DEFAULT_API_VERSION = " in line:
                 default_api_version += line.split("=")[-1].strip("\n")  # collect all default api version
-            if default_api_version == "" and "api_version" in line:
-                api_version += ", ".join(re.findall("\d{4}-\d{2}-\d{2}[-a-z]*", line))  # collect all single api version
+            if default_api_version == "" and "api_version" in line and "method_added_on" not in line :
+                api_version += ", ".join(re.findall("\"\d{4}-\d{2}-\d{2}[-a-z]*\"[^:]", line))  # collect all single api version
     if default_api_version != "":
         _LOGGER.info(f"find default api version:{default_api_version}")
         return "preview" in default_api_version

--- a/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -216,8 +216,10 @@ def judge_tag_preview(path: str, package_name: str) -> bool:
         for line in list_in:
             if "DEFAULT_API_VERSION = " in line:
                 default_api_version += line.split("=")[-1].strip("\n")  # collect all default api version
-            if default_api_version == "" and "api_version" in line and "method_added_on" not in line :
-                api_version += ", ".join(re.findall("\"\d{4}-\d{2}-\d{2}[-a-z]*\"[^:]", line))  # collect all single api version
+            if default_api_version == "" and "api_version" in line and "method_added_on" not in line:
+                api_version += ", ".join(
+                    re.findall('"\d{4}-\d{2}-\d{2}[-a-z]*"[^:]', line)
+                )  # collect all single api version
     if default_api_version != "":
         _LOGGER.info(f"find default api version:{default_api_version}")
         return "preview" in default_api_version


### PR DESCRIPTION
api-version which is in `@api_version_validation` (e.g. [here](https://github.com/azure-sdk/azure-sdk-for-python/blob/44f19d3a6876e5a968249699295d2d7814f5fe32/sdk/deviceregistry/azure-mgmt-deviceregistry/azure/mgmt/deviceregistry/operations/_operations.py#L516)) shall not be used to judge whether the tag is preview or stable.