### PR TITLE
fix: add entry name to empty path job error msg

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -1291,7 +1291,7 @@ class JobOperations(_ScopeDependentOperations):
 
         # path can be empty if the job was created from builder functions
         if isinstance(entry, Input) and not entry.path:
-            msg = "Input path can't be empty for jobs."
+            msg = "Input path can't be empty for jobs. Input entry: {}".format(entry)
             raise ValidationException(
                 message=msg,
                 target=ErrorTarget.JOB,


### PR DESCRIPTION
# Description

Nowadays I spend about couple hours to understand, why my job can not be submitted, only one informative error message:
```
 File "/home/tengo/Documents/Competo/mp-ds-chars-parser/.venv/lib/python3.12/site-packages/azure/ai/ml/operations/_job_operations.py", line 1278, in _resolve_job_input
    raise ValidationException(
azure.ai.ml.exceptions.ValidationException: Input path can't be empty for jobs.
```
But which Input entry?? I had tens of them and it was a challenge to identify(actually, I passed `Input` type of `integer`). So just added Input entry name to the err message.
