### PR TITLE
Use Root .coveragerc when publishing coverage reports

### DIFF
--- a/eng/tox/run_coverage.py
+++ b/eng/tox/run_coverage.py
@@ -13,7 +13,7 @@ from ci_tools.environment_exclusions import is_check_enabled
 from ci_tools.functions import get_total_coverage
 
 logging.basicConfig(level=logging.INFO)
-coveragerc_file = os.path.join(os.path.dirname(__file__), "tox.ini")
+coveragerc_file = os.path.join(os.path.dirname(__file__), "..", "..", ".coveragerc")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/scripts/devops_tasks/create_coverage.py
+++ b/scripts/devops_tasks/create_coverage.py
@@ -19,8 +19,7 @@ logging.getLogger().setLevel(logging.INFO)
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 coverage_dir = os.path.join(root_dir, "_coverage/")
-toxrc = os.path.join(root_dir, "eng","tox", "tox.ini")
-
+coveragerc = os.path.join(root_dir, ".coveragerc")
 
 def collect_tox_coverage_files():
     coverage_version_cmd = [sys.executable, "-m", "coverage", "--version"]
@@ -53,7 +52,7 @@ def collect_tox_coverage_files():
 def generate_coverage_xml():
     if os.path.exists(coverage_dir):
         logging.info("Generating coverage XML")
-        commands = ["coverage", "xml", "-i", "--rcfile", toxrc]
+        commands = ["coverage", "xml", "-i", "--rcfile", coveragerc]
         run_check_call(commands, root_dir, always_exit=False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_dir))

--- a/sdk/ml/azure-ai-ml/pyproject.toml
+++ b/sdk/ml/azure-ai-ml/pyproject.toml
@@ -7,7 +7,7 @@ mindependency = false
 latestdependency = false
 black = true
 absolute_cov = true
-absolute_cov_percent = 21.34
+absolute_cov_percent = 73
 
 [tool.isort]
 profile = "black"

--- a/sdk/ml/azure-ai-ml/pyproject.toml
+++ b/sdk/ml/azure-ai-ml/pyproject.toml
@@ -7,7 +7,7 @@ mindependency = false
 latestdependency = false
 black = true
 absolute_cov = true
-absolute_cov_percent = 73
+absolute_cov_percent = 65.55
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
For azure-ai-ml this should close the gap. For the rest of the packages the changes shouldn't be very large. Let's see though.