### PR TITLE
Bring over enable telemetry method

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1366,6 +1366,7 @@
       "words": [
         "aiservices",
         "azureai",
+        "GENAI",
       ]
     },
     {

--- a/sdk/ai/azure-ai-projects-onedp/README.md
+++ b/sdk/ai/azure-ai-projects-onedp/README.md
@@ -6,7 +6,7 @@ Use the AI Projects client library (in preview) to:
 * **Enumerate connected Azure resources** and get their properties.
 * **Upload documents and create Datasets** to reference them.
 * **Create and enumerate search Indexes**.
-* **Get an authenticated Assistant client**.
+* **Get an authenticated Agents client**.
 * **Get an authenticated Inference client** (Azure OpenAI or Azure AI Inference) for chat completions, text or image embeddings.
 * **Read a Prompty file or string** and render messages for inference clients.
 * **Run Evaluations** to assess the performance of generative AI applications.
@@ -82,16 +82,16 @@ project_client = AIProjectClient.from_connection_string(
 
 ## Examples
 
-### Getting an authenticated Assistant client
+### Getting an authenticated Agents client
 
-Below is a code example of how to get an authenticated `AssistantsClient` from the `azure-ai-assistants` package.
-Full samples can be found under the `assistants` folder in the [package samples][samples].
+Below is a code example of how to get an authenticated `AgentsClient` from the `azure-ai-agents` package.
+Full samples can be found under the `agents` folder in the [package samples][samples].
 
-<!-- SNIPPET:sample_get_assistants_client.assistants_sample -->
+<!-- SNIPPET:sample_get_agents_client.agents_sample -->
 
 ```python
-with project_client.assistants.get_client() as client:
-    # TODO: Do something with the assistants client...
+with project_client.agents.get_client() as client:
+    # TODO: Do something with the agents client...
     pass
 ```
 

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch.py
@@ -9,8 +9,9 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from typing import List, Any, Union, Optional
 from azure.core.credentials import AzureKeyCredential, TokenCredential
 from ._client import AIProjectClient as AIProjectClientGenerated
-from .operations import TelemetryOperations, InferenceOperations, AssistantsOperations
+from .operations import TelemetryOperations, InferenceOperations, AgentsOperations
 from ._patch_prompts import PromptTemplate
+from ._patch_telemetry import enable_telemetry
 
 
 class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes
@@ -18,8 +19,8 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
     :ivar connections: ConnectionsOperations operations
     :vartype connections: azure.ai.projects.onedp.operations.ConnectionsOperations
-    :ivar assistants: AssistantsOperations operations
-    :vartype assistants: azure.ai.projects.onedp.operations.AssistantsOperations
+    :ivar agents: AgentsOperations operations
+    :vartype agents: azure.ai.projects.onedp.operations.AgentsOperations
     :ivar inference: InferenceOperations operations
     :vartype inference: azure.ai.projects.onedp.operations.InferenceOperations
     :ivar telemetry: TelemetryOperations operations
@@ -52,12 +53,13 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         super().__init__(endpoint=endpoint, credential=credential, **kwargs)
         self.telemetry = TelemetryOperations(self)
         self.inference = InferenceOperations(self)
-        self.assistants = AssistantsOperations(self)
+        self.agents = AgentsOperations(self)
 
 
 __all__: List[str] = [
     "AIProjectClient",
     "PromptTemplate",
+    "enable_telemetry",
 ]  # Add all objects you want publicly available to users at this package level
 
 

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch_prompts.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch_prompts.py
@@ -176,12 +176,3 @@ class PromptTemplate:
             return parsed  # type: ignore
         else:
             raise ValueError("Please provide valid prompt template")
-
-
-def patch_sdk():
-    """Do not remove from this file.
-
-    `patch_sdk` is a last resort escape hatch that allows you to do customizations
-    you can't accomplish using the techniques described in
-    https://aka.ms/azsdk/python/dpcodegen/python/customize
-    """

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch_telemetry.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/_patch_telemetry.py
@@ -1,0 +1,224 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+# pylint: disable=line-too-long,R,no-member
+"""Customize generated code here.
+
+Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
+"""
+import io
+import logging
+import sys
+from typing import Union, Any, TextIO, cast
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: what about `set AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true`?
+def enable_telemetry(
+    *, destination: Union[TextIO, str, None] = None, **kwargs
+) -> None:  # pylint: disable=unused-argument
+    """Enables telemetry collection with OpenTelemetry for Azure AI clients and popular GenAI libraries.
+
+    Following instrumentations are enabled (when corresponding packages are installed):
+
+    - Azure AI Agents (`azure-ai-agents`)
+    - Azure AI Inference (`azure-ai-inference`)
+    - OpenAI (`opentelemetry-instrumentation-openai-v2`)
+    - Langchain (`opentelemetry-instrumentation-langchain`)
+
+    The recording of prompt and completion messages is disabled by default. To enable it, set the
+    `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED` environment variable to `true`.
+
+    When destination is provided, the method configures OpenTelemetry SDK to export traces to
+    stdout or OTLP (OpenTelemetry protocol) gRPC endpoint. It's recommended for local
+    development only. For production use, make sure to configure OpenTelemetry SDK directly.
+
+    :keyword destination: Recommended for local testing only. Set it to `sys.stdout` for
+        tracing to console output, or a string holding the OpenTelemetry protocol (OTLP)
+        endpoint such as "http://localhost:4317.
+        If not provided, the method enables instrumentations, but does not configure OpenTelemetry
+        SDK to export traces.
+    :paramtype destination: Union[TextIO, str, None]
+    """
+    span_exporter = _get_trace_exporter(destination)
+    _configure_tracing(span_exporter)
+
+    log_exporter = _get_log_exporter(destination)
+    _configure_logging(log_exporter)
+
+    # Silently try to load a set of relevant Instrumentors
+    try:
+        from azure.core.settings import settings
+
+        settings.tracing_implementation = "opentelemetry"
+    except ModuleNotFoundError:
+        logger.warning(
+            "Azure SDK tracing plugin is not installed. "
+            + "Please install it using 'pip install azure-core-tracing-opentelemetry'"
+        )
+
+    try:
+        from azure.ai.inference.tracing import AIInferenceInstrumentor  # type: ignore
+
+        inference_instrumentor = AIInferenceInstrumentor()
+        if not inference_instrumentor.is_instrumented():
+            inference_instrumentor.instrument()
+    except ModuleNotFoundError:
+        logger.warning(
+            "Could not call `AIInferenceInstrumentor().instrument()` since `azure-ai-inference` is not installed"
+        )
+
+    try:
+        from azure.ai.agents.tracing import AIAgentsInstrumentor
+
+        agents_instrumentor = AIAgentsInstrumentor()
+        if not agents_instrumentor.is_instrumented():
+            agents_instrumentor.instrument()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("Could not call `AIAgentsInstrumentor().instrument()`", exc_info=exc)
+
+    try:
+        from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor  # type: ignore
+
+        OpenAIInstrumentor().instrument()
+    except ModuleNotFoundError:
+        logger.warning(
+            "Could not call `OpenAIInstrumentor().instrument()` since "
+            + "`opentelemetry-instrumentation-openai-v2` is not installed"
+        )
+
+    try:
+        from opentelemetry.instrumentation.langchain import LangchainInstrumentor  # type: ignore
+
+        print("Calling LangchainInstrumentor().instrument()")
+        LangchainInstrumentor().instrument()
+    except ModuleNotFoundError:
+        logger.warning(
+            "Could not call LangchainInstrumentor().instrument()` since "
+            + "`opentelemetry-instrumentation-langchain` is not installed"
+        )
+
+
+# Internal helper functions to enable OpenTelemetry, used by both sync and async clients
+def _get_trace_exporter(destination: Union[TextIO, str, None]) -> Any:
+    if isinstance(destination, str):
+        # `destination` is the OTLP endpoint
+        # See: https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html#usage
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter  # type: ignore
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "OpenTelemetry OTLP exporter is not installed. "
+                + "Please install it using 'pip install opentelemetry-exporter-otlp-proto-grpc'"
+            ) from e
+        return OTLPSpanExporter(endpoint=destination)
+
+    if isinstance(destination, io.TextIOWrapper):
+        if destination is sys.stdout:
+            # See: https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.ConsoleSpanExporter # pylint: disable=line-too-long
+            try:
+                from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+            except ModuleNotFoundError as e:
+                raise ModuleNotFoundError(
+                    "OpenTelemetry SDK is not installed. Please install it using 'pip install opentelemetry-sdk'"
+                ) from e
+
+            return ConsoleSpanExporter()
+        raise ValueError("Only `sys.stdout` is supported at the moment for type `TextIO`")
+
+    return None
+
+
+def _get_log_exporter(destination: Union[TextIO, str, None]) -> Any:
+    if isinstance(destination, str):
+        # `destination` is the OTLP endpoint
+        # See: https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html#usage
+        try:
+            # _logs are considered beta (not internal) in OpenTelemetry Python API/SDK.
+            # So it's ok to use it for local development, but we'll swallow
+            # any errors in case of any breaking changes on OTel side.
+            from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter  # type: ignore  # pylint: disable=import-error,no-name-in-module
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            # since OTel logging is still in beta in Python, we're going to swallow any errors
+            # and just warn about them.
+            logger.warning("Failed to configure OpenTelemetry logging.", exc_info=ex)
+            return None
+
+        return OTLPLogExporter(endpoint=destination)
+
+    if isinstance(destination, io.TextIOWrapper):
+        if destination is sys.stdout:
+            # See: https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.ConsoleSpanExporter # pylint: disable=line-too-long
+            try:
+                from opentelemetry.sdk._logs.export import ConsoleLogExporter
+
+                return ConsoleLogExporter()
+            except ModuleNotFoundError as ex:
+                # since OTel logging is still in beta in Python, we're going to swallow any errors
+                # and just warn about them.
+                logger.warning("Failed to configure OpenTelemetry logging.", exc_info=ex)
+            return None
+        raise ValueError("Only `sys.stdout` is supported at the moment for type `TextIO`")
+
+    return None
+
+
+def _configure_tracing(span_exporter: Any) -> None:
+    if span_exporter is None:
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "OpenTelemetry SDK is not installed. Please install it using 'pip install opentelemetry-sdk'"
+        ) from e
+
+    # if tracing was not setup before, we need to create a new TracerProvider
+    if not isinstance(trace.get_tracer_provider(), TracerProvider):
+        # If the provider is NoOpTracerProvider, we need to create a new TracerProvider
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+
+    # get_tracer_provider returns opentelemetry.trace.TracerProvider
+    # however, we have opentelemetry.sdk.trace.TracerProvider, which implements
+    # add_span_processor method, though we need to cast it to fix type checking.
+    provider = cast(TracerProvider, trace.get_tracer_provider())
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+
+def _configure_logging(log_exporter: Any) -> None:
+    if log_exporter is None:
+        return
+
+    try:
+        # _events and _logs are considered beta (not internal) in
+        # OpenTelemetry Python API/SDK.
+        # So it's ok to use them for local development, but we'll swallow
+        # any errors in case of any breaking changes on OTel side.
+        from opentelemetry import _logs, _events
+        from opentelemetry.sdk._logs import LoggerProvider  # pylint: disable=import-error,no-name-in-module
+        from opentelemetry.sdk._events import EventLoggerProvider  # pylint: disable=import-error,no-name-in-module
+        from opentelemetry.sdk._logs.export import (
+            SimpleLogRecordProcessor,
+        )  # pylint: disable=import-error,no-name-in-module
+
+        if not isinstance(_logs.get_logger_provider(), LoggerProvider):
+            logger_provider = LoggerProvider()
+            _logs.set_logger_provider(logger_provider)
+
+        # get_logger_provider returns opentelemetry._logs.LoggerProvider
+        # however, we have opentelemetry.sdk._logs.LoggerProvider, which implements
+        # add_log_record_processor method, though we need to cast it to fix type checking.
+        logger_provider = cast(LoggerProvider, _logs.get_logger_provider())
+        logger_provider.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+        _events.set_event_logger_provider(EventLoggerProvider(logger_provider))
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        # since OTel logging is still in beta in Python, we're going to swallow any errors
+        # and just warn about them.
+        logger.warning("Failed to configure OpenTelemetry logging.", exc_info=ex)

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/_patch.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Union, Any
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
 from ._client import AIProjectClient as AIProjectClientGenerated
