### PR TITLE
[Storage] Download/Upload Blob APIs Fixes for Transport Compatibility

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
@@ -45,10 +45,6 @@ async def retry_hook(settings, **kwargs):
 async def is_checksum_retry(response):
     # retry if invalid content md5
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
-        try:
-            await response.http_response.load_body()  # Load the body in memory and close the socket
-        except (StreamClosedError, StreamConsumedError):
-            pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                        encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
@@ -44,6 +44,11 @@ async def retry_hook(settings, **kwargs):
 
 async def is_checksum_retry(response):
     # retry if invalid content md5
+    if hasattr(response.http_response, "load_body"):
+        try:
+            await response.http_response.load_body()
+        except (StreamClosedError, StreamConsumedError):
+            pass
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                        encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -46,8 +46,11 @@ T = TypeVar('T', bytes, str)
 async def process_content(data: Any, start_offset: int, end_offset: int, encryption: Dict[str, Any]) -> bytes:
     if data is None:
         raise ValueError("Response cannot be None.")
-    await data.response.load_body()
-    content = cast(bytes, data.response.body())
+    if hasattr(data.response, "read"):
+        content = b"".join([d async for d in data])
+    else:
+        await data.response.load_body()
+        content = cast(bytes, data.response.body())
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:
             return decrypt_blob(

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -46,11 +46,11 @@ T = TypeVar('T', bytes, str)
 async def process_content(data: Any, start_offset: int, end_offset: int, encryption: Dict[str, Any]) -> bytes:
     if data is None:
         raise ValueError("Response cannot be None.")
-    if hasattr(data.response, "read"):
-        content = b"".join([d async for d in data])
-    else:
+    if hasattr(data.response, "load_body"):
         await data.response.load_body()
         content = cast(bytes, data.response.body())
+    else:
+        content = b"".join([d async for d in data])
     if encryption.get('key') is not None or encryption.get('resolver') is not None:
         try:
             return decrypt_blob(

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -53,7 +53,6 @@ from azure.storage.blob._generated.models import RehydratePriority
 from devtools_testutils import FakeTokenCredential, recorded_by_proxy
 from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import BlobPreparer
-from test_helpers import MockStorageTransport
 
 # ------------------------------------------------------------------------------
 TEST_CONTAINER_PREFIX = 'container'
@@ -3531,58 +3530,5 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         # Assert
         result = blob.download_blob().readall()
         assert result == data[:length]
-
-    @BlobPreparer()
-    def test_mock_transport_no_content_validation(self, **kwargs):
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        transport = MockStorageTransport()
-        blob_client = BlobClient(
-            self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
-            blob_name='test_blob',
-            credential=storage_account_key,
-            transport=transport,
-            retry_total=0
-        )
-
-        content = blob_client.download_blob()
-        assert content is not None
-
-        props = blob_client.get_blob_properties()
-        assert props is not None
-
-        data = b"Hello World!"
-        resp = blob_client.upload_blob(data, overwrite=True)
-        assert resp is not None
-
-        blob_data = blob_client.download_blob().read()
-        assert blob_data == b"Hello World!"  # data is fixed by mock transport
-
-        resp = blob_client.delete_blob()
-        assert resp is None
-
-    @BlobPreparer()
-    def test_mock_transport_with_content_validation(self, **kwargs):
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        transport = MockStorageTransport()
-        blob_client = BlobClient(
-            self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
-            blob_name='test_blob',
-            credential=storage_account_key,
-            transport=transport,
-            retry_total=0
-        )
-
-        data = b"Hello World!"
-        resp = blob_client.upload_blob(data, overwrite=True, validate_content=True)
-        assert resp is not None
-
-        blob_data = blob_client.download_blob(validate_content=True).read()
-        assert blob_data == b"Hello World!"  # data is fixed by mock transport
 
     # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -53,6 +53,7 @@ from devtools_testutils.fake_credentials_async import AsyncFakeCredential
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
 from settings.testcase import BlobPreparer
+from test_helpers_async import AsyncStream
 
 # ------------------------------------------------------------------------------
 TEST_CONTAINER_PREFIX = 'container'

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -53,7 +53,6 @@ from devtools_testutils.fake_credentials_async import AsyncFakeCredential
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
 from settings.testcase import BlobPreparer
-from test_helpers_async import AsyncStream, MockStorageTransport
 
 # ------------------------------------------------------------------------------
 TEST_CONTAINER_PREFIX = 'container'
@@ -3456,58 +3455,4 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         result = await (await blob.download_blob()).readall()
         assert result == data[:length]
 
-    @BlobPreparer()
-    async def test_mock_transport_no_content_validation(self, **kwargs):
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        transport = MockStorageTransport()
-        blob_client = BlobClient(
-            self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
-            blob_name='test_blob',
-            credential=storage_account_key,
-            transport=transport,
-            retry_total=0
-        )
-
-        content = await blob_client.download_blob()
-        assert content is not None
-
-        props = await blob_client.get_blob_properties()
-        assert props is not None
-
-        data = b"Hello Async World!"
-        stream = AsyncStream(data)
-        resp = await blob_client.upload_blob(stream, overwrite=True)
-        assert resp is not None
-
-        blob_data = await (await blob_client.download_blob()).read()
-        assert blob_data == b"Hello Async World!"  # data is fixed by mock transport
-
-        resp = await blob_client.delete_blob()
-        assert resp is None
-
-    @BlobPreparer()
-    async def test_mock_transport_with_content_validation(self, **kwargs):
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        transport = MockStorageTransport()
-        blob_client = BlobClient(
-            self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
-            blob_name='test_blob',
-            credential=storage_account_key,
-            transport=transport,
-            retry_total=0
-        )
-
-        data = b"Hello Async World!"
-        stream = AsyncStream(data)
-        resp = await blob_client.upload_blob(stream, overwrite=True, validate_content=True)
-        assert resp is not None
-
-        blob_data = await (await blob_client.download_blob(validate_content=True)).read()
-        assert blob_data == b"Hello Async World!"  # data is fixed by mock transport
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_helpers.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers.py
@@ -8,7 +8,11 @@ from io import IOBase, UnsupportedOperation
 from typing import Any, Dict, Optional
 from typing_extensions import Self
 
-from azure.core.pipeline.transport import HttpTransport, RequestsTransportResponse
+from azure.core.pipeline.transport import (
+    HttpTransport,
+    RequestsTransport,
+    RequestsTransportResponse
+)
 from azure.core.rest import HttpRequest
 from requests import Response
 from urllib3 import HTTPResponse
@@ -138,6 +142,85 @@ class MockLegacyTransport(HttpTransport):
             )
         else:
             raise ValueError("The request is not accepted as part of MockLegacyTransport.")
+        return rest_response
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+    def open(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class MockCoreTransport(RequestsTransport):
+    def send(self, request: HttpRequest, **kwargs: Any) -> RequestsTransportResponse:
+        if request.method == 'GET':
+            # download_blob
+            headers = {
+                "Content-Type": "application/octet-stream",
+                "Content-Range": "bytes 0-17/18",
+                "Content-Length": "18",
+            }
+
+            if "x-ms-range-get-content-md5" in request.headers:
+                headers["Content-MD5"] = "7Qdih1MuhjZehB6Sv8UNjA=="  # cspell:disable-line
+
+            rest_response = RequestsTransportResponse(
+                request=request,
+                requests_response=MockHttpClientResponse(
+                    request.url,
+                    b"Hello World!",
+                    headers,
+                )
+            )
+        elif request.method == 'HEAD':
+            # get_blob_properties
+            rest_response = RequestsTransportResponse(
+                request=request,
+                requests_response=MockHttpClientResponse(
+                    request.url,
+                    b"",
+                    {
+                        "Content-Type": "application/octet-stream",
+                        "Content-Length": "1024",
+                    },
+                )
+            )
+        elif request.method == 'PUT':
+            # upload_blob
+            rest_response = RequestsTransportResponse(
+                request=request,
+                requests_response=MockHttpClientResponse(
+                    request.url,
+                    b"",
+                    {
+                        "Content-Length": "0",
+                    },
+                    201,
+                    "Created"
+                )
+            )
+        elif request.method == 'DELETE':
+            # delete_blob
+            rest_response = RequestsTransportResponse(
+                request=request,
+                requests_response=MockHttpClientResponse(
+                    request.url,
+                    b"",
+                    {
+                        "Content-Length": "0",
+                    },
+                    202,
+                    "Accepted"
+                )
+            )
+        else:
+            raise ValueError("The request is not accepted as part of MockCoreTransport.")
         return rest_response
 
     def __enter__(self) -> Self:

--- a/sdk/storage/azure-storage-blob/tests/test_helpers.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers.py
@@ -53,7 +53,7 @@ class NonSeekableStream(IOBase):
         return self.wrapped_stream.tell()
 
 
-class MockHttpClientResponse(Response):
+class MockClientResponse(Response):
     def __init__(
         self, url: str,
         body_bytes: bytes,
@@ -61,7 +61,7 @@ class MockHttpClientResponse(Response):
         status: int = 200,
         reason: str = "OK"
     ) -> None:
-        super(MockHttpClientResponse).__init__()
+        super(MockClientResponse).__init__()
         self._url = url
         self._body = body_bytes
         self._content = body_bytes
@@ -93,7 +93,7 @@ class MockLegacyTransport(HttpTransport):
 
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"Hello World!",
                     headers,
@@ -103,7 +103,7 @@ class MockLegacyTransport(HttpTransport):
             # get_blob_properties
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {
@@ -116,7 +116,7 @@ class MockLegacyTransport(HttpTransport):
             # upload_blob
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {
@@ -130,7 +130,7 @@ class MockLegacyTransport(HttpTransport):
             # delete_blob
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {
@@ -158,6 +158,10 @@ class MockLegacyTransport(HttpTransport):
 
 
 class MockCoreTransport(RequestsTransport):
+    """
+    This transport returns http response objects from azure core pipelines and is
+    intended only to test our backwards compatibility support.
+    """
     def send(self, request: HttpRequest, **kwargs: Any) -> RequestsTransportResponse:
         if request.method == 'GET':
             # download_blob
@@ -172,7 +176,7 @@ class MockCoreTransport(RequestsTransport):
 
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"Hello World!",
                     headers,
@@ -182,7 +186,7 @@ class MockCoreTransport(RequestsTransport):
             # get_blob_properties
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {
@@ -195,7 +199,7 @@ class MockCoreTransport(RequestsTransport):
             # upload_blob
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {
@@ -209,7 +213,7 @@ class MockCoreTransport(RequestsTransport):
             # delete_blob
             rest_response = RequestsTransportResponse(
                 request=request,
-                requests_response=MockHttpClientResponse(
+                requests_response=MockClientResponse(
                     request.url,
                     b"",
                     {

--- a/sdk/storage/azure-storage-blob/tests/test_helpers.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers.py
@@ -70,7 +70,7 @@ class MockHttpClientResponse(Response):
         self.raw = HTTPResponse()
 
 
-class MockStorageTransport(HttpTransport):
+class MockLegacyTransport(HttpTransport):
     """
     This transport returns legacy http response objects from azure core and is
     intended only to test our backwards compatibility support.
@@ -137,7 +137,7 @@ class MockStorageTransport(HttpTransport):
                 )
             )
         else:
-            raise ValueError("The request is not accepted as part of MockStorageTransport.")
+            raise ValueError("The request is not accepted as part of MockLegacyTransport.")
         return rest_response
 
     def __enter__(self) -> Self:

--- a/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
@@ -84,7 +84,7 @@ class MockAioHttpClientResponse(ClientResponse):
         self.reason = reason
 
 
-class MockStorageTransport(AsyncHttpTransport):
+class MockLegacyTransport(AsyncHttpTransport):
     """
     This transport returns legacy http response objects from azure core and is 
     intended only to test our backwards compatibility support.
@@ -155,7 +155,7 @@ class MockStorageTransport(AsyncHttpTransport):
                 decompress=False
             )
         else:
-            raise ValueError("The request is not accepted as part of MockStorageTransport.")
+            raise ValueError("The request is not accepted as part of MockLegacyTransport.")
 
         await rest_response.load_body()
         return rest_response

--- a/sdk/storage/azure-storage-blob/tests/test_transports.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports.py
@@ -1,0 +1,76 @@
+from azure.storage.blob import BlobClient, BlobServiceClient
+from azure.core.exceptions import ResourceExistsError
+
+from devtools_testutils.storage import StorageRecordedTestCase
+from settings.testcase import BlobPreparer
+from test_helpers import MockStorageTransport
+
+
+class TestStorageTransports(StorageRecordedTestCase):
+    def _setup(self, storage_account_name, key):
+        self.bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=key)
+        self.container_name = self.get_resource_name('utcontainer')
+        self.source_container_name = self.get_resource_name('utcontainersource')
+        if self.is_live:
+            try:
+                self.bsc.create_container(self.container_name, timeout=5)
+            except ResourceExistsError:
+                pass
+            try:
+                self.bsc.create_container(self.source_container_name, timeout=5)
+            except ResourceExistsError:
+                pass
+        self.byte_data = self.get_random_bytes(1024)
+
+    @BlobPreparer()
+    def test_legacy_transport(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockStorageTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        content = blob_client.download_blob()
+        assert content is not None
+
+        props = blob_client.get_blob_properties()
+        assert props is not None
+
+        data = b"Hello World!"
+        resp = blob_client.upload_blob(data, overwrite=True)
+        assert resp is not None
+
+        blob_data = blob_client.download_blob().read()
+        assert blob_data == b"Hello World!"  # data is fixed by mock transport
+
+        resp = blob_client.delete_blob()
+        assert resp is None
+
+    @BlobPreparer()
+    def test_legacy_transport_content_validation(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockStorageTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        data = b"Hello World!"
+        resp = blob_client.upload_blob(data, overwrite=True, validate_content=True)
+        assert resp is not None
+
+        blob_data = blob_client.download_blob(validate_content=True).read()
+        assert blob_data == b"Hello World!"  # data is fixed by mock transport

--- a/sdk/storage/azure-storage-blob/tests/test_transports.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports.py
@@ -3,7 +3,7 @@ from azure.core.exceptions import ResourceExistsError
 
 from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import BlobPreparer
-from test_helpers import MockStorageTransport
+from test_helpers import MockLegacyTransport
 
 
 class TestStorageTransports(StorageRecordedTestCase):
@@ -27,7 +27,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
-        transport = MockStorageTransport()
+        transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
             container_name='test_cont',
@@ -58,7 +58,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
-        transport = MockStorageTransport()
+        transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
             container_name='test_cont',

--- a/sdk/storage/azure-storage-blob/tests/test_transports.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports.py
@@ -3,7 +3,7 @@ from azure.core.exceptions import ResourceExistsError
 
 from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import BlobPreparer
-from test_helpers import MockLegacyTransport
+from test_helpers import MockCoreTransport, MockLegacyTransport
 
 
 class TestStorageTransports(StorageRecordedTestCase):
@@ -59,6 +59,59 @@ class TestStorageTransports(StorageRecordedTestCase):
         storage_account_key = kwargs.pop("storage_account_key")
 
         transport = MockLegacyTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        data = b"Hello World!"
+        resp = blob_client.upload_blob(data, overwrite=True, validate_content=True)
+        assert resp is not None
+
+        blob_data = blob_client.download_blob(validate_content=True).read()
+        assert blob_data == b"Hello World!"  # data is fixed by mock transport
+
+    @BlobPreparer()
+    def test_core_transport(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockCoreTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        content = blob_client.download_blob()
+        assert content is not None
+
+        props = blob_client.get_blob_properties()
+        assert props is not None
+
+        data = b"Hello World!"
+        resp = blob_client.upload_blob(data, overwrite=True)
+        assert resp is not None
+
+        blob_data = blob_client.download_blob().read()
+        assert blob_data == b"Hello World!"  # data is fixed by mock transport
+
+        resp = blob_client.delete_blob()
+        assert resp is None
+
+    @BlobPreparer()
+    def test_core_transport_content_validation(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockCoreTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
             container_name='test_cont',

--- a/sdk/storage/azure-storage-blob/tests/test_transports.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports.py
@@ -36,7 +36,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
+            container_name='container',
             blob_name='test_blob',
             credential=storage_account_key,
             transport=transport,
@@ -67,7 +67,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
+            container_name='container',
             blob_name='test_blob',
             credential=storage_account_key,
             transport=transport,
@@ -89,7 +89,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         transport = MockCoreTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
+            container_name='container',
             blob_name='test_blob',
             credential=storage_account_key,
             transport=transport,
@@ -120,7 +120,7 @@ class TestStorageTransports(StorageRecordedTestCase):
         transport = MockCoreTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
-            container_name='test_cont',
+            container_name='container',
             blob_name='test_blob',
             credential=storage_account_key,
             transport=transport,

--- a/sdk/storage/azure-storage-blob/tests/test_transports.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
 from azure.storage.blob import BlobClient, BlobServiceClient
 from azure.core.exceptions import ResourceExistsError
 

--- a/sdk/storage/azure-storage-blob/tests/test_transports_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports_async.py
@@ -1,0 +1,78 @@
+from azure.storage.blob.aio import BlobClient, BlobServiceClient
+from azure.core.exceptions import ResourceExistsError
+
+from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
+from settings.testcase import BlobPreparer
+from test_helpers_async import AsyncStream, MockStorageTransport
+
+
+class TestStorageTransportsAsync(AsyncStorageRecordedTestCase):
+    async def _setup(self, storage_account_name, key):
+        self.bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=key)
+        self.container_name = self.get_resource_name('utcontainer')
+        self.source_container_name = self.get_resource_name('utcontainersource')
+        self.byte_data = self.get_random_bytes(1024)
+        if self.is_live:
+            try:
+                await self.bsc.create_container(self.container_name)
+            except ResourceExistsError:
+                pass
+            try:
+                await self.bsc.create_container(self.source_container_name)
+            except ResourceExistsError:
+                pass
+
+    @BlobPreparer()
+    async def test_legacy_transport(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockStorageTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        content = await blob_client.download_blob()
+        assert content is not None
+
+        props = await blob_client.get_blob_properties()
+        assert props is not None
+
+        data = b"Hello Async World!"
+        stream = AsyncStream(data)
+        resp = await blob_client.upload_blob(stream, overwrite=True)
+        assert resp is not None
+
+        blob_data = await (await blob_client.download_blob()).read()
+        assert blob_data == b"Hello Async World!"  # data is fixed by mock transport
+
+        resp = await blob_client.delete_blob()
+        assert resp is None
+
+    @BlobPreparer()
+    async def test_legacy_transport_content_validation(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        transport = MockStorageTransport()
+        blob_client = BlobClient(
+            self.account_url(storage_account_name, "blob"),
+            container_name='test_cont',
+            blob_name='test_blob',
+            credential=storage_account_key,
+            transport=transport,
+            retry_total=0
+        )
+
+        data = b"Hello Async World!"
+        stream = AsyncStream(data)
+        resp = await blob_client.upload_blob(stream, overwrite=True, validate_content=True)
+        assert resp is not None
+
+        blob_data = await (await blob_client.download_blob(validate_content=True)).read()
+        assert blob_data == b"Hello Async World!"  # data is fixed by mock transport

--- a/sdk/storage/azure-storage-blob/tests/test_transports_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports_async.py
@@ -3,7 +3,7 @@ from azure.core.exceptions import ResourceExistsError
 
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
 from settings.testcase import BlobPreparer
-from test_helpers_async import AsyncStream, MockStorageTransport
+from test_helpers_async import AsyncStream, MockLegacyTransport
 
 
 class TestStorageTransportsAsync(AsyncStorageRecordedTestCase):
@@ -27,7 +27,7 @@ class TestStorageTransportsAsync(AsyncStorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
-        transport = MockStorageTransport()
+        transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
             container_name='test_cont',
@@ -59,7 +59,7 @@ class TestStorageTransportsAsync(AsyncStorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
-        transport = MockStorageTransport()
+        transport = MockLegacyTransport()
         blob_client = BlobClient(
             self.account_url(storage_account_name, "blob"),
             container_name='test_cont',

--- a/sdk/storage/azure-storage-blob/tests/test_transports_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_transports_async.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
 from azure.storage.blob.aio import BlobClient, BlobServiceClient
 from azure.core.exceptions import ResourceExistsError
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies_async.py
@@ -45,10 +45,6 @@ async def retry_hook(settings, **kwargs):
 async def is_checksum_retry(response):
     # retry if invalid content md5
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
-        try:
-            await response.http_response.load_body()  # Load the body in memory and close the socket
-        except (StreamClosedError, StreamConsumedError):
-            pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies_async.py
@@ -44,6 +44,11 @@ async def retry_hook(settings, **kwargs):
 
 async def is_checksum_retry(response):
     # retry if invalid content md5
+    if hasattr(response.http_response, "load_body"):
+        try:
+            await response.http_response.load_body()
+        except (StreamClosedError, StreamConsumedError):
+            pass
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies_async.py
@@ -45,10 +45,6 @@ async def retry_hook(settings, **kwargs):
 async def is_checksum_retry(response):
     # retry if invalid content md5
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
-        try:
-            await response.http_response.load_body()  # Load the body in memory and close the socket
-        except (StreamClosedError, StreamConsumedError):
-            pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies_async.py
@@ -44,6 +44,11 @@ async def retry_hook(settings, **kwargs):
 
 async def is_checksum_retry(response):
     # retry if invalid content md5
+    if hasattr(response.http_response, "load_body"):
+        try:
+            await response.http_response.load_body()
+        except (StreamClosedError, StreamConsumedError):
+            pass
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -33,8 +33,11 @@ async def process_content(data: Any) -> bytes:
         raise ValueError("Response cannot be None.")
 
     try:
-        await data.response.load_body()
-        return cast(bytes, data.response.body())
+        if hasattr(data.response, "read"):
+            return b"".join([d async for d in data])
+        else:
+            await data.response.load_body()
+            return cast(bytes, data.response.body())
     except Exception as error:
         raise HttpResponseError(message="Download stream interrupted.", response=data.response, error=error) from error
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -36,8 +36,7 @@ async def process_content(data: Any) -> bytes:
         if hasattr(data.response, "load_body"):
             await data.response.load_body()
             return cast(bytes, data.response.body())
-        else:
-            return b"".join([d async for d in data])
+        return b"".join([d async for d in data])
     except Exception as error:
         raise HttpResponseError(message="Download stream interrupted.", response=data.response, error=error) from error
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -33,11 +33,11 @@ async def process_content(data: Any) -> bytes:
         raise ValueError("Response cannot be None.")
 
     try:
-        if hasattr(data.response, "read"):
-            return b"".join([d async for d in data])
-        else:
+        if hasattr(data.response, "load_body"):
             await data.response.load_body()
             return cast(bytes, data.response.body())
+        else:
+            return b"".join([d async for d in data])
     except Exception as error:
         raise HttpResponseError(message="Download stream interrupted.", response=data.response, error=error) from error
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
@@ -45,10 +45,6 @@ async def retry_hook(settings, **kwargs):
 async def is_checksum_retry(response):
     # retry if invalid content md5
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
-        try:
-            await response.http_response.load_body()  # Load the body in memory and close the socket
-        except (StreamClosedError, StreamConsumedError):
-            pass
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
@@ -44,6 +44,11 @@ async def retry_hook(settings, **kwargs):
 
 async def is_checksum_retry(response):
     # retry if invalid content md5
+    if hasattr(response.http_response, "load_body"):
+        try:
+            await response.http_response.load_body()
+        except (StreamClosedError, StreamConsumedError):
+            pass
     if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                             encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))


### PR DESCRIPTION
Need a way to figure out how to mock `AsyncioRequestsTransport`, then remove the live test only pytest marker