### PR TITLE
[ServiceBus] fix AuthorizationRule.type not being passed to the request

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Fixed a bug where service errors were incorrectly required and expected to have info/description fields.
+- Fixed a bug in where the type in azure.servicebus.management.AuthorizationRule was not being correctly passed to the request.
 
 ## 7.14.0 (2025-02-13)
 

--- a/sdk/servicebus/azure-servicebus/assets.json
+++ b/sdk/servicebus/azure-servicebus/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/servicebus/azure-servicebus",
-  "Tag": "python/servicebus/azure-servicebus_5e25f00bf7"
+  "Tag": "python/servicebus/azure-servicebus_54b26ba299"
 }

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -1452,6 +1452,7 @@ class AuthorizationRule(object):
     @classmethod
     def _from_internal_entity(cls, internal_authorization_rule: InternalAuthorizationRule) -> "AuthorizationRule":
         authorization_rule = cls()
+        authorization_rule.type = internal_authorization_rule.type
         authorization_rule.claim_type = internal_authorization_rule.claim_type
         authorization_rule.claim_value = internal_authorization_rule.claim_value
         authorization_rule.rights = internal_authorization_rule.rights
@@ -1465,6 +1466,7 @@ class AuthorizationRule(object):
 
     def _to_internal_entity(self) -> InternalAuthorizationRule:
         internal_entity = InternalAuthorizationRule()
+        internal_entity.type = self.type
         internal_entity.claim_type = self.claim_type
         internal_entity.claim_value = self.claim_value
         internal_entity.rights = self.rights


### PR DESCRIPTION
Fixing an issue where the type of AuthorizationRule in the admin models was not being passed through to the request, causing a 400 error when trying to pass through a SharedAccessAuthorizationRule.