### PR TITLE
[Cosmos] set startup to false on any refresh

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed too many health checks happening when skipping the recommended client startup. See [PR ]().
+* Fixed too many health checks happening when skipping the recommended client startup. See [PR 40203](https://github.com/Azure/azure-sdk-for-python/pull/40203).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed too many health checks happening when skipping the recommended client startup. See [PR ]().
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -116,7 +116,6 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                     return
                 try:
                     await self._refresh_endpoint_list_private(database_account, **kwargs)
-                    self.startup = False
                 except Exception as e:
                     raise e
 
@@ -125,6 +124,7 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             self.location_cache.perform_on_database_account_read(database_account)
             self.refresh_needed = False
             self.last_refresh_time = self.location_cache.current_time_millis()
+            self.startup = False
         else:
             if self.location_cache.should_refresh_endpoints() or self.refresh_needed:
                 self.refresh_needed = False
@@ -136,6 +136,7 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                 else:
                     # on startup do this in foreground
                     await self._endpoints_health_check(**kwargs)
+                    self.startup = False
 
     async def _endpoints_health_check(self, **kwargs):
         """Gets the database account for each endpoint.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -116,6 +116,7 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                     return
                 try:
                     await self._refresh_endpoint_list_private(database_account, **kwargs)
+                    self.startup = False
                 except Exception as e:
                     raise e
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -124,7 +124,6 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             self.location_cache.perform_on_database_account_read(database_account)
             self.refresh_needed = False
             self.last_refresh_time = self.location_cache.current_time_millis()
-            self.startup = False
         else:
             if self.location_cache.should_refresh_endpoints() or self.refresh_needed:
                 self.refresh_needed = False


### PR DESCRIPTION
Customers not initializing their async client manually or with a context manager can be affected by too many health checks happening for their services, adding overhead latencies to their applications by having to handle all these additional requests. This change sets the `startup` attribute to `False` on the first refresh it sees as `True`, which prevents unnecessary health checks from occurring.