### PR TITLE
Got Rid of Throughput Bucket Container and Database Level Requests

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -156,7 +156,6 @@ class ContainerProxy:
         populate_quota_info: Optional[bool] = None,
         priority: Optional[Literal["High", "Low"]] = None,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
         """Read the container properties.
@@ -170,7 +169,6 @@ class ContainerProxy:
         :keyword Literal["High", "Low"] priority: Priority based execution allows users to set a priority for each
             request. Once the user has reached their provisioned throughput, low priority requests are throttled
             before high priority requests start getting throttled. Feature must first be enabled at the account level.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: Raised if the container couldn't be retrieved.
             This includes if the container does not exist.
         :returns: Dict representing the retrieved container.
@@ -187,8 +185,6 @@ class ContainerProxy:
             kwargs['priority'] = priority
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         request_options = _build_options(kwargs)
         if populate_partition_key_range_statistics is not None:
             request_options["populatePartitionKeyRangeStatistics"] = populate_partition_key_range_statistics

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -131,7 +131,6 @@ class DatabaseProxy(object):
         self,
         *,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
         """Read the database properties.
@@ -139,7 +138,6 @@ class DatabaseProxy(object):
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
         :paramtype response_hook: Callable[[Mapping[str, str], Dict[str, Any]], None]
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: If the given database couldn't be retrieved.
         :returns: A dict representing the database properties
         :rtype: Dict[str, Any]
@@ -154,8 +152,6 @@ class DatabaseProxy(object):
         database_link = _get_database_link(self)
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         request_options = _build_options(kwargs)
 
         self._properties = await self.client_connection.ReadDatabase(
@@ -181,7 +177,6 @@ class DatabaseProxy(object):
         vector_embedding_policy: Optional[Dict[str, Any]] = None,
         change_feed_policy: Optional[Dict[str, Any]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a new container with the given ID (name).
@@ -215,7 +210,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: The container creation failed.
         :returns: A `ContainerProxy` instance representing the new container.
         :rtype: ~azure.cosmos.aio.ContainerProxy
@@ -285,8 +279,6 @@ class DatabaseProxy(object):
             definition["fullTextPolicy"] = full_text_policy
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs['throughput_bucket'] = throughput_bucket
         request_options = _build_options(kwargs)
         _set_throughput_options(offer=offer_throughput, request_options=request_options)
 
@@ -312,7 +304,6 @@ class DatabaseProxy(object):
         vector_embedding_policy: Optional[Dict[str, Any]] = None,
         change_feed_policy: Optional[Dict[str, Any]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a container if it does not exist already.
@@ -348,7 +339,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: The container creation failed.
         :returns: A `ContainerProxy` instance representing the new container.
         :rtype: ~azure.cosmos.aio.ContainerProxy
@@ -393,7 +383,6 @@ class DatabaseProxy(object):
                 vector_embedding_policy=vector_embedding_policy,
                 change_feed_policy=change_feed_policy,
                 full_text_policy=full_text_policy,
-                throughput_bucket=throughput_bucket,
                 **kwargs
             )
 
@@ -431,7 +420,6 @@ class DatabaseProxy(object):
         max_item_count: Optional[int] = None,
         initial_headers: Optional[Dict[str, str]] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], AsyncItemPaged[Dict[str, Any]]], None]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs
     ) -> AsyncItemPaged[Dict[str, Any]]:
         """List the containers in the database.
@@ -439,7 +427,6 @@ class DatabaseProxy(object):
         :keyword int max_item_count: Max number of items to be returned in the enumeration operation.
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :paramtype response_hook: Callable[[Mapping[str, Any], AsyncItemPaged[Dict[str, Any]]], None]
         :returns: An AsyncItemPaged of container properties (dicts).
         :rtype: AsyncItemPaged[Dict[str, Any]]
@@ -462,8 +449,6 @@ class DatabaseProxy(object):
                 DeprecationWarning)
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         feed_options = _build_options(kwargs)
         if max_item_count is not None:
             feed_options["maxItemCount"] = max_item_count
@@ -484,7 +469,6 @@ class DatabaseProxy(object):
         max_item_count: Optional[int] = None,
         initial_headers: Optional[Dict[str, str]] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], AsyncItemPaged[Dict[str, Any]]], None]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> AsyncItemPaged[Dict[str, Any]]:
         """List the properties for containers in the current database.
