### PR TITLE
[python] add dependency `"@azure-tools/typespec-liftr-base"` back

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -13,6 +13,7 @@
         "@azure-tools/typespec-azure-resource-manager": "~0.54.0",
         "@azure-tools/typespec-azure-rulesets": "~0.54.0",
         "@azure-tools/typespec-client-generator-core": "~0.54.0",
+        "@azure-tools/typespec-liftr-base": "0.8.0",
         "@typespec/compiler": "^1.0.0-0",
         "@typespec/events": "~0.68.0",
         "@typespec/http": "^1.0.0-0",
@@ -118,6 +119,12 @@
         "@typespec/versioning": "^0.68.0",
         "@typespec/xml": "^0.68.0"
       }
+    },
+    "node_modules/@azure-tools/typespec-liftr-base": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.8.0.tgz",
+      "integrity": "sha512-xftTTtVjDuxIzugQ9nL/abmttdDM3HAf5HhqKzs9DO0Kl0ZhXQlB2DYlT1hBs/N+IWerMF9k2eKs2RncngA03g==",
+      "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
       "version": "0.42.2",
@@ -576,14 +583,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
-      "integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
+      "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
+        "@inquirer/core": "^10.1.10",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/type": "^3.0.6",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -600,13 +607,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
-      "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
+      "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5"
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -621,13 +628,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
-      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
+      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/type": "^3.0.6",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -648,13 +655,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
-      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
+      "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -670,13 +677,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
-      "integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
+      "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -701,13 +708,13 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
-      "integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+      "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5"
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -722,13 +729,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
-      "integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
+      "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5"
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -743,13 +750,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
-      "integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
+      "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -765,21 +772,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.0.tgz",
-      "integrity": "sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
+      "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.4",
-        "@inquirer/confirm": "^5.1.8",
-        "@inquirer/editor": "^4.2.9",
-        "@inquirer/expand": "^4.0.11",
-        "@inquirer/input": "^4.1.8",
-        "@inquirer/number": "^3.0.11",
-        "@inquirer/password": "^4.0.11",
-        "@inquirer/rawlist": "^4.0.11",
-        "@inquirer/search": "^3.0.11",
-        "@inquirer/select": "^4.1.0"
+        "@inquirer/checkbox": "^4.1.5",
+        "@inquirer/confirm": "^5.1.9",
+        "@inquirer/editor": "^4.2.10",
+        "@inquirer/expand": "^4.0.12",
+        "@inquirer/input": "^4.1.9",
+        "@inquirer/number": "^3.0.12",
+        "@inquirer/password": "^4.0.12",
+        "@inquirer/rawlist": "^4.0.12",
+        "@inquirer/search": "^3.0.12",
+        "@inquirer/select": "^4.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -794,13 +801,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
-      "integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
+      "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -816,14 +823,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
-      "integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
+      "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
+        "@inquirer/core": "^10.1.10",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/type": "^3.0.6",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -839,14 +846,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
-      "integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
+      "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.9",
+        "@inquirer/core": "^10.1.10",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.5",
+        "@inquirer/type": "^3.0.6",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -863,9 +870,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
-      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -17,6 +17,7 @@
     "@azure-tools/typespec-azure-resource-manager": "~0.54.0",
     "@azure-tools/typespec-autorest": "~0.54.0",
     "@azure-tools/typespec-azure-rulesets": "~0.54.0",
-    "@azure-tools/typespec-client-generator-core": "~0.54.0"
+    "@azure-tools/typespec-client-generator-core": "~0.54.0",
+    "@azure-tools/typespec-liftr-base": "0.8.0"
   }
 }


### PR DESCRIPTION
add dependency `"@azure-tools/typespec-liftr-base"` back that was deleted in https://github.com/Azure/azure-sdk-for-python/pull/40357/commits/2a62e6d3cc167449700222eee25af9d00c250026 otherwise some SDKs' generation will fail in rest repo like: https://github.com/Azure/azure-rest-api-specs/blob/917ba27f78348899fba4cafb37fcf018f1987a8e/specification/liftrpinecone/Pinecone.VectorDb.Management/main.tsp#L6.