### PR TITLE
Re-emit Python SDK from TypeSpec to get and list connections with secrets using POST

### DIFF
--- a/sdk/ai/azure-ai-projects-onedp/apiview-properties.json
+++ b/sdk/ai/azure-ai-projects-onedp/apiview-properties.json
@@ -41,6 +41,7 @@
         "azure.ai.projects.onedp.AIProjectClient.connections.get": "Azure.AI.Projects.Connections.get",
         "azure.ai.projects.onedp.AIProjectClient.connections.get_with_credentials": "Azure.AI.Projects.Connections.getWithCredentials",
         "azure.ai.projects.onedp.AIProjectClient.connections.list": "Azure.AI.Projects.Connections.list",
+        "azure.ai.projects.onedp.AIProjectClient.connections.list_with_credentials": "Azure.AI.Projects.Connections.listWithCredentials",
         "azure.ai.projects.onedp.AIProjectClient.evaluations.get": "Azure.AI.Projects.Evaluations.get",
         "azure.ai.projects.onedp.AIProjectClient.evaluations.list": "Azure.AI.Projects.Evaluations.list",
         "azure.ai.projects.onedp.AIProjectClient.evaluations.create_run": "Azure.AI.Projects.Evaluations.createRun",

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_client.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_client.py
@@ -23,6 +23,7 @@ from .operations import (
     DeploymentsOperations,
     EvaluationsOperations,
     IndexesOperations,
+    InternalOperations,
     RedTeamsOperations,
     ServicePatternsOperations,
 )
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
 class AIProjectClient:  # pylint: disable=too-many-instance-attributes
     """AIProjectClient.
 
+    :ivar internal: InternalOperations operations
+    :vartype internal: azure.ai.projects.onedp.operations.InternalOperations
     :ivar service_patterns: ServicePatternsOperations operations
     :vartype service_patterns: azure.ai.projects.onedp.operations.ServicePatternsOperations
     :ivar connections: ConnectionsOperations operations
@@ -48,8 +51,13 @@ class AIProjectClient:  # pylint: disable=too-many-instance-attributes
     :vartype deployments: azure.ai.projects.onedp.operations.DeploymentsOperations
     :ivar red_teams: RedTeamsOperations operations
     :vartype red_teams: azure.ai.projects.onedp.operations.RedTeamsOperations
-    :param endpoint: Project endpoint in the form of:
-     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :param endpoint: Project endpoint. In the form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project"
+     if your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the
+     form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>"
+     if you want to explicitly
+     specify the Foundry Project name. Required.
     :type endpoint: str
     :param credential: Credential used to authenticate requests to the service. Is either a key
      credential type or a token credential type. Required.
@@ -86,6 +94,7 @@ class AIProjectClient:  # pylint: disable=too-many-instance-attributes
         self._serialize = Serializer()
         self._deserialize = Deserializer()
         self._serialize.client_side_validation = False
+        self.internal = InternalOperations(self._client, self._config, self._serialize, self._deserialize)
         self.service_patterns = ServicePatternsOperations(
             self._client, self._config, self._serialize, self._deserialize
         )

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_configuration.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_configuration.py
@@ -23,8 +23,13 @@ class AIProjectClientConfiguration:  # pylint: disable=too-many-instance-attribu
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
-    :param endpoint: Project endpoint in the form of:
-     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :param endpoint: Project endpoint. In the form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project"
+     if your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the
+     form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>"
+     if you want to explicitly
+     specify the Foundry Project name. Required.
     :type endpoint: str
     :param credential: Credential used to authenticate requests to the service. Is either a key
      credential type or a token credential type. Required.

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_client.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_client.py
@@ -23,6 +23,7 @@ from .operations import (
     DeploymentsOperations,
     EvaluationsOperations,
     IndexesOperations,
+    InternalOperations,
     RedTeamsOperations,
     ServicePatternsOperations,
 )
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
 class AIProjectClient:  # pylint: disable=too-many-instance-attributes
     """AIProjectClient.
 
+    :ivar internal: InternalOperations operations
+    :vartype internal: azure.ai.projects.onedp.aio.operations.InternalOperations
     :ivar service_patterns: ServicePatternsOperations operations
     :vartype service_patterns: azure.ai.projects.onedp.aio.operations.ServicePatternsOperations
     :ivar connections: ConnectionsOperations operations
