### PR TITLE
[ML] Add in Six in to Support

### DIFF
--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -88,6 +88,8 @@ setup(
         "azure-common>=1.1",
         "typing-extensions",
         "azure-monitor-opentelemetry",
+        #TODO: remove six after using new autorest
+        "six>=1.11.0",
     ],
     extras_require={
         # user can run `pip install azure-ai-ml[designer]` to install mldesigner along with this package


### PR DESCRIPTION
This is a temporary addition into the setup.py till the `azure-ai-ml` library is generating based on an older version of autorest.  Once the migration has happened this line must be removed. 