### PR TITLE
[Corehttp] Remove tenant_id from TokenRequestOptions

### DIFF
--- a/sdk/core/corehttp/CHANGELOG.md
+++ b/sdk/core/corehttp/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Breaking Changes
 
+- Removed `tenant_id` from `TokenRequestOptions`. [#40731](https://github.com/Azure/azure-sdk-for-python/pull/40731)
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/corehttp/corehttp/credentials.py
+++ b/sdk/core/corehttp/corehttp/credentials.py
@@ -48,8 +48,6 @@ class TokenRequestOptions(TypedDict, total=False):
     claims: str
     """Additional claims required in the token, such as those returned in a resource provider's claims
     challenge following an authorization failure."""
-    tenant_id: str
-    """The tenant ID to include in the token request."""
 
 
 class TokenCredential(Protocol, ContextManager["TokenCredential"]):


### PR DESCRIPTION
The `tenant_id` option is Azure-specific and doesn't need to be in unbranded core.
