### PR TITLE
Update API parser version to 0.3.15

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,3 +1,3 @@
-apiview-stub-generator==0.3.13
+apiview-stub-generator==0.3.15
 azure-pylint-guidelines-checker==0.0.7
 pylint<3.0.0


### PR DESCRIPTION
# Description

Update API parser version to 0.3.15. This new parser version generates token file in new tree token model and so CI needs to use latest version as soon as APIView changes are deployed to production.