### PR TITLE
fix deployment creation when registry model is used

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bugs Fixed
  - Fix for compute Instance, disableLocalAuth property should be depend on ssh public access enabled.
  - Removing Git-related properties from job properties if a PAT token is detected in the repository URL.
+ - Fix deployment creation for registry models
 
  ### Other Changes
   - Hub and Project are officially GA'd and no longer experimental.

--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_9b9dd0f330"
+  "Tag": "python/ml/azure-ai-ml_53a7a4a178"
 }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
@@ -166,7 +166,7 @@ def upload_dependencies(deployment: Deployment, orchestrators: OperationOrchestr
             if deployment.environment
             else None
         )
-    if not is_registry_id_for_resource(deployment.model.id):
+    if not is_registry_id_for_resource(deployment.model):
         deployment.model = (
             orchestrators.get_asset_arm_id(deployment.model, azureml_type=AzureMLResourceType.MODEL)
             if deployment.model

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
@@ -166,7 +166,7 @@ def upload_dependencies(deployment: Deployment, orchestrators: OperationOrchestr
             if deployment.environment
             else None
         )
-    if not is_registry_id_for_resource(deployment.model):
+    if not is_registry_id_for_resource(deployment.model.id):
         deployment.model = (
             orchestrators.get_asset_arm_id(deployment.model, azureml_type=AzureMLResourceType.MODEL)
             if deployment.model

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
@@ -332,7 +332,8 @@ class OperationOrchestrator(object):
 
     def _get_model_arm_id(self, model: Model, register_asset: bool = True) -> Union[str, Model]:
         try:
-            self._validate_datastore_name(model.path)
+            if not is_registry_id_for_resource(model.id):
+                self._validate_datastore_name(model.path)
 
             if register_asset:
                 if model.id:

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -472,6 +472,17 @@ def data_asset_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretC
         registry_name="UnsecureTest-testFeed",
     )
 
+@pytest.fixture
+def sdkv2_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretCredential) -> MLClient:
+    """return a machine learning client using default e2e testing workspace"""
+    return MLClient(
+        credential=auth,
+        subscription_id=e2e_ws_scope.subscription_id,
+        resource_group_name=e2e_ws_scope.resource_group_name,
+        logging_enable=getenv(E2E_TEST_LOGGING_ENABLED),
+        registry_name="sdkv2-testFeed",
+    )
+
 
 @pytest.fixture
 def only_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretCredential) -> MLClient:

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -472,6 +472,7 @@ def data_asset_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretC
         registry_name="UnsecureTest-testFeed",
     )
 
+
 @pytest.fixture
 def sdkv2_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretCredential) -> MLClient:
     """return a machine learning client using default e2e testing workspace"""

--- a/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
@@ -49,51 +49,56 @@ class TestOnlineDeployment(AzureRecordedTestCase):
             raise ex
         finally:
             client.online_endpoints.begin_delete(name=endpoint.name)
-    
+
     def test_online_deployment_create_when_registry_assets(
-            self, sdkv2_registry_client: MLClient, client: MLClient, randstr: Callable[[], str], rand_online_name: Callable[[], str], rand_online_deployment_name: Callable[[], str]
-        ) -> None:
-            # create a model in registry
-            model_name = randstr("test-registry-model")
-            model = Model(name=model_name, path="./tests/test_configs/deployments/model-1/model")
-            model = sdkv2_registry_client.models.create_or_update(model)
-            assert model.name == model_name
+        self,
+        sdkv2_registry_client: MLClient,
+        client: MLClient,
+        randstr: Callable[[], str],
+        rand_online_name: Callable[[], str],
+        rand_online_deployment_name: Callable[[], str],
+    ) -> None:
+        # create a model in registry
+        model_name = randstr("test-registry-model")
+        model = Model(name=model_name, path="./tests/test_configs/deployments/model-1/model")
+        model = sdkv2_registry_client.models.create_or_update(model)
+        assert model.name == model_name
 
-            # create a endpoint
-            endpoint_yaml = "tests/test_configs/deployments/online/simple_online_endpoint_mir.yaml"
-            endpoint = load_online_endpoint(endpoint_yaml)
-            endpoint_name = rand_online_name("endpoint_name")
-            endpoint.name = endpoint_name
-            endpoint = client.online_endpoints.begin_create_or_update(endpoint).result()
-            assert endpoint.name == endpoint_name
+        # create a endpoint
+        endpoint_yaml = "tests/test_configs/deployments/online/simple_online_endpoint_mir.yaml"
+        endpoint = load_online_endpoint(endpoint_yaml)
+        endpoint_name = rand_online_name("endpoint_name")
+        endpoint.name = endpoint_name
+        endpoint = client.online_endpoints.begin_create_or_update(endpoint).result()
+        assert endpoint.name == endpoint_name
 
-            # create a deployment
-            deployment_yaml = "tests/test_configs/deployments/online/online_deployment_1.yaml"
-            deployment = load_online_deployment(deployment_yaml)
-            deployment.endpoint_name = endpoint.name
-            deployment.name = rand_online_deployment_name("deployment_name")
-            deployment.model = model
-            
-            try:
-                client.online_deployments.begin_create_or_update(deployment).result()
-                dep = client.online_deployments.get(name=deployment.name, endpoint_name=endpoint.name)
-                assert dep.name == deployment.name
+        # create a deployment
+        deployment_yaml = "tests/test_configs/deployments/online/online_deployment_1.yaml"
+        deployment = load_online_deployment(deployment_yaml)
+        deployment.endpoint_name = endpoint.name
+        deployment.name = rand_online_deployment_name("deployment_name")
+        deployment.model = model
 
