### PR TITLE
[Identity] Re-enable client secret live tests

### DIFF
--- a/sdk/identity/azure-identity/tests/conftest.py
+++ b/sdk/identity/azure-identity/tests/conftest.py
@@ -63,7 +63,6 @@ def record_imds_test(request):
 @pytest.fixture()
 def live_service_principal():
     """Fixture for live Identity tests. Skips them when environment configuration is incomplete."""
-    pytest.skip(reason="https://github.com/Azure/azure-sdk-for-python/issues/35957")
     missing_variables = [
         v
         for v in (
@@ -118,6 +117,7 @@ def get_certificate_with_password_parameters(password_protected_content: bytes, 
 
 @pytest.fixture()
 def live_pem_certificate(live_service_principal):
+    pytest.skip(reason="https://github.com/Azure/azure-sdk-for-python/issues/35957")
     content = os.environ.get("PEM_CONTENT")
     password_protected_content = os.environ.get("PEM_CONTENT_PASSWORD_PROTECTED")
     password = os.environ.get("CERTIFICATE_PASSWORD")
@@ -143,6 +143,7 @@ def live_pem_certificate(live_service_principal):
 @pytest.fixture()
 def live_pfx_certificate(live_service_principal):
     # PFX bytes arrive base64 encoded because Key Vault secrets have string values
+    pytest.skip(reason="https://github.com/Azure/azure-sdk-for-python/issues/35957")
     encoded_content = os.environ.get("PFX_CONTENTS")
     encoded_password_protected_content = os.environ.get("PFX_CONTENT_PASSWORD_PROTECTED")
     password = os.environ.get("CERTIFICATE_PASSWORD")

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -334,10 +334,11 @@ def test_live_multitenant_authentication(live_service_principal, get_token_metho
         live_service_principal["client_secret"],
         additionally_allowed_tenants=["*"],
     )
+    kwargs = {"tenant_id": live_service_principal["tenant_id"]}
+    if get_token_method == "get_token_info":
+        kwargs = {"options": kwargs}
     # then get a valid token for an actual tenant
-    token = getattr(credential, get_token_method)(
-        "https://vault.azure.net/.default", tenant_id=live_service_principal["tenant_id"]
-    )
+    token = getattr(credential, get_token_method)("https://vault.azure.net/.default", **kwargs)
     assert token.token
     assert token.expires_on
 

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -19,11 +19,11 @@ from azure.identity._constants import DEVELOPER_SIGN_ON_CLIENT_ID
 
 from helpers import get_token_payload_contents, GET_TOKEN_METHODS
 
-ARM_SCOPE = "https://management.azure.com/.default"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
 
 
 def get_token(credential, method, **kwargs):
-    token = getattr(credential, method)(ARM_SCOPE, **kwargs)
+    token = getattr(credential, method)(GRAPH_SCOPE, **kwargs)
     assert token
     assert token.token
     assert token.expires_on
@@ -66,7 +66,10 @@ def test_client_secret_credential(live_service_principal, get_token_method):
         live_service_principal["client_id"],
         live_service_principal["client_secret"],
     )
-    token = get_token(credential, get_token_method, enable_cae=True)
+    kwargs = {"enable_cae": True}
+    if get_token_method == "get_token_info":
+        kwargs = {"options": kwargs}
+    token = get_token(credential, get_token_method, **kwargs)
     parsed_payload = get_token_payload_contents(token.token)
     assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -16,11 +16,11 @@ from azure.identity.aio import (
 
 from helpers import get_token_payload_contents, GET_TOKEN_METHODS
 
-ARM_SCOPE = "https://management.azure.com/.default"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
 
 
 async def get_token(credential, get_token_method, **kwargs):
-    token = await getattr(credential, get_token_method)(ARM_SCOPE, **kwargs)
+    token = await getattr(credential, get_token_method)(GRAPH_SCOPE, **kwargs)
     assert token
     assert token.token
     assert token.expires_on
@@ -65,7 +65,10 @@ async def test_client_secret_credential(live_service_principal, get_token_method
         live_service_principal["client_id"],
         live_service_principal["client_secret"],
     )
-    token = await get_token(credential, get_token_method, enable_cae=True)
+    kwargs = {"enable_cae": True}
+    if get_token_method == "get_token_info":
+        kwargs = {"options": kwargs}
+    token = await get_token(credential, get_token_method, **kwargs)
     parsed_payload = get_token_payload_contents(token.token)
     assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 


### PR DESCRIPTION
This will leverage the TME tenant app registration in live tests.

Switching to test scope to be the MS Graph one, as Graph supports CAE and will return the xms_cc claim which is what we test for. 