### PR TITLE
[EventHub] handle lowest/"unset" timestamp value from service

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Features Added
 
-- Added a class method `from bytes` to create `EventData` from a message payload of bytes. ([#39711](https://github.com/Azure/azure-sdk-for-python/issues/39711))
+- Added a class method `from_bytes` to create `EventData` from a message payload of bytes. ([#39711](https://github.com/Azure/azure-sdk-for-python/issues/39711))
 
 ### Bugs Fixed
 
 - Fixed a bug where service errors were incorrectly required and expected to have info/description fields.
+- Fixed a bug where max number of messages was not being requested when receiving from the service due to an incorrect link credit calculation.
+- Fixed a bug where the lowest possible timestamp returned by the service to represent an unset time was not being parsed correctly.
 
 ## 5.14.0 (2025-02-13)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/utils.py
@@ -14,9 +14,21 @@ from .types import TYPE, VALUE, AMQPTypes
 from ._encode import encode_payload
 
 TZ_UTC: timezone = timezone.utc
+# Number of seconds between the Unix epoch (1/1/1970) and year 1 CE.
+# This is the lowest value that can be represented by an AMQP timestamp.
+CE_ZERO_SECONDS: int = -62_135_596_800
 
 
-def utc_from_timestamp(timestamp):
+def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+    """
+    :param int timestamp: Timestamp in seconds to be converted to datetime.
+    """
+    # The AMQP timestamp is the number of seconds since the Unix epoch.
+    # AMQP brokers represent the lowest value as -62_135_596_800 (the
+    # number of seconds between the Unix epoch (1/1/1970) and year 1 CE) as
+    # a sentinel for a time which is not set.
+    if timestamp == CE_ZERO_SECONDS:
+        return datetime.datetime.min.replace(tzinfo=TZ_UTC)
     return datetime.datetime.fromtimestamp(timestamp, tz=TZ_UTC)
 
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/utils.py
@@ -19,7 +19,7 @@ TZ_UTC: timezone = timezone.utc
 CE_ZERO_SECONDS: int = -62_135_596_800
 
 
-def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+def utc_from_timestamp(timestamp: float) -> datetime.datetime:
     """
     :param int timestamp: Timestamp in seconds to be converted to datetime.
     """

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
@@ -49,7 +49,7 @@ TZ_UTC: timezone = timezone.utc
 CE_ZERO_SECONDS: int = -62_135_596_800
 
 
-def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+def utc_from_timestamp(timestamp: float) -> datetime.datetime:
     """
     :param int timestamp: Timestamp in seconds to be converted to datetime.
     """

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
@@ -22,7 +22,6 @@ from ._constants import (
     PROP_LAST_ENQUEUED_OFFSET,
 )
 
-
 if TYPE_CHECKING:
     from ._transport._base import AmqpTransport
     from ._pyamqp.message import Message as pyamqp_Message
@@ -44,11 +43,22 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-
 TZ_UTC: timezone = timezone.utc
+# Number of seconds between the Unix epoch (1/1/1970) and year 1 CE.
+# This is the lowest value that can be represented by an AMQP timestamp.
+CE_ZERO_SECONDS: int = -62_135_596_800
 
 
-def utc_from_timestamp(timestamp):
+def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+    """
+    :param int timestamp: Timestamp in seconds to be converted to datetime.
+    """
+    # The AMQP timestamp is the number of seconds since the Unix epoch.
+    # AMQP brokers represent the lowest value as -62_135_596_800 (the
+    # number of seconds between the Unix epoch (1/1/1970) and year 1 CE) as
+    # a sentinel for a time which is not set.
+    if timestamp == CE_ZERO_SECONDS:
+        return datetime.datetime.min.replace(tzinfo=TZ_UTC)
     return datetime.datetime.fromtimestamp(timestamp, tz=TZ_UTC)
 
 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_properties_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_properties_async.py
@@ -100,10 +100,6 @@ async def test_get_partition_ids(auth_credentials_async, uamqp_transport):
         assert partition_ids == ["0", "1"]
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Large negative timestamp to datetime conversion fails on Windows with: https://bugs.python.org/issue36439",
-)
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_get_partition_properties(auth_credentials_async, uamqp_transport):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_properties.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_properties.py
@@ -97,10 +97,6 @@ def test_get_partition_ids(auth_credentials, uamqp_transport):
         assert partition_ids == ["0", "1"]
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Large negative timestamp to datetime conversion fails on Windows with: https://bugs.python.org/issue36439",
-)
 @pytest.mark.liveTest
 def test_get_partition_properties(auth_credentials, uamqp_transport):
     fully_qualified_namespace, eventhub_name, credential = auth_credentials

--- a/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
@@ -18,6 +18,8 @@ except (ModuleNotFoundError, ImportError):
     UamqpTransport = None
 from azure.eventhub._transport._pyamqp_transport import PyamqpTransport
 from azure.eventhub._pyamqp.message import Message, Properties, Header
+from azure.eventhub._utils import CE_ZERO_SECONDS
+from azure.eventhub._constants import PROP_TIMESTAMP
 from azure.eventhub.amqp import AmqpAnnotatedMessage, AmqpMessageHeader, AmqpMessageProperties
 
 from azure.eventhub import _common
@@ -101,7 +103,7 @@ def test_sys_properties(uamqp_transport):
         properties.group_sequence = 1
         properties.reply_to_group_id = "reply_to_group_id"
         message = uamqp.message.Message(properties=properties)
-        message.annotations = {_common.PROP_OFFSET: "@latest"}
+        message.annotations = {_common.PROP_OFFSET: "@latest", PROP_TIMESTAMP: CE_ZERO_SECONDS * 1000}
     else:
         properties = Properties(
             message_id="message_id",
@@ -118,7 +120,7 @@ def test_sys_properties(uamqp_transport):
             group_sequence=1,
             reply_to_group_id="reply_to_group_id",
         )
-        message_annotations = {_common.PROP_OFFSET: "@latest"}
+        message_annotations = {_common.PROP_OFFSET: "@latest", PROP_TIMESTAMP: CE_ZERO_SECONDS * 1000}
         message = Message(properties=properties, message_annotations=message_annotations)
     ed = EventData._from_message(message)  # type: EventData
 
@@ -136,6 +138,7 @@ def test_sys_properties(uamqp_transport):
     assert ed.system_properties[_common.PROP_GROUP_ID] == properties.group_id
     assert ed.system_properties[_common.PROP_GROUP_SEQUENCE] == properties.group_sequence
     assert ed.system_properties[_common.PROP_REPLY_TO_GROUP_ID] == properties.reply_to_group_id
+    assert ed.enqueued_time == datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
 
 
 def test_event_data_batch(uamqp_transport):

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug where service errors were incorrectly expected to have info/description fields set in all cases.
 - Fixed a bug where the type in azure.servicebus.management.AuthorizationRule was not being correctly passed to the request.
+- Fixed a bug where max number of messages was not being requested when receiving from the service due to an incorrect link credit calculation. ([#40156](https://github.com/Azure/azure-sdk-for-python/issues/40156))
 
 ## 7.14.0 (2025-02-13)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
@@ -65,11 +65,12 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 
+TZ_UTC: timezone = timezone.utc
 # Number of seconds between the Unix epoch (1/1/1970) and year 1 CE.
 # This is the lowest value that can be represented by an AMQP timestamp.
 CE_ZERO_SECONDS: int = -62_135_596_800
 
-def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+def utc_from_timestamp(timestamp: float) -> datetime.datetime:
     """
     :param int timestamp: Timestamp in seconds to be converted to datetime.
     """
@@ -79,7 +80,7 @@ def utc_from_timestamp(timestamp: int) -> datetime.datetime:
     # a sentinel for a time which is not set.
     if timestamp == CE_ZERO_SECONDS:
         return datetime.datetime.min.replace(tzinfo=TZ_UTC)
-    return datetime.datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    return datetime.datetime.fromtimestamp(timestamp, tz=TZ_UTC)
 
 
 def utc_now():

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
@@ -65,8 +65,20 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 
+# Number of seconds between the Unix epoch (1/1/1970) and year 1 CE.
+# This is the lowest value that can be represented by an AMQP timestamp.
+CE_ZERO_SECONDS: int = -62_135_596_800
 
-def utc_from_timestamp(timestamp):
+def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+    """
+    :param int timestamp: Timestamp in seconds to be converted to datetime.
+    """
+    # The AMQP timestamp is the number of seconds since the Unix epoch.
+    # AMQP brokers represent the lowest value as -62_135_596_800 (the
+    # number of seconds between the Unix epoch (1/1/1970) and year 1 CE) as
+    # a sentinel for a time which is not set.
+    if timestamp == CE_ZERO_SECONDS:
+        return datetime.datetime.min.replace(tzinfo=TZ_UTC)
     return datetime.datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
@@ -18,7 +18,7 @@ TZ_UTC: timezone = timezone.utc
 # This is the lowest value that can be represented by an AMQP timestamp.
 CE_ZERO_SECONDS: int = -62_135_596_800
 
-def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+def utc_from_timestamp(timestamp: float) -> datetime.datetime:
     """
     :param int timestamp: Timestamp in seconds to be converted to datetime.
     """

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
@@ -14,9 +14,20 @@ from .types import TYPE, VALUE, AMQPTypes
 from ._encode import encode_payload
 
 TZ_UTC: timezone = timezone.utc
+# Number of seconds between the Unix epoch (1/1/1970) and year 1 CE.
+# This is the lowest value that can be represented by an AMQP timestamp.
+CE_ZERO_SECONDS: int = -62_135_596_800
 
-
-def utc_from_timestamp(timestamp):
+def utc_from_timestamp(timestamp: int) -> datetime.datetime:
+    """
+    :param int timestamp: Timestamp in seconds to be converted to datetime.
+    """
+    # The AMQP timestamp is the number of seconds since the Unix epoch.
+    # AMQP brokers represent the lowest value as -62_135_596_800 (the
+    # number of seconds between the Unix epoch (1/1/1970) and year 1 CE) as
+    # a sentinel for a time which is not set.
+    if timestamp == CE_ZERO_SECONDS:
+        return datetime.datetime.min.replace(tzinfo=TZ_UTC)
     return datetime.datetime.fromtimestamp(timestamp, tz=TZ_UTC)
 
 


### PR DESCRIPTION
Following: https://github.com/Azure/azure-sdk-for-rust/blob/4e8c12fbd80acd7fcac6e35568b1c6f913cd5d14/sdk/core/azure_core_amqp/src/fe2o3/value.rs#L52

The AMQP timestamp is the number of seconds since the Unix epoch. AMQP brokers represent the lowest value as -62_135_596_800 (the number of seconds between the Unix epoch (1/1/1970) and year 1 CE) as a sentinel for a time which is not set.

Adding support to handle this value in Python.