### PR TITLE
Changed Marking from Emulator to Live accounts for flaky tests

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_backwards_compatibility.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_backwards_compatibility.py
@@ -17,7 +17,7 @@ def check_pk_range_statistics_request_headers(raw_response):
 def check_quota_info_request_headers(raw_response):
     assert raw_response.http_request.headers[http_constants.HttpHeaders.PopulateQuotaInfo] == 'True'
 
-@pytest.mark.cosmosEmulator
+@pytest.mark.cosmosLong
 class TestBackwardsCompatibility(unittest.TestCase):
     configs = test_config.TestConfig
     databaseForTest: DatabaseProxy = None

--- a/sdk/cosmos/azure-cosmos/tests/test_backwards_compatibility_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_backwards_compatibility_async.py
@@ -12,7 +12,7 @@ from azure.cosmos import PartitionKey
 from azure.cosmos.aio import CosmosClient, DatabaseProxy
 from azure.cosmos.exceptions import CosmosHttpResponseError
 
-@pytest.mark.cosmosEmulator
+@pytest.mark.cosmosLong
 class TestBackwardsCompatibilityAsync(unittest.IsolatedAsyncioTestCase):
     host = test_config.TestConfig.host
     masterKey = test_config.TestConfig.masterKey

--- a/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport.py
@@ -13,6 +13,7 @@ from azure.core.rest import HttpRequest
 import test_config
 from azure.cosmos import PartitionKey
 from azure.cosmos import CosmosClient
+from azure.cosmos import documents
 from azure.cosmos.container import ContainerProxy
 from azure.cosmos.database import DatabaseProxy
 from azure.cosmos.exceptions import CosmosHttpResponseError

--- a/sdk/cosmos/azure-cosmos/tests/test_headers.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_headers.py
@@ -23,7 +23,7 @@ def request_raw_response_hook(response):
         assert (response.http_request.headers[http_constants.HttpHeaders.ThroughputBucket]
                 == str(request_throughput_bucket_number))
 
-@pytest.mark.cosmosEmulator
+@pytest.mark.cosmosLong
 class TestHeaders(unittest.TestCase):
     database: DatabaseProxy = None
     client: cosmos_client.CosmosClient = None

--- a/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
@@ -23,7 +23,7 @@ async def request_raw_response_hook(response):
     assert (response.http_request.headers[http_constants.HttpHeaders.ThroughputBucket]
             == str(request_throughput_bucket_number))
 
-@pytest.mark.cosmosEmulator
+@pytest.mark.cosmosLong
 class TestHeadersAsync(unittest.IsolatedAsyncioTestCase):
     client: CosmosClient = None
     configs = test_config.TestConfig


### PR DESCRIPTION
# Description

Changed Marking from Emulator to Live accounts for flaky tests to account for pipeline failures. 