### PR TITLE
[Core] Add experimental tracing setting

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add a new setting `settings.tracing_experimental_enabled` to enable experimental tracing features. This setting can also be enabled via the `AZURE_TRACING_EXPERIMENTAL_ENABLED` environment variable.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -423,7 +423,11 @@ class Settings:
     :type log_level: PrioritizedSetting
     :cvar tracing_enabled: Whether tracing should be enabled across Azure SDKs (AZURE_TRACING_ENABLED)
     :type tracing_enabled: PrioritizedSetting
-    :cvar tracing_implementation: The tracing implementation to use (AZURE_SDK_TRACING_IMPLEMENTATION)
+    :cvar tracing_experimental_enabled: Whether experimental tracing should be enabled across Azure SDKs
+        (AZURE_TRACING_EXPERIMENTAL_ENABLED)
+    :type tracing_experimental_enabled: PrioritizedSetting
+    :cvar tracing_implementation: The tracing implementation to use when using plugin-based tracing
+        (AZURE_SDK_TRACING_IMPLEMENTATION)
     :type tracing_implementation: PrioritizedSetting
 
     :Example:
@@ -512,6 +516,13 @@ class Settings:
         env_var="AZURE_TRACING_ENABLED",
         convert=convert_tracing_enabled,
         default=None,
+    )
+
+    tracing_experimental_enabled: PrioritizedSetting[Union[str, bool], bool] = PrioritizedSetting(
+        "tracing_experimental_enabled",
+        env_var="AZURE_TRACING_EXPERIMENTAL_ENABLED",
+        convert=convert_bool,
+        default=False,
     )
 
     tracing_implementation: PrioritizedSetting[

--- a/sdk/core/azure-core/tests/test_settings.py
+++ b/sdk/core/azure-core/tests/test_settings.py
@@ -175,7 +175,7 @@ class TestConverters(object):
             m.convert_azure_cloud(10)
 
 
-_standard_settings = ["log_level", "tracing_enabled"]
+_standard_settings = ["log_level", "tracing_enabled", "tracing_experimental_enabled"]
 
 
 class TestStandardSettings(object):
@@ -194,9 +194,10 @@ class TestStandardSettings(object):
         assert m.settings.defaults_only is False
 
     def test_config(self):
-        val = m.settings.config(log_level=30, tracing_enabled=True)
+        val = m.settings.config(log_level=30, tracing_enabled=True, tracing_experimental_enabled=True)
         assert isinstance(val, tuple)
         assert val.tracing_enabled is True
+        assert val.tracing_experimental_enabled is True
         assert val.log_level == 30
         os.environ["AZURE_LOG_LEVEL"] = "debug"
         val = m.settings.config(tracing_enabled=False)
@@ -216,6 +217,7 @@ class TestStandardSettings(object):
         val: NamedTuple = m.settings.defaults
         assert val.log_level == logging.INFO
         assert val.tracing_enabled is None
+        assert val.tracing_experimental_enabled is False
         assert val.tracing_implementation is None
         assert val.azure_cloud == AzureClouds.AZURE_PUBLIC_CLOUD
 


### PR DESCRIPTION
This can be checked by SDK developers to see if non-stable attributes or semantic conventions should be emitted or not when tracing is enabled. (For example `gen_ai.*` attributes).

Users can set this setting to true if they want to enable experimental tracing features.