-from .operations import InferenceOperations, AssistantsOperations, TelemetryOperations
+from .operations import InferenceOperations, AgentsOperations, TelemetryOperations
 
 
 class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes
@@ -18,8 +18,8 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
     :ivar connections: ConnectionsOperations operations
     :vartype connections: azure.ai.projects.onedp.aio.operations.ConnectionsOperations
-    :ivar assistants: AssistantsOperations operations
-    :vartype assistants: azure.ai.projects.onedp.aio.operations.AssistantsOperations
+    :ivar agents: AgentsOperations operations
+    :vartype agents: azure.ai.projects.onedp.aio.operations.AgentsOperations
     :ivar inference: InferenceOperations operations
     :vartype inference: azure.ai.projects.onedp.aio.operations.InferenceOperations
     :ivar telemetry: TelemetryOperations operations
@@ -54,7 +54,7 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         super().__init__(endpoint=endpoint, credential=credential, **kwargs)
         self.telemetry = TelemetryOperations(self)
         self.inference = InferenceOperations(self)
-        self.assistants = AssistantsOperations(self)
+        self.agents = AgentsOperations(self)
 
 
 __all__: List[str] = ["AIProjectClient"]  # Add all objects you want publicly available to users at this package level

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch.py
@@ -8,16 +8,16 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 from typing import List
-from ._patch_assistants_async import AssistantsOperations
+from ._patch_agents_async import AgentsOperations
 from ._patch_datasets_async import DatasetsOperations
 from ._patch_inference_async import InferenceOperations
 from ._patch_telemetry_async import TelemetryOperations
 
 __all__: List[str] = [
     "InferenceOperations",
-    "DatasetsOperations",
-    "AssistantsOperations",
     "TelemetryOperations",
+    "DatasetsOperations",
+    "AgentsOperations",
 ]  # Add all objects you want publicly available to users at this package level
 
 

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch_agents_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch_agents_async.py
@@ -10,14 +10,14 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from azure.core.tracing.decorator import distributed_trace
 
 
-class AssistantsOperations:
+class AgentsOperations:
     """
     .. warning::
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
         :class:`~azure.ai.projects.onedp.aio.AIProjectClient`'s
-        :attr:`assistants` attribute.
+        :attr:`agents` attribute.
     """
 
     # TODO: Merge all code related to handling user-agent, into a single place.
