### PR TITLE
Add auth specific test cases

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_a93be1e527"
+  "Tag": "python/evaluation/azure-ai-evaluation_46d29a3440"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_prompty_eval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_prompty_eval.py
@@ -7,10 +7,6 @@ import re
 import os
 from typing import Dict, TypeVar, Union
 
-if os.getenv("AI_EVALS_USE_PF_PROMPTY", "false").lower() == "true":
-    from promptflow.core._flow import AsyncPrompty
-else:
-    from azure.ai.evaluation._legacy.prompty import AsyncPrompty
 from typing_extensions import override
 
 from azure.ai.evaluation._common.constants import PROMPT_BASED_REASON_EVALUATORS
@@ -66,6 +62,11 @@ class PromptyEvaluatorBase(EvaluatorBase[T]):
             self._DEFAULT_OPEN_API_VERSION,
             user_agent,
         )
+
+        if os.getenv("AI_EVALS_USE_PF_PROMPTY", "false").lower() == "true":
+            from promptflow.core._flow import AsyncPrompty
+        else:
+            from azure.ai.evaluation._legacy.prompty import AsyncPrompty
 
         self._flow = AsyncPrompty.load(source=self._prompty_file, model=prompty_model_config,
                                        is_reasoning_model=self._is_reasoning_model)

--- a/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/conftest.py
@@ -1,15 +1,12 @@
 from .__openai_patcher import TestProxyConfig, TestProxyHttpxClientBase  # isort: split
 
-import re
 import os
 import json
-import multiprocessing
 import time
 from datetime import datetime, timedelta
 import jwt
 from copy import deepcopy
 from logging import Logger
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Final, Generator, Mapping, Literal, Optional
 from unittest.mock import patch
@@ -598,3 +595,12 @@ def run_from_temp_dir(tmp_path):
     os.chdir(tmp_path)
     yield
     os.chdir(original_cwd)
+
+
+@pytest.fixture
+def restore_env_vars():
+    """Fixture to restore environment variables after the test."""
+    original_vars = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(original_vars)

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_prompty_async.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_prompty_async.py
@@ -185,3 +185,13 @@ class TestPrompty:
         response: str = result.choices[0].message.content or ""
         assert "Bob" in response
         assert "Paris" in response
+
+    @pytest.mark.asyncio
+    async def test_entra_id(self, prompty_config: Dict[str, Any]):
+        from azure.identity import DefaultAzureCredential
+
+        prompty_config["model"]["configuration"].pop("api_key", None)
+        prompty = AsyncPrompty(BASIC_PROMPTY, token_credential=DefaultAzureCredential(), **prompty_config)
+        result = await prompty(firstName="Bob", question="What is the capital of France?")
+        assert isinstance(result, str)
+        assert "Paris" in result

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List
 import json
 import math
 import os
@@ -96,15 +96,6 @@ def questions_answers_basic_file():
 @pytest.fixture
 def questions_answers_korean_file():
     return _get_file("questions_answers_korean.jsonl")
-
-
-@pytest.fixture
-def restore_env_vars():
-    """Fixture to restore environment variables after the test."""
-    original_vars = os.environ.copy()
-    yield
-    os.environ.clear()
-    os.environ.update(original_vars)
 
 
 def _target_fn(query):


### PR DESCRIPTION
Adds some test cases for Prompty based evaluators to validate the various auth scenarios (i.e. with api_key or with Entra Id)