### PR TITLE
[PYAQMP] Fix Deprecation Warning for Async WS

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added support for handling a C# DateTime.MinValue timestamp, which is returned by the service as a sentinel for time which is not set.
 - Deprecating `uamqp_transport` in favor of pyAMQP transport. The `uamqp_transport` will be removed in the next minor release.
+- Fixed aiohttp websocket library showing a deprecation warning due to an incorrect timeout type ([#40429](https://github.com/Azure/azure-sdk-for-python/issues/40429))
 - Dropped support for Python 3.8
 - The following change has been temporarily pulled out and will be added to a future release:
   - Implemented a new websockets library so that using `AmqpOverWebsocket` no longer requires separate optional dependency installations.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -438,6 +438,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
             from aiohttp import (  # pylint: disable=networking-import-outside-azure-core-transport
                 ClientSession,
                 ClientConnectorError,
+                ClientWSTimeout,
             )
             from urllib.parse import urlsplit
         except ImportError:
@@ -466,7 +467,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
 
             self.sock = await self.session.ws_connect(
                 url=url,
-                timeout=self.socket_timeout,  # timeout for connect
+                timeout=ClientWSTimeout(ws_close=self.socket_timeout),
                 protocols=[AMQP_WS_SUBPROTOCOL],
                 autoclose=False,
                 proxy=http_proxy_host,

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added support for handling a C# DateTime.MinValue timestamp, which is returned by the service as a sentinel for time which is not set.
 - Deprecating `uamqp_transport` in favor of pyAMQP transport. The `uamqp_transport` will be removed in the next minor release.
+- Fixed aiohttp websocket library showing a deprecation warning due to an incorrect timeout type ([#40429](https://github.com/Azure/azure-sdk-for-python/issues/40429))
 - Dropped support for Python 3.8
 
 ## 7.14.1 (2025-03-12)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -438,6 +438,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
             from aiohttp import (  # pylint: disable=networking-import-outside-azure-core-transport
                 ClientSession,
                 ClientConnectorError,
+                ClientWSTimeout,
             )
             from urllib.parse import urlsplit
         except ImportError:
@@ -466,7 +467,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
 
             self.sock = await self.session.ws_connect(
                 url=url,
-                timeout=self.socket_timeout,  # timeout for connect
+                timeout=ClientWSTimeout(ws_close=self.socket_timeout),
                 protocols=[AMQP_WS_SUBPROTOCOL],
                 autoclose=False,
                 proxy=http_proxy_host,


### PR DESCRIPTION
Fix to remove the deprecation warning when using async websockets. Aiohttp requires `ClientWSTimeout` to be passed in for the timeout versus simply passing in a float.

Fixes #40429