### PR TITLE
AOAI results nits: fix order and _result column

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/text_similarity_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/text_similarity_grader.py
@@ -68,7 +68,6 @@ class AzureOpenAITextSimilarityGrader(AzureOpenAIGrader):
             "rouge_3",
             "rouge_4",
             "rouge_5",
-            "rouge_l",
             "cosine",
         ],
         input: str,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate_aoai.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate_aoai.py
@@ -208,7 +208,7 @@ def _get_single_run_results(
     if run_results.status != "completed":
         raise EvaluationException(
             message=f"AOAI evaluation run {run_info['eval_group_id']}/{run_info['eval_run_id']}"
-             + " failed with status {run_results.status}.",
+             + f" failed with status {run_results.status}.",
             blame=ErrorBlame.UNKNOWN,
             category=ErrorCategory.FAILED_EXECUTION,
             target=ErrorTarget.AOAI_GRADER,


### PR DESCRIPTION
Apparently OAI likes to return their results in backwards (or possibly random) order, so I've changed the OAI results parsing to sort the results before merging them with the other evaluation results.

Also there was a bug in the pass/fail _result column code that would always result in the same value for that entire column. Changed to properly be a per-row result.