@@ -38,29 +38,28 @@ class AssistantsOperations:
         self._outer_instance = outer_instance
 
     @distributed_trace
-    def get_client(self, **kwargs) -> "AssistantsClient":  # type: ignore[name-defined]
-        """Get an authenticated asynchronous AssistantsClient (from the package azure-ai-assistants) to use with
+    def get_client(self, **kwargs) -> "AgentsClient":  # type: ignore[name-defined]
+        """Get an authenticated asynchronous AgentsClient (from the package azure-ai-agents) to use with
         your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
+        AgentsClient.
 
-        .. note:: The package `azure-ai-assistants` must be installed prior to calling this method.
+        .. note:: The package `azure-ai-agents` must be installed prior to calling this method.
 
-        :return: An authenticated Assistant Client.
-        :rtype: ~azure.ai.assistants.AssistantsClient
+        :return: An authenticated Agents Client.
+        :rtype: ~azure.ai.agents.AgentsClient
 
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-assistants` package
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-agents` package
          is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         try:
-            from azure.ai.assistants.aio import AssistantsClient
+            from azure.ai.agents.aio import AgentsClient
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError(
-                "Azure AI Assistant SDK is not installed. Please install it using 'pip install azure-ai-assistants'"
+                "Azure AI Agents SDK is not installed. Please install it using 'pip install azure-ai-agents'"
             ) from e
 
