### PR TITLE
Do not use sudo for npm install in typespec automation init

### DIFF
--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -9,7 +9,7 @@ pip install setuptools==78.1.0 > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)
 echo Install tsp-client
-sudo npm install -g @azure-tools/typespec-client-generator-cli@0.20.0 > /dev/null
+npm install -g @azure-tools/typespec-client-generator-cli@0.20.0 > /dev/null
 
 echo "{}" >> $2
 echo "[Generate] init success!!!"


### PR DESCRIPTION
Do not use sudo for npm install in typespec automation init