### PR TITLE
[EventHub] decode ms datetime-offset

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -241,7 +241,6 @@ class EventData:
         event_data._message = amqp_message
         event_data._raw_amqp_message = AmqpAnnotatedMessage(message=amqp_message)
         return event_data
-
     @classmethod
     def _from_message(
         cls,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/constants.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/constants.py
@@ -79,6 +79,12 @@ CBS_OPERATION = "operation"
 CBS_TYPE = "type"
 CBS_EXPIRATION = "expiration"
 
+# Add a DESCRIPTOR constant for Microsoft DateTimeOffset
+VENDOR = b"com.microsoft"
+DATETIME_OFFSET_SYMBOL = b"%b:datetime-offset" % VENDOR
+TICKS_MASK = 0x3FFFFFFFFFFFFFFF
+KIND_SHIFT = 62
+
 SEND_DISPOSITION_ACCEPT = "accepted"
 SEND_DISPOSITION_REJECT = "rejected"
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
@@ -49,6 +49,7 @@ TZ_UTC: timezone = timezone.utc
 CE_ZERO_SECONDS: int = -62_135_596_800
 
 
+# TODO: decide whether to pass in timezone when calling property, or decode as datetime in _decode.py
 def utc_from_timestamp(timestamp: float) -> datetime.datetime:
     """
     :param float timestamp: Timestamp in seconds to be converted to datetime.


### PR DESCRIPTION
Service may send back either a DateTime or DateTimeOffset. Currently, Python does not account for this.

To do so, client needs to check for the symbol b"com.microsoft:datetime-offset" and decode the value.