### PR TITLE
[Identity] Fix live tests post provisioning

### DIFF
--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -16,7 +16,7 @@ param (
 
 $ProvisionLiveResources = $AdditionalParameters['ProvisionLiveResources']
 Write-Host "ProvisionLiveResources: $ProvisionLiveResources"
-if ($CI -and !$ProvisionLiveResources) {
+if (!$ProvisionLiveResources) {
     Write-Host "Skipping test resource post-provisioning."
     return
 }


### PR DESCRIPTION
`$CI` isn't set in the post deploy script anymore, but we don't really need to check it, so let's remove it so that we aren't trying to run post-deploy steps when we don't need to be.

