### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -841,3 +841,4 @@
 /eng/emitter-package-lock.json                                       @mccoyp @catalinaperalta @kristapratico @iscai-msft
 
 /pylintrc                                                            @l0lawrence
+/sdk/**/ci.yml                                                       @msyyc @lmazuel


### PR DESCRIPTION
`ci.yml` is put in folder which may contain both Mgmt-plane SDK and data-plane SDK.

Since I own Mgmt SDK, I hope to add myself as codeowner so that new release of Mgmt SDK will not be blocked.