### PR TITLE
max retry for auto toolcalls

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -13,6 +13,7 @@ import io
 import logging
 import os
 import time
+import json
 from pathlib import Path
 from typing import (
     IO,
@@ -664,6 +665,7 @@ class AgentsOperations(AgentsOperationsGenerated):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._function_tool = _models.AsyncFunctionTool(set())
+        self._function_tool_max_retry = 10
 
     # pylint: disable=arguments-differ
     @overload
@@ -1622,6 +1624,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         )
 
         # Monitor and process the run status
+        current_retry = 0
         while run.status in [
             RunStatus.QUEUED,
             RunStatus.IN_PROGRESS,
@@ -1643,6 +1646,17 @@ class AgentsOperations(AgentsOperationsGenerated):
                     toolset.add(self._function_tool)
                     tool_outputs = await toolset.execute_tool_calls(tool_calls)
 
+                    if self._has_errors_in_toolcalls_output(tool_outputs):
+                        if current_retry >= self._function_tool_max_retry:
+                            logging.warning(
+                                f"Tool outputs contain errors - reaching max retry {self._function_tool_max_retry}"
+                            )
+                            await self.cancel_run(thread_id=thread_id, run_id=run.id)
+                            break
+                        else:
+                            logging.warning(f"Tool outputs contain errors - retrying")
+                            current_retry += 1
+
                     logging.info("Tool outputs: %s", tool_outputs)
                     if tool_outputs:
                         await self.submit_tool_outputs_to_run(
@@ -1652,6 +1666,25 @@ class AgentsOperations(AgentsOperationsGenerated):
             logging.info("Current run status: %s", run.status)
 
         return run
+
+    def _has_errors_in_toolcalls_output(self, tool_outputs: List[Dict]) -> bool:
+        """
+        Check if any tool output contains an error.
+
+        :param List[Dict] tool_outputs: A list of tool outputs to check.
+        :return: True if any output contains an error, False otherwise.
+        :rtype: bool
+        """
+        for tool_output in tool_outputs:
+            output = tool_output.get("output")
+            if isinstance(output, str):
+                try:
+                    output_json = json.loads(output)
+                    if "error" in output_json:
+                        return True
+                except json.JSONDecodeError:
+                    continue
+        return False
 
     @overload
     async def create_stream(
@@ -2090,6 +2123,8 @@ class AgentsOperations(AgentsOperationsGenerated):
 
         if not event_handler:
             event_handler = cast(_models.BaseAsyncAgentEventHandlerT, _models.AsyncAgentEventHandler())
+        if isinstance(event_handler, _models.AsyncAgentEventHandler):
+            event_handler.set_max_retry(self._function_tool_max_retry)
 
         return _models.AsyncAgentRunStream(response_iterator, self._handle_submit_tool_outputs, event_handler)
 
@@ -2320,13 +2355,14 @@ class AgentsOperations(AgentsOperationsGenerated):
         event_handler.initialize(response_iterator, self._handle_submit_tool_outputs)
 
     async def _handle_submit_tool_outputs(
-        self, run: _models.ThreadRun, event_handler: _models.BaseAsyncAgentEventHandler
-    ) -> None:
+        self, run: _models.ThreadRun, event_handler: _models.BaseAsyncAgentEventHandler, submit_with_error: bool
+    ) -> Any:
+        tool_outputs = []
         if isinstance(run.required_action, _models.SubmitToolOutputsAction):
             tool_calls = run.required_action.submit_tool_outputs.tool_calls
             if not tool_calls:
                 logger.debug("No tool calls to execute.")
-                return
+                return tool_outputs
 
             # We need tool set only if we are executing local function. In case if
             # the tool is azure_function we just need to wait when it will be finished.
@@ -2338,11 +2374,20 @@ class AgentsOperations(AgentsOperationsGenerated):
                 toolset.add(self._function_tool)
                 tool_outputs = await toolset.execute_tool_calls(tool_calls)
 
+                if self._has_errors_in_toolcalls_output(tool_outputs):
+                    if submit_with_error:
+                        logging.warning(f"Tool outputs contain errors - retrying")
+                    else:
+                        logging.warning(f"Tool outputs contain errors - reaching max retry limit")
+                        await self.cancel_run(thread_id=run.thread_id, run_id=run.id)
+                        return tool_outputs
+
                 logger.info("Tool outputs: %s", tool_outputs)
                 if tool_outputs:
                     await self.submit_tool_outputs_to_stream(
                         thread_id=run.thread_id, run_id=run.id, tool_outputs=tool_outputs, event_handler=event_handler
                     )
+        return tool_outputs
 
     # pylint: disable=arguments-differ
     @overload
@@ -3128,25 +3173,31 @@ class AgentsOperations(AgentsOperationsGenerated):
         return await super().delete_agent(agent_id, **kwargs)
 
     @overload
-    def enable_auto_function_calls(self, *, functions: Set[Callable[..., Any]]) -> None:
+    def enable_auto_function_calls(self, *, functions: Set[Callable[..., Any]], max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword functions: A set of callable functions to be used as tools.
         :type functions: Set[Callable[..., Any]]
         """
 
     @overload
-    def enable_auto_function_calls(self, *, function_tool: _models.AsyncFunctionTool) -> None:
+    def enable_auto_function_calls(self, *, function_tool: _models.AsyncFunctionTool, max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword function_tool: An AsyncFunctionTool object representing the tool to be used.
         :type function_tool: Optional[_models.AsyncFunctionTool]
         """
 
     @overload
-    def enable_auto_function_calls(self, *, toolset: _models.AsyncToolSet) -> None:
+    def enable_auto_function_calls(self, *, toolset: _models.AsyncToolSet, max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword toolset: An AsyncToolSet object representing the set of tools to be used.
         :type toolset: Optional[_models.AsyncToolSet]
         """
@@ -3157,9 +3208,12 @@ class AgentsOperations(AgentsOperationsGenerated):
         functions: Optional[Set[Callable[..., Any]]] = None,
         function_tool: Optional[_models.AsyncFunctionTool] = None,
         toolset: Optional[_models.AsyncToolSet] = None,
+        max_retry: int = 10,
     ) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword functions: A set of callable functions to be used as tools.
         :type functions: Set[Callable[..., Any]]
         :keyword function_tool: An AsyncFunctionTool object representing the tool to be used.
@@ -3174,6 +3228,8 @@ class AgentsOperations(AgentsOperationsGenerated):
         elif toolset:
             tool = toolset.get_tool(_models.AsyncFunctionTool)
             self._function_tool = tool
+
+        self._function_tool_max_retry = max_retry
 
 
 class _SyncCredentialWrapper(TokenCredential):

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
@@ -100,6 +100,26 @@ logger = logging.getLogger(__name__)
 StreamEventData = Union["MessageDeltaChunk", "ThreadMessage", ThreadRun, RunStep, str]
 
 
+def _has_errors_in_toolcalls_output(tool_outputs: List[Dict]) -> bool:
+    """
+    Check if any tool output contains an error.
+
+    :param List[Dict] tool_outputs: A list of tool outputs to check.
+    :return: True if any output contains an error, False otherwise.
+    :rtype: bool
+    """
+    for tool_output in tool_outputs:
+        output = tool_output.get("output")
+        if isinstance(output, str):
+            try:
+                output_json = json.loads(output)
+                if "error" in output_json:
+                    return True
+            except json.JSONDecodeError:
+                continue
+    return False
+
+
 def _filter_parameters(model_class: Type, parameters: Dict[str, Any]) -> Dict[str, Any]:
     """
     Remove the parameters, non present in class public fields; return shallow copy of a dictionary.
@@ -736,7 +756,7 @@ class FunctionTool(BaseFunctionTool):
         try:
             function, parsed_arguments = self._get_func_and_args(tool_call)
             return function(**parsed_arguments) if parsed_arguments else function()
-        except TypeError as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             error_message = f"Error executing function '{tool_call.function.name}': {e}"
             logging.error(error_message)
             # Return error message as JSON string back to agent in order to make possible self
@@ -747,13 +767,12 @@ class FunctionTool(BaseFunctionTool):
 class AsyncFunctionTool(BaseFunctionTool):
 
     async def execute(self, tool_call: RequiredFunctionToolCall) -> Any:  # pylint: disable=invalid-overridden-method
-        function, parsed_arguments = self._get_func_and_args(tool_call)
-
         try:
+            function, parsed_arguments = self._get_func_and_args(tool_call)
             if inspect.iscoroutinefunction(function):
                 return await function(**parsed_arguments) if parsed_arguments else await function()
             return function(**parsed_arguments) if parsed_arguments else function()
-        except TypeError as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             error_message = f"Error executing function '{tool_call.function.name}': {e}"
             logging.error(error_message)
             # Return error message as JSON string back to agent in order to make possible self correction
@@ -1555,13 +1574,13 @@ class BaseAgentEventHandler(Iterator[T]):
 
     def __init__(self) -> None:
         self.response_iterator: Optional[Iterator[bytes]] = None
-        self.submit_tool_outputs: Optional[Callable[[ThreadRun, "BaseAgentEventHandler[T]"], None]] = None
+        self.submit_tool_outputs: Optional[Callable[[ThreadRun, "BaseAgentEventHandler[T]", bool], Any]]
         self.buffer: Optional[bytes] = None
 
     def initialize(
         self,
         response_iterator: Iterator[bytes],
-        submit_tool_outputs: Callable[[ThreadRun, "BaseAgentEventHandler[T]"], None],
+        submit_tool_outputs: Callable[[ThreadRun, "BaseAgentEventHandler[T]", bool], Any],
     ) -> None:
         self.response_iterator = (
             itertools.chain(self.response_iterator, response_iterator) if self.response_iterator else response_iterator
@@ -1613,17 +1632,33 @@ class BaseAgentEventHandler(Iterator[T]):
 
 
 class AsyncAgentEventHandler(BaseAsyncAgentEventHandler[Tuple[str, StreamEventData, Optional[EventFunctionReturnT]]]):
+    def __init__(self) -> None:
+        super().__init__()
+        self._max_retry = 10
+        self.current_retry = 0
+
+    def set_max_retry(self, max_retry: int) -> None:
+        """
+        Set the maximum number of retries for tool output submission.
+
+        :param int max_retry: The maximum number of retries.
+        """
+        self._max_retry = max_retry
 
     async def _process_event(self, event_data_str: str) -> Tuple[str, StreamEventData, Optional[EventFunctionReturnT]]:
+
         event_type, event_data_obj = _parse_event(event_data_str)
         if (
             isinstance(event_data_obj, ThreadRun)
             and event_data_obj.status == "requires_action"
             and isinstance(event_data_obj.required_action, SubmitToolOutputsAction)
         ):
-            await cast(Callable[[ThreadRun, "BaseAsyncAgentEventHandler"], Awaitable[None]], self.submit_tool_outputs)(
-                event_data_obj, self
-            )
+            tool_output = await cast(
+                Callable[[ThreadRun, "BaseAsyncAgentEventHandler", bool], Awaitable[Any]], self.submit_tool_outputs
+            )(event_data_obj, self, self.current_retry < self._max_retry)
+
+            if _has_errors_in_toolcalls_output(tool_output):
+                self.current_retry += 1
 
         func_rt: Optional[EventFunctionReturnT] = None
         try:
@@ -1726,6 +1761,18 @@ class AsyncAgentEventHandler(BaseAsyncAgentEventHandler[Tuple[str, StreamEventDa
 
 
 class AgentEventHandler(BaseAgentEventHandler[Tuple[str, StreamEventData, Optional[EventFunctionReturnT]]]):
+    def __init__(self) -> None:
+        super().__init__()
+        self._max_retry = 10
+        self.current_retry = 0
+
+    def set_max_retry(self, max_retry: int) -> None:
+        """
+        Set the maximum number of retries for tool output submission.
+
+        :param int max_retry: The maximum number of retries.
+        """
+        self._max_retry = max_retry
 
     def _process_event(self, event_data_str: str) -> Tuple[str, StreamEventData, Optional[EventFunctionReturnT]]:
 
@@ -1735,9 +1782,12 @@ class AgentEventHandler(BaseAgentEventHandler[Tuple[str, StreamEventData, Option
             and event_data_obj.status == "requires_action"
             and isinstance(event_data_obj.required_action, SubmitToolOutputsAction)
         ):
-            cast(Callable[[ThreadRun, "BaseAgentEventHandler"], Awaitable[None]], self.submit_tool_outputs)(
-                event_data_obj, self
+            tool_output = cast(Callable[[ThreadRun, "BaseAgentEventHandler", bool], Any], self.submit_tool_outputs)(
+                event_data_obj, self, self.current_retry < self._max_retry
             )
+
+            if _has_errors_in_toolcalls_output(tool_output):
+                self.current_retry += 1
 
         func_rt: Optional[EventFunctionReturnT] = None
         try:
@@ -1836,7 +1886,7 @@ class AsyncAgentRunStream(Generic[BaseAsyncAgentEventHandlerT]):
     def __init__(
         self,
         response_iterator: AsyncIterator[bytes],
-        submit_tool_outputs: Callable[[ThreadRun, BaseAsyncAgentEventHandlerT], Awaitable[None]],
+        submit_tool_outputs: Callable[[ThreadRun, BaseAsyncAgentEventHandlerT, bool], Awaitable[Any]],
         event_handler: BaseAsyncAgentEventHandlerT,
     ):
         self.response_iterator = response_iterator
@@ -1844,7 +1894,7 @@ class AsyncAgentRunStream(Generic[BaseAsyncAgentEventHandlerT]):
         self.submit_tool_outputs = submit_tool_outputs
         self.event_handler.initialize(
             self.response_iterator,
-            cast(Callable[[ThreadRun, BaseAsyncAgentEventHandler], Awaitable[None]], submit_tool_outputs),
+            cast(Callable[[ThreadRun, BaseAsyncAgentEventHandler], Awaitable[Any]], submit_tool_outputs),
         )
 
     async def __aenter__(self):
@@ -1862,7 +1912,7 @@ class AgentRunStream(Generic[BaseAgentEventHandlerT]):
     def __init__(
         self,
         response_iterator: Iterator[bytes],
-        submit_tool_outputs: Callable[[ThreadRun, BaseAgentEventHandlerT], None],
+        submit_tool_outputs: Callable[[ThreadRun, BaseAgentEventHandlerT, bool], Any],
         event_handler: BaseAgentEventHandlerT,
     ):
         self.response_iterator = response_iterator
@@ -1870,7 +1920,7 @@ class AgentRunStream(Generic[BaseAgentEventHandlerT]):
         self.submit_tool_outputs = submit_tool_outputs
         self.event_handler.initialize(
             self.response_iterator,
-            cast(Callable[[ThreadRun, BaseAgentEventHandler], None], submit_tool_outputs),
+            cast(Callable[[ThreadRun, BaseAgentEventHandler, bool], Any], submit_tool_outputs),
         )
 
     def __enter__(self):

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -12,6 +12,7 @@ import logging
 import os
 import sys
 import time
+import json
 from pathlib import Path
 from typing import (
     IO,
@@ -844,6 +845,7 @@ class AgentsOperations(AgentsOperationsGenerated):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._function_tool = _models.FunctionTool(set())
+        self._function_tool_max_retry = 10
 
     # pylint: disable=arguments-differ
     @overload
@@ -1803,6 +1805,7 @@ class AgentsOperations(AgentsOperationsGenerated):
         )
 
         # Monitor and process the run status
+        current_retry = 0
         while run.status in [
             RunStatus.QUEUED,
             RunStatus.IN_PROGRESS,
@@ -1826,13 +1829,46 @@ class AgentsOperations(AgentsOperationsGenerated):
                     toolset.add(self._function_tool)
                     tool_outputs = toolset.execute_tool_calls(tool_calls)
 
+                    if self._has_errors_in_toolcalls_output(tool_outputs):
+                        if current_retry >= self._function_tool_max_retry:
+                            logging.warning(
+                                f"Tool outputs contain errors - reaching max retry {self._function_tool_max_retry}"
+                            )
+                            self.cancel_run(thread_id=thread_id, run_id=run.id)
+                            break
+                        else:
+                            logging.warning(f"Tool outputs contain errors - retrying")
+                            current_retry += 1
+
                     logging.info("Tool outputs: %s", tool_outputs)
                     if tool_outputs:
-                        self.submit_tool_outputs_to_run(thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs)
+                        run2 = self.submit_tool_outputs_to_run(
+                            thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs
+                        )
+                        logging.info("Tool outputs submitted to run: %s", run2.id)
 
             logging.info("Current run status: %s", run.status)
 
         return run
+
+    def _has_errors_in_toolcalls_output(self, tool_outputs: List[Dict]) -> bool:
+        """
+        Check if any tool output contains an error.
+
+        :param List[Dict] tool_outputs: A list of tool outputs to check.
+        :return: True if any output contains an error, False otherwise.
+        :rtype: bool
+        """
+        for tool_output in tool_outputs:
+            output = tool_output.get("output")
+            if isinstance(output, str):
+                try:
+                    output_json = json.loads(output)
+                    if "error" in output_json:
+                        return True
+                except json.JSONDecodeError:
+                    continue
+        return False
 
     @overload
     def create_stream(
@@ -2272,6 +2308,8 @@ class AgentsOperations(AgentsOperationsGenerated):
 
         if not event_handler:
             event_handler = cast(_models.BaseAgentEventHandlerT, _models.AgentEventHandler())
+        if isinstance(event_handler, _models.AgentEventHandler):
+            event_handler.set_max_retry(self._function_tool_max_retry)
         return _models.AgentRunStream(response_iterator, self._handle_submit_tool_outputs, event_handler)
 
     # pylint: disable=arguments-differ
@@ -2508,12 +2546,15 @@ class AgentsOperations(AgentsOperationsGenerated):
 
         event_handler.initialize(response_iterator, self._handle_submit_tool_outputs)
 
-    def _handle_submit_tool_outputs(self, run: _models.ThreadRun, event_handler: _models.BaseAgentEventHandler) -> None:
+    def _handle_submit_tool_outputs(
+        self, run: _models.ThreadRun, event_handler: _models.BaseAgentEventHandler, submit_with_error: bool
+    ) -> Any:
+        tool_outputs = []
         if isinstance(run.required_action, _models.SubmitToolOutputsAction):
             tool_calls = run.required_action.submit_tool_outputs.tool_calls
             if not tool_calls:
                 logger.debug("No tool calls to execute.")
-                return
+                return tool_outputs
 
             # We need tool set only if we are executing local function. In case if
             # the tool is azure_function we just need to wait when it will be finished.
@@ -2526,6 +2567,14 @@ class AgentsOperations(AgentsOperationsGenerated):
                 toolset.add(self._function_tool)
                 tool_outputs = toolset.execute_tool_calls(tool_calls)
 
+                if self._has_errors_in_toolcalls_output(tool_outputs):
+                    if submit_with_error:
+                        logging.warning(f"Tool outputs contain errors - retrying")
+                    else:
+                        logging.warning(f"Tool outputs contain errors - reaching max retry limit")
+                        self.cancel_run(thread_id=run.thread_id, run_id=run.id)
+                        return tool_outputs
+
                 logger.info("Tool outputs: %s", tool_outputs)
                 if tool_outputs:
                     self.submit_tool_outputs_to_stream(
@@ -2534,6 +2583,7 @@ class AgentsOperations(AgentsOperationsGenerated):
                         tool_outputs=tool_outputs,
                         event_handler=event_handler,
                     )
+        return tool_outputs
 
     # pylint: disable=arguments-differ
     @overload
@@ -3309,27 +3359,39 @@ class AgentsOperations(AgentsOperationsGenerated):
         return super().delete_agent(agent_id, **kwargs)
 
     @overload
-    def enable_auto_function_calls(self, *, functions: Set[Callable[..., Any]]) -> None:
+    def enable_auto_function_calls(self, *, functions: Set[Callable[..., Any]], max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword functions: A set of callable functions to be used as tools.
         :type functions: Set[Callable[..., Any]]
+        :keyword max_retry: Maximum number of errors allowed and retry per run or stream. Default value is 10.
+        :type max_retry: int
         """
 
     @overload
-    def enable_auto_function_calls(self, *, function_tool: _models.FunctionTool) -> None:
+    def enable_auto_function_calls(self, *, function_tool: _models.FunctionTool, max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword function_tool: A FunctionTool object representing the tool to be used.
         :type function_tool: Optional[_models.FunctionTool]
+        :keyword max_retry: Maximum number of errors allowed and retry per run or stream. Default value is 10.
+        :type max_retry: int
         """
 
     @overload
-    def enable_auto_function_calls(self, *, toolset: _models.ToolSet) -> None:
+    def enable_auto_function_calls(self, *, toolset: _models.ToolSet, max_retry: int = 10) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword toolset: A ToolSet object representing the set of tools to be used.
         :type toolset: Optional[_models.ToolSet]
+        :keyword max_retry: Maximum number of errors allowed and retry per run or stream. Default value is 10.
+        :type max_retry: int
         """
 
     @distributed_trace
@@ -3339,15 +3401,20 @@ class AgentsOperations(AgentsOperationsGenerated):
         functions: Optional[Set[Callable[..., Any]]] = None,
         function_tool: Optional[_models.FunctionTool] = None,
         toolset: Optional[_models.ToolSet] = None,
+        max_retry: int = 10,
     ) -> None:
         """Enables tool calls to be executed automatically during create_and_process_run or streaming.
         If this is not set, functions must be called manually.
+        If automatic function calls fail, the agents will receive error messages allowing it to retry with another
+        function call or figure out the answer with its knowledge.
         :keyword functions: A set of callable functions to be used as tools.
         :type functions: Set[Callable[..., Any]]
         :keyword function_tool: A FunctionTool object representing the tool to be used.
         :type function_tool: Optional[_models.FunctionTool]
         :keyword toolset: A ToolSet object representing the set of tools to be used.
         :type toolset: Optional[_models.ToolSet]
+        :keyword max_retry: Maximum number of errors allowed and retry per run or stream. Default value is 10.
+        :type max_retry: int
         """
         if functions:
             self._function_tool = _models.FunctionTool(functions)
@@ -3356,6 +3423,8 @@ class AgentsOperations(AgentsOperationsGenerated):
         elif toolset:
             tool = toolset.get_tool(_models.FunctionTool)
             self._function_tool = tool
+
+        self._function_tool_max_retry = max_retry
 
 
 __all__: List[str] = [

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_run_with_toolset.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_run_with_toolset.py
@@ -45,7 +45,7 @@ with project_client:
     toolset.add(code_interpreter)
 
     # To enable tool calls executed automatically
-    project_client.agents.enable_auto_function_calls(toolset=toolset)
+    project_client.agents.enable_auto_function_calls(toolset=toolset, max_retry=3)
 
     agent = project_client.agents.create_agent(
         model=os.environ["MODEL_DEPLOYMENT_NAME"],

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_models.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_models.py
@@ -175,8 +175,17 @@ class TestAgentEventHandler:
     class MyAgentEventHandler(AgentEventHandler[None]):
         pass
 
+    @pytest.mark.parametrize(
+        "has_errors_in_toolcalls_output,expected_current_retry",
+        [
+            (True, 1),
+            (False, 0),
+        ],
+    )
     @patch("azure.ai.projects.models._patch._parse_event")
-    def test_tool_calls(self, mock_parse_event: Mock):
+    def test_tool_calls(
+        self, mock_parse_event: Mock, has_errors_in_toolcalls_output: bool, expected_current_retry: int
+    ):
         # Test if the event type and status are met, submit function calls.
         submit_tool_outputs = Mock()
         handler = self.MyAgentEventHandler()
@@ -188,13 +197,18 @@ class TestAgentEventHandler:
         event_obj.required_action = SubmitToolOutputsAction({})
         mock_parse_event.return_value = ("", event_obj)
 
-        for _ in handler:
-            handler.until_done()
+        with patch(
+            "azure.ai.projects.models._patch._has_errors_in_toolcalls_output",
+            return_value=has_errors_in_toolcalls_output,
+        ):
+            for _ in handler:
+                handler.until_done()
 
         assert mock_parse_event.call_count == 1
         assert mock_parse_event.call_args[0][0] == "event"
         assert submit_tool_outputs.call_count == 1
-        assert submit_tool_outputs.call_args[0] == (event_obj, handler)
+        assert submit_tool_outputs.call_args[0] == (event_obj, handler, True)
+        assert handler.current_retry == expected_current_retry
 
     @patch("azure.ai.projects.models._patch.AgentEventHandler.on_unhandled_event")
     @pytest.mark.parametrize("event_type", [e.value for e in AgentStreamEvent])

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_operations_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_operations_async.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.aio.operations import AgentsOperations
 from azure.ai.projects.models import (
+    AsyncAgentEventHandler,
     AsyncFunctionTool,
     AsyncToolSet,
     CodeInterpreterTool,
@@ -52,6 +53,10 @@ def function2():
     return "output from the second agent"
 
 
+def function_throw_exception():
+    raise ValueError("Just a minute")
+
+
 class TestAgentsOperations:
     """Tests for agent operations"""
 
@@ -67,7 +72,6 @@ class TestAgentsOperations:
             credential=AsyncMock(),
         )
         client.agents.submit_tool_outputs_to_run = AsyncMock()
-        client.agents.submit_tool_outputs_to_stream = AsyncMock()
         # Set sync method to avoid warning.
         client.agents._client.format_url = MagicMock()
         return client
@@ -219,16 +223,30 @@ class TestAgentsOperations:
         self, project_client: AgentsOperations, toolset1: Optional[AsyncToolSet], toolset2: Optional[AsyncToolSet]
     ) -> None:
         """Set the tool calls for the agent."""
+        max_retry = 3
         if toolset1 and toolset2:
             function_in_toolset1 = set(toolset1.get_tool(tool_type=AsyncFunctionTool)._functions.values())
             function_in_toolset2 = set(toolset2.get_tool(tool_type=AsyncFunctionTool)._functions.values())
             function_tool = AsyncFunctionTool(function_in_toolset1)
             function_tool.add_functions(function_in_toolset2)
-            project_client.enable_auto_function_calls(function_tool=function_tool)
+            project_client.enable_auto_function_calls(function_tool=function_tool, max_retry=max_retry)
         elif toolset1:
-            project_client.enable_auto_function_calls(toolset=toolset1)
+            project_client.enable_auto_function_calls(toolset=toolset1, max_retry=max_retry)
         elif toolset2:
-            project_client.enable_auto_function_calls(toolset=toolset2)
+            project_client.enable_auto_function_calls(toolset=toolset2, max_retry=max_retry)
+
+    def _read_file(self, file_name: str) -> str:
+        with open(os.path.join(os.path.dirname(__file__), "assets", f"{file_name}.txt"), "r") as file:
+            return file.read()
+
+    async def _convert_to_byte_iterator(self, input: str) -> AsyncIterator[bytes]:
+        yield input.encode()
+
+    def _get_stream_with_tool_calls(self) -> AsyncIterator[bytes]:
+        fetch_current_datetime_and_weather_stream_response = self._read_file(
+            "fetch_current_datetime_and_weather_stream_response"
+        )
+        return self._convert_to_byte_iterator(fetch_current_datetime_and_weather_stream_response)
 
     @pytest.mark.asyncio
     @patch("azure.ai.projects.aio._patch.AsyncPipelineClient")
@@ -404,6 +422,94 @@ class TestAgentsOperations:
                 self._assert_tool_call(project_client.agents.submit_tool_outputs_to_run, "run123", toolset1)
 
     @pytest.mark.asyncio
+    @patch("azure.ai.projects.aio.operations._operations.AgentsOperations.cancel_run")
+    @patch("azure.ai.projects.aio._patch.AsyncPipelineClient")
+    async def test_auto_function_calls_retry(
+        self,
+        mock_pipeline_client_gen: AsyncMock,
+        mock_cancel_run: AsyncMock,
+    ) -> None:
+        """Test azure function with toolset."""
+        toolset = self.get_toolset("file_for_agent1", function_throw_exception)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = [
+            self._get_agent_json("first", "123", toolset),
+            self._get_run("run1", toolset),  # create_run
+            self._get_run("run2", toolset),  # get_run
+            self._get_run("run3", toolset),  # get_run
+            self._get_run("run4", toolset),  # get_run
+            self._get_run("run5", toolset),  # get_run
+        ]
+        mock_pipeline_response = AsyncMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = AsyncMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        project_client = self.get_mock_client()
+        async with project_client:
+            # Check that pipelines are created as expected.
+            self._set_toolcalls(project_client.agents, toolset, None)
+            agent1 = await project_client.agents.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful assistant",
+                toolset=toolset,
+            )
+            # Create run with new tool set, which also can be none.
+            await project_client.agents.create_and_process_run(thread_id="some_thread_id", agent_id=agent1.id)
+            assert mock_cancel_run.call_count == 1
+            assert project_client.agents.submit_tool_outputs_to_run.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.projects.aio.operations._operations.AgentsOperations.cancel_run")
+    @patch("azure.ai.projects.aio._patch.AsyncPipelineClient")
+    async def test_auto_function_calls_in_stream(
+        self,
+        mock_pipeline_client_gen: AsyncMock,
+        mock_cancel_run: AsyncMock,
+    ) -> None:
+        """Test azure function with toolset."""
+        toolset = self.get_toolset("file_for_agent1", function_throw_exception)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = [
+            self._get_agent_json("first", "123", toolset),
+        ]
+
+        mock_pipeline_response = AsyncMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = AsyncMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        project_client = self.get_mock_client()
+        async with project_client:
+            # Check that pipelines are created as expected.
+            self._set_toolcalls(project_client.agents, toolset, None)
+            agent1 = await project_client.agents.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful assistant",
+                toolset=toolset,
+            )
+            # Create run with new tool set, which also can be none.
+
+            mock_response.iter_bytes.side_effect = [
+                self._get_stream_with_tool_calls(),  # create_run
+                self._get_stream_with_tool_calls(),  # submit_tool_outputs_to_run
+                self._get_stream_with_tool_calls(),  # submit_tool_outputs_to_run
+                self._get_stream_with_tool_calls(),  # submit_tool_outputs_to_run
+            ]
+
+            event_handler = AsyncAgentEventHandler()
+            async with await project_client.agents.create_stream(
+                thread_id="some_thread_id", agent_id=agent1.id, event_handler=event_handler
+            ) as stream:
+                await stream.until_done()
+            assert mock_cancel_run.call_count == 1
+            assert event_handler.current_retry == 4
+
+    @pytest.mark.asyncio
     @patch("azure.ai.projects.aio._patch.AsyncPipelineClient")
     @pytest.mark.parametrize(
         "file_agent_1,add_azure_fn",
@@ -504,6 +610,8 @@ class TestAgentsOperations:
         mock_pipeline_client_gen.return_value = mock_pipeline
         project_client = self.get_mock_client()
         async with project_client:
+            project_client.agents.submit_tool_outputs_to_stream = AsyncMock()
+
             self._set_toolcalls(project_client.agents, toolset, None)
             # Check that pipelines are created as expected.
             agent1 = await project_client.agents.create_agent(


### PR DESCRIPTION
Allow dev to configure max number of retry function calls by submitting errors as response and let agent raise action required again.