@@ -48,8 +51,13 @@ class AIProjectClient:  # pylint: disable=too-many-instance-attributes
     :vartype deployments: azure.ai.projects.onedp.aio.operations.DeploymentsOperations
     :ivar red_teams: RedTeamsOperations operations
     :vartype red_teams: azure.ai.projects.onedp.aio.operations.RedTeamsOperations
-    :param endpoint: Project endpoint in the form of:
-     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :param endpoint: Project endpoint. In the form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project"
+     if your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the
+     form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>"
+     if you want to explicitly
+     specify the Foundry Project name. Required.
     :type endpoint: str
     :param credential: Credential used to authenticate requests to the service. Is either a key
      credential type or a token credential type. Required.
@@ -88,6 +96,7 @@ class AIProjectClient:  # pylint: disable=too-many-instance-attributes
         self._serialize = Serializer()
         self._deserialize = Deserializer()
         self._serialize.client_side_validation = False
+        self.internal = InternalOperations(self._client, self._config, self._serialize, self._deserialize)
         self.service_patterns = ServicePatternsOperations(
             self._client, self._config, self._serialize, self._deserialize
         )

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_configuration.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_configuration.py
@@ -23,8 +23,13 @@ class AIProjectClientConfiguration:  # pylint: disable=too-many-instance-attribu
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
-    :param endpoint: Project endpoint in the form of:
-     https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>. Required.
+    :param endpoint: Project endpoint. In the form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project"
+     if your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the
+     form
+     "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>"
+     if you want to explicitly
+     specify the Foundry Project name. Required.
     :type endpoint: str
     :param credential: Credential used to authenticate requests to the service. Is either a key
      credential type or a token credential type. Required.

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/__init__.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ._patch import *  # pylint: disable=unused-wildcard-import
 
+from ._operations import InternalOperations  # type: ignore
 from ._operations import ServicePatternsOperations  # type: ignore
 from ._operations import ConnectionsOperations  # type: ignore
 from ._operations import EvaluationsOperations  # type: ignore
