### PR TITLE
fix attribute mapping for ManagedIdentityToken

### DIFF
--- a/sdk/managedapplications/azure-mgmt-managedapplications/CHANGELOG.md
+++ b/sdk/managedapplications/azure-mgmt-managedapplications/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0b2 (Unreleased)
+
+### Bugs Fixed
+
+* attribute mapping in ManagedIdentityToken
+
 ## 1.0.0b1 (2023-09-20)
 
 * Initial Release

--- a/sdk/managedapplications/azure-mgmt-managedapplications/azure/mgmt/managedapplications/models/_models_py3.py
+++ b/sdk/managedapplications/azure-mgmt-managedapplications/azure/mgmt/managedapplications/models/_models_py3.py
@@ -1836,13 +1836,13 @@ class ManagedIdentityToken(_serialization.Model):
     """
 
     _attribute_map = {
-        "access_token": {"key": "accessToken", "type": "str"},
-        "expires_in": {"key": "expiresIn", "type": "str"},
-        "expires_on": {"key": "expiresOn", "type": "str"},
-        "not_before": {"key": "notBefore", "type": "str"},
+        "access_token": {"key": "access_token", "type": "str"},
+        "expires_in": {"key": "expires_in", "type": "str"},
+        "expires_on": {"key": "expires_on", "type": "str"},
+        "not_before": {"key": "not_before", "type": "str"},
         "authorization_audience": {"key": "authorizationAudience", "type": "str"},
         "resource_id": {"key": "resourceId", "type": "str"},
-        "token_type": {"key": "tokenType", "type": "str"},
+        "token_type": {"key": "token_type", "type": "str"},
     }
 
     def __init__(


### PR DESCRIPTION
As per the [documentation the response to listTokens is formatted](https://learn.microsoft.com/en-us/azure/azure-resource-manager/managed-applications/publish-managed-identity#accessing-the-managed-identity-token) as:
```
{"value":[{"authorizationAudience":"https://management.azure.com/","resourceId":"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}","access_token":"...","expires_in":"86399","expires_on":"1743242070","not_before":"1743155371","token_type":"Bearer"}]}
```

The current mapping expects all the attributes to be in camel case, when the token parts are actually in snake; in particular 'access_token' and 'token_type'.

This commit fixes the mapping so that `<ManagedIdentityToken>.access_token` no longer always returns None.