### PR TITLE
Temporary set whl_no_aio= false for azure-ai-projects SDK to unblock current release

### DIFF
--- a/sdk/ai/azure-ai-projects/pyproject.toml
+++ b/sdk/ai/azure-ai-projects/pyproject.toml
@@ -35,3 +35,7 @@ extend_skip_glob = [
   "*/doc/*",
   "*/.tox/*",
 ]
+
+[tool.azure-sdk-build]
+whl_no_aio= false
+


### PR DESCRIPTION
# Description

Temporary fix for test failures in Main branch. See related post here: https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1741401129309?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1741401129309&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1741401129309

We have a test file with file name that does not end with _async.py, which does both sync and async tests. We will fix this after this release, but in order to unblock the release I'm suppressing this check.