### PR TITLE
Updates to new 1DP Python Projects SDK

### DIFF
--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch.py
@@ -6,9 +6,53 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import List
+from typing import List, Any, Union, Optional
+from azure.core.credentials import AzureKeyCredential
+from ._client import AIProjectClient as AIProjectClientGenerated
+from .operations import TelemetryOperations, InferenceOperations
 
-__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes
+    """AIProjectClient.
+
+    :ivar service_patterns: ServicePatternsOperations operations
+    :vartype service_patterns: azure.ai.projects.onedp.operations.ServicePatternsOperations
+    :ivar connections: ConnectionsOperations operations
+    :vartype connections: azure.ai.projects.onedp.operations.ConnectionsOperations
+    :ivar evaluations: EvaluationsOperations operations
+    :vartype evaluations: azure.ai.projects.onedp.operations.EvaluationsOperations
+    :ivar datasets: DatasetsOperations operations
+    :vartype datasets: azure.ai.projects.onedp.operations.DatasetsOperations
+    :ivar indexes: IndexesOperations operations
+    :vartype indexes: azure.ai.projects.onedp.operations.IndexesOperations
+    :ivar deployments: DeploymentsOperations operations
+    :vartype deployments: azure.ai.projects.onedp.operations.DeploymentsOperations
+    :ivar evaluation_results: EvaluationResultsOperations operations
+    :vartype evaluation_results: azure.ai.projects.onedp.operations.EvaluationResultsOperations
+    :ivar red_teams: RedTeamsOperations operations
+    :vartype red_teams: azure.ai.projects.onedp.operations.RedTeamsOperations
+    :param endpoint: Project endpoint in the form of:
+     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :type endpoint: str
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Required.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials.TokenCredential
+    :keyword api_version: The API version to use for this operation. Default value is
+     "2025-05-15-preview". Note that overriding this default value may result in unsupported
+     behavior.
+    :paramtype api_version: str
+    """
+
+    def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, "TokenCredential"], **kwargs: Any) -> None:
+        self._user_agent: Optional[str] = kwargs.get("user_agent", None)
+        super().__init__(endpoint=endpoint, credential=credential, **kwargs)
+        self.telemetry = TelemetryOperations(self)
+        self.inference = InferenceOperations(self)
+
+
+__all__: List[str] = [
+    "AIProjectClient"
+]  # Add all objects you want publicly available to users at this package level
 
 
 def patch_sdk():

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_patch.py
@@ -6,9 +6,54 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import List
+from typing import List, Optional, Union, Any
+from azure.core.credentials import AzureKeyCredential
+from ._client import AIProjectClient as AIProjectClientGenerated
+from .operations import InferenceOperations
 
-__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes
+    """AIProjectClient.
+
+    :ivar service_patterns: ServicePatternsOperations operations
+    :vartype service_patterns: azure.ai.projects.onedp.aio.operations.ServicePatternsOperations
+    :ivar connections: ConnectionsOperations operations
+    :vartype connections: azure.ai.projects.onedp.aio.operations.ConnectionsOperations
+    :ivar evaluations: EvaluationsOperations operations
+    :vartype evaluations: azure.ai.projects.onedp.aio.operations.EvaluationsOperations
+    :ivar datasets: DatasetsOperations operations
+    :vartype datasets: azure.ai.projects.onedp.aio.operations.DatasetsOperations
+    :ivar indexes: IndexesOperations operations
+    :vartype indexes: azure.ai.projects.onedp.aio.operations.IndexesOperations
+    :ivar deployments: DeploymentsOperations operations
+    :vartype deployments: azure.ai.projects.onedp.aio.operations.DeploymentsOperations
+    :ivar evaluation_results: EvaluationResultsOperations operations
+    :vartype evaluation_results: azure.ai.projects.onedp.aio.operations.EvaluationResultsOperations
+    :ivar red_teams: RedTeamsOperations operations
+    :vartype red_teams: azure.ai.projects.onedp.aio.operations.RedTeamsOperations
+    :param endpoint: Project endpoint in the form of:
+     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :type endpoint: str
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Required.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword api_version: The API version to use for this operation. Default value is
+     "2025-05-15-preview". Note that overriding this default value may result in unsupported
+     behavior.
+    :paramtype api_version: str
+    """
+
+    def __init__(
+        self, endpoint: str, credential: Union[AzureKeyCredential, "AsyncTokenCredential"], **kwargs: Any
+    ) -> None:
+        self._user_agent: Optional[str] = kwargs.get("user_agent", None)
+        super().__init__(endpoint=endpoint, credential=credential, **kwargs)
+        self.inference = InferenceOperations(self)
+
+
+__all__: List[str] = [
+    "AIProjectClient"
+]  # Add all objects you want publicly available to users at this package level
 
 
 def patch_sdk():

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch.py
@@ -11,7 +11,10 @@ import logging
 import inspect
 from typing import List, Optional, Any, Tuple
 from pathlib import Path
