### PR TITLE
[Identity] Emit warning in EnvironmentCredential for user/pass

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
@@ -63,12 +63,16 @@ class UsernamePasswordCredential(InteractiveCredential):
     """
 
     def __init__(self, client_id: str, username: str, password: str, **kwargs: Any) -> None:
-        warnings.warn(
-            f"{self.__class__.__name__} is deprecated, as is it doesn't support multifactor "
-            "authentication (MFA). For more details, see https://aka.ms/azsdk/identity/mfa.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
+        if not kwargs.pop("_silence_deprecation_warning", False):
+            # Only emit the deprecation warning if the credential was constructed directly and not via
+            # EnvironmentCredential since EnvironmentCredential will emit its own deprecation
+            # warning if it is used to create a UsernamePasswordCredential.
+            warnings.warn(
+                f"{self.__class__.__name__} is deprecated, as it doesn't support multifactor "
+                "authentication (MFA). For more details, see https://aka.ms/azsdk/identity/mfa.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
         # The base class will accept an AuthenticationRecord, allowing this credential to authenticate silently the
         # first time it's asked for a token. However, we want to ensure this first authentication is not silent, to
         # validate the given password. This class therefore doesn't document the authentication_record argument, and we

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -21,8 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 class EnvironmentCredential(AsyncContextManager):
     """A credential configured by environment variables.
 
-    This credential is capable of authenticating as a service principal using a client secret or a certificate, or as
-    a user with a username and password. Configuration is attempted in this order, using these environment variables:
+    This credential is capable of authenticating as a service principal using a client secret or a certificate.
+    Configuration is attempted in this order, using these environment variables:
 
     Service principal with secret:
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.

--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -175,3 +175,21 @@ def test_username_password_configuration():
     assert kwargs["password"] == password
     assert kwargs["tenant_id"] == tenant_id
     assert kwargs["foo"] == bar
+
+
+def test_username_password_deprecation_warning():
+    """the credential should pass expected values and any keyword arguments to its inner credential"""
+
+    client_id = "client-id"
+    username = "username"
+    password = "password"
+    environment = {
+        EnvironmentVariables.AZURE_CLIENT_ID: client_id,
+        EnvironmentVariables.AZURE_USERNAME: username,
+        EnvironmentVariables.AZURE_PASSWORD: password,
+    }
+
+    with mock.patch.dict("os.environ", environment, clear=True):
+        # the deprecation warning is only raised when the credential is used
+        with pytest.deprecated_call():
+            EnvironmentCredential()


### PR DESCRIPTION
If UsernamePasswordCredential environment variables are detected in EnvironmentCredential and DefaultAzureCredential, we now ensure that a warning noting its deprecation is emitted with the correct stacklevel that point's to the user's credential instantiation.

Without this, by default, the user won't see the warning emitted in the UsernamePasswordCredential initializer if UsernamePasswordCredential wasn't directly instantiated by the user.
