### PR TITLE
Set min Python to 3.9 instead of 3.8

### DIFF
--- a/sdk/ai/azure-ai-projects-onedp/README.md
+++ b/sdk/ai/azure-ai-projects-onedp/README.md
@@ -27,7 +27,7 @@ To report an issue with the client library, or request additional features, plea
 
 ### Prerequisite
 
-- Python 3.8 or later.
+- Python 3.9 or later.
 - An [Azure subscription][azure_sub].
 - A [project in Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/how-to/create-projects).
 - The project endpoint URL, of the form `https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>`. It can be found in your Azure AI Foundry project overview page, under "Project details". Below we will assume the environment variable `PROJECT_ENDPOINT` was defined to hold this value.

--- a/sdk/ai/azure-ai-projects-onedp/setup.py
+++ b/sdk/ai/azure-ai-projects-onedp/setup.py
@@ -43,7 +43,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -72,7 +71,7 @@ setup(
         "typing-extensions>=4.12.2",
         "azure-storage-blob>=12.15.0",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     extras_require={
         "prompts": ["prompty"],
     },


### PR DESCRIPTION
Per https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy, we were asked to drop 3.8.