### PR TITLE
[ServiceBus] revert link credit calc to cumulative

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -147,7 +147,7 @@ class AMQPClientAsync(AMQPClientSync):
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
                     await asyncio.shield(
-                        self._connection.listen(wait=self._socket_timeout, batch=self._link.total_link_credit)
+                        self._connection.listen(wait=self._socket_timeout, batch=self._link.current_link_credit)
                     )
                     start_time = current_time
                 await asyncio.sleep(1)
@@ -733,7 +733,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
         :rtype: bool
         """
         try:
-            if self._link.total_link_credit <= 0:
+            if self._link.current_link_credit<= 0:
                 await self._link.flow(link_credit=self._link_credit)
             await self._connection.listen(wait=self._socket_timeout, **kwargs)
         except ValueError:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -64,7 +64,6 @@ class ReceiverLink(Link):
         if not frame[5]:
             self.delivery_count += 1
             self.current_link_credit -= 1
-            self.total_link_credit -= 1
         if self.received_delivery_id is not None:
             self._first_frame = frame
         if not self.received_delivery_id and not self._received_payload:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -237,7 +237,7 @@ class AMQPClient(object):  # pylint: disable=too-many-instance-attributes
                 current_time = time.time()
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
-                    self._connection.listen(wait=self._socket_timeout, batch=self._link.total_link_credit)
+                    self._connection.listen(wait=self._socket_timeout, batch=self._link.current_link_credit)
                     start_time = current_time
                 time.sleep(1)
         except Exception as e:  # pylint: disable=broad-except
@@ -852,7 +852,7 @@ class ReceiveClient(AMQPClient):  # pylint:disable=too-many-instance-attributes
         :rtype: bool
         """
         try:
-            if self._link.total_link_credit <= 0:
+            if self._link.current_link_credit <= 0:
                 self._link.flow(link_credit=self._link_credit)
             self._connection.listen(wait=self._socket_timeout, **kwargs)
         except ValueError:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
@@ -92,7 +92,6 @@ class Link:  # pylint: disable=too-many-instance-attributes
         self._on_link_state_change = kwargs.get("on_link_state_change")
         self._on_attach = kwargs.get("on_attach")
         self._error: Optional[AMQPLinkError] = None
-        self.total_link_credit = self.link_credit
 
     def __enter__(self) -> "Link":
         self.attach()
@@ -273,18 +272,5 @@ class Link:  # pylint: disable=too-many-instance-attributes
             self._set_state(LinkState.DETACHED)
 
     def flow(self, *, link_credit: Optional[int] = None, **kwargs: Any) -> None:
-        # Given the desired link credit `link_credit`, the link credit sent via
-        # FlowFrame is calculated as follows: The link credit to flow on the wire
-        # `self.current_link_credit` is the desired link credit
-        # `link_credit` minus the current link credit on the wire `self.total_link_credit`.
-        self.current_link_credit = link_credit - self.total_link_credit if link_credit is not None else self.link_credit
-
-        # If the link credit to flow is greater than 0 (i.e the desired link credit is greater than
-        # the current link credit on the wire), then we will send a flow to issue more link credit.
-        # Otherwise link credit on the wire is sufficient.
-        if self.current_link_credit > 0:
-            # Calculate the total link credit on the wire, by adding the credit we will flow to the total link credit.
-            self.total_link_credit = (
-                self.current_link_credit + self.total_link_credit if link_credit is not None else self.link_credit
-            )
-            self._outgoing_flow(**kwargs)
+        self.current_link_credit = link_credit if link_credit is not None else self.link_credit
+        self._outgoing_flow(**kwargs)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
@@ -60,7 +60,6 @@ class ReceiverLink(Link):
         # If more is false --> this is the last frame of the message
         if not frame[5]:
             self.current_link_credit -= 1
-            self.total_link_credit -= 1
             self.delivery_count += 1
         self.received_delivery_id = frame[1]  # delivery_id
         if self.received_delivery_id is not None:

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_link.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_link.py
@@ -131,8 +131,6 @@ def test_receive_transfer_and_flow():
     )
 
     link._outgoing_flow = mock_outgoing
-    link.total_link_credit = 0  # Set the total link credit to 0 to start, no credit on the wire
-
     link.flow(link_credit=100)  # Send a flow frame with desired link credit of 100
 
     # frame: handle, delivery_id, delivery_tag, message_format, settled, more, rcv_settle_mode, state, resume, aborted, batchable, payload
@@ -142,20 +140,15 @@ def test_receive_transfer_and_flow():
 
     link._incoming_transfer(transfer_frame_one)
     assert link.current_link_credit == 99
-    assert link.total_link_credit == 99
 
     # Only received 1 transfer frame per receive call, we set desired link credit again
     # this will send a flow of 1
     link.flow(link_credit=100)
