### PR TITLE
[Core] Add method for setting span error status

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added a `set_span_error_status` method to the `OpenTelemetryTracer` class. This method allows users to set the status of a span to `ERROR` after it has been created. #40703
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/tracing/opentelemetry.py
+++ b/sdk/core/azure-core/azure/core/tracing/opentelemetry.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import (
     Span,
     SpanKind as OpenTelemetrySpanKind,
     Link as OpenTelemetryLink,
+    StatusCode,
 )
 from opentelemetry.trace.propagation import get_current_span as get_current_span_otel
 from opentelemetry.propagate import extract, inject
@@ -160,6 +161,17 @@ class OpenTelemetryTracer:
             span, record_exception=False, end_on_exit=end_on_exit
         ) as active_span:
             yield active_span
+
+    @staticmethod
+    def set_span_error_status(span: Span, description: Optional[str] = None) -> None:
+        """Set the status of a span to ERROR with the provided description, if any.
+
+        :param span: The span to set the ERROR status on.
+        :type span: ~opentelemetry.trace.Span
+        :param description: An optional description of the error.
+        :type description: str
+        """
+        span.set_status(StatusCode.ERROR, description=description)
 
     def _parse_links(self, links: Optional[Sequence[Link]]) -> Optional[Sequence[OpenTelemetryLink]]:
         if not links:


### PR DESCRIPTION
Spans started by `OpenTelemetryTracer` in core return an OpenTelemetry span. The `set_status` on this method requires that a user imports `opentelemetry` types for `StatusCode` enums.

We want to avoid SDK developers needing to import `opentelemetry` in order to set a span status. However, in all cases so far, where a status on a span is being set, it's to set it to `ERROR`.  Here, we are adding a utility method on the `OpenTelemetryTracer` class to enable setting an error status on a provided span.

