### PR TITLE
[Identity] Enable brokered auth in DAC

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Valid values are `EnvironmentCredential`, `WorkloadIdentityCredential`, `ManagedIdentityCredential`, `AzureCliCredential`, `AzurePowershellCredential`, `AzureDeveloperCliCredential`, and `InteractiveBrowserCredential`. ([#41709](https://github.com/Azure/azure-sdk-for-python/pull/41709))
 - Re-enabled `VisualStudioCodeCredential` - Previously deprecated `VisualStudioCodeCredential` has been re-implemented to work with the VS Code Azure Resources extension instead of the deprecated Azure Account extension. This requires the `azure-identity-broker` package to be installed for authentication. ([#41822](https://github.com/Azure/azure-sdk-for-python/pull/41822))
   - `VisualStudioCodeCredential` is now included in the `DefaultAzureCredential` token chain by default.
-
+- `DefaultAzureCredential` now supports authentication with the currently signed-in Windows account, provided the `azure-identity-broker` package is installed. This auth mechanism is added at the end of the `DefaultAzureCredential` credential chain.  ([#40335](https://github.com/Azure/azure-sdk-for-python/pull/40335))
 
 ### Breaking Changes
 

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -321,7 +321,7 @@ The Azure Identity library offers both in-memory and persistent disk caching. Fo
 
 ## Brokered authentication
 
-An authentication broker is an application that runs on a user’s machine and manages the authentication handshakes and token maintenance for connected accounts. Currently, only the Windows Web Account Manager (WAM) is supported. To enable support, use the [`azure-identity-broker`][azure_identity_broker] package. For details on authenticating using WAM, see the [broker plugin documentation][azure_identity_broker_readme].
+An authentication broker is an application that runs on a user’s machine and manages the authentication handshakes and token maintenance for connected accounts. Currently, only the Windows Web Account Manager (WAM) is supported. Authentication via WAM is used by `DefaultAzureCredential` to enable secure sign-in. To enable support, use the [`azure-identity-broker`][azure_identity_broker] package. For details on authenticating using WAM, see the [broker plugin documentation][azure_identity_broker_readme].
 
 ## Troubleshooting
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/broker.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/broker.py
@@ -35,6 +35,7 @@ class BrokerCredential(SupportsTokenInfo):
                     "tenant_id": self._tenant_id,
                     "parent_window_handle": msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
                     "use_default_broker_account": True,
+                    "disable_interactive_fallback": True,
                     **kwargs,
                 }
                 if self._client_id:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/broker.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/broker.py
@@ -1,0 +1,78 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import sys
+from typing import Any
+
+import msal
+from azure.core.credentials import AccessToken, AccessTokenInfo, SupportsTokenInfo
+from .._exceptions import CredentialUnavailableError
+from .._internal.utils import get_broker_credential, is_wsl
+
+
+class BrokerCredential(SupportsTokenInfo):
+    """A broker credential that handles prerequisite checking and falls back appropriately.
+
+    This credential checks if the azure-identity-broker package is available and the platform
+    is supported. If both conditions are met, it uses the real broker credential. Otherwise,
+    it raises CredentialUnavailableError with an appropriate message.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+
+        self._tenant_id = kwargs.pop("tenant_id", None)
+        self._client_id = kwargs.pop("client_id", None)
+        self._broker_credential = None
+        self._unavailable_message = None
+
+        # Check prerequisites and initialize the appropriate credential
+        broker_credential_class = get_broker_credential()
+        if broker_credential_class and (sys.platform.startswith("win") or is_wsl()):
+            # The silent auth flow for brokered auth is available on Windows/WSL with the broker package
+            try:
+                broker_credential_args = {
+                    "tenant_id": self._tenant_id,
+                    "parent_window_handle": msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
+                    "use_default_broker_account": True,
+                    **kwargs,
+                }
+                if self._client_id:
+                    broker_credential_args["client_id"] = self._client_id
+                self._broker_credential = broker_credential_class(**broker_credential_args)
+            except Exception as ex:  # pylint: disable=broad-except
+                self._unavailable_message = f"InteractiveBrowserBrokerCredential initialization failed: {ex}"
+        else:
+            # Determine the specific reason for unavailability
+            if broker_credential_class is None:
+                self._unavailable_message = (
+                    "InteractiveBrowserBrokerCredential unavailable. "
+                    "The 'azure-identity-broker' package is required to use brokered authentication."
+                )
+            else:
+                self._unavailable_message = (
+                    "InteractiveBrowserBrokerCredential unavailable. "
+                    "Brokered authentication is only supported on Windows and WSL platforms."
+                )
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        if self._broker_credential:
+            return self._broker_credential.get_token(*scopes, **kwargs)
+        raise CredentialUnavailableError(message=self._unavailable_message)
+
+    def get_token_info(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:
+        if self._broker_credential:
+            return self._broker_credential.get_token_info(*scopes, **kwargs)
+        raise CredentialUnavailableError(message=self._unavailable_message)
+
+    def __enter__(self) -> "BrokerCredential":
+        if self._broker_credential:
+            self._broker_credential.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        if self._broker_credential:
+            self._broker_credential.__exit__(*args)
+
+    def close(self) -> None:
+        self.__exit__()

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -43,9 +43,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
     5. The identity currently logged in to the Azure CLI.
     6. The identity currently logged in to Azure PowerShell.
     7. The identity currently logged in to the Azure Developer CLI.
-    8. Brokered authentication. On Windows and WSL, this uses an authentication broker such as
-       Web Account Manager (WAM). On other platforms or when the azure-identity-broker package is not installed,
-       this credential will raise CredentialUnavailableError.
+    8. Brokered authentication. On Windows and WSL only, this uses the default account logged in via
+       Web Account Manager (WAM) if the `azure-identity-broker` package is installed.
 
     This default behavior is configurable with keyword arguments.
 
@@ -69,8 +68,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     :keyword bool exclude_interactive_browser_credential: Whether to exclude interactive browser authentication (see
         :class:`~azure.identity.InteractiveBrowserCredential`). Defaults to **True**.
     :keyword bool exclude_broker_credential: Whether to exclude the broker credential from the credential chain.
-        Defaults to **False**. When False, the broker credential is always included in the chain but will raise
-        CredentialUnavailableError if the azure-identity-broker package is not installed.
+        Defaults to **False**.
     :keyword str interactive_browser_tenant_id: Tenant ID to use when authenticating a user through
         :class:`~azure.identity.InteractiveBrowserCredential`. Defaults to the value of environment variable
         AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -74,6 +74,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
     :keyword str interactive_browser_tenant_id: Tenant ID to use when authenticating a user through
         :class:`~azure.identity.InteractiveBrowserCredential`. Defaults to the value of environment variable
         AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.
+    :keyword str broker_tenant_id: The tenant ID to use when using brokered authentication. Defaults to the value of
+        environment variable AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.
     :keyword str managed_identity_client_id: The client ID of a user-assigned managed identity. Defaults to the value
         of the environment variable AZURE_CLIENT_ID, if any. If not specified, a system-assigned identity will be used.
     :keyword str workload_identity_client_id: The client ID of an identity assigned to the pod. Defaults to the value
@@ -82,6 +84,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         Defaults to the value of environment variable AZURE_TENANT_ID, if any.
     :keyword str interactive_browser_client_id: The client ID to be used in interactive browser credential. If not
         specified, users will authenticate to an Azure development application.
+    :keyword str broker_client_id: The client ID to be used in brokered authentication. If not specified, users will
+        authenticate to an Azure development application.
     :keyword str shared_cache_username: Preferred username for :class:`~azure.identity.SharedTokenCacheCredential`.
         Defaults to the value of environment variable AZURE_USERNAME, if any.
     :keyword str shared_cache_tenant_id: Preferred tenant for :class:`~azure.identity.SharedTokenCacheCredential`.
@@ -123,6 +127,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
             "workload_identity_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
         interactive_browser_client_id = kwargs.pop("interactive_browser_client_id", None)
+
+        broker_tenant_id = kwargs.pop("broker_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID))
+        broker_client_id = kwargs.pop("broker_client_id", None)
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(
@@ -257,9 +264,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
             else:
                 credentials.append(InteractiveBrowserCredential(tenant_id=interactive_browser_tenant_id, **kwargs))
         if not exclude_broker_credential:
-            broker_credential_args = {"tenant_id": interactive_browser_tenant_id, **kwargs}
-            if interactive_browser_client_id:
-                broker_credential_args["client_id"] = interactive_browser_client_id
+            broker_credential_args = {"tenant_id": broker_tenant_id, **kwargs}
+            if broker_client_id:
+                broker_credential_args["client_id"] = broker_client_id
             credentials.append(BrokerCredential(**broker_credential_args))
 
         within_dac.set(False)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -8,8 +8,9 @@ from typing import List, Any, Optional, cast
 
 from azure.core.credentials import AccessToken, AccessTokenInfo, TokenRequestOptions, SupportsTokenInfo, TokenCredential
 from .._constants import EnvironmentVariables
-from .._internal import get_default_authority, normalize_authority, within_dac, process_credential_exclusions
+from .._internal.utils import get_default_authority, normalize_authority, within_dac, process_credential_exclusions
 from .azure_powershell import AzurePowerShellCredential
+from .broker import BrokerCredential
 from .browser import InteractiveBrowserCredential
 from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
@@ -42,6 +43,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
     5. The identity currently logged in to the Azure CLI.
     6. The identity currently logged in to Azure PowerShell.
     7. The identity currently logged in to the Azure Developer CLI.
+    8. Brokered authentication. On Windows and WSL, this uses an authentication broker such as
+       Web Account Manager (WAM). On other platforms or when the azure-identity-broker package is not installed,
+       this credential will raise CredentialUnavailableError.
 
     This default behavior is configurable with keyword arguments.
 
@@ -64,6 +68,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         **False**.
     :keyword bool exclude_interactive_browser_credential: Whether to exclude interactive browser authentication (see
         :class:`~azure.identity.InteractiveBrowserCredential`). Defaults to **True**.
+    :keyword bool exclude_broker_credential: Whether to exclude the broker credential from the credential chain.
+        Defaults to **False**. When False, the broker credential is always included in the chain but will raise
+        CredentialUnavailableError if the azure-identity-broker package is not installed.
     :keyword str interactive_browser_tenant_id: Tenant ID to use when authenticating a user through
         :class:`~azure.identity.InteractiveBrowserCredential`. Defaults to the value of environment variable
         AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.
@@ -147,6 +154,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
             },
             "visual_studio_code": {
                 "exclude_param": "exclude_visual_studio_code_credential",
+                "env_name": "visualstudiocodecredential",
                 "default_exclude": False,
             },
             "cli": {
@@ -168,6 +176,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 "exclude_param": "exclude_interactive_browser_credential",
                 "env_name": "interactivebrowsercredential",
                 "default_exclude": True,
+            },
+            "broker": {
+                "exclude_param": "exclude_broker_credential",
+                "env_name": "interactivebrowserbrokercredential",
+                "default_exclude": False,
             },
         }
 
@@ -192,6 +205,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         exclude_developer_cli_credential = exclude_flags["developer_cli"]
         exclude_powershell_credential = exclude_flags["powershell"]
         exclude_interactive_browser_credential = exclude_flags["interactive_browser"]
+        exclude_broker_credential = exclude_flags["broker"]
 
         credentials: List[SupportsTokenInfo] = []
         within_dac.set(True)
@@ -242,6 +256,12 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 )
             else:
                 credentials.append(InteractiveBrowserCredential(tenant_id=interactive_browser_tenant_id, **kwargs))
+        if not exclude_broker_credential:
+            broker_credential_args = {"tenant_id": interactive_browser_tenant_id, **kwargs}
+            if interactive_browser_client_id:
+                broker_credential_args["client_id"] = interactive_browser_client_id
+            credentials.append(BrokerCredential(**broker_credential_args))
+
         within_dac.set(False)
         super(DefaultAzureCredential, self).__init__(*credentials)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -184,7 +184,6 @@ class DefaultAzureCredential(ChainedTokenCredential):
             },
             "broker": {
                 "exclude_param": "exclude_broker_credential",
-                "env_name": "interactivebrowserbrokercredential",
                 "default_exclude": False,
             },
         }

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+import platform
 import logging
 from contextvars import ContextVar
 from string import ascii_letters, digits
@@ -209,3 +210,11 @@ def get_broker_credential() -> Optional[type]:
         return InteractiveBrowserBrokerCredential
     except ImportError:
         return None
+
+
+def is_wsl() -> bool:
+    # This is how MSAL checks for WSL.
+    uname = platform.uname()
+    platform_name = getattr(uname, "system", uname[0]).lower()
+    release = getattr(uname, "release", uname[2]).lower()
+    return platform_name == "linux" and "microsoft" in release

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -458,7 +458,34 @@ def test_broker_credential():
         broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
         assert len(broker_credentials) == 1, "BrokerCredential should be in the chain"
     # InteractiveBrowserBrokerCredential should be instantiated by BrokerCredential
-    assert mock_credential.call_count > 1, "InteractiveBrowserBrokerCredential should be instantiated"
+    assert mock_credential.call_count >= 1, "InteractiveBrowserBrokerCredential should be instantiated"
+
+
+def test_broker_credential_client_id():
+    """Test that DefaultAzureCredential allows configuring a client ID for BrokerCredential"""
+
+    client_id = "broker-client-id"
+    credential = DefaultAzureCredential(broker_client_id=client_id)
+    broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+    assert (
+        len(broker_credentials) == 1
+    ), "BrokerCredential should be in the chain even when broker package is not installed"
+    broker_credential = broker_credentials[0]
+    assert broker_credential._client_id == client_id, "Credential should be instantiated with the specified client ID"
+
+
+def test_broker_credential_tenant_id():
+    """Test that DefaultAzureCredential allows configuring a tenant ID for BrokerCredential"""
+
+    tenant_id = "broker-tenant-id"
+
+    credential = DefaultAzureCredential(broker_tenant_id=tenant_id)
+    broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+    assert (
+        len(broker_credentials) == 1
+    ), "BrokerCredential should be in the chain even when broker package is not installed"
+    broker_credential = broker_credentials[0]
+    assert broker_credential._tenant_id == tenant_id, "Credential should be instantiated with the specified tenant ID"
 
 
 def test_broker_credential_requirements_not_installed():


### PR DESCRIPTION
# Description

This adds `InteractiveBrowserBrokerCredential` silent flow authentication to the end of the  `DefaultAzureCredential` chain. Here, we opt to conditionally add it to the chain only if the broker package is installed.

Additional context: https://gist.github.com/christothes/f8a0dc6249261cb36a6c452717c4e932

Closes: https://github.com/Azure/azure-sdk-for-python/issues/39966

