### PR TITLE
remove duplicate __init__ docstring in AutoLockRenewer

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -31,6 +31,8 @@ SHORT_RENEW_SCALING_FACTOR = 0.75  # In this situation we need a "Short renew" a
 
 class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
     """Auto renew locks for messages and sessions using a background thread pool.
+    When handling multiple messages or sessions concurrently,
+    set `max_workers` high or pass a ThreadPoolExecutor with sufficient `max_workers`.
 
     :param max_lock_renewal_duration: A time in seconds that locks registered to this renewer
      should be maintained for. Default value is 300 (5 minutes).
@@ -71,24 +73,6 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
         executor: Optional[ThreadPoolExecutor] = None,
         max_workers: Optional[int] = None,
     ) -> None:
-        """Auto renew locks for messages and sessions using a background thread pool. It is recommended
-        setting max_worker to a large number or passing ThreadPoolExecutor of large max_workers number when
-        AutoLockRenewer is supposed to deal with multiple messages or sessions simultaneously.
-
-        :param max_lock_renewal_duration: A time in seconds that locks registered to this renewer
-         should be maintained for. Default value is 300 (5 minutes).
-        :type max_lock_renewal_duration: float
-        :param on_lock_renew_failure: A callback may be specified to be called when the lock is lost on the renewable
-         that is being registered. Default value is None (no callback).
-        :type on_lock_renew_failure: Optional[LockRenewFailureCallback]
-        :param executor: A user-specified thread pool. This cannot be combined with
-         setting `max_workers`.
-        :type executor: Optional[~concurrent.futures.ThreadPoolExecutor]
-        :param max_workers: Specify the maximum workers in the thread pool. If not
-         specified the number used will be derived from the core count of the environment.
-         This cannot be combined with `executor`.
-        :type max_workers: Optional[int]
-        """
         self._executor = executor or ThreadPoolExecutor(max_workers=max_workers)
         # None indicates it's unknown whether the provided executor has max workers > 1
         self._is_max_workers_greater_than_one = None if executor else (max_workers is None or max_workers > 1)


### PR DESCRIPTION
This PR removes the redundant `__init__`-level docstring from the `AutoLockRenewer` class, consolidating all parameter documentation into the class-level docstring. This change ensures that the generated documentation correctly displays only four parameter tables, avoiding duplication.

https://learn.microsoft.com/en-us/python/api/azure-servicebus/azure.servicebus.autolockrenewer?view=azure-python

- Deleted the `__init__` docstring block.
- Centralized parameter descriptions in the class-level docstring.
- Verified that Sphinx/AutoAPI generates the correct number of parameter tables.

This update prevents incorrect "required" flags on defaulted parameters and maintains clarity in the API reference documentation.

## Checklist

- [x] The pull request does not introduce breaking changes.
- [x] CHANGELOG update is not required.
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).

## General Guidelines and Best Practices

- [x] The title of the pull request is clear and informative.
- [x] There are a small number of commits, each with an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, see [this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
