### PR TITLE
Agents: suppress generic spans for manually instrumented operations

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/agents/_ai_agents_instrumentor.py
@@ -1100,8 +1100,6 @@ class _AIAgentsInstrumentorPreview:
         if span is None:
             return function(*args, **kwargs)
 
-        # TODO: how to keep span active in the current context without existing?
-        # TODO: dummy span for none
         with span.change_context(span.span_instance):
             try:
                 kwargs["event_handler"] = self.wrap_handler(event_handler, span)
@@ -1332,24 +1330,33 @@ class _AIAgentsInstrumentorPreview:
             class_function_name = function.__qualname__
 
             if class_function_name.startswith("AgentsOperations.create_agent"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_agent(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_thread"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_thread(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_message"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_message(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_run"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_run(OperationName.START_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_and_process_run"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_run(OperationName.PROCESS_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_run"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_submit_tool_outputs(False, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_stream"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_submit_tool_outputs(True, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations._handle_submit_tool_outputs"):
                 return self.trace_handle_submit_tool_outputs(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_stream"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_create_stream(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.list_messages"):
+                kwargs.setdefault('merge_span', True)
                 return self.trace_list_messages(function, *args, **kwargs)
             if class_function_name.startswith("AgentRunStream.__exit__"):
                 return self.handle_run_stream_exit(function, *args, **kwargs)
@@ -1391,24 +1398,33 @@ class _AIAgentsInstrumentorPreview:
             class_function_name = function.__qualname__
 
             if class_function_name.startswith("AgentsOperations.create_agent"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_agent_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_thread"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_thread_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_message"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_message_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_run"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_run_async(OperationName.START_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_and_process_run"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_run_async(OperationName.PROCESS_THREAD_RUN, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_run"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_submit_tool_outputs_async(False, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.submit_tool_outputs_to_stream"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_submit_tool_outputs_async(True, function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations._handle_submit_tool_outputs"):
                 return await self.trace_handle_submit_tool_outputs_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.create_stream"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_create_stream_async(function, *args, **kwargs)
             if class_function_name.startswith("AgentsOperations.list_messages"):
+                kwargs.setdefault('merge_span', True)
                 return await self.trace_list_messages_async(function, *args, **kwargs)
             if class_function_name.startswith("AsyncAgentRunStream.__aexit__"):
                 return self.handle_run_stream_exit(function, *args, **kwargs)


### PR DESCRIPTION
Suppress some of the generic spans created by decorator that duplicate manually instrumented operations.

this does not cover nested calls and depends on the https://github.com/Azure/azure-sdk-for-python/pull/39994 to suppress the rest