-        client = AssistantsClient(
+        client = AgentsClient(
             endpoint=self._outer_instance._config.endpoint,  # pylint: disable=protected-access
             credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
             user_agent=kwargs.pop("user_agent", self._user_agent),

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch_datasets_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/aio/operations/_patch_datasets_async.py
@@ -140,7 +140,7 @@ class DatasetsOperations(DatasetsOperationsGenerated):
 
                     logger.debug("[upload_file_and_create] Done uploading")
 
-                    dataset_version = await self.create_version(
+                    dataset_version = await self.create_version(  # TODO: Change this to self.create_or_update_version
                         name=name,
                         version=output_version,
                         body=DatasetVersion(
@@ -203,7 +203,7 @@ class DatasetsOperations(DatasetsOperationsGenerated):
             if not files_uploaded:
                 raise ValueError("The provided folder is empty.")
 
-            dataset_version = await self.create_version(
+            dataset_version = await self.create_version(  # TODO: Change this to self.create_or_update_version
                 name=name,
                 version=output_version,
                 body=DatasetVersion(

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/models/_enums.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/models/_enums.py
@@ -42,7 +42,7 @@ class ConnectionType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     AZURE_BLOB_STORAGE = "AzureBlob"
     """Azure Blob Storage, with specified container"""
     AZURE_STORAGE_ACCOUNT = "AzureStorageAccount"
-    """Azure Blob Storage, with container not specified (used by Assistants)"""
+    """Azure Blob Storage, with container not specified (used by Agents)"""
     AZURE_AI_SEARCH = "CognitiveSearch"
     """Azure AI Search"""
     COSMOS_DB = "CosmosDB"

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch.py
@@ -8,7 +8,7 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 from typing import List
-from ._patch_assistants import AssistantsOperations
+from ._patch_agents import AgentsOperations
 from ._patch_datasets import DatasetsOperations
 from ._patch_inference import InferenceOperations
 from ._patch_telemetry import TelemetryOperations
@@ -18,7 +18,7 @@ __all__: List[str] = [
     "InferenceOperations",
     "TelemetryOperations",
     "DatasetsOperations",
-    "AssistantsOperations",
+    "AgentsOperations",
 ]  # Add all objects you want publicly available to users at this package level
 
 

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch_agents.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch_agents.py
@@ -10,14 +10,14 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from azure.core.tracing.decorator import distributed_trace
 
 
-class AssistantsOperations:
+class AgentsOperations:
     """
     .. warning::
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
         :class:`~azure.ai.projects.onedp.AIProjectClient`'s
-        :attr:`assistants` attribute.
+        :attr:`agents` attribute.
     """
 
     # TODO: Merge all code related to handling user-agent, into a single place.
@@ -38,29 +38,28 @@ class AssistantsOperations:
         self._outer_instance = outer_instance
 
     @distributed_trace
-    def get_client(self, **kwargs) -> "AssistantsClient":  # type: ignore[name-defined]
-        """Get an authenticated AssistantsClient (from the package azure-ai-assistants) to use with
+    def get_client(self, **kwargs) -> "AgentsClient":  # type: ignore[name-defined]
+        """Get an authenticated AgentsClient (from the package azure-ai-agents) to use with
         your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
+        AgentsClient.
 
-        .. note:: The package `azure-ai-assistants` must be installed prior to calling this method.
+        .. note:: The package `azure-ai-agents` must be installed prior to calling this method.
 
-        :return: An authenticated Assistant Client.
-        :rtype: ~azure.ai.assistants.AssistantsClient
+        :return: An authenticated Agents Client.
+        :rtype: ~azure.ai.agents.AgentsClient
 
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-assistants` package
+        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-agents` package
          is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         try:
-            from azure.ai.assistants import AssistantsClient
+            from azure.ai.agents import AgentsClient
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError(
-                "Azure AI Assistant SDK is not installed. Please install it using 'pip install azure-ai-assistants'"
+                "Azure AI Agents SDK is not installed. Please install it using 'pip install azure-ai-agents'"
             ) from e
 
-        client = AssistantsClient(
+        client = AgentsClient(
             endpoint=self._outer_instance._config.endpoint,  # pylint: disable=protected-access
             credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
             user_agent=kwargs.pop("user_agent", self._user_agent),

--- a/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch_datasets.py
+++ b/sdk/ai/azure-ai-projects-onedp/azure/ai/projects/onedp/operations/_patch_datasets.py
@@ -139,7 +139,7 @@ class DatasetsOperations(DatasetsOperationsGenerated):
 
                     logger.debug("[upload_file_and_create] Done uploading")
 
-                    dataset_version = self.create_version(
+                    dataset_version = self.create_version(  # TODO: Change this to self.create_or_update_version
                         name=name,
                         version=output_version,
                         body=DatasetVersion(
@@ -201,7 +201,7 @@ class DatasetsOperations(DatasetsOperationsGenerated):
             if not files_uploaded:
                 raise ValueError("The provided folder is empty.")
 
-            dataset_version = self.create_version(
+            dataset_version = self.create_version(  # TODO: Change this to self.create_or_update_version
                 name=name,
                 version=output_version,
                 body=DatasetVersion(

--- a/sdk/ai/azure-ai-projects-onedp/samples/agents/sample_get_agents_client.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/agents/sample_get_agents_client.py
@@ -6,15 +6,15 @@
 """
 DESCRIPTION:
     Given an AIProjectClient, this sample demonstrates how to get an authenticated 
-    AssistantsClient from the azure.ai.assistants package. For more information on 
-    the azure.ai.assistants package see https://pypi.org/project/azure-ai-assistants/.
+    AgentsClient from the azure.ai.agents package. For more information on 
+    the azure.ai.agents package see https://pypi.org/project/azure-ai-agents/.
 
 USAGE:
-    python sample_get_assistants_client.py
+    python sample_get_agents_client.py
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-assistants azure-identity
+    pip install azure-ai-projects azure-ai-agents azure-identity
 
     Set this environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
@@ -32,8 +32,8 @@ with AIProjectClient(
     credential=DefaultAzureCredential(exclude_interactive_browser_credential=False),
 ) as project_client:
 
-    # [START assistants_sample]
-    with project_client.assistants.get_client() as client:
-        # TODO: Do something with the assistants client...
+    # [START agents_sample]
+    with project_client.agents.get_client() as client:
+        # TODO: Do something with the agents client...
         pass
     # [END sample]

--- a/sdk/ai/azure-ai-projects-onedp/samples/agents/sample_get_agents_client_async.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/agents/sample_get_agents_client_async.py
@@ -6,15 +6,15 @@
 """
 DESCRIPTION:
     Given an AIProjectClient, this sample demonstrates how to get an authenticated 
-    asynchronous AssistantsClient from the azure.ai.assistants package. For more information on 
-    the azure.ai.assistants package see https://pypi.org/project/azure-ai-assistants/.
+    asynchronous AgentsClient from the azure.ai.agents package. For more information on 
+    the azure.ai.agents package see https://pypi.org/project/azure-ai-agents/.
 
 USAGE:
-    python sample_get_assistants_client_async.py
+    python sample_get_agents_client_async.py
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-assistants aiohttp azure-identity
+    pip install azure-ai-projects azure-ai-agents aiohttp azure-identity
 
     Set this environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
@@ -27,7 +27,7 @@ from azure.identity.aio import DefaultAzureCredential
 from azure.ai.projects.onedp.aio import AIProjectClient
 
 
-async def sample_get_assistants_client_async():
+async def sample_get_agents_client_async():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
 
@@ -36,13 +36,13 @@ async def sample_get_assistants_client_async():
         credential=DefaultAzureCredential(),
     ) as project_client:
 
-        async with project_client.assistants.get_client() as client:
-            # TODO: Do something with the assistant client...
+        async with project_client.agents.get_client() as client:
+            # TODO: Do something with the agents client...
             pass
 
 
 async def main():
-    await sample_get_assistants_client_async()
+    await sample_get_agents_client_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py
@@ -1,0 +1,62 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    ChatCompletionsClient from the azure.ai.inference package and perform one chat completion
+    operation. The client is already instrumented to upload traces to Azure Monitor. View the results
+    in the "Tracing" tab in your Azure AI Foundry project page.
+    For more information on the azure.ai.inference package see https://pypi.org/project/azure-ai-inference/.
+
+USAGE:
+    sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-inference azure-identity azure-monitor-opentelemetry
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+       Azure AI Foundry project.
+    2) DEPLOYMENT_NAME - The AI model deployment name, as found in your AI Foundry project.
+    3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
+       messages, which may contain personal data. False by default.
+"""
+
+import os
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects.onedp import AIProjectClient, enable_telemetry
+from azure.ai.inference.models import UserMessage
+from azure.monitor.opentelemetry import configure_azure_monitor
+
+# Enable additional instrumentations for openai and langchain
+# which are not included by Azure Monitor out of the box
+enable_telemetry()
+
+endpoint = os.environ["PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+with AIProjectClient(
+    endpoint=endpoint,
+    credential=DefaultAzureCredential(exclude_interactive_browser_credential=False),
+) as project_client:
+
+    # Enable Azure Monitor tracing
+    application_insights_connection_string = project_client.telemetry.get_connection_string()
+    if not application_insights_connection_string:
+        print("Application Insights was not enabled for this project.")
+        print("Enable it via the 'Tracing' tab in your AI Foundry project page.")
+        exit()
+
+    configure_azure_monitor(connection_string=application_insights_connection_string)
+
+    with project_client.inference.get_chat_completions_client() as client:
+
+        response = client.complete(
+            model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+        )
+
+        print(response.choices[0].message.content)

--- a/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py
@@ -1,0 +1,62 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    ChatCompletionsClient from the azure.ai.inference package and perform one chat completion
+    operation. It also shows how to turn on local tracing.
+    For more information on the azure.ai.inference package see https://pypi.org/project/azure-ai-inference/.
+
+USAGE:
+    sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-inference azure-identity
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+       Azure AI Foundry project.
+    2) MODEL_DEPLOYMENT_NAME - The AI model deployment name, as found in your AI Foundry project.
+
+ALTERNATIVE USAGE:
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    instead of to the console, also install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
+
+    And also define:
+    3) OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT - Optional. Set to `true` to trace the content of chat
+       messages, which may contain personal data. False by default.    
+"""
+
+import os
+import sys
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects.onedp import AIProjectClient, enable_telemetry
+from azure.ai.inference.models import UserMessage
+
+# Enable console tracing.
+# or, if you have local OTLP endpoint running, change it to
+# enable_telemetry(destination="http://localhost:4317")
+enable_telemetry(destination=sys.stdout)
+
+endpoint = os.environ["PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+with AIProjectClient(
+    endpoint=endpoint,
+    credential=DefaultAzureCredential(exclude_interactive_browser_credential=False),
+) as project_client:
+
+    with project_client.inference.get_chat_completions_client() as client:
+
+        response = client.complete(
+            model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+        )
+
+        print(response.choices[0].message.content)

--- a/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py
@@ -1,0 +1,70 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    AzureOpenAI client from the openai package, and perform one chat completion operation.
+    The client is already instrumented to upload traces to Azure Monitor. View the results 
+    in the "Tracing" tab in your Azure AI Foundry project page.
+
+
+USAGE:
+    python sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects openai azure-monitor-opentelemetry opentelemetry-instrumentation-openai-v2
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+       Azure AI Foundry project.
+    2) DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project.
+    3) OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT - Optional. Set to `true` to trace the content of chat
+       messages, which may contain personal data. False by default.
+
+    Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
+    https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+"""
+
+import os
+from azure.ai.projects.onedp import AIProjectClient, enable_telemetry
+from azure.identity import DefaultAzureCredential
+from azure.monitor.opentelemetry import configure_azure_monitor
+
+# Enable additional instrumentations for openai and langchain
+# which are not included by Azure Monitor out of the box
+enable_telemetry()
+
+endpoint = os.environ["PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+with AIProjectClient(
+    endpoint=endpoint,
+    credential=DefaultAzureCredential(exclude_interactive_browser_credential=False),
+) as project_client:
+
+    # Enable Azure Monitor tracing
+    application_insights_connection_string = project_client.telemetry.get_connection_string()
+    if not application_insights_connection_string:
+        print("Application Insights was not enabled for this project.")
+        print("Enable it via the 'Tracing' tab in your AI Foundry project page.")
+        exit()
+
+    configure_azure_monitor(connection_string=application_insights_connection_string)
+
+    with project_client.inference.get_azure_openai_client(api_version="2024-06-01") as client:
+
+        response = client.chat.completions.create(
+            model=model_deployment_name,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "How many feet are in a mile?",
+                },
+            ],
+        )
+
+        print(response.choices[0].message.content)

--- a/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_openai_client_and_console_tracing.py
+++ b/sdk/ai/azure-ai-projects-onedp/samples/inference/sample_chat_completions_with_azure_openai_client_and_console_tracing.py
@@ -1,0 +1,69 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    AzureOpenAI client from the openai package, and perform one chat completion operation.
+    The client is already instrumented with console OpenTelemetry tracing.
+
+USAGE:
+    python sample_chat_completions_with_azure_openai_client_and_console_tracing.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects openai opentelemetry-sdk opentelemetry-instrumentation-openai-v2
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+       Azure AI Foundry project.
+    2) MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project.
+
+    Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
+    https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
+
+ALTERNATIVE USAGE:
+    If you want to export telemetry to OTLP endpoint (such as Aspire dashboard
+    https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash)
+    instead of to the console, also install:
+
+    pip install opentelemetry-exporter-otlp-proto-grpc
+
+    And also define:
+    3) OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT - Optional. Set to `true` to trace the content of chat
+       messages, which may contain personal data. False by default.
+"""
+
+import os
+import sys
+from azure.ai.projects.onedp import AIProjectClient, enable_telemetry
+from azure.identity import DefaultAzureCredential
+
+# Enable console tracing.
+# or, if you have local OTLP endpoint running, change it to
+# enable_telemetry(destination="http://localhost:4317")
+enable_telemetry(destination=sys.stdout)
+
+endpoint = os.environ["PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+with AIProjectClient(
+    endpoint=endpoint,
+    credential=DefaultAzureCredential(exclude_interactive_browser_credential=False),
+) as project_client:
+
+    with project_client.inference.get_azure_openai_client(api_version="2024-06-01") as client:
+
+        response = client.chat.completions.create(
+            model=model_deployment_name,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "How many feet are in a mile?",
+                },
+            ],
+        )
+
+        print(response.choices[0].message.content)


### PR DESCRIPTION
* Update "Assistants" to "Agents" wherever used, following recent package & client naming agreement (separate `azure-ai-agents` package and `AgentsClient`.
* Bring over hand-writte code related to enabling telemetry from the old Projects SDK. Implement it as a package function (not a `AIProjectClient` method as before), per Johan's request, since it does not need an instance of the client. It's just "global" tracing setting of other packages. Bring over samples. All this is still being tested, but I do want to get this PR in so we have an updated apiview.dev link to show in the SDK Review on Thursday.