+from urllib.parse import urlparse
 from azure.storage.blob.aio import ContainerClient
+from azure.core.tracing.decorator_async import distributed_trace_async
+from azure.core.tracing.decorator import distributed_trace
 
 from ._operations import DatasetsOperations as DatasetsOperationsGenerated
 from ...models._models import (
@@ -23,9 +26,267 @@ from ...models._models import (
 from ...models._enums import (
     DatasetType,
     AuthenticationType,
+    ConnectionType
 )
 
 logger = logging.getLogger(__name__)
+
+class InferenceOperations:
+
+    def __init__(self, outer_instance: "AIProjectClient") -> None:
+
+        # TODO: Put the user agent initialization code below in a common place used by both sync and async operations.
+    
+        # All returned inference clients will have this application id set on their user-agent.
+        # For more info on user-agent HTTP header, see:
+        # https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
+        USER_AGENT_APP_ID = "AIProjectClient"
+
+        if hasattr(outer_instance, "_user_agent") and outer_instance._user_agent:
+            # If the calling application has set "user_agent" when constructing the AIProjectClient,
+            # take that value and prepend it to USER_AGENT_APP_ID.
+            self._user_agent = f"{outer_instance._user_agent}-{USER_AGENT_APP_ID}"
+        else:
+            self._user_agent = USER_AGENT_APP_ID
+
+        self._outer_instance = outer_instance
+
+
+    # TODO: Use a common method for both the sync and async operations
+    @classmethod
+    def _get_inference_url(cls, input_url: str) -> str:
+        """
+        Converts an input URL in the format:
+        https://<host-name>/<some-path>
+        to:
+        https://<host-name>/api/models
+        """
+        parsed = urlparse(input_url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise ValueError("Invalid endpoint URL format. Must be an https URL with a host.")
+        new_url = f"https://{parsed.netloc}/api/models"
+        return new_url
+
+
+    @distributed_trace
+    def get_chat_completions_client(self, **kwargs) -> "ChatCompletionsClient":
+        """Get an authenticated ChatCompletionsClient (from the package azure-ai-inference) to use with 
+        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
+        ChatCompletionsClient.
+
+        At least one AI model that supports chat completions must be deployed.
+
+        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+
+        :return: An authenticated chat completions client.
+        :rtype: ~azure.ai.inference.aio.ChatCompletionsClient
+
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+         is not installed.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+        try:
+            from azure.ai.inference.aio import ChatCompletionsClient
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
+            ) from e
+
+        endpoint = self._get_inference_url(self._outer_instance._endpoint)
+        # Older Inference SDK versions use ml.azure.com as the scope. Make sure to set the correct value here. This
+        # is only relevent of course if EntraID auth is used.
+        credential_scopes = ["https://cognitiveservices.azure.com/.default"]
+
+        client = ChatCompletionsClient(
+            endpoint=endpoint,
+            credential=self._outer_instance._config.credential,
+            credential_scopes=credential_scopes,
+            user_agent=kwargs.pop("user_agent", self._user_agent),
+            **kwargs,
+        )
+
+        return client
+
+
+    @distributed_trace
+    def get_embeddings_client(self, **kwargs) -> "EmbeddingsClient":
+        """Get an authenticated EmbeddingsClient (from the package azure-ai-inference) to use with 
+        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
+        ChatCompletionsClient.
+
+        At least one AI model that supports text embeddings must be deployed.
+
+        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+
+        :return: An authenticated Embeddings client.
+        :rtype: ~azure.ai.inference.aio.EmbeddingsClient
+
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+         is not installed.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+        try:
+            from azure.ai.inference.aio import EmbeddingsClient
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
+            ) from e
+
+        endpoint = self._get_inference_url(self._outer_instance._endpoint)
+        # Older Inference SDK versions use ml.azure.com as the scope. Make sure to set the correct value here. This
+        # is only relevent of course if EntraID auth is used.
+        credential_scopes = ["https://cognitiveservices.azure.com/.default"]
+
+        client = EmbeddingsClient(
+            endpoint=endpoint,
+            credential=self._outer_instance._config.credential,
+            credential_scopes=credential_scopes,
+            user_agent=kwargs.pop("user_agent", self._user_agent),
+            **kwargs,
+        )
+
+        return client
+
+
+    @distributed_trace
+    def get_image_embeddings_client(self, **kwargs) -> "ImageEmbeddingsClient":
+        """Get an authenticated ImageEmbeddingsClient (from the package azure-ai-inference) to use with 
+        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
+        ChatCompletionsClient.
+
+        At least one AI model that supports image embeddings must be deployed.
+
+        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
+
+        :return: An authenticated Image Embeddings client.
+        :rtype: ~azure.ai.inference.aio.ImageEmbeddingsClient
+
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
+         is not installed.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+        try:
+            from azure.ai.inference.aio import ImageEmbeddingsClient
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
+            ) from e
+
+        endpoint = self._get_inference_url(self._outer_instance._endpoint)
+        # Older Inference SDK versions use ml.azure.com as the scope. Make sure to set the correct value here. This
+        # is only relevent of course if EntraID auth is used.
+        credential_scopes = ["https://cognitiveservices.azure.com/.default"]
+
+        client = ImageEmbeddingsClient(
+            endpoint=endpoint,
+            credential=self._outer_instance._config.credential,
+            credential_scopes=credential_scopes,
+            user_agent=kwargs.pop("user_agent", self._user_agent),
+            **kwargs,
+        )
+
+        return client
+
+
+    @distributed_trace_async
+    async def get_azure_openai_client(
+        self, *, api_version: Optional[str] = None, connection_name: Optional[str] = None, **kwargs
+    ) -> "AsyncAzureOpenAI":
+        """Get an authenticated AsyncAzureOpenAI client (from the `openai` package) for the default
+        Azure OpenAI connection (if `connection_name` is not specificed), or from the Azure OpenAI
+        resource given by its connection name.
+
+        .. note:: The package `openai` must be installed prior to calling this method.
+
+        :keyword api_version: The Azure OpenAI api-version to use when creating the client. Optional.
+         See "Data plane - Inference" row in the table at
+         https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs. If this keyword
+         is not specified, you must set the environment variable `OPENAI_API_VERSION` instead.
+        :paramtype api_version: str
+        :keyword connection_name: The name of a connection to an Azure OpenAI resource in your AI Foundry project.
+         resource. Optional. If not provided, the default Azure OpenAI connection will be used.
+        :type connection_name: str
+
+        :return: An authenticated AsyncAzureOpenAI client
+        :rtype: ~openai.AzureAsyncAzureOpenAIOpenAI
+
+        :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
+         does not exist.
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `openai` package
+         is not installed.
+        :raises ValueError: if the connection name is an empty string.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        if connection_name is not None and not connection_name:
+            raise ValueError("Connection name cannot be empty")
+
+        try:
+            from openai import AsyncAzureOpenAI
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "OpenAI SDK is not installed. Please install it using 'pip install openai'"
+            ) from e
+
+        if connection_name:
+            connection = await self._outer_instance.connections.get(name=connection_name, **kwargs)
+        else:
+            connection = await self._outer_instance.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI, **kwargs)
+            logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
+
+        azure_endpoint = (
+            connection.target[:-1]
+            if connection.target.endswith("/")
+            else connection.target
+        )
+
+        if connection.auth_type == AuthenticationType.API_KEY:
+
+            # For api-key authentication, we need to make another service call to get the connection with credentials.
+            connection_with_credentials = self._outer_instance.connections.get_with_credentials(name=connection.name, **kwargs)
+
+            api_key: Optional[str] = None
+            if hasattr(connection_with_credentials.properties, "credentials"):
+                if hasattr(connection_with_credentials.properties.credentials, "key"):  # type: ignore
+                    api_key = connection_with_credentials.properties.credentials.key  # type: ignore
+
+            logger.debug(
+                "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI using API key authentication"
+            )
+            client = AsyncAzureOpenAI(
+                api_key=api_key,
+                azure_endpoint=azure_endpoint,
+                api_version=api_version
+            )
+
+        elif connection.auth_type == AuthenticationType.ENTRA_ID:
+
+            logger.debug(
+                "[InferenceOperations.get_azure_openai_client] " + "Creating AzureOpenAI using Entra ID authentication"
+            )
+
+            try:
+                from azure.identity.aio import get_bearer_token_provider
+            except ModuleNotFoundError as e:
+                raise ModuleNotFoundError(
+                    "azure.identity package not installed. Please install it using 'pip install azure.identity'"
+                ) from e
+
+            client = AsyncAzureOpenAI(
+                # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider # pylint: disable=line-too-long
+                azure_ad_token_provider=get_bearer_token_provider(
+                    self._outer_instance._config.credential, "https://cognitiveservices.azure.com/.default"
+                ),
+                azure_endpoint=azure_endpoint,
+                api_version=api_version,
+            )
+
+        else:
+            raise ValueError("Unsupported authentication type {connection.auth_type}")
+
+        return client
 
 
 class DatasetsOperations(DatasetsOperationsGenerated):
