### PR TITLE
AAD tests sample

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/test_config.py
+++ b/sdk/cosmos/azure-cosmos/test/test_config.py
@@ -27,10 +27,10 @@ except:
 
 
 class TestConfig(object):
-    local_host = 'https://localhost:8081/'
+    local_host = 'https://localhost:8081/' # Will need to change this to your account endpoint if you're not running the emulator
     # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Cosmos DB Emulator Key")]
     masterKey = os.getenv('ACCOUNT_KEY',
-                          'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==')
+                          'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==') # Will need to change this to your account key if you're not running the emulator
     host = os.getenv('ACCOUNT_HOST', local_host)
     connection_str = os.getenv('ACCOUNT_CONNECTION_STR', 'AccountEndpoint={};AccountKey={};'.format(host, masterKey))
 

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -27,6 +27,7 @@ import test_config
 from azure.cosmos import _retry_utility
 from azure.cosmos.http_constants import HttpHeaders, StatusCodes
 from azure.cosmos.partition_key import PartitionKey
+from azure.identity import DefaultAzureCredential
 
 
 class TimeoutTransport(RequestsTransport):
@@ -81,7 +82,8 @@ class TestCRUDOperations(unittest.TestCase):
                 "You must specify your Azure Cosmos account values for "
                 "'masterKey' and 'host' at the top of this class to run the "
                 "tests.")
-        cls.client = cosmos_client.CosmosClient(cls.host, cls.masterKey)
+        credentials = DefaultAzureCredential()
+        cls.client = cosmos_client.CosmosClient(cls.host, credentials)
         cls.databaseForTest = cls.client.get_database_client(cls.configs.TEST_DATABASE_ID)
 
     def test_database_crud(self):

--- a/sdk/cosmos/azure-cosmos/test/test_crud_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud_async.py
@@ -25,6 +25,7 @@ import test_config
 from azure.cosmos.aio import CosmosClient, _retry_utility_async, DatabaseProxy
 from azure.cosmos.http_constants import HttpHeaders, StatusCodes
 from azure.cosmos.partition_key import PartitionKey
+from azure.identity.aio import DefaultAzureCredential
 
 
 class TimeoutTransport(AsyncioRequestsTransport):
@@ -82,7 +83,8 @@ class TestCRUDOperationsAsync(unittest.IsolatedAsyncioTestCase):
                 "tests.")
 
     async def asyncSetUp(self):
-        self.client = CosmosClient(self.host, self.masterKey)
+        credentials = DefaultAzureCredential()
+        self.client = CosmosClient(self.host, credentials)
         self.database_for_test = self.client.get_database_client(self.configs.TEST_DATABASE_ID)
 
     async def asyncTearDown(self):


### PR DESCRIPTION
Sample showing how to use AAD with the current CRUD tests we have.

DefaultAzureCredential will pull directly from your environment variables/ `az login`.
More on that here:
https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python
https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains?tabs=dac#defaultazurecredential-overview