### PR TITLE
Merging *-Next to Main and updating to 3.9

### DIFF
--- a/doc/analyze_check_versions.md
+++ b/doc/analyze_check_versions.md
@@ -5,9 +5,9 @@ This table is to clarify the currently pinned version of tools we run in CI and 
 
 | Tool | Current Version | Next Version | Next Version Merge Date |
 |------|-----------------|--------------|-------------------------|
-Pylint | 3.2.7 | 3.2.7 | 2025-04-14 |
-Pylint Guidelines Checker | 0.4.1 | 0.5.1 | 2025-04-14 |
-MyPy | 1.13.0 | 1.14.1 | 2025-04-14 |
-Pyright | 1.1.389 | 1.1.391 | 2025-04-14 |
+Pylint | 3.2.7 | 3.2.7 | 2025-07-21 |
+Pylint Guidelines Checker | 0.5.2 | 0.5.2 | 2025-07-21 |
+MyPy | 1.14.1 | 1.14.1 | 2025-07-21 |
+Pyright | 1.1.391 | 1.1.391 | 2025-07-21 |
 Sphinx | 8.2.0 | N/A | N/A |
 Black | 24.4.0 | N/A | N/A |

--- a/doc/analyze_check_versions.md
+++ b/doc/analyze_check_versions.md
@@ -6,7 +6,7 @@ This table is to clarify the currently pinned version of tools we run in CI and 
 | Tool | Current Version | Next Version | Next Version Merge Date |
 |------|-----------------|--------------|-------------------------|
 Pylint | 3.2.7 | 3.2.7 | 2025-07-21 |
-Pylint Guidelines Checker | 0.5.2 | 0.5.2 | 2025-07-21 |
+Pylint Guidelines Checker | 0.5.3 | 0.5.3 | 2025-07-21 |
 MyPy | 1.14.1 | 1.14.1 | 2025-07-21 |
 Pyright | 1.1.391 | 1.1.391 | 2025-07-21 |
 Sphinx | 8.2.0 | N/A | N/A |

--- a/eng/pylintrc
+++ b/eng/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-py-version=3.8
+py-version=3.9
 ignore-patterns=test_*,conftest,setup
 reports=no
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -102,7 +102,7 @@ commands =
 
 [testenv:next-pylint]
 description=Lints a package with pylint (version {[testenv:next-pylint]pylint_version})
-pylint_version=3.3.6
+pylint_version=3.2.7
 skipsdist = true
 skip_install = true
 usedevelop = false
@@ -146,7 +146,7 @@ commands =
 
 [testenv:mypy]
 description=Typechecks a package with mypy (version {[testenv:mypy]mypy_version})
-mypy_version=1.13.0
+mypy_version=1.14.1
 skipsdist = true
 skip_install = true
 usedevelop = true
@@ -198,7 +198,7 @@ commands =
 
 [testenv:pyright]
 description=Typechecks a package with pyright (version {[testenv:pyright]pyright_version})
-pyright_version=1.1.389
+pyright_version=1.1.391
 skipsdist = true
 skip_install = true
 usedevelop = true

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -92,7 +92,7 @@ deps =
   -rdev_requirements.txt
 commands =
     python -m pip install pylint=={[testenv:pylint]pylint_version}
-    python -m pip install azure-pylint-guidelines-checker==0.5.2 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+    python -m pip install azure-pylint-guidelines-checker==0.5.3 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \
       -p {tox_root} \
@@ -117,7 +117,7 @@ deps =
   PyGitHub>=1.59.0
 commands =
     python -m pip install pylint=={[testenv:next-pylint]pylint_version}
-    python -m pip install azure-pylint-guidelines-checker==0.5.2 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+    python -m pip install azure-pylint-guidelines-checker==0.5.3 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \
       -p {tox_root} \

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -102,7 +102,7 @@ commands =
 
 [testenv:next-pylint]
 description=Lints a package with pylint (version {[testenv:next-pylint]pylint_version})
-pylint_version=3.2.7
+pylint_version=3.3.6
 skipsdist = true
 skip_install = true
 usedevelop = false

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-py-version=3.8
+py-version=3.9
 ignore-patterns=test_*,conftest,setup
 reports=no
 

--- a/pylintrc
+++ b/pylintrc
@@ -21,7 +21,7 @@ load-plugins=pylint_guidelines_checker
 # Let's black deal with bad-continuation
 
 # Added disables from super-with-arguments
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,client-paging-methods-use-list,docstring-type-do-not-use-class,consider-using-max-builtin,too-many-lines,possibly-used-before-assignment,do-not-log-raised-errors,do-not-use-legacy-typing,do-not-import-asyncio,invalid-use-of-overload,do-not-hardcode-connection-verify,do-not-log-exceptions,unapproved-client-method-name-prefix,do-not-hardcode-dedent,networking-import-outside-azure-core-transport
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,client-paging-methods-use-list,docstring-type-do-not-use-class,consider-using-max-builtin,too-many-lines,possibly-used-before-assignment,do-not-log-raised-errors,do-not-log-exceptions,networking-import-outside-azure-core-transport
 
 [FORMAT]
 max-line-length=120

--- a/pylintrc
+++ b/pylintrc
@@ -21,7 +21,7 @@ load-plugins=pylint_guidelines_checker
 # Let's black deal with bad-continuation
 
 # Added disables from super-with-arguments
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,client-paging-methods-use-list,docstring-type-do-not-use-class,consider-using-max-builtin,too-many-lines,possibly-used-before-assignment,do-not-log-raised-errors,do-not-log-exceptions,networking-import-outside-azure-core-transport
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,client-paging-methods-use-list,docstring-type-do-not-use-class,consider-using-max-builtin,too-many-lines,possibly-used-before-assignment,do-not-log-raised-errors,do-not-log-exceptions,networking-import-outside-azure-core-transport,do-not-hardcode-dedent,arguments-differ,signature-differs
 
 [FORMAT]
 max-line-length=120


### PR DESCRIPTION
Updating run to 3.9 --- will cause a diff in pylint as the py-version flag is buggy and does not cover all checkers (minimal diff for arg-differ, sig-differ, deprecated-class) can disable in pylintrc to reduce conflicts