-                deps = client.online_deployments.list(endpoint_name=endpoint.name)
-                assert len(list(deps)) > 0
+        try:
+            client.online_deployments.begin_create_or_update(deployment).result()
+            dep = client.online_deployments.get(name=deployment.name, endpoint_name=endpoint.name)
+            assert dep.name == deployment.name
 
-                endpoint.traffic = {deployment.name: 100}
-                client.online_endpoints.begin_create_or_update(endpoint).result()
-                endpoint_updated = client.online_endpoints.get(endpoint.name)
-                assert endpoint_updated.traffic[deployment.name] == 100
-                client.online_endpoints.invoke(
-                    endpoint_name=endpoint.name,
-                    request_file="tests/test_configs/deployments/model-1/sample-request.json",
-                )
-            except Exception as ex:
-                raise ex
-            finally:
-                client.online_endpoints.begin_delete(name=endpoint.name)
+            deps = client.online_deployments.list(endpoint_name=endpoint.name)
+            assert len(list(deps)) > 0
+
+            endpoint.traffic = {deployment.name: 100}
+            client.online_endpoints.begin_create_or_update(endpoint).result()
+            endpoint_updated = client.online_endpoints.get(endpoint.name)
+            assert endpoint_updated.traffic[deployment.name] == 100
+            client.online_endpoints.invoke(
+                endpoint_name=endpoint.name,
+                request_file="tests/test_configs/deployments/model-1/sample-request.json",
+            )
+        except Exception as ex:
+            raise ex
+        finally:
+            client.online_endpoints.begin_delete(name=endpoint.name)
 
     def test_online_deployment_update(
         self, client: MLClient, rand_online_name: Callable[[], str], rand_online_deployment_name: Callable[[], str]

--- a/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
@@ -95,8 +95,6 @@ class TestOnlineDeployment(AzureRecordedTestCase):
                 endpoint_name=endpoint.name,
                 request_file="tests/test_configs/deployments/model-1/sample-request.json",
             )
-        except Exception as ex:
-            raise ex
         finally:
             client.online_endpoints.begin_delete(name=endpoint.name)
 

--- a/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/e2etests/test_online_deployment.py
@@ -2,8 +2,8 @@ from typing import Callable
 
 import pytest
 from devtools_testutils import AzureRecordedTestCase
-
-from azure.ai.ml import MLClient, load_online_deployment, load_online_endpoint
+from pathlib import Path
+from azure.ai.ml import MLClient, load_online_deployment, load_online_endpoint, load_model
 from azure.ai.ml.entities import ManagedOnlineDeployment, ManagedOnlineEndpoint, Model, CodeConfiguration, Environment
 
 
@@ -49,6 +49,51 @@ class TestOnlineDeployment(AzureRecordedTestCase):
             raise ex
         finally:
             client.online_endpoints.begin_delete(name=endpoint.name)
+    
+    def test_online_deployment_create_when_registry_assets(
+            self, sdkv2_registry_client: MLClient, client: MLClient, randstr: Callable[[], str], rand_online_name: Callable[[], str], rand_online_deployment_name: Callable[[], str]
+        ) -> None:
+            # create a model in registry
+            model_name = randstr("test-registry-model")
+            model = Model(name=model_name, path="./tests/test_configs/deployments/model-1/model")
+            model = sdkv2_registry_client.models.create_or_update(model)
+            assert model.name == model_name
+
+            # create a endpoint
+            endpoint_yaml = "tests/test_configs/deployments/online/simple_online_endpoint_mir.yaml"
+            endpoint = load_online_endpoint(endpoint_yaml)
+            endpoint_name = rand_online_name("endpoint_name")
+            endpoint.name = endpoint_name
+            endpoint = client.online_endpoints.begin_create_or_update(endpoint).result()
+            assert endpoint.name == endpoint_name
+
+            # create a deployment
+            deployment_yaml = "tests/test_configs/deployments/online/online_deployment_1.yaml"
+            deployment = load_online_deployment(deployment_yaml)
+            deployment.endpoint_name = endpoint.name
+            deployment.name = rand_online_deployment_name("deployment_name")
+            deployment.model = model
+            
+            try:
+                client.online_deployments.begin_create_or_update(deployment).result()
+                dep = client.online_deployments.get(name=deployment.name, endpoint_name=endpoint.name)
+                assert dep.name == deployment.name
+
+                deps = client.online_deployments.list(endpoint_name=endpoint.name)
+                assert len(list(deps)) > 0
+
+                endpoint.traffic = {deployment.name: 100}
+                client.online_endpoints.begin_create_or_update(endpoint).result()
+                endpoint_updated = client.online_endpoints.get(endpoint.name)
+                assert endpoint_updated.traffic[deployment.name] == 100
+                client.online_endpoints.invoke(
+                    endpoint_name=endpoint.name,
+                    request_file="tests/test_configs/deployments/model-1/sample-request.json",
+                )
+            except Exception as ex:
+                raise ex
+            finally:
+                client.online_endpoints.begin_delete(name=endpoint.name)
 
     def test_online_deployment_update(
         self, client: MLClient, rand_online_name: Callable[[], str], rand_online_deployment_name: Callable[[], str]


### PR DESCRIPTION
# Description

Deployment created using registry models were failing due datastore validation which is not needed in case of registry models.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
