### PR TITLE
[EH] Use Partition Count for Buffered Producer

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
@@ -51,7 +51,9 @@ class BufferedProducerDispatcher:
         self._amqp_transport = amqp_transport
 
         if not executor:
-            self._executor = ThreadPoolExecutor()
+            # set max workers to the number of partitions & one for the close operation.
+            max_workers: int = len(self._partition_ids) + 1
+            self._executor = ThreadPoolExecutor(max_workers=max_workers)
         elif isinstance(executor, ThreadPoolExecutor):
             self._existing_executor = True
             self._executor = executor


### PR DESCRIPTION
Set the max worker count for `ThreadpoolExecutor` to be the number of partitions for the hub and one more for the final close operation.

Fixes #38961