@@ -25,6 +26,7 @@ from ._patch import *
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
+    "InternalOperations",
     "ServicePatternsOperations",
     "ConnectionsOperations",
     "EvaluationsOperations",

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_operations.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_operations.py
@@ -38,6 +38,7 @@ from ...operations._operations import (
     build_connections_get_request,
     build_connections_get_with_credentials_request,
     build_connections_list_request,
+    build_connections_list_with_credentials_request,
     build_datasets_create_version_request,
     build_datasets_delete_version_request,
     build_datasets_get_credentials_request,
@@ -64,6 +65,24 @@ from .._configuration import AIProjectClientConfiguration
 T = TypeVar("T")
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 JSON = MutableMapping[str, Any]
+
+
+class InternalOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azure.ai.projects.onedp.aio.AIProjectClient`'s
+        :attr:`internal` attribute.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        input_args = list(args)
+        self._client: AsyncPipelineClient = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config: AIProjectClientConfiguration = input_args.pop(0) if input_args else kwargs.pop("config")
+        self._serialize: Serializer = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
 
 
 class ServicePatternsOperations:
@@ -280,6 +299,113 @@ class ConnectionsOperations:
             if not next_link:
 
                 _request = build_connections_list_request(
+                    connection_type=connection_type,
+                    default_connection=default_connection,
+                    top=top,
+                    skip=skip,
+                    maxpagesize=maxpagesize,
+                    api_version=self._config.api_version,
+                    headers=_headers,
+                    params=_params,
+                )
+                path_format_arguments = {
+                    "endpoint": self._serialize.url(
+                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                    ),
+                }
+                _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+            else:
+                # make call to next link with the client's api-version
+                _parsed_next_link = urllib.parse.urlparse(next_link)
+                _next_request_params = case_insensitive_dict(
+                    {
+                        key: [urllib.parse.quote(v) for v in value]
+                        for key, value in urllib.parse.parse_qs(_parsed_next_link.query).items()
+                    }
+                )
+                _next_request_params["api-version"] = self._config.api_version
+                _request = HttpRequest(
+                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                )
+                path_format_arguments = {
+                    "endpoint": self._serialize.url(
+                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                    ),
+                }
+                _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+            return _request
+
+        async def extract_data(pipeline_response):
+            deserialized = pipeline_response.http_response.json()
+            list_of_elem = _deserialize(List[_models.Connection], deserialized.get("value", []))
+            if cls:
+                list_of_elem = cls(list_of_elem)  # type: ignore
+            return deserialized.get("nextLink") or None, AsyncList(list_of_elem)
+
+        async def get_next(next_link=None):
+            _request = prepare_request(next_link)
+
+            _stream = False
+            pipeline_response: PipelineResponse = await self._client._pipeline.run(  # pylint: disable=protected-access
+                _request, stream=_stream, **kwargs
+            )
+            response = pipeline_response.http_response
+
+            if response.status_code not in [200]:
+                map_error(status_code=response.status_code, response=response, error_map=error_map)
+                raise HttpResponseError(response=response)
+
+            return pipeline_response
+
+        return AsyncItemPaged(get_next, extract_data)
+
+    @distributed_trace
+    def list_with_credentials(
+        self,
+        *,
+        connection_type: Optional[Union[str, _models.ConnectionType]] = None,
+        default_connection: Optional[bool] = None,
+        top: Optional[int] = None,
+        skip: Optional[int] = None,
+        **kwargs: Any
+    ) -> AsyncIterable["_models.Connection"]:
+        """List all connections in the project, with their connection credentials.
+
+        :keyword connection_type: List connections of this specific type. Known values are:
+         "AzureOpenAI", "AzureBlob", "AzureStorageAccount", "CognitiveSearch", "CosmosDB", "ApiKey",
+         "AppConfig", "AppInsights", and "CustomKeys". Default value is None.
+        :paramtype connection_type: str or ~azure.ai.projects.onedp.models.ConnectionType
+        :keyword default_connection: List connections that are default connections. Default value is
+         None.
+        :paramtype default_connection: bool
+        :keyword top: The number of result items to return. Default value is None.
+        :paramtype top: int
+        :keyword skip: The number of result items to skip. Default value is None.
+        :paramtype skip: int
+        :return: An iterator like instance of Connection
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.ai.projects.onedp.models.Connection]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        maxpagesize = kwargs.pop("maxpagesize", None)
+        cls: ClsType[List[_models.Connection]] = kwargs.pop("cls", None)
+
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        def prepare_request(next_link=None):
+            if not next_link:
+
+                _request = build_connections_list_with_credentials_request(
                     connection_type=connection_type,
                     default_connection=default_connection,
                     top=top,

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/__init__.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ._patch import *  # pylint: disable=unused-wildcard-import
 
+from ._operations import InternalOperations  # type: ignore
 from ._operations import ServicePatternsOperations  # type: ignore
 from ._operations import ConnectionsOperations  # type: ignore
 from ._operations import EvaluationsOperations  # type: ignore
@@ -25,6 +26,7 @@ from ._patch import *
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
+    "InternalOperations",
     "ServicePatternsOperations",
     "ConnectionsOperations",
     "EvaluationsOperations",

--- a/sdk/ai/azure-ai-projects-onedp/generated_tests/test_ai_project_connections_operations.py
+++ b/sdk/ai/azure-ai-projects-onedp/generated_tests/test_ai_project_connections_operations.py
@@ -42,3 +42,12 @@ class TestAIProjectConnectionsOperations(AIProjectClientTestBase):
         result = [r for r in response]
         # please add some check logic here by yourself
         # ...
+
+    @AIProjectPreparer()
+    @recorded_by_proxy
+    def test_connections_list_with_credentials(self, aiproject_endpoint):
+        client = self.create_client(endpoint=aiproject_endpoint)
+        response = client.connections.list_with_credentials()
+        result = [r for r in response]
+        # please add some check logic here by yourself
+        # ...

--- a/sdk/ai/azure-ai-projects-onedp/generated_tests/test_ai_project_connections_operations_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/generated_tests/test_ai_project_connections_operations_async.py
@@ -43,3 +43,12 @@ class TestAIProjectConnectionsOperationsAsync(AIProjectClientTestBaseAsync):
         result = [r async for r in response]
         # please add some check logic here by yourself
         # ...
+
+    @AIProjectPreparer()
+    @recorded_by_proxy_async
+    async def test_connections_list_with_credentials(self, aiproject_endpoint):
+        client = self.create_async_client(endpoint=aiproject_endpoint)
+        response = client.connections.list_with_credentials()
+        result = [r async for r in response]
+        # please add some check logic here by yourself
+        # ...

--- a/sdk/ai/azure-ai-projects-onedp/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects-onedp/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/Azure.AI.Projects
-commit: ee660236ef26d2c6a80a574982bd2a81713f0dfe
+commit: a8ac82984187d6d1141254f50b11ce771d995461
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Re-emit Python SDK from latest commit in this TypeSpec PR: https://github.com/Azure/azure-rest-api-specs/pull/33929 (this TypeSpec PR is now merged)