@@ -234,6 +495,7 @@ class DatasetsOperations(DatasetsOperationsGenerated):
 
 
 __all__: List[str] = [
+    "InferenceOperations",
     "DatasetsOperations"
 ]  # Add all objects you want publicly available to users at this package level
 

--- a/sdk/ai/azure-ai-projects-onedp/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/connections/sample_connections.py
@@ -29,28 +29,37 @@ from azure.core.credentials import AzureKeyCredential
 from azure.ai.projects.onedp import AIProjectClient
 from azure.ai.projects.onedp.models import ConnectionType
 
+# TODO: Remove console logging
+import sys
+import logging
+logger = logging.getLogger("azure")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+# End logging
+
 endpoint = os.environ["PROJECT_ENDPOINT"]
-#connection_name = os.environ["CONNECTION_NAME"]
+connection_name = os.environ["CONNECTION_NAME"]
 
 with AIProjectClient(
     endpoint=endpoint,
     #credential=DefaultAzureCredential(),
     credential=AzureKeyCredential(os.environ["PROJECT_API_KEY"]),
+    logging_enable=True, # TODO: Remove console logging
 ) as project_client:
 
-    print("List the properties of all connections")
+    print("List the properties of all connections:")
     connections = project_client.connections.list()
     for connection in connections:
         print(connection)
