### PR TITLE
Move to the new pools

### DIFF
--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,18 +2,18 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2004-general
+    value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool-mms-win-2022-general
+    value: azsdk-pool
   - name: MACPOOL
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2004-1espt
+    value: ubuntu-22.04
   - name: LINUXNEXTVMIMAGE
     value: ubuntu-22.04
   - name: WINDOWSVMIMAGE
-    value: azsdk-pool-mms-win-2022-1espt
+    value: windows-2022
   - name: MACVMIMAGE
     value: macos-latest
 


### PR DESCRIPTION
20.04 is getting deprecated very soon. I'm taking the opportunity to swap us to the new unified 1ES pools as well. One pool, both linux and windows agents! 

As more and more repos migrate over, our buffering capacity will increase a lot.