### PR TITLE
[Identity] Emit warning in EnvironmentCredential for user/pass

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -98,6 +98,11 @@ class EnvironmentCredential:
                 tenant_id=os.environ.get(EnvironmentVariables.AZURE_TENANT_ID),  # optional for username/password auth
                 **kwargs
             )
+            _LOGGER.warning(
+                "EnvironmentCredential is configured to use username and password authentication. "
+                "This authentication method doesn't support multifactor authentication (MFA) and is deprecated. "
+                "For more details on Microsoft Entra MFA enforcement, see https://aka.ms/azsdk/identity/mfa."
+            )
 
         if self._credential:
             _LOGGER.info("Environment is configured for %s", self._credential.__class__.__name__)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -21,8 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 class EnvironmentCredential(AsyncContextManager):
     """A credential configured by environment variables.
 
-    This credential is capable of authenticating as a service principal using a client secret or a certificate, or as
-    a user with a username and password. Configuration is attempted in this order, using these environment variables:
+    This credential is capable of authenticating as a service principal using a client secret or a certificate.
+    Configuration is attempted in this order, using these environment variables:
 
     Service principal with secret:
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.


### PR DESCRIPTION
If UsernamePasswordCredential environment variables are detected in EnvironmentCredential, a warning noting its deprecation is emitted.
