### PR TITLE
[release helper] don't check readme tag for typespec release

### DIFF
--- a/scripts/release_helper/common.py
+++ b/scripts/release_helper/common.py
@@ -208,11 +208,12 @@ class IssueProcess:
         self.target_readme_tag = self.target_readme_tag.replace('tag-', '')
         if self.default_readme_tag != self.target_readme_tag:
             self.add_label(INCONSISTENT_TAG)
-            self.comment(f'Hi, @{self.owner}, according to [rule](https://github.com/Azure/azure-rest-api-specs/blob/'
-                         f'main/documentation/release-request/rules-for-release-request.md#3-readme-tag-to-be-released),'
-                         f' your **Readme Tag** is `{self.target_readme_tag}`, but in [readme.md]({self.readme_link}#basic-information) '
-                         f'it is still `{self.default_readme_tag}`, please modify the readme.md or your '
-                         f'**Readme Tag** above ')
+            if "typespec" not in self.full_issue_title.lower():
+                self.comment(f'Hi, @{self.owner}, according to [rule](https://github.com/Azure/azure-rest-api-specs/blob/'
+                            f'main/documentation/release-request/rules-for-release-request.md#3-readme-tag-to-be-released),'
+                            f' your **Readme Tag** is `{self.target_readme_tag}`, but in [readme.md]({self.readme_link}#basic-information) '
+                            f'it is still `{self.default_readme_tag}`, please modify the readme.md or your '
+                            f'**Readme Tag** above ')
 
     def get_package_name(self) -> None:
         issue_body_list = self.get_issue_body()
@@ -239,8 +240,7 @@ class IssueProcess:
         # get default tag with readme_link
         self.get_default_readme_tag()
 
-        if "typespec" not in self.full_issue_title.lower():
-            self.check_tag_consistency()
+        self.check_tag_consistency()
 
         self.edit_issue_body()
 

--- a/scripts/release_helper/common.py
+++ b/scripts/release_helper/common.py
@@ -65,6 +65,7 @@ class IssueProcess:
         self.date_from_target = 0
         self.is_open = True
         self.issue_title = issue_package.issue.title.split(": ", 1)[-1]
+        self.full_issue_title = issue_package.issue.title
         self.spec_repo = Path(os.getenv('SPEC_REPO'))
         self.typespec_json = Path(os.getenv('TYPESPEC_JSON'))
         self.language_name = "common"
@@ -238,7 +239,8 @@ class IssueProcess:
         # get default tag with readme_link
         self.get_default_readme_tag()
 
-        self.check_tag_consistency()
+        if "typespec" not in self.full_issue_title.lower():
+            self.check_tag_consistency()
 
         self.edit_issue_body()
 


### PR DESCRIPTION
When release issue is for typespec (e.g. [here](https://github.com/Azure/sdk-release-request/issues/5989)), there is no need to check readme tag (e.g. [here](https://github.com/Azure/sdk-release-request/issues/5989)).