### PR TITLE
Don't ascii escape unicode chars in prompts and completions

### DIFF
--- a/sdk/ai/azure-ai-inference/assets.json
+++ b/sdk/ai/azure-ai-inference/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ai/azure-ai-inference",
-  "Tag": "python/ai/azure-ai-inference_3f06cee8a7"
+  "Tag": "python/ai/azure-ai-inference_01cf9f82e3"
 }

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
@@ -208,7 +208,7 @@ class _AIInferenceInstrumentorPreview:
                     f"gen_ai.{message.get('role')}.message",
                     {
                         "gen_ai.system": _INFERENCE_GEN_AI_SYSTEM_NAME,
-                        "gen_ai.event.content": json.dumps(message),
+                        "gen_ai.event.content": json.dumps(message, ensure_ascii=False),
                     },
                     timestamp,
                 )
@@ -300,7 +300,7 @@ class _AIInferenceInstrumentorPreview:
                     full_response["message"]["tool_calls"] = [tool.as_dict() for tool in choice.message.tool_calls]
                 attributes = {
                     "gen_ai.system": _INFERENCE_GEN_AI_SYSTEM_NAME,
-                    "gen_ai.event.content": json.dumps(full_response),
+                    "gen_ai.event.content": json.dumps(full_response, ensure_ascii=False),
                 }
             else:
                 response: Dict[str, Any] = {
@@ -318,7 +318,7 @@ class _AIInferenceInstrumentorPreview:
 
                 attributes = {
                     "gen_ai.system": _INFERENCE_GEN_AI_SYSTEM_NAME,
-                    "gen_ai.event.content": json.dumps(response),
+                    "gen_ai.event.content": json.dumps(response, ensure_ascii=False),
                 }
             last_event_timestamp_ns = self._record_event(span, "gen_ai.choice", attributes, last_event_timestamp_ns)
 
@@ -478,7 +478,7 @@ class _AIInferenceInstrumentorPreview:
                                     )
                     attributes = {
                         "gen_ai.system": _INFERENCE_GEN_AI_SYSTEM_NAME,
-                        "gen_ai.event.content": json.dumps(accumulate),
+                        "gen_ai.event.content": json.dumps(accumulate, ensure_ascii=False),
                     }
                     self._instrumentor._record_event(span, "gen_ai.choice", attributes, previous_event_timestamp)
                     span.finish()
@@ -532,7 +532,7 @@ class _AIInferenceInstrumentorPreview:
                                 self._accumulate["message"]["tool_calls"] = list(tools_no_recording)
                 attributes = {
                     "gen_ai.system": _INFERENCE_GEN_AI_SYSTEM_NAME,
-                    "gen_ai.event.content": json.dumps(self._accumulate),
+                    "gen_ai.event.content": json.dumps(self._accumulate, ensure_ascii=False),
                 }
                 self._last_event_timestamp_ns = self._instrumentor._record_event(  # pylint: disable=protected-access, line-too-long # pyright: ignore [reportFunctionMemberAccess]
                     span, "gen_ai.choice", attributes, self._last_event_timestamp_ns

--- a/sdk/ai/azure-ai-inference/tests/test_client_tracing.py
+++ b/sdk/ai/azure-ai-inference/tests/test_client_tracing.py
@@ -342,7 +342,7 @@ class TestClientTracing(ModelClientTestBase):
             ],
         )
         processor.force_flush()
-        spans = exporter.get_spans_by_name_starts_with("chat ")
+        spans = exporter.get_spans_by_name_starts_with("chat")
         assert len(spans) == 1
         expected_events = [
             {
@@ -397,14 +397,12 @@ class TestClientTracing(ModelClientTestBase):
         )
         response_content = ""
         for update in response:
-            if update.choices:
+            if update.choices and update.choices[0].delta.content:
                 response_content = response_content + update.choices[0].delta.content
         client.close()
 
         processor.force_flush()
-        spans = exporter.get_spans_by_name_starts_with("chat ")
-        if len(spans) == 0:
-            spans = exporter.get_spans_by_name("chat")
+        spans = exporter.get_spans_by_name_starts_with("chat")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -456,7 +454,7 @@ class TestClientTracing(ModelClientTestBase):
         )
         response_content = ""
         for update in response:
-            if update.choices:
+            if update.choices and update.choices[0].delta.content:
                 response_content = response_content + update.choices[0].delta.content
         client.close()
 
@@ -580,9 +578,7 @@ class TestClientTracing(ModelClientTestBase):
                 # With the additional tools information on hand, get another response from the model
                 response = client.complete(messages=messages, tools=[weather_description])
         processor.force_flush()
-        spans = exporter.get_spans_by_name_starts_with("chat ")
-        if len(spans) == 0:
-            spans = exporter.get_spans_by_name("chat")
+        spans = exporter.get_spans_by_name_starts_with("chat")
         assert len(spans) == 2
         expected_attributes = [
             ("gen_ai.operation.name", "chat"),

--- a/sdk/ai/azure-ai-inference/tests/test_client_tracing.py
+++ b/sdk/ai/azure-ai-inference/tests/test_client_tracing.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import json
 import os
 import azure.ai.inference as sdk
 from azure.ai.inference.tracing import AIInferenceInstrumentor
@@ -320,6 +321,58 @@ class TestClientTracing(ModelClientTestBase):
         ]
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
+        AIInferenceInstrumentor().uninstrument()
+
+    @ServicePreparerChatCompletions()
+    @recorded_by_proxy
+    def test_chat_completion_tracing_content_unicode(self, **kwargs):
+        # Make sure code is not instrumented due to a previous test exception
+        try:
+            AIInferenceInstrumentor().uninstrument()
+        except RuntimeError as e:
+            pass
+        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
+        client = self._create_chat_client(**kwargs)
+        processor, exporter = self.setup_memory_trace_exporter()
+        AIInferenceInstrumentor().instrument()
+        response = client.complete(
+            messages=[
+                sdk.models.SystemMessage(content="You are a helpful assistant."),
+                sdk.models.UserMessage(content="将“hello world”翻译成中文和乌克兰语"),
+            ],
+        )
+        processor.force_flush()
+        spans = exporter.get_spans_by_name_starts_with("chat ")
+        assert len(spans) == 1
+        expected_events = [
+            {
+                "name": "gen_ai.system.message",
+                "attributes": {
+                    "gen_ai.system": "az.ai.inference",
+                    "gen_ai.event.content": '{"role": "system", "content": "You are a helpful assistant."}',
+                },
+            },
+            {
+                "name": "gen_ai.user.message",
+                "attributes": {
+                    "gen_ai.system": "az.ai.inference",
+                    "gen_ai.event.content": '{"role": "user", "content": "将“hello world”翻译成中文和乌克兰语"}',
+                },
+            },
+            {
+                "name": "gen_ai.choice",
+                "attributes": {
+                    "gen_ai.system": "az.ai.inference",
+                    "gen_ai.event.content": '{"message": {"content": "*"}, "finish_reason": "stop", "index": 0}',
+                },
+            },
+        ]
+        events_match = GenAiTraceVerifier().check_span_events(spans[0], expected_events)
+        assert events_match == True
+
+        completion_event_content = json.loads(spans[0].events[2].attributes["gen_ai.event.content"])
+        assert False == completion_event_content["message"]["content"].isascii()
+        assert response.choices[0].message.content == completion_event_content["message"]["content"]
         AIInferenceInstrumentor().uninstrument()
 
     @ServicePreparerChatCompletions()

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -1293,7 +1293,7 @@ tracer = trace.get_tracer(__name__)
 
 with tracer.start_as_current_span(scenario):
     with project_client:
-        project_client.telemetry.enable()
+        # project_client.telemetry.enable()
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -580,7 +580,7 @@ agent = project_client.agents.create_agent(
 Currently, the Azure Function integration for the AI Agent has the following limitations:
 
 - Azure Functions integration is available **only for non-streaming scenarios**.
-- Supported trigger for Azure Function is currently limited to **Queue triggers** only.  
+- Supported trigger for Azure Function is currently limited to **Queue triggers** only.
   HTTP or other trigger types and streaming responses are not supported at this time.
 
 ---
@@ -601,8 +601,8 @@ app = func.FunctionApp()
 @app.get_weather(arg_name="inputQueue",
                    queue_name="input",
                    connection="AzureWebJobsStorage")
-@app.queue_output(arg_name="outputQueue", 
-                  queue_name="output", 
+@app.queue_output(arg_name="outputQueue",
+                  queue_name="output",
                   connection="AzureWebJobsStorage")
 def get_weather(inputQueue: func.QueueMessage, outputQueue: func.Out[str]):
     try:
@@ -852,7 +852,7 @@ message = project_client.agents.create_message(
 
 #### Create Message with Code Interpreter Attachment
 
-To attach a file to a message for data analysis, use `MessageAttachment` and `CodeInterpreterTool` classes. You must pass `CodeInterpreterTool` as `tools` or `toolset` in `create_agent` call or the file attachment cannot be opened for code interpreter.  
+To attach a file to a message for data analysis, use `MessageAttachment` and `CodeInterpreterTool` classes. You must pass `CodeInterpreterTool` as `tools` or `toolset` in `create_agent` call or the file attachment cannot be opened for code interpreter.
 
 Here is an example to pass `CodeInterpreterTool` as tool:
 
@@ -1288,12 +1288,14 @@ if not application_insights_connection_string:
     exit()
 configure_azure_monitor(connection_string=application_insights_connection_string)
 
+# enable additional instrumentations
+project_client.telemetry.enable()
+
 scenario = os.path.basename(__file__)
 tracer = trace.get_tracer(__name__)
 
 with tracer.start_as_current_span(scenario):
     with project_client:
-        # project_client.telemetry.enable()
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/ai/azure-ai-projects/assets.json
+++ b/sdk/ai/azure-ai-projects/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ai/azure-ai-projects",
-  "Tag": "python/ai/azure-ai-projects_04dc35e78c"
+  "Tag": "python/ai/azure-ai-projects_e7dc31a23f"
 }

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
@@ -518,7 +518,9 @@ class _AIAgentsInstrumentorPreview:
                     body = {"content": tool_output["output"], "id": tool_output["tool_call_id"]}
                 else:
                     body = {"content": "", "id": tool_output["tool_call_id"]}
-                span.span_instance.add_event("gen_ai.tool.message", {"gen_ai.event.content": json.dumps(body, ensure_ascii=False)})
+                span.span_instance.add_event(
+                    "gen_ai.tool.message", {"gen_ai.event.content": json.dumps(body, ensure_ascii=False)}
+                )
             return True
 
         return False
@@ -1330,33 +1332,33 @@ class _AIAgentsInstrumentorPreview:
             class_function_name = function.__qualname__
 
             if class_function_name.startswith("AgentsOperations.create_agent"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_agent(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_thread"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_thread(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_message"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_message(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_run(OperationName.START_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_and_process_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_run(OperationName.PROCESS_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_submit_tool_outputs(False, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_stream"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_submit_tool_outputs(True, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations._handle_submit_tool_outputs"):
                 return self.trace_handle_submit_tool_outputs(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_stream"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_create_stream(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.list_messages"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return self.trace_list_messages(function, *args, **kwargs)
             if class_function_name.startswith("AgentRunStream.__exit__"):
                 return self.handle_run_stream_exit(function, *args, **kwargs)
@@ -1398,33 +1400,33 @@ class _AIAgentsInstrumentorPreview:
             class_function_name = function.__qualname__
 
             if class_function_name.startswith("AgentsOperations.create_agent"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_agent_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_thread"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_thread_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_message"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_message_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_run_async(OperationName.START_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_and_process_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_run_async(OperationName.PROCESS_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_run"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_submit_tool_outputs_async(False, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_stream"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_submit_tool_outputs_async(True, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations._handle_submit_tool_outputs"):
                 return await self.trace_handle_submit_tool_outputs_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_stream"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_create_stream_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.list_messages"):
-                kwargs.setdefault('merge_span', True)
+                kwargs.setdefault("merge_span", True)
                 return await self.trace_list_messages_async(function, *args, **kwargs)
             if class_function_name.startswith("AsyncAgentRunStream.__aexit__"):
                 return self.handle_run_stream_exit(function, *args, **kwargs)

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
@@ -343,7 +343,7 @@ class _AIAgentsInstrumentorPreview:
             message_status=message_status,
             usage=usage,
         )
-        attributes[GEN_AI_EVENT_CONTENT] = json.dumps(event_body)
+        attributes[GEN_AI_EVENT_CONTENT] = json.dumps(event_body, ensure_ascii=False)
         span.span_instance.add_event(name=f"gen_ai.{role}.message", attributes=attributes)
 
     def _get_field(self, obj: Any, field: str) -> Any:
@@ -374,7 +374,7 @@ class _AIAgentsInstrumentorPreview:
                 event_body["content"] = instructions or additional_instructions
 
         attributes = self._create_event_attributes(agent_id=agent_id, thread_id=thread_id)
-        attributes[GEN_AI_EVENT_CONTENT] = json.dumps(event_body)
+        attributes[GEN_AI_EVENT_CONTENT] = json.dumps(event_body, ensure_ascii=False)
         span.span_instance.add_event(name=GEN_AI_SYSTEM_MESSAGE, attributes=attributes)
 
     def _get_role(self, role: Optional[Union[str, MessageRole]]) -> str:
@@ -413,10 +413,10 @@ class _AIAgentsInstrumentorPreview:
         )
 
         if _trace_agents_content:
-            attributes[GEN_AI_EVENT_CONTENT] = json.dumps({"tool_calls": tool_calls})
+            attributes[GEN_AI_EVENT_CONTENT] = json.dumps({"tool_calls": tool_calls}, ensure_ascii=False)
         else:
             tool_calls_non_recording = self._remove_function_call_names_and_arguments(tool_calls=tool_calls)
-            attributes[GEN_AI_EVENT_CONTENT] = json.dumps({"tool_calls": tool_calls_non_recording})
+            attributes[GEN_AI_EVENT_CONTENT] = json.dumps({"tool_calls": tool_calls_non_recording}, ensure_ascii=False)
         span.span_instance.add_event(name="gen_ai.assistant.message", attributes=attributes)
 
     def set_end_run(self, span: "AbstractSpan", run: Optional[ThreadRun]) -> None:
@@ -518,7 +518,7 @@ class _AIAgentsInstrumentorPreview:
                     body = {"content": tool_output["output"], "id": tool_output["tool_call_id"]}
                 else:
                     body = {"content": "", "id": tool_output["tool_call_id"]}
-                span.span_instance.add_event("gen_ai.tool.message", {"gen_ai.event.content": json.dumps(body)})
+                span.span_instance.add_event("gen_ai.tool.message", {"gen_ai.event.content": json.dumps(body, ensure_ascii=False)})
             return True
 
         return False

--- a/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
@@ -32,6 +32,7 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 scenario = os.path.basename(__file__)
 tracer = trace.get_tracer(__name__)
 
+
 async def main() -> None:
 
     async with DefaultAzureCredential() as creds:
@@ -51,7 +52,9 @@ async def main() -> None:
             async with project_client:
                 project_client.telemetry.enable()
                 agent = await project_client.agents.create_agent(
-                    model=os.environ["MODEL_DEPLOYMENT_NAME"], name="my-assistant", instructions="You are helpful assistant"
+                    model=os.environ["MODEL_DEPLOYMENT_NAME"],
+                    name="my-assistant",
+                    instructions="You are helpful assistant",
                 )
                 print(f"Created agent, agent ID: {agent.id}")
 

--- a/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/async_samples/sample_agents_basics_async_with_azure_monitor_tracing.py
@@ -48,9 +48,11 @@ async def main() -> None:
             exit()
         configure_azure_monitor(connection_string=application_insights_connection_string)
 
+        # enable additional instrumentations
+        project_client.telemetry.enable()
+
         with tracer.start_as_current_span(scenario):
             async with project_client:
-                project_client.telemetry.enable()
                 agent = await project_client.agents.create_agent(
                     model=os.environ["MODEL_DEPLOYMENT_NAME"],
                     name="my-assistant",

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
@@ -51,7 +51,7 @@ tracer = trace.get_tracer(__name__)
 
 with tracer.start_as_current_span(scenario):
     with project_client:
-        #project_client.telemetry.enable()
+        # project_client.telemetry.enable()
         # [END enable_tracing]
         agent = project_client.agents.create_agent(
             model=os.environ["MODEL_DEPLOYMENT_NAME"], name="my-assistant", instructions="You are helpful assistant"

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_basics_with_azure_monitor_tracing.py
@@ -19,7 +19,7 @@ USAGE:
     Set these environment variables with your own values:
     1) PROJECT_CONNECTION_STRING - The project connection string, as found in the overview page of your
        Azure AI Foundry project.
-    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in 
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
@@ -46,12 +46,14 @@ if not application_insights_connection_string:
     exit()
 configure_azure_monitor(connection_string=application_insights_connection_string)
 
+# enable additional instrumentations
+project_client.telemetry.enable()
+
 scenario = os.path.basename(__file__)
 tracer = trace.get_tracer(__name__)
 
 with tracer.start_as_current_span(scenario):
     with project_client:
-        # project_client.telemetry.enable()
         # [END enable_tracing]
         agent = project_client.agents.create_agent(
             model=os.environ["MODEL_DEPLOYMENT_NAME"], name="my-assistant", instructions="You are helpful assistant"

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_functions_with_azure_monitor_tracing.py
@@ -19,7 +19,7 @@ USAGE:
     Set these environment variables with your own values:
     1) PROJECT_CONNECTION_STRING - The project connection string, as found in the overview page of your
        Azure AI Foundry project.
-    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in 
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
@@ -45,6 +45,9 @@ if not application_insights_connection_string:
     print("Enable it via the 'Tracing' tab in your AI Foundry project page.")
     exit()
 configure_azure_monitor(connection_string=application_insights_connection_string)
+
+# enable additional instrumentations if needed
+project_client.telemetry.enable()
 
 scenario = os.path.basename(__file__)
 tracer = trace.get_tracer(__name__)
@@ -84,7 +87,6 @@ functions = FunctionTool(functions=user_functions)
 
 with tracer.start_as_current_span(scenario):
     with project_client:
-        project_client.telemetry.enable()
         # Create an agent and run user's request with function calls
         agent = project_client.agents.create_agent(
             model=os.environ["MODEL_DEPLOYMENT_NAME"],

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
@@ -19,7 +19,7 @@ USAGE:
     Set these environment variables with your own values:
     1) PROJECT_CONNECTION_STRING - The project connection string, as found in the overview page of your
        Azure AI Foundry project.
-    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in 
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
@@ -86,9 +86,11 @@ configure_azure_monitor(connection_string=application_insights_connection_string
 scenario = os.path.basename(__file__)
 tracer = trace.get_tracer(__name__)
 
+# enable additional instrumentations
+project_client.telemetry.enable()
+
 with tracer.start_as_current_span(scenario):
     with project_client:
-        project_client.telemetry.enable()
         # Create an agent and run stream with event handler
         agent = project_client.agents.create_agent(
             model=os.environ["MODEL_DEPLOYMENT_NAME"], name="my-assistant", instructions="You are a helpful assistant"

--- a/sdk/ai/azure-ai-projects/tests/telemetry/telemetry_test_base.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/telemetry_test_base.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+# cSpell:disable# cSpell:disable
 import re
 import sys
 import logging

--- a/sdk/ai/azure-ai-projects/tests/telemetry/telemetry_test_base.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/telemetry_test_base.py
@@ -15,10 +15,11 @@ from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader
 Set these environment variables before running the test:
 set AZURE_AI_PROJECTS_DIAGNOSTICS_TEST_PROJECT_CONNECTION_STRING=
 """
-servicePreparerTelemetryTests = functools.partial(
+agentClientPreparer = functools.partial(
     EnvironmentVariableLoader,
-    "azure_ai_projects_telemetry_test",
-    azure_ai_projects_telemetry_tests_project_connection_string="region.api.azureml.ms;00000000-0000-0000-0000-000000000000;rg-name;project-name",
+    "azure_ai_projects",
+    azure_ai_projects_agents_tests_project_connection_string="region.api.azureml.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
+    azure_ai_projects_agents_tests_data_path="azureml://subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-resour-cegr-oupfoo1/workspaces/abcd-abcdabcdabcda-abcdefghijklm/datastores/workspaceblobstore/paths/LocalUpload/000000000000/product_info_1.md",
 )
 
 # Set to True to enable SDK logging
@@ -43,7 +44,7 @@ class TelemetryTestBase(AzureRecordedTestCase):
     )
 
     def get_sync_client(self, **kwargs) -> AIProjectClient:
-        conn_str = kwargs.pop("azure_ai_projects_telemetry_tests_project_connection_string")
+        conn_str = kwargs.pop("azure_ai_projects_agents_tests_project_connection_string")
         project_client = AIProjectClient.from_connection_string(
             credential=self.get_credential(AIProjectClient, is_async=False),
             conn_str=conn_str,
@@ -52,7 +53,7 @@ class TelemetryTestBase(AzureRecordedTestCase):
         return project_client
 
     def get_async_client(self, **kwargs) -> AIProjectClientAsync:
-        conn_str = kwargs.pop("azure_ai_projects_telemetry_tests_project_connection_string")
+        conn_str = kwargs.pop("azure_ai_projects_agents_tests_project_connection_string")
         project_client = AIProjectClientAsync.from_connection_string(
             credential=self.get_credential(AIProjectClientAsync, is_async=True),
             conn_str=conn_str,

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor.py
@@ -13,8 +13,8 @@ import functools
 from typing import Set, Callable, Any
 from azure.ai.projects.telemetry.agents._ai_agents_instrumentor import _AIAgentsInstrumentorPreview
 from azure.ai.projects.models import AgentsApiResponseFormatMode, AgentsApiResponseFormat
-
 from azure.ai.projects.models import AgentEventHandler
+from azure.ai.projects.telemetry.agents import _utils
 
 from azure.ai.projects.telemetry.agents import AIAgentsInstrumentor
 from azure.core.settings import settings
@@ -41,39 +41,63 @@ from azure.ai.projects.models import (
     ToolSet,
 )
 
+
 agentClientPreparer = functools.partial(
     EnvironmentVariableLoader,
     "azure_ai_projects",
-    azure_ai_projects_connection_string="https://foo.bar.some-domain.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
-    azure_ai_projects_data_path="azureml://subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-resour-cegr-oupfoo1/workspaces/abcd-abcdabcdabcda-abcdefghijklm/datastores/workspaceblobstore/paths/LocalUpload/000000000000/product_info_1.md",
+    azure_ai_projects_agents_tests_project_connection_string="region.api.azureml.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
+    azure_ai_projects_agents_tests_data_path="azureml://subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-resour-cegr-oupfoo1/workspaces/abcd-abcdabcdabcda-abcdefghijklm/datastores/workspaceblobstore/paths/LocalUpload/000000000000/product_info_1.md",
 )
-"""
-agentClientPreparer = functools.partial(
-    EnvironmentVariableLoader,
-    'azure_ai_project',
-    azure_ai_project_host_name="https://foo.bar.some-domain.ms",
-    azure_ai_project_subscription_id="00000000-0000-0000-0000-000000000000",
-    azure_ai_project_resource_group_name="rg-resour-cegr-oupfoo1",
-    azure_ai_project_workspace_name="abcd-abcdabcdabcda-abcdefghijklm",
-)
-"""
 
 CONTENT_TRACING_ENV_VARIABLE = "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED"
-content_tracing_initial_value = os.getenv(CONTENT_TRACING_ENV_VARIABLE)
+settings.tracing_implementation = "OpenTelemetry"
+_utils._span_impl_type = settings.tracing_implementation()
+
+
+# TODO - remove when https://github.com/Azure/azure-sdk-for-python/issues/40086 is fixed
+class FakeToolSetDict(dict):
+    def __init__(self, toolset=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.toolset = toolset
+
+    def get(self, k, default=None):
+        return self.toolset
 
 
 class TestAiAgentsInstrumentor(AzureRecordedTestCase):
     """Tests for AI agents instrumentor."""
 
-    @classmethod
-    def teardown_class(cls):
-        if content_tracing_initial_value is not None:
-            os.environ[CONTENT_TRACING_ENV_VARIABLE] = content_tracing_initial_value
+    @pytest.fixture(scope="function")
+    def instrument_with_content(self):
+        os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "True"})
+        self.setup()
+        yield
+        self.cleanup()
+
+    @pytest.fixture(scope="function")
+    def instrument_without_content(self):
+        os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "False"})
+        self.setup()
+        yield
+        self.cleanup()
+
+    def setup(self):
+        trace._TRACER_PROVIDER = TracerProvider()
+        self.exporter = MemoryTraceExporter()
+        span_processor = SimpleSpanProcessor(self.exporter)
+        trace.get_tracer_provider().add_span_processor(span_processor)
+        AIAgentsInstrumentor().instrument()
+
+    def cleanup(self):
+        self.exporter.shutdown()
+        AIAgentsInstrumentor().uninstrument()
+        trace._TRACER_PROVIDER = None
+        os.environ.pop(CONTENT_TRACING_ENV_VARIABLE, None)
 
     # helper function: create client and using environment variables
     def create_client(self, **kwargs):
         # fetch environment variables
-        connection_string = kwargs.pop("azure_ai_projects_connection_string")
+        connection_string = kwargs.pop("azure_ai_projects_agents_tests_project_connection_string")
         credential = self.get_credential(AIProjectClient, is_async=False)
 
         # create and return client
@@ -104,171 +128,64 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         actual = _AIAgentsInstrumentorPreview.agent_api_response_to_str(fmt)
         assert actual == expected
 
-    def setup_memory_trace_exporter(self) -> MemoryTraceExporter:
-        # Setup Azure Core settings to use OpenTelemetry tracing
-        settings.tracing_implementation = "OpenTelemetry"
-        trace.set_tracer_provider(TracerProvider())
-        tracer = trace.get_tracer(__name__)
-        memoryExporter = MemoryTraceExporter()
-        span_processor = SimpleSpanProcessor(memoryExporter)
-        trace.get_tracer_provider().add_span_processor(span_processor)
-        return span_processor, memoryExporter
-
-    def modify_env_var(self, name, new_value):
-        current_value = os.getenv(name)
-        os.environ[name] = new_value
-        return current_value
-
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
     def test_instrumentation(self, **kwargs):
         # Make sure code is not instrumented due to a previous test exception
         AIAgentsInstrumentor().uninstrument()
-        with self.create_client(**kwargs) as client:
-            exception_caught = False
-            try:
-                assert AIAgentsInstrumentor().is_instrumented() == False
-                AIAgentsInstrumentor().instrument()
-                assert AIAgentsInstrumentor().is_instrumented() == True
-                AIAgentsInstrumentor().uninstrument()
-                assert AIAgentsInstrumentor().is_instrumented() == False
-            except RuntimeError as e:
-                exception_caught = True
-                print(e)
-            assert exception_caught == False
+        exception_caught = False
+        try:
+            assert AIAgentsInstrumentor().is_instrumented() == False
+            AIAgentsInstrumentor().instrument()
+            assert AIAgentsInstrumentor().is_instrumented() == True
+            AIAgentsInstrumentor().uninstrument()
+            assert AIAgentsInstrumentor().is_instrumented() == False
+        except RuntimeError as e:
+            exception_caught = True
+            print(e)
+        assert exception_caught == False
 
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
     def test_instrumenting_twice_does_not_cause_exception(self, **kwargs):
         # Make sure code is not instrumented due to a previous test exception
         AIAgentsInstrumentor().uninstrument()
-        with self.create_client(**kwargs) as client:
-            exception_caught = False
-            try:
-                AIAgentsInstrumentor().instrument()
-                AIAgentsInstrumentor().instrument()
-            except RuntimeError as e:
-                exception_caught = True
-                print(e)
-            AIAgentsInstrumentor().uninstrument()
-            assert exception_caught == False
+        exception_caught = False
+        try:
+            AIAgentsInstrumentor().instrument()
+            AIAgentsInstrumentor().instrument()
+        except RuntimeError as e:
+            exception_caught = True
+            print(e)
+        AIAgentsInstrumentor().uninstrument()
+        assert exception_caught == False
 
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
     def test_uninstrumenting_uninstrumented_does_not_cause_exception(self, **kwargs):
         # Make sure code is not instrumented due to a previous test exception
         AIAgentsInstrumentor().uninstrument()
-        with self.create_client(**kwargs) as client:
-            exception_caught = False
-            try:
-                AIAgentsInstrumentor().uninstrument()
-            except RuntimeError as e:
-                exception_caught = True
-                print(e)
-            assert exception_caught == False
-
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
-    def test_uninstrumenting_twice_does_not_cause_exception(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        AIAgentsInstrumentor().uninstrument()
-        with self.create_client(**kwargs) as client:
-            exception_caught = False
-            uninstrumented_once = False
-            try:
-                AIAgentsInstrumentor().instrument()
-                AIAgentsInstrumentor().uninstrument()
-                AIAgentsInstrumentor().uninstrument()
-            except RuntimeError as e:
-                exception_caught = True
-                print(e)
-            assert exception_caught == False
-
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
-    def test_is_content_recording_enabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        AIAgentsInstrumentor().uninstrument()
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-        with self.create_client(**kwargs) as client:
-            exception_caught = False
-            uninstrumented_once = False
-            try:
-                # From environment variable instrumenting from uninstrumented
-                AIAgentsInstrumentor().instrument()
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == False
-                AIAgentsInstrumentor().uninstrument()
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == True
-                AIAgentsInstrumentor().uninstrument()
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "invalid")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == False
-
-                # From environment variable instrumenting from instrumented
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == True
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == True
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "invalid")
-                AIAgentsInstrumentor().instrument()
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == False
-
-                # From parameter instrumenting from uninstrumented
-                AIAgentsInstrumentor().uninstrument()
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-                AIAgentsInstrumentor().instrument(enable_content_recording=False)
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == False
-                AIAgentsInstrumentor().uninstrument()
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-                AIAgentsInstrumentor().instrument(enable_content_recording=True)
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == True
-
-                # From parameter instrumenting from instrumented
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-                AIAgentsInstrumentor().instrument(enable_content_recording=False)
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == False
-                self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-                AIAgentsInstrumentor().instrument(enable_content_recording=True)
-                content_recording_enabled = AIAgentsInstrumentor().is_content_recording_enabled()
-                assert content_recording_enabled == True
-            except RuntimeError as e:
-                exception_caught = True
-                print(e)
-            assert exception_caught == False
-
-    @pytest.mark.skip
-    @agentClientPreparer()
-    @recorded_by_proxy
-    def test_agent_chat_with_tracing_content_recording_enabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
+        exception_caught = False
         try:
             AIAgentsInstrumentor().uninstrument()
         except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
+            exception_caught = True
+            print(e)
+        assert exception_caught == False
 
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
+    def test_uninstrumenting_twice_does_not_cause_exception(self, **kwargs):
+        # Make sure code is not instrumented due to a previous test exception
+        AIAgentsInstrumentor().uninstrument()
+        exception_caught = False
+        try:
+            AIAgentsInstrumentor().instrument()
+            AIAgentsInstrumentor().uninstrument()
+            AIAgentsInstrumentor().uninstrument()
+        except RuntimeError as e:
+            exception_caught = True
+            print(e)
+        assert exception_caught == False
+
+    @pytest.mark.usefixtures("instrument_with_content")
+    @agentClientPreparer()
+    @recorded_by_proxy
+    def test_agent_chat_with_tracing_content_recording_enabled(self, **kwargs):
+        assert True == AIAgentsInstrumentor().is_content_recording_enabled()
+        assert True == AIAgentsInstrumentor().is_instrumented()
 
         client = self.create_client(**kwargs)
         agent = client.agents.create_agent(model="gpt-4o", name="my-agent", instructions="You are helpful agent")
@@ -289,8 +206,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = client.agents.list_messages(thread_id=thread.id)
         client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -316,7 +233,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -328,7 +245,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -354,7 +271,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("start_thread_run")
+        spans = self.exporter.get_spans_by_name("start_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -369,7 +286,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -391,7 +308,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                     "gen_ai.agent.id": "*",
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
-                    "gen_ai.message.status": "completed",
+                    # "gen_ai.message.status": "completed", - there is not status over-the wire
                     "gen_ai.event.content": '{"content": {"text": {"value": "*"}}, "role": "assistant"}',
                 },
             },
@@ -408,21 +325,11 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_without_content")
     @agentClientPreparer()
     @recorded_by_proxy
     def test_agent_chat_with_tracing_content_recording_disabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
+        assert False == AIAgentsInstrumentor().is_content_recording_enabled()
 
         client = self.create_client(**kwargs)
         agent = client.agents.create_agent(model="gpt-4o", name="my-agent", instructions="You are helpful agent")
@@ -443,8 +350,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = client.agents.list_messages(thread_id=thread.id)
         client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -470,7 +377,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -482,7 +389,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -508,7 +415,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("start_thread_run")
+        spans = self.exporter.get_spans_by_name("start_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -523,7 +430,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -561,22 +468,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_with_content")
     @agentClientPreparer()
     @recorded_by_proxy
     def test_agent_streaming_with_toolset_with_tracing_content_recording_enabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         def fetch_weather(location: str) -> str:
             """
             Fetches the weather information for the specified location.
@@ -604,6 +499,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         agent = client.agents.create_agent(
             model="gpt-4o", name="my-agent", instructions="You are helpful agent", toolset=toolset
         )
+
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+        client.agents._toolset = FakeToolSetDict(toolset=toolset)
+
         thread = client.agents.create_thread()
         message = client.agents.create_message(
             thread_id=thread.id, role="user", content="What is the weather in New York?"
@@ -620,8 +519,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = client.agents.list_messages(thread_id=thread.id)
         client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -647,7 +546,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -659,7 +558,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -685,7 +584,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("submit_tool_outputs")
+        spans = self.exporter.get_spans_by_name("submit_tool_outputs")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -698,7 +597,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("process_thread_run")
+        spans = self.exporter.get_spans_by_name("process_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -725,7 +624,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.status": "completed",
                     "gen_ai.usage.input_tokens": "+",
@@ -738,7 +637,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
                     "gen_ai.message.status": "completed",
@@ -751,7 +650,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -789,22 +688,120 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
+    @pytest.mark.usefixtures("instrument_with_content")
+    @agentClientPreparer()
+    @recorded_by_proxy
+    def test_agent_streaming_with_toolset_with_tracing_content_recording_enabled_unicode(self, **kwargs):
+        def fetch_weather(location: str) -> str:
+            """
+            Fetches the weather information for the specified location.
 
-    @pytest.mark.skip
+            :param location (str): The location to fetch weather for.
+            :return: Weather information as a JSON string.
+            :rtype: str
+            """
+            # In a real-world scenario, you'd integrate with a weather API.
+            # Here, we'll mock the response.
+            mock_weather_data = {"New York": "Sunny", "London": "Cloudy", "Sofia": "Дъждовно"}
+            weather = mock_weather_data.get(location, f"Weather data not available for this location: {location}")
+            weather_json = json.dumps({"weather": weather}, ensure_ascii=False)
+            return weather_json
+
+        user_functions: Set[Callable[..., Any]] = {
+            fetch_weather,
+        }
+
+        functions = FunctionTool(user_functions)
+        toolset = ToolSet()
+        toolset.add(functions)
+
+        client = self.create_client(**kwargs)
+        agent = client.agents.create_agent(
+            model="gpt-4o",
+            name="my-agent",
+            instructions="You are helpful agent. Translate user message to English before executing tools.",
+            toolset=toolset,
+        )
+
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+        client.agents._toolset = FakeToolSetDict(toolset=toolset)
+
+        thread = client.agents.create_thread()
+        message = client.agents.create_message(thread_id=thread.id, role="user", content="Времето в София?")
+
+        with client.agents.create_stream(
+            thread_id=thread.id, agent_id=agent.id, event_handler=MyEventHandler()
+        ) as stream:
+            stream.until_done()
+
+        # delete agent and close client
+        client.agents.delete_agent(agent.id)
+        print("Deleted agent")
+        messages = client.agents.list_messages(thread_id=thread.id)
+        client.close()
+
+        self.exporter.force_flush()
+
+        spans = self.exporter.get_spans_by_name("create_message")
+        assert len(spans) == 1
+        span = spans[0]
+
+        expected_events = [
+            {
+                "name": "gen_ai.user.message",
+                "attributes": {
+                    "gen_ai.system": "az.ai.agents",
+                    "gen_ai.thread.id": "*",
+                    "gen_ai.event.content": '{"content": "Времето в София?", "role": "user"}',
+                },
+            }
+        ]
+        events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
+        assert events_match == True
+
+        spans = self.exporter.get_spans_by_name("process_thread_run")
+        assert len(spans) == 1
+        span = spans[0]
+        expected_events = [
+            {
+                "name": "gen_ai.tool.message",
+                "attributes": {"gen_ai.event.content": '{"content": "{\\"weather\\": \\"Дъждовно\\"}", "id": "*"}'},
+            },
+            {
+                "name": "gen_ai.assistant.message",
+                "attributes": {
+                    "gen_ai.system": "az.ai.agents",
+                    "gen_ai.thread.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+                    "gen_ai.thread.run.id": "*",
+                    "gen_ai.message.status": "completed",
+                    "gen_ai.usage.input_tokens": "+",
+                    "gen_ai.usage.output_tokens": "+",
+                    "gen_ai.event.content": '{"tool_calls": [{"id": "*", "type": "function", "function": {"name": "fetch_weather", "arguments": {"location": "Sofia"}}}]}',
+                },
+            },
+            {
+                "name": "gen_ai.assistant.message",
+                "attributes": {
+                    "gen_ai.system": "az.ai.agents",
+                    "gen_ai.thread.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+                    "gen_ai.thread.run.id": "*",
+                    "gen_ai.message.id": "*",
+                    "gen_ai.message.status": "completed",
+                    "gen_ai.usage.input_tokens": "+",
+                    "gen_ai.usage.output_tokens": "+",
+                    "gen_ai.event.content": '{"content": {"text": {"value": "*"}}, "role": "assistant"}',
+                },
+            },
+        ]
+        events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
+        assert events_match == True
+
+    @pytest.mark.usefixtures("instrument_without_content")
     @agentClientPreparer()
     @recorded_by_proxy
     def test_agent_streaming_with_toolset_with_tracing_content_recording_disabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         def fetch_weather(location: str) -> str:
             """
             Fetches the weather information for the specified location.
@@ -832,6 +829,9 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         agent = client.agents.create_agent(
             model="gpt-4o", name="my-agent", instructions="You are helpful agent", toolset=toolset
         )
+
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+        client.agents._toolset = FakeToolSetDict(toolset=toolset)
         thread = client.agents.create_thread()
         message = client.agents.create_message(
             thread_id=thread.id, role="user", content="What is the weather in New York?"
@@ -848,8 +848,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = client.agents.list_messages(thread_id=thread.id)
         client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -875,7 +875,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -887,7 +887,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -913,7 +913,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("submit_tool_outputs")
+        spans = self.exporter.get_spans_by_name("submit_tool_outputs")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -926,7 +926,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("process_thread_run")
+        spans = self.exporter.get_spans_by_name("process_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -953,7 +953,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.status": "completed",
                     "gen_ai.usage.input_tokens": "+",
@@ -966,7 +966,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
                     "gen_ai.message.status": "completed",
@@ -979,7 +979,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -1001,7 +1001,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                     "gen_ai.agent.id": "*",
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
-                    "gen_ai.message.status": "completed",
+                    # "gen_ai.message.status": "completed", - there is no status over-the wire
                     "gen_ai.event.content": '{"role": "assistant"}',
                 },
             },
@@ -1017,8 +1017,6 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         ]
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
-
-        AIAgentsInstrumentor().uninstrument()
 
 
 class MyEventHandler(AgentEventHandler):

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor.py
@@ -70,18 +70,18 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
     @pytest.fixture(scope="function")
     def instrument_with_content(self):
         os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "True"})
-        self.setup()
+        self.setup_telemetry()
         yield
         self.cleanup()
 
     @pytest.fixture(scope="function")
     def instrument_without_content(self):
         os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "False"})
-        self.setup()
+        self.setup_telemetry()
         yield
         self.cleanup()
 
-    def setup(self):
+    def setup_telemetry(self):
         trace._TRACER_PROVIDER = TracerProvider()
         self.exporter = MemoryTraceExporter()
         span_processor = SimpleSpanProcessor(self.exporter)

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor_async.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor_async.py
@@ -16,7 +16,7 @@ from azure.ai.projects.models import AgentsApiResponseFormatMode, AgentsApiRespo
 
 from azure.ai.projects.models import AsyncAgentEventHandler
 
-from azure.ai.projects.telemetry.agents import AIAgentsInstrumentor
+from azure.ai.projects.telemetry.agents import AIAgentsInstrumentor, _utils
 from azure.core.settings import settings
 from memory_trace_exporter import MemoryTraceExporter
 from gen_ai_trace_verifier import GenAiTraceVerifier
@@ -38,39 +38,65 @@ from azure.ai.projects.models import (
     AsyncToolSet,
 )
 
+CONTENT_TRACING_ENV_VARIABLE = "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED"
+settings.tracing_implementation = "OpenTelemetry"
+_utils._span_impl_type = settings.tracing_implementation()
+
 agentClientPreparer = functools.partial(
     EnvironmentVariableLoader,
     "azure_ai_projects",
-    azure_ai_projects_connection_string="https://foo.bar.some-domain.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
-    azure_ai_projects_data_path="azureml://subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-resour-cegr-oupfoo1/workspaces/abcd-abcdabcdabcda-abcdefghijklm/datastores/workspaceblobstore/paths/LocalUpload/000000000000/product_info_1.md",
+    azure_ai_projects_agents_tests_project_connection_string="region.api.azureml.ms;00000000-0000-0000-0000-000000000000;rg-resour-cegr-oupfoo1;abcd-abcdabcdabcda-abcdefghijklm",
+    azure_ai_projects_agents_tests_data_path="azureml://subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-resour-cegr-oupfoo1/workspaces/abcd-abcdabcdabcda-abcdefghijklm/datastores/workspaceblobstore/paths/LocalUpload/000000000000/product_info_1.md",
 )
-"""
-agentClientPreparer = functools.partial(
-    EnvironmentVariableLoader,
-    'azure_ai_project',
-    azure_ai_project_host_name="https://foo.bar.some-domain.ms",
-    azure_ai_project_subscription_id="00000000-0000-0000-0000-000000000000",
-    azure_ai_project_resource_group_name="rg-resour-cegr-oupfoo1",
-    azure_ai_project_workspace_name="abcd-abcdabcdabcda-abcdefghijklm",
-)
-"""
 
 CONTENT_TRACING_ENV_VARIABLE = "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED"
 content_tracing_initial_value = os.getenv(CONTENT_TRACING_ENV_VARIABLE)
 
 
+# TODO - remove when https://github.com/Azure/azure-sdk-for-python/issues/40086 is fixed
+class FakeToolSetDict(dict):
+    def __init__(self, toolset=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.toolset = toolset
+
+    def get(self, k, default=None):
+        return self.toolset
+
+
 class TestAiAgentsInstrumentor(AzureRecordedTestCase):
     """Tests for AI agents instrumentor."""
 
-    @classmethod
-    def teardown_class(cls):
-        if content_tracing_initial_value is not None:
-            os.environ[CONTENT_TRACING_ENV_VARIABLE] = content_tracing_initial_value
+    @pytest.fixture(scope="function")
+    def instrument_with_content(self):
+        os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "True"})
+        self.setup()
+        yield
+        self.cleanup()
+
+    @pytest.fixture(scope="function")
+    def instrument_without_content(self):
+        os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "False"})
+        self.setup()
+        yield
+        self.cleanup()
+
+    def setup(self):
+        trace._TRACER_PROVIDER = TracerProvider()
+        self.exporter = MemoryTraceExporter()
+        span_processor = SimpleSpanProcessor(self.exporter)
+        trace.get_tracer_provider().add_span_processor(span_processor)
+        AIAgentsInstrumentor().instrument()
+
+    def cleanup(self):
+        self.exporter.shutdown()
+        AIAgentsInstrumentor().uninstrument()
+        trace._TRACER_PROVIDER = None
+        os.environ.pop(CONTENT_TRACING_ENV_VARIABLE, None)
 
     # helper function: create client and using environment variables
     def create_client(self, **kwargs):
         # fetch environment variables
-        connection_string = kwargs.pop("azure_ai_projects_connection_string")
+        connection_string = kwargs.pop("azure_ai_projects_agents_tests_project_connection_string")
         credential = self.get_credential(AIProjectClient, is_async=True)
 
         # create and return client
@@ -101,35 +127,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         actual = _AIAgentsInstrumentorPreview.agent_api_response_to_str(fmt)
         assert actual == expected
 
-    def setup_memory_trace_exporter(self) -> MemoryTraceExporter:
-        # Setup Azure Core settings to use OpenTelemetry tracing
-        settings.tracing_implementation = "OpenTelemetry"
-        trace.set_tracer_provider(TracerProvider())
-        tracer = trace.get_tracer(__name__)
-        memoryExporter = MemoryTraceExporter()
-        span_processor = SimpleSpanProcessor(memoryExporter)
-        trace.get_tracer_provider().add_span_processor(span_processor)
-        return span_processor, memoryExporter
-
-    def modify_env_var(self, name, new_value):
-        current_value = os.getenv(name)
-        os.environ[name] = new_value
-        return current_value
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_with_content")
     @agentClientPreparer()
     @recorded_by_proxy_async
     async def test_agent_chat_with_tracing_content_recording_enabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         client = self.create_client(**kwargs)
         agent = await client.agents.create_agent(model="gpt-4o", name="my-agent", instructions="You are helpful agent")
         thread = await client.agents.create_thread()
@@ -149,8 +150,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = await client.agents.list_messages(thread_id=thread.id)
         await client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -176,7 +177,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -188,7 +189,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -214,7 +215,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("start_thread_run")
+        spans = self.exporter.get_spans_by_name("start_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -229,7 +230,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -267,22 +268,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_without_content")
     @agentClientPreparer()
     @recorded_by_proxy_async
     async def test_agent_chat_with_tracing_content_recording_disabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         client = self.create_client(**kwargs)
         agent = await client.agents.create_agent(model="gpt-4o", name="my-agent", instructions="You are helpful agent")
         thread = await client.agents.create_thread()
@@ -302,8 +291,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = await client.agents.list_messages(thread_id=thread.id)
         await client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -329,7 +318,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -341,7 +330,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -367,7 +356,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("start_thread_run")
+        spans = self.exporter.get_spans_by_name("start_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -382,7 +371,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -420,22 +409,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_with_content")
     @agentClientPreparer()
     @recorded_by_proxy_async
     async def test_agent_streaming_with_toolset_with_tracing_content_recording_enabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "True")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         def fetch_weather(location: str) -> str:
             """
             Fetches the weather information for the specified location.
@@ -463,6 +440,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         agent = await client.agents.create_agent(
             model="gpt-4o", name="my-agent", instructions="You are helpful agent", toolset=toolset
         )
+
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+        client.agents._toolset = FakeToolSetDict(toolset=toolset)
+
         thread = await client.agents.create_thread()
         message = await client.agents.create_message(
             thread_id=thread.id, role="user", content="What is the weather in New York?"
@@ -479,8 +460,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = await client.agents.list_messages(thread_id=thread.id)
         await client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -506,7 +487,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -518,7 +499,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -544,7 +525,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("submit_tool_outputs")
+        spans = self.exporter.get_spans_by_name("submit_tool_outputs")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -557,7 +538,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("process_thread_run")
+        spans = self.exporter.get_spans_by_name("process_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -584,7 +565,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.status": "completed",
                     "gen_ai.usage.input_tokens": "+",
@@ -597,7 +578,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
                     "gen_ai.message.status": "completed",
@@ -610,7 +591,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -648,22 +629,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        AIAgentsInstrumentor().uninstrument()
-
-    @pytest.mark.skip
+    @pytest.mark.usefixtures("instrument_without_content")
     @agentClientPreparer()
     @recorded_by_proxy_async
     async def test_agent_streaming_with_toolset_with_tracing_content_recording_disabled(self, **kwargs):
-        # Make sure code is not instrumented due to a previous test exception
-        try:
-            AIAgentsInstrumentor().uninstrument()
-        except RuntimeError as e:
-            pass
-        self.modify_env_var(CONTENT_TRACING_ENV_VARIABLE, "False")
-
-        processor, exporter = self.setup_memory_trace_exporter()
-        AIAgentsInstrumentor().instrument()
-
         def fetch_weather(location: str) -> str:
             """
             Fetches the weather information for the specified location.
@@ -691,6 +660,10 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         agent = await client.agents.create_agent(
             model="gpt-4o", name="my-agent", instructions="You are helpful agent", toolset=toolset
         )
+
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
+        client.agents._toolset = FakeToolSetDict(toolset=toolset)
+
         thread = await client.agents.create_thread()
         message = await client.agents.create_message(
             thread_id=thread.id, role="user", content="What is the weather in New York?"
@@ -707,8 +680,8 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         messages = await client.agents.list_messages(thread_id=thread.id)
         await client.close()
 
-        processor.force_flush()
-        spans = exporter.get_spans_by_name("create_agent my-agent")
+        self.exporter.force_flush()
+        spans = self.exporter.get_spans_by_name("create_agent my-agent")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -734,7 +707,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("create_thread")
+        spans = self.exporter.get_spans_by_name("create_thread")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -746,7 +719,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("create_message")
+        spans = self.exporter.get_spans_by_name("create_message")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -772,7 +745,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("submit_tool_outputs")
+        spans = self.exporter.get_spans_by_name("submit_tool_outputs")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -785,7 +758,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         attributes_match = GenAiTraceVerifier().check_span_attributes(span, expected_attributes)
         assert attributes_match == True
 
-        spans = exporter.get_spans_by_name("process_thread_run")
+        spans = self.exporter.get_spans_by_name("process_thread_run")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -812,7 +785,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.status": "completed",
                     "gen_ai.usage.input_tokens": "+",
@@ -825,7 +798,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
                 "attributes": {
                     "gen_ai.system": "az.ai.agents",
                     "gen_ai.thread.id": "*",
-                    "gen_ai.agent.id": "*",
+                    # "gen_ai.agent.id": "*", - workaround for https://github.com/Azure/azure-sdk-for-python/issues/40086
                     "gen_ai.thread.run.id": "*",
                     "gen_ai.message.id": "*",
                     "gen_ai.message.status": "completed",
@@ -838,7 +811,7 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
 
-        spans = exporter.get_spans_by_name("list_messages")
+        spans = self.exporter.get_spans_by_name("list_messages")
         assert len(spans) == 1
         span = spans[0]
         expected_attributes = [
@@ -875,8 +848,6 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
         ]
         events_match = GenAiTraceVerifier().check_span_events(span, expected_events)
         assert events_match == True
-
-        AIAgentsInstrumentor().uninstrument()
 
 
 class MyEventHandler(AsyncAgentEventHandler):

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor_async.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_ai_agents_instrumentor_async.py
@@ -69,18 +69,18 @@ class TestAiAgentsInstrumentor(AzureRecordedTestCase):
     @pytest.fixture(scope="function")
     def instrument_with_content(self):
         os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "True"})
-        self.setup()
+        self.setup_telemetry()
         yield
         self.cleanup()
 
     @pytest.fixture(scope="function")
     def instrument_without_content(self):
         os.environ.update({CONTENT_TRACING_ENV_VARIABLE: "False"})
-        self.setup()
+        self.setup_telemetry()
         yield
         self.cleanup()
 
-    def setup(self):
+    def setup_telemetry(self):
         trace._TRACER_PROVIDER = TracerProvider()
         self.exporter = MemoryTraceExporter()
         span_processor = SimpleSpanProcessor(self.exporter)

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_telemetry.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_telemetry.py
@@ -5,13 +5,13 @@
 import sys
 from devtools_testutils import recorded_by_proxy
 from azure.ai.projects import AIProjectClient
-from telemetry_test_base import TelemetryTestBase, servicePreparerTelemetryTests
+from telemetry_test_base import TelemetryTestBase, agentClientPreparer
 
 
 # The test class name needs to start with "Test" to get collected by pytest
 class TestTelemetry(TelemetryTestBase):
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     @recorded_by_proxy
     def test_telemetry_get_connection_string(self, **kwargs):
         with self.get_sync_client(**kwargs) as project_client:
@@ -21,13 +21,13 @@ class TestTelemetry(TelemetryTestBase):
             assert bool(TelemetryTestBase.REGEX_APPINSIGHTS_CONNECTION_STRING.match(connection_string))
             assert connection_string == project_client.telemetry.get_connection_string()
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     def test_telemetry_enable_console_tracing(self, **kwargs):
         with self.get_sync_client(**kwargs) as project_client:
             project_client.telemetry.enable()
             # TODO: Create inference client and do chat completions. How do I know if traces were emitted?
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     def test_telemetry_enable_console_tracing_to_stdout(self, **kwargs):
         with self.get_sync_client(**kwargs) as project_client:
             project_client.telemetry.enable(destination=sys.stdout)

--- a/sdk/ai/azure-ai-projects/tests/telemetry/test_telemetry_async.py
+++ b/sdk/ai/azure-ai-projects/tests/telemetry/test_telemetry_async.py
@@ -4,13 +4,13 @@
 # ------------------------------------
 import sys
 from devtools_testutils.aio import recorded_by_proxy_async
-from telemetry_test_base import TelemetryTestBase, servicePreparerTelemetryTests
+from telemetry_test_base import TelemetryTestBase, agentClientPreparer
 
 
 # The test class name needs to start with "Test" to get collected by pytest
 class TestTelemetryAsync(TelemetryTestBase):
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     @recorded_by_proxy_async
     async def test_telemetry_get_connection_string_async(self, **kwargs):
         async with self.get_async_client(**kwargs) as project_client:
@@ -20,13 +20,13 @@ class TestTelemetryAsync(TelemetryTestBase):
             assert bool(TelemetryTestBase.REGEX_APPINSIGHTS_CONNECTION_STRING.match(connection_string))
             assert connection_string == await project_client.telemetry.get_connection_string()
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     async def test_telemetry_enable_console_tracing_async(self, **kwargs):
         async with self.get_async_client(**kwargs) as project_client:
             project_client.telemetry.enable()
             # TODO: Create inference client and do chat completions. How do I know if traces were emitted?
 
-    @servicePreparerTelemetryTests()
+    @agentClientPreparer()
     async def test_telemetry_enable_console_tracing_to_stdout_async(self, **kwargs):
         async with self.get_async_client(**kwargs) as project_client:
             project_client.telemetry.enable(destination=sys.stdout)


### PR DESCRIPTION
`json.dumps` escapes unicode characters by default, so non-latin prompts look like this in azmon:

<img width="1580" alt="image" src="https://github.com/user-attachments/assets/28bc3366-69ee-4898-b3e4-7f58362883b6" />

there is no need to escape unicode characters - json supports unicode, so this PR removes the encoding resulting in 

<img width="1617" alt="image" src="https://github.com/user-attachments/assets/08ae98ae-43b4-4967-836a-07bc5f98a2ab" />


or 

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/1152ceed-78d2-4f12-860b-6c63dd7a9e58" />

in Foundry UI