### PR TITLE
[Monitor Exporter] Update Azure SDK messaging span util

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Support `syntheticSource` from `user_agent.synthetic.type` semantic convention
   ([#40004](https://github.com/Azure/azure-sdk-for-python/pull/40004))
+- Support `server.address` attributes when converting Azure SDK messaging spans to envelopes
+  ([#40059](https://github.com/Azure/azure-sdk-for-python/pull/40059))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_utils.py
@@ -68,8 +68,9 @@ def _get_azure_sdk_target_source(attributes: Attributes) -> Optional[str]:
     # Currently logic only works for ServiceBus and EventHub
     if attributes:
         # New semconv attributes: https://github.com/Azure/azure-sdk-for-python/pull/29203
-        # TODO: Keep track of when azure-sdk supports stable semconv for these fields
-        peer_address = attributes.get("net.peer.name") or attributes.get("peer.address")
+        peer_address = (
+            attributes.get("server.address") or attributes.get("net.peer.name") or attributes.get("peer.address")
+        )
         destination = attributes.get("messaging.destination.name") or attributes.get("message_bus.destination")
         if peer_address and destination:
             return str(peer_address) + "/" + str(destination)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1002,6 +1002,14 @@ class TestAzureTraceExporter(unittest.TestCase):
         envelope = exporter._span_to_envelope(span)
         self.assertEqual(envelope.data.base_data.source, "Test_name//testdest")
 
+        span._attributes = {
+            "az.namespace": "Microsoft.EventHub",
+            "server.address": "Test_name",
+            "messaging.destination.name": "/testdest",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.source, "Test_name//testdest")
+
     def test_span_envelope_server_http(self):
         exporter = self._exporter
         start_time = 1575494316027613500


### PR DESCRIPTION
The utility method that gets the target source for Azure SDK messaging span will now also check for `server.address`. A newer version of the core OTel plugin will automatically convert `net.peer.name` to `server.address`. This ensures that this case can be handled.
