### PR TITLE
azure-core: remove six dependency

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Other Changes
 
 - Added `opentelemetry-api` as an optional dependency for tracing. This can be installed with `pip install azure-core[tracing]`. #39563
+- Remove `six` as a dependency as unused.
 
 ## 1.32.0 (2024-10-31)
 

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -70,7 +70,6 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "requests>=2.21.0",
-        "six>=1.11.0",
         "typing-extensions>=4.6.0",
     ],
     extras_require={


### PR DESCRIPTION
# Description

This PR removes the dependency on the `six` Python 2/Python 3 compatibility library in `azure-core`, as it doesn't use it.

See #36859 for the last attempt about this (autumn 2024), which was approved, and then not merged (?!).
(Also see my previous attempt from 2023, #32248.)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
  - If other libraries depend on `six`, they should depend on it explicitly. 
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Since there is no code that uses `six` in the core library, there is nothing to test.