-    exit()
-
-    print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections)")
+    
+    print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections):")
     connections = project_client.connections.list(
         connection_type=ConnectionType.AZURE_OPEN_AI,
     )
     for connection in connections:
         print(connection)
 
-    print(f"Get the properties of a connection named {connection_name}")
+    print(f"Get the properties of a connection named `{connection_name}`:")
     connection = project_client.connections.get(connection_name)
     print(connection)
+

--- a/sdk/ai/azure-ai-projects-onedp/samples/connections/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/connections/sample_connections_async.py
@@ -34,7 +34,7 @@ from azure.ai.projects.onedp.models import ConnectionType
 async def sample_connections_async() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
-    #connection_name = os.environ["CONNECTION_NAME"]
+    connection_name = os.environ["CONNECTION_NAME"]
 
     async with AIProjectClient(
         endpoint=endpoint,
@@ -42,18 +42,17 @@ async def sample_connections_async() -> None:
         credential=AzureKeyCredential(os.environ["PROJECT_API_KEY"]),
     ) as project_client:
 
-        print("List the properties of all connections")
+        print("List the properties of all connections:")
         async for connection in project_client.connections.list():
             print(connection)
-        exit()
 
-        print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections)")
+        print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections):")
         async for connection in project_client.connections.list(
             connection_type=ConnectionType.AZURE_OPEN_AI,
         ):
             print(connection)
 