-    assert link.current_link_credit == 1
-    assert link.total_link_credit == 100
-
+    assert link.current_link_credit == 100
     link._incoming_transfer(transfer_frame_two)
-    assert link.current_link_credit == 0
-    assert link.total_link_credit == 99
+    assert link.current_link_credit == 99
     link._incoming_transfer(transfer_frame_three)
-    assert link.current_link_credit == -1
-    assert link.total_link_credit == 98
+    assert link.current_link_credit == 98
 
 @pytest.mark.parametrize(
     "frame",

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -147,7 +147,7 @@ class AMQPClientAsync(AMQPClientSync):
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
                     await asyncio.shield(
-                        self._connection.listen(wait=self._socket_timeout, batch=self._link.total_link_credit)
+                        self._connection.listen(wait=self._socket_timeout, batch=self._link.current_link_credit)
                     )
                     start_time = current_time
                 await asyncio.sleep(1)
@@ -733,7 +733,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
         :rtype: bool
         """
         try:
-            if self._link.total_link_credit <= 0:
+            if self._link.current_link_credit<= 0:
                 await self._link.flow(link_credit=self._link_credit)
             await self._connection.listen(wait=self._socket_timeout, **kwargs)
         except ValueError:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -64,7 +64,6 @@ class ReceiverLink(Link):
         if not frame[5]:
             self.delivery_count += 1
             self.current_link_credit -= 1
-            self.total_link_credit -= 1
         if self.received_delivery_id is not None:
             self._first_frame = frame
         if not self.received_delivery_id and not self._received_payload:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -237,7 +237,7 @@ class AMQPClient(object):  # pylint: disable=too-many-instance-attributes
                 current_time = time.time()
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
-                    self._connection.listen(wait=self._socket_timeout, batch=self._link.total_link_credit)
+                    self._connection.listen(wait=self._socket_timeout, batch=self._link.current_link_credit)
                     start_time = current_time
                 time.sleep(1)
         except Exception as e:  # pylint: disable=broad-except
@@ -852,7 +852,7 @@ class ReceiveClient(AMQPClient):  # pylint:disable=too-many-instance-attributes
         :rtype: bool
         """
         try:
-            if self._link.total_link_credit <= 0:
+            if self._link.current_link_credit <= 0:
                 self._link.flow(link_credit=self._link_credit)
             self._connection.listen(wait=self._socket_timeout, **kwargs)
         except ValueError:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
@@ -92,7 +92,6 @@ class Link:  # pylint: disable=too-many-instance-attributes
         self._on_link_state_change = kwargs.get("on_link_state_change")
         self._on_attach = kwargs.get("on_attach")
         self._error: Optional[AMQPLinkError] = None
-        self.total_link_credit = self.link_credit
 
     def __enter__(self) -> "Link":
         self.attach()
@@ -273,18 +272,5 @@ class Link:  # pylint: disable=too-many-instance-attributes
             self._set_state(LinkState.DETACHED)
 
     def flow(self, *, link_credit: Optional[int] = None, **kwargs: Any) -> None:
-        # Given the desired link credit `link_credit`, the link credit sent via
-        # FlowFrame is calculated as follows: The link credit to flow on the wire
-        # `self.current_link_credit` is the desired link credit
-        # `link_credit` minus the current link credit on the wire `self.total_link_credit`.
-        self.current_link_credit = link_credit - self.total_link_credit if link_credit is not None else self.link_credit
-
-        # If the link credit to flow is greater than 0 (i.e the desired link credit is greater than
-        # the current link credit on the wire), then we will send a flow to issue more link credit.
-        # Otherwise link credit on the wire is sufficient.
-        if self.current_link_credit > 0:
-            # Calculate the total link credit on the wire, by adding the credit we will flow to the total link credit.
-            self.total_link_credit = (
-                self.current_link_credit + self.total_link_credit if link_credit is not None else self.link_credit
-            )
-            self._outgoing_flow(**kwargs)
+        self.current_link_credit = link_credit if link_credit is not None else self.link_credit
+        self._outgoing_flow(**kwargs)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -60,7 +60,6 @@ class ReceiverLink(Link):
         # If more is false --> this is the last frame of the message
         if not frame[5]:
             self.current_link_credit -= 1
-            self.total_link_credit -= 1
             self.delivery_count += 1
         self.received_delivery_id = frame[1]  # delivery_id
         if self.received_delivery_id is not None:


### PR DESCRIPTION
addresses #40156

Reverting #37427 as it's causing the issue in #40156 - After comparing against .NET using the AMQP proxy to inspect traffic, found that .NET also has the decreasing lock time on large messages behavior, since they also request credit but don't release extra messages in the background or drain extra link credit. The client is receiving expired messages. Whether this is because of service behavior or network latency is yet to be determined.

As a workaround for the decreasing message locked_until, users should increase the lock duration on the queue and set max_message_count to a lower value when calling receive_messages.