### PR TITLE
[Identity] Refactor synchronous ClientAssertionCredential

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Other Changes
 
 - Deprecated `VisualStudioCodeCredential` as the VS Code Azure Account extension on which this credential depends on has been deprecated. See the Azure Account extension [deprecation notice](https://github.com/microsoft/vscode-azure-account/issues/964).  ([#40613](https://github.com/Azure/azure-sdk-for-python/pull/40613))
+- Updated the synchronous `ClientAssertionCredential` to use the Microsoft Authentication Library (MSAL) for its implementation.  ([#40277](https://github.com/Azure/azure-sdk-for-python/pull/40277))
 
 ## 1.21.0 (2025-03-11)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
@@ -20,7 +20,7 @@ def _get_known_kwargs(kwargs: Dict[str, Any]):
 
 
 class ClientCredentialBase(MsalCredential, GetTokenMixin):
-    """Base class for credentials authenticating a service principal with a certificate or secret"""
+    """Base class for credentials authenticating a service principal with a certificate, secret, or JWT assertion."""
 
     @wrap_exceptions
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessTokenInfo]:

--- a/sdk/identity/azure-identity/tests/test_client_assertion_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_assertion_credential.py
@@ -4,16 +4,17 @@
 # ------------------------------------
 from typing import Callable
 from unittest.mock import MagicMock, Mock, patch
+from urllib.parse import urlparse
 
 from azure.identity._internal.aad_client_base import JWT_BEARER_ASSERTION
 from azure.identity import ClientAssertionCredential, TokenCachePersistenceOptions
 import pytest
 
-from helpers import build_aad_response, mock_response, GET_TOKEN_METHODS
+from helpers import build_aad_response, mock_response, get_discovery_response, GET_TOKEN_METHODS
 
 
 def test_init_with_kwargs():
-    tenant_id: str = "TENANT_ID"
+    tenant_id: str = "tenant-id"
     client_id: str = "CLIENT_ID"
     func: Callable[[], str] = lambda: "TOKEN"
 
@@ -26,7 +27,7 @@ def test_init_with_kwargs():
 
 
 def test_context_manager():
-    tenant_id: str = "TENANT_ID"
+    tenant_id: str = "tenant-id"
     client_id: str = "CLIENT_ID"
     func: Callable[[], str] = lambda: "TOKEN"
 
@@ -46,22 +47,30 @@ def test_token_cache_persistence(get_token_method):
     """The credential should use a persistent cache if cache_persistence_options are configured."""
 
     access_token = "foo"
-    tenant_id: str = "TENANT_ID"
+    tenant_id: str = "tenant-id"
     client_id: str = "CLIENT_ID"
     scope = "scope"
     assertion = "ASSERTION_TOKEN"
     func: Callable[[], str] = lambda: assertion
 
     def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
+        parsed = urlparse(request.url)
+        tenant = parsed.path.split("/")[1]
+        if "/oauth2/v2.0/token" not in parsed.path:
+            return get_discovery_response("https://{}/{}".format(parsed.netloc, tenant))
+
         assert request.data["client_assertion"] == assertion
         assert request.data["client_assertion_type"] == JWT_BEARER_ASSERTION
         assert request.data["client_id"] == client_id
         assert request.data["grant_type"] == "client_credentials"
         assert request.data["scope"] == scope
-
+        assert tenant_id in request.url
         return mock_response(json_payload=build_aad_response(access_token=access_token))
 
-    with patch("azure.identity._internal.aad_client_base._load_persistent_cache") as load_persistent_cache:
+    with patch("azure.identity._internal.msal_credentials._load_persistent_cache") as load_persistent_cache:
         credential = ClientAssertionCredential(
             tenant_id=tenant_id,
             client_id=client_id,
@@ -71,18 +80,37 @@ def test_token_cache_persistence(get_token_method):
         )
 
         assert load_persistent_cache.call_count == 0
-        assert credential._client._cache is None
-        assert credential._client._cae_cache is None
+        assert credential._cache is None
+        assert credential._cae_cache is None
 
         token = getattr(credential, get_token_method)(scope)
         assert token.token == access_token
         assert load_persistent_cache.call_count == 1
-        assert credential._client._cache is not None
-        assert credential._client._cae_cache is None
+        assert credential._cache is not None
+        assert credential._cae_cache is None
 
         kwargs = {"enable_cae": True}
         if get_token_method == "get_token_info":
             kwargs = {"options": kwargs}
         token = getattr(credential, get_token_method)(scope, **kwargs)
         assert load_persistent_cache.call_count == 2
-        assert credential._client._cae_cache is not None
+        assert credential._cae_cache is not None
+
+
+def test_client_capabilities():
+    """The credential should use the CAE-enabled client when enable_cae is True"""
+    assertion = "ASSERTION_TOKEN"
+    transport = Mock(send=Mock(side_effect=Exception("this test mocks MSAL, so no request should be sent")))
+    func: Callable[[], str] = lambda: assertion
+    credential = ClientAssertionCredential("tenant-id", "client-id", func, transport=transport)
+    with patch("msal.ConfidentialClientApplication") as ConfidentialClientApplication:
+        credential._get_app()
+
+        assert ConfidentialClientApplication.call_count == 1
+        _, kwargs = ConfidentialClientApplication.call_args
+        assert kwargs["client_capabilities"] == None
+
+        credential._get_app(enable_cae=True)
+        assert ConfidentialClientApplication.call_count == 2
+        _, kwargs = ConfidentialClientApplication.call_args
+        assert kwargs["client_capabilities"] == ["CP1"]

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -87,7 +87,7 @@ async def test_tenant_id(environ, get_token_method):
         credential = ManagedIdentityCredential(
             transport=transport, raw_request_hook=request_hook, raw_response_hook=response_hook
         )
-    await getattr(credential, get_token_method)(scope)
+        await getattr(credential, get_token_method)(scope)
 
     assert request_hook.call_count == 1
     assert response_hook.call_count == 1

--- a/sdk/identity/azure-identity/tests/test_workload_identity_credential.py
+++ b/sdk/identity/azure-identity/tests/test_workload_identity_credential.py
@@ -3,11 +3,13 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from unittest.mock import mock_open, MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 from azure.identity import WorkloadIdentityCredential
+from azure.identity._internal.aad_client_base import JWT_BEARER_ASSERTION
 
-from helpers import mock_response, build_aad_response, GET_TOKEN_METHODS
+from helpers import mock_response, build_aad_response, get_discovery_response, GET_TOKEN_METHODS
 
 
 def test_workload_identity_credential_initialize():
@@ -26,11 +28,29 @@ def test_workload_identity_credential_get_token(get_token_method):
     access_token = "foo"
     token_file_path = "foo-path"
     assertion = "foo-assertion"
+    scope = "scope"
 
     def send(request, **kwargs):
         assert "claims" not in kwargs
         assert "tenant_id" not in kwargs
         assert request.data.get("client_assertion") == assertion
+        return mock_response(json_payload=build_aad_response(access_token=access_token))
+
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
+        parsed = urlparse(request.url)
+        tenant = parsed.path.split("/")[1]
+        if "/oauth2/v2.0/token" not in parsed.path:
+            return get_discovery_response("https://{}/{}".format(parsed.netloc, tenant))
+
+        assert request.data["client_assertion"] == assertion
+        assert request.data["client_assertion_type"] == JWT_BEARER_ASSERTION
+        assert request.data["client_id"] == client_id
+        assert request.data["grant_type"] == "client_credentials"
+        assert request.data["scope"] == scope
+        assert tenant_id in request.url
         return mock_response(json_payload=build_aad_response(access_token=access_token))
 
     transport = MagicMock(send=send)
@@ -40,7 +60,7 @@ def test_workload_identity_credential_get_token(get_token_method):
 
     open_mock = mock_open(read_data=assertion)
     with patch("builtins.open", open_mock):
-        token = getattr(credential, get_token_method)("scope")
+        token = getattr(credential, get_token_method)(scope)
         assert token.token == access_token
 
     open_mock.assert_called_once_with(token_file_path, encoding="utf-8")


### PR DESCRIPTION
`ClientAssertionCredential` was refactored to use MSAL underneath. This also means the sync `WorkloadIdentityCredential` and `AzurePipelinesCredential`, which leverage `ClientAssertionCredential`, will also use MSAL.