@@ -496,7 +480,6 @@ class DatabaseProxy(object):
         :keyword int max_item_count: Max number of items to be returned in the enumeration operation.
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :paramtype response_hook: Callable[[Mapping[str, Any], AsyncItemPaged[Dict[str, Any]]], None]
         :returns: An AsyncItemPaged of container properties (dicts).
         :rtype: AsyncItemPaged[Dict[str, Any]]
@@ -509,8 +492,6 @@ class DatabaseProxy(object):
                 DeprecationWarning)
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         feed_options = _build_options(kwargs)
         if max_item_count is not None:
             feed_options["maxItemCount"] = max_item_count
@@ -538,7 +519,6 @@ class DatabaseProxy(object):
         analytical_storage_ttl: Optional[int] = None,
         computed_properties: Optional[List[Dict[str, str]]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Reset the properties of the container.
@@ -567,7 +547,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: A `ContainerProxy` instance representing the container after replace completed.
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: Raised if the container couldn't be replaced.
             This includes if the container with given id does not exist.
@@ -603,8 +582,6 @@ class DatabaseProxy(object):
                 DeprecationWarning)
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs['throughput_bucket'] = throughput_bucket
         request_options = _build_options(kwargs)
 
         container_id = self._get_container_id(container)
@@ -637,7 +614,6 @@ class DatabaseProxy(object):
         container: Union[str, ContainerProxy, Mapping[str, Any]],
         *,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Delete a container.
