### PR TITLE
Add tests that run all samples

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -189,6 +189,10 @@ print(f"List all deployments by the model publisher `{model_publisher}`:")
 for deployment in project_client.deployments.list(model_publisher=model_publisher):
     print(deployment)
 
+print(f"List all deployments of model `{model_name}`:")
+for deployment in project_client.deployments.list(model_name=model_name):
+    print(deployment)
+
 print(f"Get a single deployment named `{model_deployment_name}`:")
 deployment = project_client.deployments.get(model_deployment_name)
 print(deployment)
@@ -211,6 +215,13 @@ for connection in project_client.connections.list():
 print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections):")
 for connection in project_client.connections.list(
     connection_type=ConnectionType.AZURE_OPEN_AI,
+):
+    print(connection)
+
+print("To list the default connection of a particular type  (in this case, Azure Store Account):")
+for connection in project_client.connections.list(
+    connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
+    default_connection=True,
 ):
     print(connection)
 
@@ -239,7 +250,7 @@ print(
 dataset: DatasetVersion = project_client.datasets.upload_file(
     name=dataset_name,
     version=dataset_version_1,
-    file_path="sample_folder/sample_file1.txt",
+    file_path=file_path,
 )
 print(dataset)
 
@@ -249,7 +260,7 @@ print(
 dataset = project_client.datasets.upload_folder(
     name=dataset_name,
     version=dataset_version_2,
-    folder="sample_folder",
+    folder=folder_path,
 )
 print(dataset)
 
@@ -302,7 +313,7 @@ print(f"Listing all versions of the Index named `{index_name}`:")
 for index in project_client.indexes.list_versions(name=index_name):
     print(index)
 
-print(f"Delete Index`{index_name}` version `{index_version}`:")
+print(f"Delete Index `{index_name}` version `{index_version}`:")
 project_client.indexes.delete(name=index_name, version=index_version)
 ```
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -250,7 +250,9 @@ class InferenceOperations:
         # If the connection uses API key authentication, we need to make another service call to get
         # the connection with API key populated.
         if connection.credentials.type == CredentialType.API_KEY:
-            connection = await self._outer_instance.connections._get_with_credentials(name=connection_name, **kwargs) # pylint: disable=protected-access
+            connection = await self._outer_instance.connections._get_with_credentials(  # pylint: disable=protected-access
+                name=connection_name, **kwargs
+            )
 
         logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_telemetry_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_telemetry_async.py
@@ -58,7 +58,9 @@ class TelemetryOperations:
             if not connection_name:
                 raise ResourceNotFoundError("No Application Insights connection found.")
 
-            connection = await self._outer_instance.connections._get_with_credentials(name=connection_name)  # pylint: disable=protected-access
+            connection = await self._outer_instance.connections._get_with_credentials(  # pylint: disable=protected-access
+                name=connection_name
+            )
 
             if isinstance(connection.credentials, ApiKeyCredentials):
                 if not connection.credentials.api_key:

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -313,15 +313,15 @@ class BaseCredentials(_Model):
 class ApiKeyCredentials(BaseCredentials, discriminator="ApiKey"):
     """API Key Credential definition.
 
-    :ivar type: The credentail type. Required. API Key credential
+    :ivar type: The credential type. Required. API Key credential
     :vartype type: str or ~azure.ai.projects.models.API_KEY
     :ivar api_key: API Key.
     :vartype api_key: str
     """
 
     type: Literal[CredentialType.API_KEY] = rest_discriminator(name="type", visibility=["read"])  # type: ignore
-    """The credentail type. Required. API Key credential"""
-    api_key: Optional[str] = rest_field(name="Key", visibility=["read"])
+    """The credential type. Required. API Key credential"""
+    api_key: Optional[str] = rest_field(name="key", visibility=["read"])
     """API Key."""
 
     @overload

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
@@ -246,7 +246,9 @@ class InferenceOperations:
         # If the connection uses API key authentication, we need to make another service call to get
         # the connection with API key populated.
         if connection.credentials.type == CredentialType.API_KEY:
-            connection = self._outer_instance.connections._get_with_credentials(name=connection_name, **kwargs)  # pylint: disable=protected-access
+            connection = self._outer_instance.connections._get_with_credentials(  # pylint: disable=protected-access
+                name=connection_name, **kwargs
+            )
 
         logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_telemetry.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_telemetry.py
@@ -54,7 +54,9 @@ class TelemetryOperations:
             if not connection_name:
                 raise ResourceNotFoundError("No Application Insights connection found.")
 
-            connection = self._outer_instance.connections._get_with_credentials(name=connection_name)  # pylint: disable=protected-access
+            connection = self._outer_instance.connections._get_with_credentials(  # pylint: disable=protected-access
+                name=connection_name
+            )
 
             if isinstance(connection.credentials, ApiKeyCredentials):
                 if not connection.credentials.api_key:

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_async.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_async.py
@@ -29,7 +29,7 @@ from azure.identity.aio import DefaultAzureCredential
 from azure.ai.projects.aio import AIProjectClient
 
 
-async def sample_agents_async() -> None:
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
@@ -50,10 +50,6 @@ async def sample_agents_async() -> None:
 
             await project_client.agents.delete_agent(agent.id)
             print("Deleted agent")
-
-
-async def main():
-    await sample_agents_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
@@ -46,6 +46,13 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
         ):
             print(connection)
 
+        print("To list the default connection of a particular type  (in this case, Azure Store Account):")
+        for connection in project_client.connections.list(
+            connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
+            default_connection=True,
+        ):
+            print(connection)
+
         print(f"Get the properties of a connection named `{connection_name}`, without its credentials:")
         connection = project_client.connections.get(connection_name)
         print(connection)

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections_async.py
@@ -30,7 +30,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import ConnectionType
 
 
-async def sample_connections_async() -> None:
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     connection_name = os.environ["CONNECTION_NAME"]
@@ -51,6 +51,13 @@ async def sample_connections_async() -> None:
             ):
                 print(connection)
 
+            print("To list the default connection of a particular type  (in this case, Azure Store Account):")
+            async for connection in project_client.connections.list(
+                connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
+                default_connection=True,
+            ):
+                print(connection)
+
             print(f"Get the properties of a connection named `{connection_name}`, without its credentials:")
             connection = await project_client.connections.get(connection_name)
             print(connection)
@@ -58,10 +65,6 @@ async def sample_connections_async() -> None:
             print(f"Get the properties of a connection named `{connection_name}`, with its credentials:")
             connection = await project_client.connections.get(connection_name, include_credentials=True)
             print(connection)
-
-
-async def main():
-    await sample_connections_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets.py
+++ b/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets.py
@@ -35,6 +35,11 @@ dataset_name = os.environ.get("DATASET_NAME", "dataset-test")
 dataset_version_1 = os.environ.get("DATASET_VERSION_1", "1.0")
 dataset_version_2 = os.environ.get("DATASET_VERSION_2", "2.0")
 
+# Construct the full folder path `sample_folder`, and full file path `sample_folder/sample_file1.txt`
+script_dir = os.path.dirname(os.path.abspath(__file__))
+folder_path = os.path.join(script_dir, "sample_folder")
+file_path = os.path.join(folder_path, "sample_file1.txt")
+
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
     with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
@@ -46,7 +51,7 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
         dataset: DatasetVersion = project_client.datasets.upload_file(
             name=dataset_name,
             version=dataset_version_1,
-            file_path="sample_folder/sample_file1.txt",
+            file_path=file_path,
         )
         print(dataset)
 
@@ -56,7 +61,7 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
         dataset = project_client.datasets.upload_folder(
             name=dataset_name,
             version=dataset_version_2,
-            folder="sample_folder",
+            folder=folder_path,
         )
         print(dataset)
 

--- a/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets_async.py
+++ b/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets_async.py
@@ -31,8 +31,13 @@ from azure.identity.aio import DefaultAzureCredential
 from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import DatasetVersion
 
+# Construct the full folder path `sample_folder`, and full file path `sample_folder/sample_file1.txt`
+script_dir = os.path.dirname(os.path.abspath(__file__))
+folder_path = os.path.join(script_dir, "sample_folder")
+file_path = os.path.join(folder_path, "sample_file1.txt")
 
-async def sample_datasets_async() -> None:
+
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     dataset_name = os.environ.get("DATASET_NAME", "dataset-test")
@@ -49,7 +54,7 @@ async def sample_datasets_async() -> None:
             dataset: DatasetVersion = await project_client.datasets.upload_file(
                 name=dataset_name,
                 version=dataset_version_1,
-                file_path="sample_folder/sample_file1.txt",
+                file_path=file_path,
             )
             print(dataset)
 
@@ -59,7 +64,7 @@ async def sample_datasets_async() -> None:
             dataset = await project_client.datasets.upload_folder(
                 name=dataset_name,
                 version=dataset_version_2,
-                folder="sample_folder",
+                folder=folder_path,
             )
             print(dataset)
 
@@ -78,10 +83,6 @@ async def sample_datasets_async() -> None:
             print("Delete all Dataset versions created above:")
             await project_client.datasets.delete(name=dataset_name, version=dataset_version_1)
             await project_client.datasets.delete(name=dataset_name, version=dataset_version_2)
-
-
-async def main():
-    await sample_datasets_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/deployments/sample_deployments.py
+++ b/sdk/ai/azure-ai-projects/samples/deployments/sample_deployments.py
@@ -19,7 +19,8 @@ USAGE:
     1) PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Azure AI Foundry project.
     2) MODEL_DEPLOYMENT_NAME - Required. The name of the deployment to retrieve.
-    3) MODEL_PUBLISHER - Required. The publisher of the model to filter by.
+    3) MODEL_PUBLISHER - Optional. The publisher of the model to filter by.
+    4) MODEL_NAME - Optional. The name of the model to filter by.
 """
 
 import os
@@ -28,7 +29,8 @@ from azure.ai.projects import AIProjectClient
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
-model_publisher = os.environ["MODEL_PUBLISHER"]
+model_publisher = os.environ.get("MODEL_PUBLISHER", "Microsoft")
+model_name = os.environ.get("MODEL_NAME", "Phi-4")
 
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
@@ -41,6 +43,10 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
 
         print(f"List all deployments by the model publisher `{model_publisher}`:")
         for deployment in project_client.deployments.list(model_publisher=model_publisher):
+            print(deployment)
+
+        print(f"List all deployments of model `{model_name}`:")
+        for deployment in project_client.deployments.list(model_name=model_name):
             print(deployment)
 
         print(f"Get a single deployment named `{model_deployment_name}`:")

--- a/sdk/ai/azure-ai-projects/samples/deployments/sample_deployments_async.py
+++ b/sdk/ai/azure-ai-projects/samples/deployments/sample_deployments_async.py
@@ -19,7 +19,8 @@ USAGE:
     1) PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Azure AI Foundry project.
     2) MODEL_DEPLOYMENT_NAME - Required. The name of the deployment to retrieve.
-    3) MODEL_PUBLISHER - Required. The publisher of the model to filter by.       
+    3) MODEL_PUBLISHER - Optional. The publisher of the model to filter by.
+    4) MODEL_NAME - Optional. The name of the model to filter by.
 """
 
 import asyncio
@@ -28,11 +29,12 @@ from azure.identity.aio import DefaultAzureCredential
 from azure.ai.projects.aio import AIProjectClient
 
 
-async def sample_deployments_async() -> None:
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
-    model_publisher = os.environ["MODEL_PUBLISHER"]
+    model_publisher = os.environ.get("MODEL_PUBLISHER", "Microsoft")
+    model_name = os.environ.get("MODEL_NAME", "Phi-4")
 
     async with DefaultAzureCredential() as credential:
 
@@ -46,13 +48,13 @@ async def sample_deployments_async() -> None:
             async for deployment in project_client.deployments.list(model_publisher=model_publisher):
                 print(deployment)
 
+            print(f"List all deployments of model `{model_name}`:")
+            async for deployment in project_client.deployments.list(model_name=model_name):
+                print(deployment)
+
             print(f"Get a single deployment named `{model_deployment_name}`:")
             deployment = await project_client.deployments.get(model_deployment_name)
             print(deployment)
-
-
-async def main():
-    await sample_deployments_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/evaluation/sample_evaluations_async.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluation/sample_evaluations_async.py
@@ -38,7 +38,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-async def sample_evaluations_async() -> None:
+async def main() -> None:
     endpoint = os.environ["PROJECT_ENDPOINT"]
     # dataset_name = os.environ["DATASET_NAME"]
 
@@ -86,10 +86,6 @@ async def sample_evaluations_async() -> None:
                 print(evaluation)
 
             # [END evaluations_sample]
-
-
-async def main():
-    await sample_evaluations_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/indexes/sample_indexes.py
+++ b/sdk/ai/azure-ai-projects/samples/indexes/sample_indexes.py
@@ -63,6 +63,6 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
         for index in project_client.indexes.list_versions(name=index_name):
             print(index)
 
-        print(f"Delete Index`{index_name}` version `{index_version}`:")
+        print(f"Delete Index `{index_name}` version `{index_version}`:")
         project_client.indexes.delete(name=index_name, version=index_version)
         # [END indexes_sample]

--- a/sdk/ai/azure-ai-projects/samples/indexes/sample_indexes_async.py
+++ b/sdk/ai/azure-ai-projects/samples/indexes/sample_indexes_async.py
@@ -32,7 +32,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import AzureAISearchIndex
 
 
-async def sample_indexes_async() -> None:
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     index_name = os.environ.get("INDEX_NAME", "index-test")
@@ -68,10 +68,6 @@ async def sample_indexes_async() -> None:
 
             print(f"Delete Index`{index_name}` version `{index_version}`:")
             await project_client.indexes.delete(name=index_name, version=index_version)
-
-
-async def main():
-    await sample_indexes_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
@@ -30,7 +30,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.inference.models import UserMessage
 
 
-async def sample_chat_completions_with_azure_ai_inference_client_async():
+async def main():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
@@ -45,10 +45,6 @@ async def sample_chat_completions_with_azure_ai_inference_client_async():
                     model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
                 )
                 print(response.choices[0].message.content)
-
-
-async def main():
-    await sample_chat_completions_with_azure_ai_inference_client_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
@@ -31,7 +31,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.identity.aio import DefaultAzureCredential
 
 
-async def sample_chat_completions_with_azure_openai_client_async():
+async def main():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
@@ -54,10 +54,6 @@ async def sample_chat_completions_with_azure_openai_client_async():
                 )
 
                 print(response.choices[0].message.content)
-
-
-async def main():
-    await sample_chat_completions_with_azure_openai_client_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_image_embeddings_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_image_embeddings_with_azure_ai_inference_client_async.py
@@ -31,7 +31,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.inference.models import ImageEmbeddingInput
 
 
-async def sample_image_embeddings_with_azure_ai_inference_client_async():
+async def main():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
@@ -53,10 +53,6 @@ async def sample_image_embeddings_with_azure_ai_inference_client_async():
                         f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
                         f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
                     )
-
-
-async def main():
-    await sample_image_embeddings_with_azure_ai_inference_client_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
@@ -29,7 +29,7 @@ from azure.identity.aio import DefaultAzureCredential
 from azure.ai.projects.aio import AIProjectClient
 
 
-async def sample_text_embeddings_with_azure_ai_inference_client_async():
+async def main():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
@@ -50,10 +50,6 @@ async def sample_text_embeddings_with_azure_ai_inference_client_async():
                         f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
                         f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
                     )
-
-
-async def main():
-    await sample_text_embeddings_with_azure_ai_inference_client_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/telemetry/sample_telemetry_async.py
+++ b/sdk/ai/azure-ai-projects/samples/telemetry/sample_telemetry_async.py
@@ -28,7 +28,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import ConnectionType
 
 
-async def sample_telemetry_async() -> None:
+async def main() -> None:
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
 
@@ -39,10 +39,6 @@ async def sample_telemetry_async() -> None:
             print("Get the Application Insights connection string:")
             connection_string = await project_client.telemetry.get_connection_string()
             print(connection_string)
-
-
-async def main():
-    await sample_telemetry_async()
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
@@ -1,0 +1,154 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+import pytest
+import importlib.util
+
+
+class TestSamples:
+
+    @classmethod
+    def setup_class(cls):
+        current_path = os.path.abspath(__file__)
+        cls._samples_folder_path = os.path.join(current_path, "..", "..", "..", "samples")
+        cls._results: dict[str, bool] = {}
+        cls._results_async: dict[str, bool] = {}
+
+    @classmethod
+    def teardown_class(cls):
+        print("\n***********************************************************************")
+        if len(cls._results) > 0:
+            print("\n Samples results:")
+            for result in cls._results.items():
+                test_name, passed = result
+                print(f" {'PASS' if passed else 'FAIL'}: {test_name}")
+            print(
+                f" {len(cls._results)} samples run. {sum(cls._results.values())} passed, {len(cls._results) - sum(cls._results.values())} failed."
+            )
+        if len(cls._results_async) > 0:
+            print("\n Asynchronous samples results:")
+            for result in cls._results_async.items():
+                test_name, passed = result
+                print(f" {'PASS' if passed else 'FAIL'}: {test_name}")
+            print(
+                f" {len(cls._results_async)} samples run. {sum(cls._results_async.values())} passed, {len(cls._results_async) - sum(cls._results_async.values())} failed."
+            )
+        print("\n***********************************************************************")
+
+    @classmethod
+    def _set_env_vars(cls, sample_name: str, **kwargs):
+        print(f"\nRunning {sample_name} with environment variables: ", end="")
+        for key, value in kwargs.items():
+            if value:
+                env_key = key.upper()
+                os.environ[env_key] = value
+                print(f"{env_key}={value} ", end="")
+        print("\n")
+
+    @classmethod
+    def _run_sample(cls, sample_path: str) -> None:
+        with open(sample_path) as f:
+            code = f.read()
+            exec(code)
+
+    @classmethod
+    async def _run_sample_async(cls, sample_path: str) -> None:
+        # Dynamically import the module from the given path
+        module_name = os.path.splitext(os.path.basename(sample_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, sample_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load module {module_name} from {sample_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        # Await the main() coroutine defined in the sample
+        await module.main()
+
+    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    @pytest.mark.parametrize(
+        "sample_name, model_deployment_name, connection_name",
+        [
+            ("agents\\sample_agents.py", "gpt-4o", ""),
+            ("connections\\sample_connections.py", "", "connection1"),
+            ("deployments\\sample_deployments.py", "DeepSeek-V3", ""),
+            ("datasets\\sample_datasets.py", "", ""),
+            # ("evaluation\\sample_evaluations.py", "", ""),
+            ("indexes\\sample_indexes.py", "", ""),
+            ("inference\\sample_chat_completions_with_azure_ai_inference_client.py", "Phi-4", ""),
+            (
+                "inference\\sample_chat_completions_with_azure_ai_inference_client_and_azure_monitor_tracing.py",
+                "Phi-4",
+                "",
+            ),
+            ("inference\\sample_chat_completions_with_azure_ai_inference_client_and_console_tracing.py", "Phi-4", ""),
+            ("inference\\sample_chat_completions_with_azure_ai_inference_client_and_prompty_file.py", "Phi-4", ""),
+            ("inference\\sample_chat_completions_with_azure_ai_inference_client_and_prompt_string.py", "Phi-4", ""),
+            ("inference\\sample_chat_completions_with_azure_openai_client.py", "gpt-4o", ""),
+            ("inference\\sample_chat_completions_with_azure_openai_client_and_azure_monitor_tracing.py", "gpt-4o", ""),
+            ("inference\\sample_chat_completions_with_azure_openai_client_and_console_tracing.py", "gpt-4o", ""),
+            ("inference\\sample_image_embeddings_with_azure_ai_inference_client.py", "to-do-add-model", ""),
+            ("inference\\sample_text_embeddings_with_azure_ai_inference_client.py", "text-embedding-3-large", ""),
+            ("telemetry\\sample_telemetry.py", "", ""),
+        ],
+    )
+    def test_samples(self, sample_name: str, model_deployment_name: str, connection_name: str) -> None:
+        """
+        Run all the synchronous sample code in the samples folder. If a sample throws an exception, which for example
+        happens when the service responds with an error, the test will fail.
+
+        Before running this test, you need to define the following environment variables:
+        1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+           Azure AI Foundry project.
+        """
+
+        TestSamples._results[sample_name] = False
+        self._set_env_vars(
+            sample_name, **{"model_deployment_name": model_deployment_name, "connection_name": connection_name}
+        )
+        sample_path = os.path.normpath(os.path.join(TestSamples._samples_folder_path, sample_name))
+        TestSamples._run_sample(sample_path)
+        TestSamples._results[sample_name] = True
+
+    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    @pytest.mark.parametrize(
+        "sample_name, model_deployment_name, connection_name",
+        [
+            ("agents\\sample_agents_async.py", "", ""),
+            ("connections\\sample_connections_async.py", "", "connection1"),
+            ("datasets\\sample_datasets_async.py", "", ""),
+            ("deployments\\sample_deployments_async.py", "DeepSeek-V3", ""),
+            # ("evaluation\\sample_evaluations_async.py", "", ""),
+            ("indexes\\sample_indexes_async.py", "", ""),
+            ("inference\\async_samples\\sample_chat_completions_with_azure_ai_inference_client_async.py", "Phi-4", ""),
+            ("inference\\async_samples\\sample_chat_completions_with_azure_openai_client_async.py", "gpt-4o", ""),
+            (
+                "inference\\async_samples\\sample_image_embeddings_with_azure_ai_inference_client_async.py",
+                "to-do-add-model",
+                "",
+            ),
+            (
+                "inference\\async_samples\\sample_text_embeddings_with_azure_ai_inference_client_async.py",
+                "text-embedding-3-large",
+                "",
+            ),
+            ("telemetry\\sample_telemetry_async.py", "", ""),
+        ],
+    )
+    async def test_samples_async(self, sample_name: str, model_deployment_name: str, connection_name: str) -> None:
+        """
+        Run all the asynchronous sample code in the samples folder. If a sample throws an exception, which for example
+        happens when the service responds with an error, the test will fail.
+
+        Before running this test, you need to define the following environment variables:
+        1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
+           Azure AI Foundry project.
+        """
+
+        TestSamples._results_async[sample_name] = False
+        self._set_env_vars(
+            sample_name, **{"model_deployment_name": model_deployment_name, "connection_name": connection_name}
+        )
+        sample_path = os.path.normpath(os.path.join(TestSamples._samples_folder_path, sample_name))
+        await TestSamples._run_sample_async(sample_path)
+        TestSamples._results_async[sample_name] = True


### PR DESCRIPTION
Add two tests, one that runs all sync samples and one that runs all async samples. The appropriate environment variables are set before running sample. A report at the end shows which samples succeeded and which failed. Failed means an exception has been thrown (e.g. when the service returns an error).
Automatically running the samples required some minor change to them.
There is still one problem to be solved, so there will likely be another PR related to this. 