### PR TITLE
Extend version range for `psutil` to include 7.x

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -89,7 +89,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api~=1.26",
         "opentelemetry-sdk~=1.26",
-        "psutil>=5.9,<7",
+        "psutil>=5.9,<8",
     ],
     entry_points={
         "opentelemetry_traces_exporter": [


### PR DESCRIPTION
# Description

Extend the supported version range of `psutil` to include version 7.x. The only relevant breaking change (dropped support for Python 2.7) doesn't affect azure-sdk-for-python, which already requires Python 3.8+.

See https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#700

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
