### PR TITLE
[Identity] Add README section about Powershell credential

### DIFF
--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -41,6 +41,12 @@ To authenticate with the [Azure Developer CLI][azure_developer_cli], run the com
 
 For systems without a default web browser, the `azd auth login --use-device-code` command uses the device code authentication flow.
 
+#### Authenticate via the Azure PowerShell
+
+Developers coding outside of an IDE can also use [Azure PowerShell][azure_powershell] to authenticate. Applications using `DefaultAzureCredential` or `AzurePowerShellCredential` can then use this account to authenticate calls in their application when running locally.
+
+To authenticate with Azure PowerShell, run the `Connect-AzAccount` cmdlet. By default, like the Azure CLI, `Connect-AzAccount` launches the default web browser to authenticate the user. For systems without a default web browser, the `Connect-AzAccount` uses the device code authentication flow. The user can also force Azure PowerShell to use the device code flow rather than launching a browser by specifying the `-UseDeviceAuthentication` argument.
+
 ## Key concepts
 
 ### Credentials
@@ -363,6 +369,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [azd_cli_cred_ref]: https://aka.ms/azsdk/python/identity/azuredeveloperclicredential
 [azure_cli]: https://learn.microsoft.com/cli/azure
 [azure_developer_cli]:https://aka.ms/azure-dev
+[azure_powershell]: https://learn.microsoft.com/powershell/azure
 [azure_core_transport_doc]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#transport
 [azure_identity_broker]: https://pypi.org/project/azure-identity-broker
 [azure_identity_broker_readme]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity-broker

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -41,7 +41,7 @@ To authenticate with the [Azure Developer CLI][azure_developer_cli], run the com
 
 For systems without a default web browser, the `azd auth login --use-device-code` command uses the device code authentication flow.
 
-#### Authenticate via the Azure PowerShell
+#### Authenticate via Azure PowerShell
 
 Developers coding outside of an IDE can also use [Azure PowerShell][azure_powershell] to authenticate. Applications using `DefaultAzureCredential` or `AzurePowerShellCredential` can then use this account to authenticate calls in their application when running locally.
 


### PR DESCRIPTION
In the `Authenticate during local development` section, we are missing a subsection about using the `AzurePowerShellCredential`. 

This is present in other language READMEs, so we must have missed it here.