@@ -649,7 +625,6 @@ class DatabaseProxy(object):
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
         :paramtype response_hook: Callable[[Mapping[str, str], None], None]
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: If the container couldn't be deleted.
         :rtype: None
         """
@@ -673,8 +648,6 @@ class DatabaseProxy(object):
                 DeprecationWarning)
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs['throughput_bucket'] = throughput_bucket
         request_options = _build_options(kwargs)
 
         collection_link = self._get_container_link(container)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -154,7 +154,6 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
         *,
         priority: Optional[Literal["High", "Low"]] = None,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         response_hook: Optional[Callable[[Mapping[str, str], Dict[str, Any]], None]] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
@@ -170,7 +169,6 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
         :paramtype response_hook: Callable[[Mapping[str, str], Dict[str, Any]], None]
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: Raised if the container couldn't be retrieved.
             This includes if the container does not exist.
         :returns: Dict representing the retrieved container.
@@ -186,8 +184,6 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
             kwargs['priority'] = priority
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         if response_hook is not None:
             kwargs['response_hook'] = response_hook
         request_options = build_options(kwargs)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -126,14 +126,12 @@ class DatabaseProxy(object):
         populate_query_metrics: Optional[bool] = None,
         *,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
         """Read the database properties.
 
         :keyword dict[str,str] initial_headers: Initial headers to be sent as part of the request.
         :keyword Callable response_hook: A callable invoked with the response metadata.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: A dict representing the database properties.
         :rtype: Dict[Str, Any]
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: If the given database couldn't be retrieved.
@@ -144,8 +142,6 @@ class DatabaseProxy(object):
                 "The 'session_token' flag does not apply to this method and is always ignored even if passed."
                 " It will now be removed in the future.",
                 DeprecationWarning)
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         if populate_query_metrics is not None:
             warnings.warn(
                 "the populate_query_metrics flag does not apply to this method and will be removed in the future",
@@ -179,7 +175,6 @@ class DatabaseProxy(object):
         vector_embedding_policy: Optional[Dict[str, Any]] = None,
         change_feed_policy: Optional[Dict[str, Any]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a new container with the given ID (name).
@@ -210,7 +205,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: A `ContainerProxy` instance representing the new container.
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: The container creation failed.
         :rtype: ~azure.cosmos.ContainerProxy
@@ -284,8 +278,6 @@ class DatabaseProxy(object):
             definition["fullTextPolicy"] = full_text_policy
         if initial_headers is not None:
             kwargs['initial_headers'] = initial_headers
-        if throughput_bucket is not None:
-            kwargs['throughput_bucket'] = throughput_bucket
         request_options = build_options(kwargs)
         _set_throughput_options(offer=offer_throughput, request_options=request_options)
         result = self.client_connection.CreateContainer(
@@ -312,7 +304,6 @@ class DatabaseProxy(object):
         vector_embedding_policy: Optional[Dict[str, Any]] = None,
         change_feed_policy: Optional[Dict[str, Any]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a container if it does not exist already.
@@ -345,7 +336,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: A `ContainerProxy` instance representing the container.
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: The container read or creation failed.
         :rtype: ~azure.cosmos.ContainerProxy
@@ -373,7 +363,6 @@ class DatabaseProxy(object):
             container_proxy = self.get_container_client(id)
             container_proxy.read(
                 populate_query_metrics=populate_query_metrics,
-                throughput_bucket=throughput_bucket,
                 initial_headers=initial_headers,
                 **kwargs
             )
@@ -394,7 +383,6 @@ class DatabaseProxy(object):
                 vector_embedding_policy=vector_embedding_policy,
                 change_feed_policy=change_feed_policy,
                 full_text_policy=full_text_policy,
-                throughput_bucket=throughput_bucket,
                 **kwargs
             )
 
@@ -405,7 +393,6 @@ class DatabaseProxy(object):
         populate_query_metrics: Optional[bool] = None,
         *,
         initial_headers: Optional[Dict[str, str]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Delete a container.
@@ -420,7 +407,6 @@ class DatabaseProxy(object):
             has changed, and act according to the condition specified by the `match_condition` parameter.
         :keyword ~azure.core.MatchConditions match_condition: The match condition to use upon the etag.
         :keyword Callable response_hook: A callable invoked with the response metadata.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: If the container couldn't be deleted.
         :rtype: None
         """
@@ -442,8 +428,6 @@ class DatabaseProxy(object):
                 "The 'match_condition' flag does not apply to this method and is always ignored even if passed."
                 " It will now be removed in the future.",
                 DeprecationWarning)
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         if populate_query_metrics is not None:
             warnings.warn(
                 "the populate_query_metrics flag does not apply to this method and will be removed in the future",
@@ -490,7 +474,6 @@ class DatabaseProxy(object):
         *,
         initial_headers: Optional[Dict[str, str]] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], ItemPaged[Dict[str, Any]]], None]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ItemPaged[Dict[str, Any]]:
         """List the containers in the database.
@@ -500,7 +483,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
         :paramtype response_hook: Callable[[Mapping[str, Any], ItemPaged[Dict[str, Any]]], None]
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: An Iterable of container properties (dicts).
         :rtype: Iterable[Dict[str, Any]]
 
@@ -519,8 +501,6 @@ class DatabaseProxy(object):
                 "The 'session_token' flag does not apply to this method and is always ignored even if passed."
                 " It will now be removed in the future.",
                 DeprecationWarning)
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         if populate_query_metrics is not None:
             warnings.warn(
                 "the populate_query_metrics flag does not apply to this method and will be removed in the future",
@@ -549,7 +529,6 @@ class DatabaseProxy(object):
         *,
         initial_headers: Optional[Dict[str, str]] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], ItemPaged[Dict[str, Any]]], None]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ItemPaged[Dict[str, Any]]:
         """List the properties for containers in the current database.
@@ -560,7 +539,6 @@ class DatabaseProxy(object):
         :param int max_item_count: Max number of items to be returned in the enumeration operation.
         :keyword Dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :paramtype response_hook: Callable[[Mapping[str, Any], ItemPaged[Dict[str, Any]]], None]
         :returns: An Iterable of container properties (dicts).
         :rtype: Iterable[Dict[str, Any]]
@@ -571,8 +549,6 @@ class DatabaseProxy(object):
                 "The 'session_token' flag does not apply to this method and is always ignored even if passed."
                 " It will now be removed in the future.",
                 DeprecationWarning)
-        if throughput_bucket is not None:
-            kwargs["throughput_bucket"] = throughput_bucket
         if populate_query_metrics is not None:
             warnings.warn(
                 "the populate_query_metrics flag does not apply to this method and will be removed in the future",
@@ -608,7 +584,6 @@ class DatabaseProxy(object):
         analytical_storage_ttl: Optional[int] = None,
         computed_properties: Optional[List[Dict[str, str]]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
-        throughput_bucket: Optional[int] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Reset the properties of the container.
@@ -635,7 +610,6 @@ class DatabaseProxy(object):
         :keyword Dict[str, Any] full_text_policy: **provisional** The full text policy for the container.
             Used to denote the default language to be used for all full text indexes, or to individually
             assign a language to each full text index path.
-        :keyword int throughput_bucket: The desired throughput bucket for the client
         :returns: A `ContainerProxy` instance representing the container after replace completed.
         :raises ~azure.cosmos.exceptions.CosmosHttpResponseError: Raised if the container couldn't be replaced.
             This includes if the container with given id does not exist.
@@ -668,8 +642,6 @@ class DatabaseProxy(object):
                 "The 'match_condition' flag does not apply to this method and is always ignored even if passed."
                 " It will now be removed in the future.",
                 DeprecationWarning)
-        if throughput_bucket is not None:
-            kwargs['throughput_bucket'] = throughput_bucket
         if populate_query_metrics is not None:
             warnings.warn(
                 "the populate_query_metrics flag does not apply to this method and will be removed in the future",

--- a/sdk/cosmos/azure-cosmos/samples/throughput_bucket_management.py
+++ b/sdk/cosmos/azure-cosmos/samples/throughput_bucket_management.py
@@ -23,16 +23,14 @@ import config
 #
 # 1. Setting throughput buckets at the Client Level
 #
-# 2. Setting Throughput Buckets at the Database Level
-#    2.1 - Create and Delete Database
+# 2. Setting Throughput Buckets at the Item Level
+#    2.1 - Read Item
+#    2.2 - Create Item
 #
-# 3. Setting Throughput Buckets at the Container Level
-#    3.1 - Create container
-#    3.2 - Query Container
-#
-# 4. Setting Throughput Buckets at the Item Level
-#    4.1 - Read Item
-#    4.2 - Create Item
+# 3. Multi-Bucket Usage
+#    3.1 - Create and Delete Item with Separate Buckets
+#    3.2 - Create Client and Create Item with Separate Buckets
+#    3.3 - Create, Upsert, and Delete Item with Separate Buckets
 # ----------------------------------------------------------------------------------------------------------
 # Note -
 #
@@ -51,37 +49,7 @@ def create_client_with_throughput_bucket(host=HOST, master_key=MASTER_KEY):
     cosmos_client.CosmosClient(host, master_key,
         throughput_bucket=1)
 
-# Applies throughput bucket 2 to create and delete a database
-def create_and_delete_database_with_throughput_bucket(client):
-    created_db = client.create_database_if_not_exists(
-        "test_db" + str(uuid.uuid4()),
-        throughput_bucket=2)
-
-    client.delete_database(
-        created_db.id,
-        throughput_bucket=2)
-
-# Applies throughput bucket 3 to create a container
-def create_container_with_throughput_bucket(client):
-    database = client.get_database_client(DATABASE_ID)
-
-    created_container = database.create_container(
-        str(uuid.uuid4()),
-        PartitionKey(path="/pk"),
-        throughput_bucket=3)
-
-    database.delete_container(created_container.id)
-
-# Applies throughput bucket 3 for requests to query containers
-def query_containers_with_throughput_bucket(client):
-    database = client.get_database_client(DATABASE_ID)
-
-    query = 'SELECT * from c'
-    database.query_containers(
-        query=query,
-        throughput_bucket=3)
-
-# Applies throughput bucket 4 for read item requests
+# Applies throughput bucket 2 for read item requests
 def container_read_item_throughput_bucket(client):
     database = client.get_database_client(DATABASE_ID)
     created_container = database.create_container(
@@ -92,11 +60,11 @@ def container_read_item_throughput_bucket(client):
     created_container.read_item(
          item=created_document['id'],
          partition_key="mypk",
-         throughput_bucket=4)
+         throughput_bucket=2)
 
     database.delete_container(created_container.id)
 
-# Applies throughput bucket 5 for create item requests
+# Applies throughput bucket 3 for create item requests
 def container_create_item_throughput_bucket(client):
     database = client.get_database_client(DATABASE_ID)
 
@@ -106,8 +74,66 @@ def container_create_item_throughput_bucket(client):
 
     created_container.create_item(
         body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
-        throughput_bucket=5)
+        throughput_bucket=3)
 
+    database.delete_container(created_container.id)
+
+# Applies throughput bucket 3 for create item requests and bucket 4 for delete item requests
+def container_create_and_delete_item_throughput_bucket(client):
+    database = client.get_database_client(DATABASE_ID)
+
+    created_container = database.create_container(
+        str(uuid.uuid4()),
+        PartitionKey(path="/pk"))
+
+    created_item = created_container.create_item(
+        body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+        throughput_bucket=3)
+
+    created_container.delete_item(
+        created_item['id'],
+        partition_key='mypk',
+        throughput_bucket=4)
+
+    database.delete_container(created_container.id)
+
+# Applies throughput bucket 1 to all requests from a client application, and bucket 2 to create item requests
+def create_client_and_item_with_throughput_bucket(host=HOST, master_key=MASTER_KEY):
+    client = cosmos_client.CosmosClient(host, master_key,
+        throughput_bucket=1)
+    database = client.get_database_client(DATABASE_ID)
+
+    created_container = database.create_container(
+        str(uuid.uuid4()),
+        PartitionKey(path="/pk"))
+
+    created_container.create_item(
+        body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+        throughput_bucket=2)
+
+    database.delete_container(created_container.id)
+
+# Applies throughput bucket 3 for create item requests, bucket 4 for upsert item requests, and bucket 5 for delete item
+def container_create_upsert_and_delete_item_throughput_bucket(client):
+    database = client.get_database_client(DATABASE_ID)
+
+    created_container = database.create_container(
+        str(uuid.uuid4()),
+        PartitionKey(path="/pk"))
+
+    created_item = created_container.create_item(
+        body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+        throughput_bucket=3)
+
+    # add items for partition key 1
+    for i in range(1, 3):
+        created_container.upsert_item(
+            dict(id="item{}".format(i), pk='mypk', throughput_bucket=4))
+
+    created_container.delete_item(
+        created_item['id'],
+        partition_key='mypk',
+        throughput_bucket=5)
     database.delete_container(created_container.id)
 
 def run_sample():
@@ -117,20 +143,20 @@ def run_sample():
         # creates client
         create_client_with_throughput_bucket()
 
-        # creates and deletes a database
-        create_and_delete_database_with_throughput_bucket(client)
-
-        # create a container
-        create_container_with_throughput_bucket(client)
-
-        # queries containers in a database
-        query_containers_with_throughput_bucket(client)
-
         # reads an item from a container
         container_read_item_throughput_bucket(client)
 
         # writes an item to a container
         container_create_item_throughput_bucket(client)
+
+        # creates and deletes an item to a container
+        container_create_and_delete_item_throughput_bucket(client)
+
+        # creates a client and item with separate throughput buckets
+        create_client_and_item_with_throughput_bucket()
+
+        # creates an item, upserts multiple items, and deletes an item all on separate throughput buckets
+        container_create_upsert_and_delete_item_throughput_bucket(client)
 
     except exceptions.CosmosHttpResponseError as e:
         print('\nrun_sample has caught an error. {0}'.format(e.message))

--- a/sdk/cosmos/azure-cosmos/samples/throughput_bucket_management_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/throughput_bucket_management_async.py
@@ -24,16 +24,14 @@ import config
 #
 # 1. Setting throughput buckets at the Client Level
 #
-# 2. Setting Throughput Buckets at the Database Level
-#    2.1 - Create and Delete Database
+# 2. Setting Throughput Buckets at the Item Level
+#    2.1 - Read Item
+#    2.2 - Create Item
 #
-# 3. Setting Throughput Buckets at the Container Level
-#    3.1 - Create container
-#    3.2 - Query Container
-#
-# 4. Setting Throughput Buckets at the Item Level
-#    4.1 - Read Item
-#    4.2 - Create Item
+# 3. Multi-Bucket Usage
+#    3.1 - Create and Delete Item with Separate Buckets
+#    3.2 - Create Client and Create Item with Separate Buckets
+#    3.3 - Create, Upsert, and Delete Item with Separate Buckets
 # ----------------------------------------------------------------------------------------------------------
 # Note -
 #
@@ -52,37 +50,7 @@ async def create_client_with_throughput_bucket(host=HOST, master_key=MASTER_KEY)
     async with CosmosClient(host, master_key, throughput_bucket=1) as client:
         pass
 
-# Applies throughput bucket 2 to create and delete a database
-async def create_and_delete_database_with_throughput_bucket(client):
-    created_db = await client.create_database_if_not_exists(
-        "test_db" + str(uuid.uuid4()),
-        throughput_bucket=2)
-
-    await client.delete_database(
-        created_db.id,
-        throughput_bucket=2)
-
-# Applies throughput bucket 3 to create a container
-async def create_container_with_throughput_bucket(client):
-    database = client.get_database_client(DATABASE_ID)
-
-    created_container = await database.create_container(
-        str(uuid.uuid4()),
-        PartitionKey(path="/pk"),
-        throughput_bucket=3)
-
-    await database.delete_container(created_container.id)
-
-# Applies throughput bucket 3 for requests to query containers
-async def query_containers_with_throughput_bucket(client):
-    database = client.get_database_client(DATABASE_ID)
-
-    query = 'SELECT * from c'
-    database.query_containers(
-        query=query,
-        throughput_bucket=3)
-
-# Applies throughput bucket 4 for read item requests
+# Applies throughput bucket 2 for read item requests
 async def container_read_item_throughput_bucket(client):
     database = client.get_database_client(DATABASE_ID)
     created_container = await database.create_container(
@@ -93,11 +61,11 @@ async def container_read_item_throughput_bucket(client):
     await created_container.read_item(
          item=created_document['id'],
          partition_key="mypk",
-         throughput_bucket=4)
+         throughput_bucket=2)
 
     await database.delete_container(created_container.id)
 
-# Applies throughput bucket 5 for create item requests
+# Applies throughput bucket 3 for create item requests
 async def container_create_item_throughput_bucket(client):
     database = client.get_database_client(DATABASE_ID)
 
@@ -107,9 +75,68 @@ async def container_create_item_throughput_bucket(client):
 
     await created_container.create_item(
         body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
-        throughput_bucket=5)
+        throughput_bucket=3)
 
     await database.delete_container(created_container.id)
+
+# Applies throughput bucket 3 for create item requests and bucket 4 for delete item requests
+async def container_create_and_delete_item_throughput_bucket(client):
+    database = client.get_database_client(DATABASE_ID)
+
+    created_container = await database.create_container(
+        str(uuid.uuid4()),
+        PartitionKey(path="/pk"))
+
+    created_item = await created_container.create_item(
+        body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+        throughput_bucket=3)
+
+    await created_container.delete_item(
+        created_item['id'],
+        partition_key='mypk',
+        throughput_bucket=4)
+
+    await database.delete_container(created_container.id)
+
+# Applies throughput bucket 1 to all requests from a client application, and bucket 2 to create item requests
+async def create_client_and_item_with_throughput_bucket(host=HOST, master_key=MASTER_KEY):
+    async with CosmosClient(host, master_key,
+        throughput_bucket=1) as client:
+
+        database = client.get_database_client(DATABASE_ID)
+
+        created_container = await database.create_container(
+            str(uuid.uuid4()),
+            PartitionKey(path="/pk"))
+
+        await created_container.create_item(
+            body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+            throughput_bucket=2)
+
+        await database.delete_container(created_container.id)
+
+# Applies throughput bucket 3 for create item requests, bucket 4 for upsert item requests, and bucket 5 for delete item
+async def container_create_upsert_and_delete_item_throughput_bucket(client):
+    database = client.get_database_client(DATABASE_ID)
+
+    created_container = await database.create_container(
+        str(uuid.uuid4()),
+        PartitionKey(path="/pk"))
+
+    created_item = await created_container.create_item(
+        body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
+        throughput_bucket=3)
+
+    # add items for partition key 1
+    for i in range(1, 3):
+        await created_container.upsert_item(
+            dict(id="item{}".format(i), pk='mypk', throughput_bucket=4))
+
+    await created_container.delete_item(
+        created_item['id'],
+        partition_key='mypk',
+        throughput_bucket=5)
+    database.delete_container(created_container.id)
 
 async def run_sample():
     async with CosmosClient(HOST, {'masterKey': MASTER_KEY} ) as client:
@@ -118,20 +145,20 @@ async def run_sample():
             # creates client
             await create_client_with_throughput_bucket()
 
-            # creates and deletes a database
-            await create_and_delete_database_with_throughput_bucket(client)
-
-            # create a container
-            await create_container_with_throughput_bucket(client)
-
-            # queries containers in a database
-            await query_containers_with_throughput_bucket(client)
-
             # reads an item from a container
             await container_read_item_throughput_bucket(client)
 
             # writes an item to a container
             await container_create_item_throughput_bucket(client)
+
+            # creates and deletes an item to a container
+            await container_create_and_delete_item_throughput_bucket(client)
+
+            # creates a client and item with separate throughput buckets
+            await create_client_and_item_with_throughput_bucket()
+
+            # creates an item, upserts multiple items, and deletes an item all on separate throughput buckets
+            await container_create_upsert_and_delete_item_throughput_bucket(client)
 
         except exceptions.CosmosHttpResponseError as e:
             print('\nrun_sample has caught an error. {0}'.format(e.message))

--- a/sdk/cosmos/azure-cosmos/tests/test_headers.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_headers.py
@@ -106,87 +106,15 @@ class TestHeaders(unittest.TestCase):
     def test_request_precedence_throughput_bucket(self):
         client = cosmos_client.CosmosClient(self.host, self.masterKey,
                                    throughput_bucket=client_throughput_bucket_number)
-        created_db = client.create_database(
-            "test_db" + str(uuid.uuid4()),
+        created_db = client.create_database("test_db" + str(uuid.uuid4()))
+        created_container = created_db.create_container(
+            str(uuid.uuid4()),
+            PartitionKey(path="/pk"))
+        created_container.create_item(
+            body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
             throughput_bucket=request_throughput_bucket_number,
             raw_response_hook=request_raw_response_hook)
         client.delete_database(created_db.id)
-
-    def test_create_db_if_not_exists_and_delete_db_throughput_bucket(self):
-        created_db = self.client.create_database_if_not_exists(
-           "test_db" + str(uuid.uuid4()),
-           throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-        self.client.delete_database(
-            created_db.id,
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_list_db_throughput_bucket(self):
-        self.client.list_databases(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_query_db_throughput_bucket(self):
-        self.client.query_databases(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_db_read_throughput_bucket(self):
-        self.database.read(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_create_container_throughput_bucket(self):
-        created_collection = self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        self.database.delete_container(created_collection.id)
-
-    def test_create_container_if_not_exists_throughput_bucket(self):
-        created_collection = self.database.create_container_if_not_exists(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        self.database.delete_container(created_collection.id)
-
-    def test_delete_container_throughput_bucket(self):
-        created_collection = self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"))
-        self.database.delete_container(
-            created_collection.id,
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_list_containers_throughput_bucket(self):
-        self.database.list_containers(
-           throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-
-    def test_query_containers_throughput_bucket(self):
-        self.database.query_containers(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    def test_replace_container_throughput_bucket(self):
-        created_collection = self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"))
-        replaced_collection = self.database.replace_container(
-            created_collection.id,
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        self.database.delete_container(replaced_collection.id)
-
-    def test_container_read_throughput_bucket(self):
-        self.container.read(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
 
     def test_container_read_item_throughput_bucket(self):
         created_document = self.container.create_item(body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'})

--- a/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
@@ -53,91 +53,15 @@ class TestHeadersAsync(unittest.IsolatedAsyncioTestCase):
     async def test_request_precedence_throughput_bucket_async(self):
         client = CosmosClient(self.host, self.masterKey,
                                    throughput_bucket=client_throughput_bucket_number)
-        created_db = await client.create_database(
-            "test_db" + str(uuid.uuid4()),
+        created_db = await client.create_database("test_db" + str(uuid.uuid4()))
+        created_container = await created_db.create_container(
+            str(uuid.uuid4()),
+            PartitionKey(path="/pk"))
+        await created_container.create_item(
+            body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'},
             throughput_bucket=request_throughput_bucket_number,
             raw_response_hook=request_raw_response_hook)
         await client.delete_database(created_db.id)
-
-    async def test_create_db_if_not_exists_and_delete_db_throughput_bucket_async(self):
-        created_db = await self.client.create_database_if_not_exists(
-           "test_db" + str(uuid.uuid4()),
-           throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-        await self.client.delete_database(
-            created_db.id,
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    async def test_list_db_throughput_bucket_async(self):
-        self.client.list_databases(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    async def test_query_db_throughput_bucket_async(self):
-        query = 'SELECT * from c'
-        self.client.query_databases(
-            query=query,
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    async def test_db_read_throughput_bucket_async(self):
-       await self.database.read(
-            throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-
-    async def test_create_container_throughput_bucket_async(self):
-        created_collection = await self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        await self.database.delete_container(created_collection.id)
-
-    async def test_create_container_if_not_exists_throughput_bucket_async(self):
-        created_collection = await self.database.create_container_if_not_exists(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        await self.database.delete_container(created_collection.id)
-
-    async def test_delete_container_throughput_bucket_async(self):
-        created_collection = await self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"))
-        await self.database.delete_container(
-            created_collection.id,
-           throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-
-    async def test_list_containers_throughput_bucket_async(self):
-        self.database.list_containers(
-           throughput_bucket=request_throughput_bucket_number,
-           raw_response_hook=request_raw_response_hook)
-
-    async def test_query_containers_throughput_bucket_async(self):
-        query = 'SELECT * from c'
-        self.database.query_containers(
-            query=query,
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-
-    async def test_replace_container_throughput_bucket_async(self):
-        created_collection = await self.database.create_container(
-            str(uuid.uuid4()),
-            PartitionKey(path="/pk"))
-        replaced_collection = await self.database.replace_container(
-            created_collection.id,
-            PartitionKey(path="/pk"),
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
-        await self.database.delete_container(replaced_collection.id)
-
-    async def test_container_read_throughput_bucket_async(self):
-        await self.container.read(
-            throughput_bucket=request_throughput_bucket_number,
-            raw_response_hook=request_raw_response_hook)
 
     async def test_container_read_item_throughput_bucket_async(self):
         created_document = await self.container.create_item(body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'})


### PR DESCRIPTION
# Description

Got rid of the Throughput Bucket Container and Database Level Requests to eliminate potential customer confusion, since these operations don't apply throughput buckets to their requests. Additionally, I updated the test_headers and test_headers_async files to reflect the requests only at the client and item level. Also, I added new samples to show customers how throughput buckets requests can be made following these changes. 