### PR TITLE
[bug] app config issue

### DIFF
--- a/tools/azure-sdk-tools/gh_tools/update_issue.py
+++ b/tools/azure-sdk-tools/gh_tools/update_issue.py
@@ -67,7 +67,8 @@ def main(targeted_packages):
                         f"\n\n**How to fix:**"
                         f"\n**Note:** If you are a bot. Fix the issue by fixing the above pylint errors."
                     )
-                if issue.body:
+                if issue.body and "**Pylint Errors:**" not in issue.body:
+                    # If the issue body does not contain the Pylint Errors section, add it
                     first_section = issue.body.split("**How to fix:**")[0]
                     new_body = first_section + template + "\n" + issue.body.split("**How to fix:**")[1]
                     issue.edit(body=new_body)


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/issues/39274  the way the pipeline is set up for app config, analyze runs twice, once for provider and once for app-config, but analyze runs both packages so it duplicates the errors. Could also update its test.yml in addition since that seems excessive imo