### PR TITLE
[APIView] update to 0.3.18

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -14,4 +14,4 @@ tomli==2.2.1
 tomlkit==0.13.2
 typing_extensions==4.12.2
 wrapt==1.17.2
-apiview-stub-generator==0.3.17
+apiview-stub-generator==0.3.18


### PR DESCRIPTION
Updating pinned version to include apistubgen with default mapping file "apiview-properties.json".