-        print(f"Get the properties of a connection named {connection_name}")
+        print(f"Get the properties of a connection named `{connection_name}`:")
         connection = await project_client.connections.get(connection_name)
         print(connection)
 

--- a/sdk/ai/azure-ai-projects-onedp/samples/datasets/sample_datasets.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/datasets/sample_datasets.py
@@ -24,32 +24,38 @@ USAGE:
 
 import os
 from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AzureKeyCredential
 from azure.ai.projects.onedp import AIProjectClient
 from azure.ai.projects.onedp.models import DatasetVersion, ListViewType
+
+# TODO: Remove console logging
+import sys
+import logging
+logger = logging.getLogger("azure")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+# End logging
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 dataset_name = os.environ["DATASET_NAME"]
 
 with AIProjectClient(
     endpoint=endpoint,
-    credential=DefaultAzureCredential(),
+    #credential=DefaultAzureCredential(),
+    credential=AzureKeyCredential(os.environ["PROJECT_API_KEY"]),
+    logging_enable=True, # TODO: Remove console logging
 ) as project_client:
-
-    print(
-        """Upload a single file and create a new Dataset to reference the file.
-    Here we explicitly specify the dataset version."""
-    )
+    
+    print("Upload a single file and create a new Dataset to reference the file. Here we explicitly specify the dataset version.")
     dataset: DatasetVersion = project_client.datasets.upload_file_and_create(
         name=dataset_name,
         version="1",
-        file="sample_folder/file1.txt",
+        file="sample_folder/sample_file1.txt",
     )
     print(dataset)
 
-    print(
-        """Upload all files in a folder (including subfolders) to the existing Dataset to reference the folder."
-    Here again we explicitly specify the a new dataset version"""
-    )
+    """
+    print("Upload all files in a folder (including subfolders) to the existing Dataset to reference the folder. Here again we explicitly specify the a new dataset version")
     dataset = project_client.datasets.upload_folder_and_create(
         name=dataset_name,
         version="2",
@@ -80,3 +86,4 @@ with AIProjectClient(
     project_client.datasets.delete_version(name=dataset_name, version="1")
     project_client.datasets.delete_version(name=dataset_name, version="2")
     project_client.datasets.delete_version(name=dataset_name, version="3")
+    """

--- a/sdk/ai/azure-ai-projects-onedp/samples/datasets/sample_datasets_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/datasets/sample_datasets_async.py
@@ -46,7 +46,7 @@ async def sample_datasets_async() -> None:
         dataset: DatasetVersion = await project_client.datasets.upload_file_and_create(
             name=dataset_name,
             version="1",
-            file="sample_folder/file1.txt",
+            file="sample_folder/sample_file1.txt",
         )
         print(dataset)
 

--- a/sdk/ai/azure-ai-projects-onedp/samples/deployments/sample_deployments_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/deployments/sample_deployments_async.py
@@ -49,7 +49,7 @@ async def sample_deployments_async() -> None:
         async for deployment in project_client.deployments.list(model_publisher=model_publisher):
             print(deployment)
 
-        print("Get a single deployment named `f{deployment_name}`:")
+        print(f"Get a single deployment named `{deployment_name}`:")
         deployment = await project_client.deployments.get(deployment_name)
         print(deployment)
 

