### PR TITLE
[Core] Update `DistributedTracingPolicy` spans

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_storage_live.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_storage_live.py
@@ -23,7 +23,7 @@ class TestStorageTracing:
         # We expect 3 spans, one for the root span, one for the method call, and one for the HTTP request.
         assert len(spans) == 3
         span_names_list = [span.name for span in spans]
-        assert span_names_list == ["/", "BlobServiceClient.get_service_properties", "root"]
+        assert span_names_list == ["GET", "BlobServiceClient.get_service_properties", "root"]
 
         http_span: ReadableSpan = spans[0]
         assert http_span.kind == SpanKind.CLIENT

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -22,6 +22,10 @@
 ### Breaking Changes
 
 - Removed automatic tracing enablement for the OpenTelemetry plugin if `opentelemetry` was imported. To enable tracing with the plugin, please import `azure.core.settings.settings` and set `settings.tracing_implementation` to `"opentelemetry"`. #39563
+- In `DistributedTracingPolicy`, the default span name is now just the HTTP method (e.g., "GET", "POST") and no longer includes the URL path. This change was made to converge with the OpenTelemetry HTTP semantic conventions. The full URL is still included in the span attributes.
+- Renamed span attributes in `DistributedTracingPolicy`:
+    - "x-ms-client-request-id" is now "az.client_request_id"
+    - "x-ms-request-id" is now "az.service_request_id"
 
 ### Bugs Fixed
 

--- a/sdk/core/azure-core/tests/test_tracing_policy.py
+++ b/sdk/core/azure-core/tests/test_tracing_policy.py
@@ -52,24 +52,24 @@ class TestTracingPolicyPluginImplementation:
 
         # Check on_response
         network_span = root_span.children[0]
-        assert network_span.name == "/temp"
+        assert network_span.name == "GET"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_METHOD) == "GET"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_URL) == "http://localhost/temp?query=query"
         assert network_span.attributes.get(HttpSpanMixin._NET_PEER_NAME) == "localhost"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_USER_AGENT) is None
-        assert network_span.attributes.get(policy._RESPONSE_ID) == "some request id"
-        assert network_span.attributes.get(policy._REQUEST_ID) == "some client request id"
+        assert network_span.attributes.get(policy._RESPONSE_ID_ATTR) == "some request id"
+        assert network_span.attributes.get(policy._REQUEST_ID_ATTR) == "some client request id"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_STATUS_CODE) == 202
         assert policy._ERROR_TYPE not in network_span.attributes
 
         # Check on_exception
         network_span = root_span.children[1]
-        assert network_span.name == "/temp"
+        assert network_span.name == "GET"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_METHOD) == "GET"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_URL) == "http://localhost/temp?query=query"
-        assert network_span.attributes.get(policy._REQUEST_ID) == "some client request id"
+        assert network_span.attributes.get(policy._REQUEST_ID_ATTR) == "some client request id"
         assert network_span.attributes.get(HttpSpanMixin._HTTP_USER_AGENT) is None
-        assert network_span.attributes.get(policy._RESPONSE_ID) == None
+        assert network_span.attributes.get(policy._RESPONSE_ID_ATTR) == None
         assert network_span.attributes.get(HttpSpanMixin._HTTP_STATUS_CODE) == 504
         assert network_span.attributes.get(policy._ERROR_TYPE)
 
@@ -90,7 +90,7 @@ class TestTracingPolicyPluginImplementation:
 
             policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
             network_span = root_span.children[0]
-            assert network_span.name == "/temp"
+            assert network_span.name == "GET"
             assert network_span.attributes.get(policy._ERROR_TYPE) == "403"
 
     @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
@@ -211,21 +211,21 @@ class TestTracingPolicyPluginImplementation:
                 user_agent.on_response(pipeline_request, pipeline_response)
 
             network_span = root_span.children[0]
