### PR TITLE
[Deprecation] remove deprecated pkg from main

### DIFF
--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -29,14 +29,14 @@ Clone the `azure-sdk-for-python` repository and update the following files of yo
 
 A disclaimer should be added indicating end-of-life date (EOLDate) of the package and directing to a replacement package and migration guide as necessary.
   - The EOLDate should be in the format `MM-DD-YYYY`.
-    - If there is no replacement package, the package EOLDate should be the service retirement date. This does not necessarily need to be the same as the release date in the CHANGELOG.md, since the package may be deprecated before/after the service is retired.
+    - If there is no replacement package, the package EOLDate should be the service retirement date.
     - If there is a replacement package (or repo), the EOLDate should be the same as the deprecation release date of the old package in the CHANGELOG.md.
     - Service retirement dates MAY be listed [here](https://aka.ms/servicesretirementworkbook), where retiring feature says 'Entire service'.
   - The link to the replacement package should be a PyPI link: `https://pypi.org/project/azure-mynewpackage/`.
   - The link to the migration guide should be a link in the format `https://aka.ms/azsdk/python/migrate/my-new-package`. To create this aka.ms link, follow the "How to create aka.ms links" section [here](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/233/Azure-SDK-AKA.ms-Links?anchor=how-to-create-aka.ms-links).
     - **NOTE**: You may decide to postpone or skip writing a migration guide based on downloads numbers (found on [pypistats](https://pypistats.org/), [pepy.tech](https://www.pepy.tech/), etc.) and internal knowledge of the usage of the package.
 
-The disclaimer should be added at the very top of the README.md before any other text in the following format.
+Replace ALL existing text with a disclaimer in the following format.
 
   - If a replacement package and migration guide exist:
 
@@ -79,6 +79,22 @@ The disclaimer should be added at the very top of the README.md before any other
   - This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/). Refer to the migration guide (https://aka.ms/azsdk/python/migrate/my-new-package) for guidance on upgrading.
   ```
 
+## Remove all links pointing to the package in the main branch
+
+Ensure all links in the samples/README.md and other files that point to the package in the main branch are removed or redirected, as the package will be deleted from main after release.
+
+E.g. In `samples/README.md`, update:
+
+```md
+[send.py](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/mypackage/azure-mypackage/samples/sync/send.py) - Example of sending data.
+```
+
+to
+
+```md
+sync/send.py - Example of sending data.
+```
+
 ## sdk_packaging.toml
 
 - Add `auto_update = false` if not already present to avoid the bot overriding your changes.
@@ -104,7 +120,6 @@ The disclaimer should be added at the very top of the README.md before any other
       - name: azure-mypackage
         safeName: azuremypackage
   ```
-
 
 # Step 2: Resolve all open issues/PRs corresponding to the library.
 

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -169,16 +169,7 @@ You may see tests/mypy/pylint or other checks failing on other packages in the C
 
 Check to make sure that the new version of the package has been released on PyPI and that the release has been tagged in the `azure-sdk-for-python` repo with `azure-mypackage_<version>`.
 
-**NOTE: If your package has been released, there should be a corresponding GitHub release tag. If there is not, you can manually add a release tag:**
-- Navigate to the releases page: https://github.com/Azure/azure-sdk-for-python/releases
-- Click on the "Draft a new release" button.
-- Fill in the Release details:
-  - Tag version: Enter the tag name in the format `azure-mypackage_<version>` (e.g., azure-mypackage_1.2.4).
-  - Target: Select the branch or commit you want to tag (usually main or the commit corresponding to the release).
-  - Release title: Should be the same as the release tag (e.g., azure-mypackage_1.2.4).
-  - Description: Add the section from the CHANGELOG.md corresponding to the release.
-  - Attach the sdist and zip files from the release (which can be downloaded from PyPI).
-  - Click "Publish release"
+**NOTE: If your package has been released, there should be a corresponding [GitHub release tag](https://github.com/Azure/azure-sdk-for-python/tags). If there is not, create a post in the [Engineering System channel](https://teams.microsoft.com/l/channel/19%3A59dbfadafb5e41c4890e2cd3d74cc7ba%40thread.skype/Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) that the release tag cannot be found and add a link to the release build.**
 
 Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-cognitiveservices-language-spellcheck_2.0.1)
 

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -206,14 +206,18 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, all other packages in the `mypackage` folder should already have been deprecated. Remove `ci.yml` from `mypackage` along with the following files, if they exist: `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
+  - If the only package listed is `azure-mypackage`, remove the `Artifacts` section altogether.
+    ```yml
+    extends:
+      parameters:
+        ...
+    ```
+  - If the only package listed is `azure-mypackage`, the service is retired, and customers should not expect to receive ANY future updates, remove the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
 - Once the PR has been approved by codeowner, merge.
 - You're responsible for fixing any CI issues related to this PR.
-
-Example post-deprecation PR for azure-cognitiveservices-language-spellcheck [here](https://github.com/Azure/azure-sdk-for-python/pull/37459/files).
 
 # Step 6: Update API Documentation
 
@@ -254,7 +258,7 @@ If the service is retired and customers should not expect to receive any future 
 
 To archive your project, reach out to Laurent Mazuel (lmazuel). You cannot complete this step yourself.
 
-Note: Project archival is not deletion. Archiving a project does not remove it from the index, and does not prevent users from installing it.
+Note: Project archival is not deletion. Archiving a project does not remove it from the index, and does not prevent users from installing it. Before doing so, publish a final release with any necessary updates to the README/CHANGELOG/docs to warn customers that the project will not receive further updates.
 
 ## Update overview/conceptual documentation that points to deprecated packages
 

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -167,10 +167,30 @@ You may see tests/mypy/pylint or other checks failing on other packages in the C
 
 ## Post-Release
 
-Check to make sure that the new version of the package has been released on PyPI.
+Check to make sure that the new version of the package has been released on PyPI and that the release has been tagged in the `azure-sdk-for-python` repo with `azure-mypackage_<version>`.
 
-# Step 5: Create a new PR to remove the package from CI
+**NOTE: If your package has been released, there should be a corresponding GitHub release tag. If there is not, you can manually add a release tag:**
+- Navigate to the releases page: https://github.com/Azure/azure-sdk-for-python/releases
+- Click on the "Draft a new release" button.
+- Fill in the Release details:
+  - Tag version: Enter the tag name in the format `azure-mypackage_<version>` (e.g., azure-mypackage_1.2.4).
+  - Target: Select the branch or commit you want to tag (usually main or the commit corresponding to the release).
+  - Release title: Should be the same as the release tag (e.g., azure-mypackage_1.2.4).
+  - Description: Add the section from the CHANGELOG.md corresponding to the release.
+  - Attach the sdist and zip files from the release (which can be downloaded from PyPI).
+  - Click "Publish release"
 
+Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-cognitiveservices-language-spellcheck_2.0.1)
+
+# Step 5: Create a new PR to remove the package from the main branch
+
+- Delete all files under `sdk/mypackage/azure-mypackage` EXCEPT for the README.md.
+- Add a note to the README that the package has been moved under the latest release tag. E.g.
+  ```md
+  # Microsoft Azure SDK for Python
+
+  **NOTE**: This package has been deprecated and moved to [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage). This package will only receive security fixes until <EOLDate> and will no longer be maintained after then.
+  ```
 - You will see an `Artifacts` parameter in the `mypackage/ci.yml`.
   ```yml
   extends:
@@ -180,13 +200,7 @@ Check to make sure that the new version of the package has been released on PyPI
       - name: azure-mypackage
         safeName: azuremypackage
   ```
- - If the only package listed is `azure-mypackage`, remove the `Artifacts` section altogether.
-    ```yml
-    extends:
-      parameters:
-        ...
-    ```
- - If there are multiple packages listed, remove the `name` and corresponding `safeName` lines for only `azure-mypackage`.
+  - If there are multiple packages listed, remove the `name` and corresponding `safeName` lines for only `azure-mypackage`.
     ```yml
     extends:
       parameters:
@@ -194,8 +208,13 @@ Check to make sure that the new version of the package has been released on PyPI
         Artifacts:
           ...
     ```
+  - If the only package listed is `azure-mypackage`, remove the `Artifacts` section altogether.
+    ```yml
+    extends:
+      parameters:
+        ...
+    ```
 
-- Add the line `ci_enabled = false` to `azure-mypackage/pyproject.toml`.
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
 - Once the PR has been approved by codeowner, merge.
@@ -238,7 +257,7 @@ More detailed instructions on updating the CSV file can be found [here](https://
 
 ## Archive the project in PyPI
 
-If the service is retired and customers should not expect to receive any future updates, including security fixes or maintenance, [your project can be marked as archived](https://blog.pypi.org/posts/2025-01-30-archival/). Before doing so, publish a final release with any necessary updates to the README/CHANGELOG/docs to warn customers that the project will not receive further updates.
+If the service is retired and customers should not expect to receive any future updates, including security fixes or maintenance, [your project can be marked as archived](https://blog.pypi.org/posts/2025-01-30-archival/).
 
 To archive your project, reach out to Laurent Mazuel (lmazuel). You cannot complete this step yourself.
 

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -41,25 +41,25 @@ Replace ALL existing text with a disclaimer in the following format.
   - If a replacement package and migration guide exist:
 
     ```md
-    **NOTE**: This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/). Refer to the migration guide (https://aka.ms/azsdk/python/migrate/my-new-package) for guidance on upgrading.
+     This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/). Refer to the migration guide (https://aka.ms/azsdk/python/migrate/my-new-package) for guidance on upgrading.
     ```
 
   - If a migration guide is not provided:
 
     ```md
-    **NOTE**: This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/).
+     This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/).
     ```
 
   - If a replacement package does not exist:
 
     ```md
-    **NOTE**: This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>.
+     This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>.
     ```
 
   - If a new service has replaced the service, and existing customers should be directed to the new service's Rest API docs/repo:
 
     ```md
-    **NOTE**: This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. Refer to the samples in the [My New Service repo](https://github.com/microsoft/my-new-service/tree/main) instead.
+     This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. Refer to the samples in the [My New Service repo](https://github.com/microsoft/my-new-service/tree/main) instead.
     
     For additional support, open a new issue in the [Issues](https://github.com/microsoft/my-new-service/issues) section of the My New Service repo.
     ```
@@ -174,12 +174,18 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
 
 # Step 5: Create a new PR to remove the package from the main branch
 
-- Append the following to the end of the existing README.md.
+Append a note to the README.md deprecation message stating the package has been removed from the main branch, a link to the latest GitHub release tag and package on PyPI, and contact info for questions. The full README text should now look like the following:
+
   ```md
+  # Microsoft Azure SDK for Python
+
+  This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>.
+
   Package source code and samples have been removed from the `main` branch and can be found under the release tag for the latest version. See [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage). The latest release can be found on [PyPI](https://pypi.org/project/azure-mypackage/).
 
   If you have any questions, please open a [GitHub Issue](https://github.com/Azure/azure-sdk-for-python/issues) or email `azpysdkhelp@microsoft.com`.
   ```
+
 - Delete all files in the package directory `sdk/mypackage/azure-mypackage` EXCEPT for the README.md at the package directory root.
 - You will see an `Artifacts` parameter in `mypackage/ci.yml`.
   ```yml
@@ -198,7 +204,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package in the `mypackage` service directory is `azure-mypackage`, delete all files -- _not package subdirectories_-- in the `mypackage` service directory (i.e. `ci.yml`, `tests.yml`, `test-resources.bicep`, etc.).
+  - If the only package listed is `azure-mypackage`, delete `ci.yml` and all files -- _not package subdirectories_-- in the `mypackage` service directory (i.e. `tests.yml`, `test-resources.bicep`, etc.).
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -79,22 +79,6 @@ Replace ALL existing text with a disclaimer in the following format.
   - This package has been deprecated and will no longer be maintained after <EOLDate>. This package will only receive security fixes until <EOLDate>. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [azure-mynewpackage](https://pypi.org/project/azure-mynewpackage/). Refer to the migration guide (https://aka.ms/azsdk/python/migrate/my-new-package) for guidance on upgrading.
   ```
 
-## Remove all links pointing to the package in the main branch
-
-Ensure all links in the samples/README.md and other files that point to the package in the main branch are removed or redirected, as the package will be deleted from main after release.
-
-E.g. In `samples/README.md`, update:
-
-```md
-[send.py](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/mypackage/azure-mypackage/samples/sync/send.py) - Example of sending data.
-```
-
-to
-
-```md
-sync/send.py - Example of sending data.
-```
-
 ## sdk_packaging.toml
 
 - Add `auto_update = false` if not already present to avoid the bot overriding your changes.
@@ -192,7 +176,9 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
 
 - Append the following to the end of the existing README.md.
   ```md
-  Package source code and samples have been removed from the `main` branch and can be found under the release tag for the latest version. See [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage).
+  Package source code and samples have been removed from the `main` branch and can be found under the release tag for the latest version. See [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage). The latest release can be found on [PyPI](https://pypi.org/project/azure-mypackage/).
+
+  If you have any questions, please open a [GitHub Issue](https://github.com/Azure/azure-sdk-for-python/issues) or email `azpysdkhelp@microsoft.com`.
   ```
 - Delete all files under `sdk/mypackage/azure-mypackage` EXCEPT for the README.md at the package root.
 - You will see an `Artifacts` parameter in `mypackage/ci.yml`.
@@ -212,7 +198,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, remove the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
+  - If the only package in the `mypackage` directory is `azure-mypackage`, delete all files -- _not subdirectories_-- in `mypackage` (i.e. `ci.yml`, `tests.yml`, `test-resources.bicep`, etc.).
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -206,7 +206,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, all packages in the `mypackage` folder should be deprecated. Remove any and all of the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
+  - If the only package listed is `azure-mypackage`, all other packages in the `mypackage` folder should already have been deprecated. Remove `ci.yml` from `mypackage` along with the following files, if they exist: `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -184,14 +184,12 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
 
 # Step 5: Create a new PR to remove the package from the main branch
 
-- Delete all files under `sdk/mypackage/azure-mypackage` EXCEPT for the README.md.
-- Add a note to the README that the package has been moved under the latest release tag. E.g.
+- Append the following to the end of the existing README.md.
   ```md
-  # Microsoft Azure SDK for Python
-
-  **NOTE**: This package has been deprecated and moved to [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage). This package will only receive security fixes until <EOLDate> and will no longer be maintained after then.
+  Package source code and samples have been removed from the `main` branch and can be found under the release tag for the latest version. See [azure-mypackage_<version>](https://github.com/Azure/azure-sdk-for-python/tree/azure-mypackage_<version>/sdk/mypackage/azure-mypackage).
   ```
-- You will see an `Artifacts` parameter in the `mypackage/ci.yml`.
+- Delete all files under `sdk/mypackage/azure-mypackage` EXCEPT for the README.md at the package root.
+- You will see an `Artifacts` parameter in `mypackage/ci.yml`.
   ```yml
   extends:
     parameters:
@@ -208,12 +206,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, remove the `Artifacts` section altogether.
-    ```yml
-    extends:
-      parameters:
-        ...
-    ```
+  - If the only package listed is `azure-mypackage`, all packages in the `mypackage` folder should be deprecated. Remove any and all of the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -212,13 +212,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, remove the `Artifacts` section altogether.
-    ```yml
-    extends:
-      parameters:
-        ...
-    ```
-  - If the only package listed is `azure-mypackage`, the service is retired, and customers should not expect to receive ANY future updates, remove the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
+  - If the only package listed is `azure-mypackage`, remove the following files from `mypackage`: `ci.yml`, `tests.yml`, `test-resources.bicep`, `test-resources.json`, `perf.yml`, `perf-tests.yml`, `perf-resources.bicep`.
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
@@ -260,11 +254,11 @@ More detailed instructions on updating the CSV file can be found [here](https://
 
 ## Archive the project in PyPI
 
-If the service is retired and customers should not expect to receive any future updates, including security fixes or maintenance, [your project can be marked as archived](https://blog.pypi.org/posts/2025-01-30-archival/).
+If the service is retired and customers should not expect to receive any future updates, including security fixes or maintenance, [your project can be marked as archived](https://blog.pypi.org/posts/2025-01-30-archival/). Before doing so, publish a final release with any necessary updates to the README/CHANGELOG/docs to warn customers that the project will not receive further updates.
 
 To archive your project, reach out to Laurent Mazuel (lmazuel). You cannot complete this step yourself.
 
-Note: Project archival is not deletion. Archiving a project does not remove it from the index, and does not prevent users from installing it. Before doing so, publish a final release with any necessary updates to the README/CHANGELOG/docs to warn customers that the project will not receive further updates.
+Note: Project archival is not deletion. Archiving a project does not remove it from the index, and does not prevent users from installing it.
 
 ## Update overview/conceptual documentation that points to deprecated packages
 

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -180,7 +180,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
 
   If you have any questions, please open a [GitHub Issue](https://github.com/Azure/azure-sdk-for-python/issues) or email `azpysdkhelp@microsoft.com`.
   ```
-- Delete all files under `sdk/mypackage/azure-mypackage` EXCEPT for the README.md at the package root.
+- Delete all files in the package directory `sdk/mypackage/azure-mypackage` EXCEPT for the README.md at the package directory root.
 - You will see an `Artifacts` parameter in `mypackage/ci.yml`.
   ```yml
   extends:
@@ -198,7 +198,7 @@ Example release tag: [azure-cognitiveservices-language-spellcheck_2.0.1](https:/
         Artifacts:
           ...
     ```
-  - If the only package in the `mypackage` directory is `azure-mypackage`, delete all files -- _not subdirectories_-- in `mypackage` (i.e. `ci.yml`, `tests.yml`, `test-resources.bicep`, etc.).
+  - If the only package in the `mypackage` service directory is `azure-mypackage`, delete all files -- _not package subdirectories_-- in the `mypackage` service directory (i.e. `ci.yml`, `tests.yml`, `test-resources.bicep`, etc.).
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).

--- a/doc/deprecation_process.md
+++ b/doc/deprecation_process.md
@@ -204,7 +204,7 @@ Append a note to the README.md deprecation message stating the package has been 
         Artifacts:
           ...
     ```
-  - If the only package listed is `azure-mypackage`, delete `ci.yml` and all files -- _not package subdirectories_-- in the `mypackage` service directory (i.e. `tests.yml`, `test-resources.bicep`, etc.).
+  - If the only package listed is `azure-mypackage`, delete `ci.yml` and all other files -- _not package subdirectories_-- in the `mypackage` service directory (i.e. `tests.yml`, `test-resources.bicep`, etc.).
 
 - Create a new PR targeting the `main` branch of the repository.
 - Post the PR in the [review channel for Python](https://teams.microsoft.com/l/channel/19%3a4175567f1e154a80ab5b88cbd22ea92f%40thread.skype/Language%2520-%2520Python%2520-%2520Reviews?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).


### PR DESCRIPTION
Updating the deprecation process doc to remove the deprecated package from the main branch, with the exception of the README, which links to the latest release tag.