--- a/sdk/ai/azure-ai-projects-onedp/samples/indexes/sample_indexes.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/indexes/sample_indexes.py
@@ -22,8 +22,18 @@ USAGE:
     2) INDEX_NAME - Required. The name of an Index to create and use in this sample.
 """
 
+# TODO: Remove console logging
+import sys
+import logging
+logger = logging.getLogger("azure")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+# End logging
+
+
 import os
 from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AzureKeyCredential
 from azure.ai.projects.onedp import AIProjectClient
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
@@ -31,16 +41,19 @@ index_name = os.environ["INDEX_NAME"]
 
 with AIProjectClient(
     endpoint=endpoint,
-    credential=DefaultAzureCredential(),
+    #credential=DefaultAzureCredential(),
+    credential=AzureKeyCredential(os.environ["PROJECT_API_KEY"]),
+    logging_enable=True, # TODO: Remove console logging
 ) as project_client:
-
-    print("Get an existing Index version `1`:")
-    index = project_client.indexes.get_version(name=index_name, version="1")
-    print(index)
 
     print(f"Listing all versions of the Index named `{index_name}`:")
     for index in project_client.indexes.list_versions(name=index_name):
         print(index)
+    exit()
+
+    print("Get an existing Index version `1`:")
+    index = project_client.indexes.get_version(name=index_name, version="1")
+    print(index)
 
     print("List latest versions of all Indexes:")
     for index in project_client.indexes.list_latest():

--- a/sdk/ai/azure-ai-projects-onedp/samples/telemetry/sample_telemetry.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/telemetry/sample_telemetry.py
@@ -6,10 +6,10 @@
 """
 DESCRIPTION:
     Given an AIProjectClient, this sample demonstrates how to use the synchronous
-    `.deployments` methods to enumerate AI models deployed to your AI Foundry Project.
+    `.telemtry` methods to get the Application Insights connection string.
 
 USAGE:
-    python sample_deployments.py
+    python sample_telemetry.py
 
     Before running the sample:
 
@@ -18,42 +18,31 @@ USAGE:
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Azure AI Foundry project.
-    2) DEPLOYMENT_NAME - Required. The name of the deployment to retrieve.
-    3) MODEL_PUBLISHER - Required. The publisher of the model to filter by.
 """
 
 import os
 from azure.identity import DefaultAzureCredential
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.projects.onedp import AIProjectClient
+from azure.ai.projects.onedp.models import ConnectionType
 
-# TODO: Remove console logging
+# Start remove me -- logging
 import sys
 import logging
 logger = logging.getLogger("azure")
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
-# End logging
+# End remove me
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
-deployment_name = os.environ["DEPLOYMENT_NAME"]
-model_publisher = os.environ["MODEL_PUBLISHER"]
 
 with AIProjectClient(
     endpoint=endpoint,
     #credential=DefaultAzureCredential(),
     credential=AzureKeyCredential(os.environ["PROJECT_API_KEY"]),
-    logging_enable=True, # TODO: Remove console logging
+    logging_enable=True,
 ) as project_client:
 
-    print("List all deployments:")
-    for deployment in project_client.deployments.list():
-        print(deployment)
-
-    print(f"List all deployments by the model publisher `{model_publisher}`:")
-    for deployment in project_client.deployments.list(model_publisher=model_publisher):
-        print(deployment)
-
-    print(f"Get a single deployment named `{deployment_name}`:")
-    deployment = project_client.deployments.get(deployment_name)
-    print(deployment)
+    print("Get the Application Insights connection string:")
+    connection_string = project_client.telemetry.get_connection_string()
+    print(connection_string)


### PR DESCRIPTION
This is mostly saving of work in progress, as I need to apply new TypeSpec changes.

* Add Inference operations (`project_client.inference.get_xyz_client()`). Not yet run, and about to go through some changes when new TypeSpec will be applied
* Updates to connection, deployment, dataset and indexes samples. The connection samples are now running following service-side fixes. Datasets and deployments routes are broken on the service today. Following up with the service team.