-            assert network_span.name == "/"
+            assert network_span.name == "GET"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_METHOD) == "GET"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_URL) == "http://localhost"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_USER_AGENT).endswith("mytools")
-            assert network_span.attributes.get(policy._RESPONSE_ID) == "some request id"
-            assert network_span.attributes.get(policy._REQUEST_ID) == "some client request id"
+            assert network_span.attributes.get(policy._RESPONSE_ID_ATTR) == "some request id"
+            assert network_span.attributes.get(policy._REQUEST_ID_ATTR) == "some client request id"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_STATUS_CODE) == 202
 
             network_span = root_span.children[1]
-            assert network_span.name == "/"
+            assert network_span.name == "GET"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_METHOD) == "GET"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_URL) == "http://localhost"
             assert network_span.attributes.get(HttpSpanMixin._HTTP_USER_AGENT).endswith("mytools")
-            assert network_span.attributes.get(policy._REQUEST_ID) == "some client request id"
-            assert network_span.attributes.get(policy._RESPONSE_ID) is None
+            assert network_span.attributes.get(policy._REQUEST_ID_ATTR) == "some client request id"
+            assert network_span.attributes.get(policy._RESPONSE_ID_ATTR) is None
             assert network_span.attributes.get(HttpSpanMixin._HTTP_STATUS_CODE) == 504
             # Exception should propagate status for Opencensus
             assert network_span.status == "Transport trouble"
@@ -378,7 +378,7 @@ class TestTracingPolicyNativeTracing:
 
         finished_spans = tracing_helper.exporter.get_finished_spans()
         assert len(finished_spans) == 2
-        assert finished_spans[0].name == "/temp"
+        assert finished_spans[0].name == "GET"
         assert finished_spans[0].parent is root_span.get_span_context()
 
         assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
@@ -405,7 +405,7 @@ class TestTracingPolicyNativeTracing:
             policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
 
         finished_spans = tracing_helper.exporter.get_finished_spans()
-        assert finished_spans[0].name == "/temp"
+        assert finished_spans[0].name == "GET"
         assert finished_spans[0].attributes.get("error.type") == "403"
 
     @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
@@ -433,7 +433,7 @@ class TestTracingPolicyNativeTracing:
             policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
 
         finished_spans = tracing_helper.exporter.get_finished_spans()
-        assert finished_spans[0].name == "/temp"
+        assert finished_spans[0].name == "GET"
         assert finished_spans[0].attributes.get(policy._ERROR_TYPE) == "403"
         assert finished_spans[0].instrumentation_scope.name == "my-library"
         assert finished_spans[0].instrumentation_scope.version == "1.0.0"
@@ -495,7 +495,7 @@ class TestTracingPolicyNativeTracing:
 
         finished_spans = tracing_helper.exporter.get_finished_spans()
         assert len(finished_spans) == 2
-        assert finished_spans[0].name == "/temp"
+        assert finished_spans[0].name == "GET"
         assert finished_spans[0].parent is root_span.get_span_context()
 
         assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
@@ -579,7 +579,7 @@ class TestTracingPolicyNativeTracing:
         finished_spans = tracing_helper.exporter.get_finished_spans()
         assert len(finished_spans) == 2
 
-        assert finished_spans[0].name == "/temp"
+        assert finished_spans[0].name == "GET"
         assert finished_spans[0].parent is root_span.get_span_context()
 
         assert finished_spans[0].attributes.get(policy._HTTP_REQUEST_METHOD) == "GET"
@@ -655,5 +655,5 @@ class TestTracingPolicyNativeTracing:
 
         assert len(root_span.children) == 1
         network_span = root_span.children[0]
-        assert network_span.name == "/temp"
+        assert network_span.name == "GET"
         assert network_span.kind == SpanKind.CLIENT


### PR DESCRIPTION
These are technically breaking changes in the sense that some span-related things are renamed, but these shouldn't really break people in practice.

- Renamed some Microsoft specific span attributes. The OTel tracing plugin has already been remapping these attribute names for [a while now](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py#L30), so this shouldn't really have any impact on users.
- Updated the default HTTP span name to just the HTTP method per OpenTelemetry [HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name). We've been violating this convention for a while now, and it's time to fix it. 


