### PR TITLE
[SDK generation pipeline] add dependency

### DIFF
--- a/scripts/auto_release/requirement.txt
+++ b/scripts/auto_release/requirement.txt
@@ -6,3 +6,4 @@ packaging==24.1
 pytest==6.2.5
 fastcore==1.3.25
 tox==4.15.0
+wheel

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -15,6 +15,7 @@ export PATH
 python -m pip install -U pip > /dev/null
 python scripts/dev_setup.py -p azure-core > /dev/null
 pip install tox==4.15.0 > /dev/null
+pip install wheel > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)
 echo Install tsp-client


### PR DESCRIPTION
Add missing dependency `wheel` to fix pipeline failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4736291&view=logs&j=b7f68bce-9df8-5468-1c9f-74766cfc9a39&t=25fc8ae6-51ed-58e2-b772-f4d054412fe3&l=1437