### PR TITLE
WRRF Feature Branch

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.11.0b2 (Unreleased)
 
 #### Features Added
+* Added ability to use weighted RRF (Reciprocal Rank Fusion) for Hybrid full text search queries. See [PR #####]().
 
 #### Breaking Changes
 
@@ -16,6 +17,8 @@
 * Added ability to set `throughput_bucket` header at the client level and for all requests. See [PR 40340](https://github.com/Azure/azure-sdk-for-python/pull/40340).
 * Added ability to use Filters from Logging module on Diagnostics Logging based on Http request/response related attributes. See [PR 39897](https://github.com/Azure/azure-sdk-for-python/pull/39897).
 * Added ability to use `excluded_locations` on client level and document API request level. See [PR 40298](https://github.com/Azure/azure-sdk-for-python/pull/40298) 
+
+#### Breaking Changes
 
 #### Bugs Fixed
 * Fixed bug where change feed requests would not respect the partition key filter. See [PR 40677](https://github.com/Azure/azure-sdk-for-python/pull/40677).

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### 4.11.0b2 (Unreleased)
 
 #### Features Added
-* Added ability to use weighted RRF (Reciprocal Rank Fusion) for Hybrid full text search queries. See [PR #####]().
+* Added ability to use weighted RRF (Reciprocal Rank Fusion) for Hybrid full text search queries. See [PR 40899](https://github.com/Azure/azure-sdk-for-python/pull/40899/files).
+
+#### Bugs Fixed
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -867,6 +867,14 @@ All of these mentioned queries would look something like this:
 
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}))"`
 
+You can also use Weighted Reciprocal Rank Fusion (WRRF) to assign different weights to the different scores being used in the RRF function.
+This is done by passing in a list of weights to the RRF function, which will be used to multiply the scores before the fusion is done.
+A Negative value on a weight will reverse the ordering for that score. Usually it is descending, but a negative weight will order it ascending.
+- `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}), [0.5, 0.3, 0.2])`
+
+
+- `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}), [-0.5, 0.3, 0.2])`
+
 These queries must always use a TOP or LIMIT clause within the query since hybrid search queries have to look through a lot of data otherwise and may become too expensive or long-running.
 Since these queries are relatively expensive, the SDK sets a default limit of 1000 max items per query - if you'd like to raise that further, you
 can use the `AZURE_COSMOS_HYBRID_SEARCH_MAX_ITEMS` environment variable to do so. However, be advised that queries with too many vector results

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -868,7 +868,7 @@ All of these mentioned queries would look something like this:
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}))"`
 
 You can also use Weighted Reciprocal Rank Fusion to assign different weights to the different scores being used in the RRF function.
-This is done by passing in a list of weights to the RRF function in the query.
+This is done by passing in a list of weights to the RRF function in the query. **NOTE: If more weights are given than there are components of the RRF function, the extra weights will be truncated. If weights are missing a BAD REQUEST exception will occur.**
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}), [0.5, 0.3, 0.2])`
 
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -868,8 +868,7 @@ All of these mentioned queries would look something like this:
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}))"`
 
 You can also use Weighted Reciprocal Rank Fusion to assign different weights to the different scores being used in the RRF function.
-This is done by passing in a list of weights to the RRF function, which will be used to multiply the scores before the fusion is done.
-A Negative value on a weight will reverse the ordering for that score. Usually it is descending, but a negative weight will order it ascending.
+This is done by passing in a list of weights to the RRF function in the query.
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}), [0.5, 0.3, 0.2])`
 
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -867,7 +867,7 @@ All of these mentioned queries would look something like this:
 
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}))"`
 
-You can also use Weighted Reciprocal Rank Fusion (WRRF) to assign different weights to the different scores being used in the RRF function.
+You can also use Weighted Reciprocal Rank Fusion to assign different weights to the different scores being used in the RRF function.
 This is done by passing in a list of weights to the RRF function, which will be used to multiply the scores before the fusion is done.
 A Negative value on a weight will reverse the ordering for that score. Usually it is descending, but a negative weight will order it ascending.
 - `SELECT TOP 10 c.id, c.text FROM c ORDER BY RANK RRF(FullTextScore(c.text, ['quantum', 'theory']), FullTextScore(c.text, ['model']), VectorDistance(c.embedding, {item_embedding}), [0.5, 0.3, 0.2])`

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3196,7 +3196,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                                     documents._QueryFeature.Top + "," +
                                     documents._QueryFeature.NonStreamingOrderBy + "," +
                                     documents._QueryFeature.HybridSearch + "," +
-                                    documents._QueryFeature.CountIf)
+                                    documents._QueryFeature.CountIf + "," +
+                                    documents._QueryFeature.WeightedRankFusion)
         if os.environ.get(Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG,
                           Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG_DEFAULT) == "True":
             supported_query_features = (documents._QueryFeature.Aggregate + "," +

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3197,7 +3197,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                                     documents._QueryFeature.NonStreamingOrderBy + "," +
                                     documents._QueryFeature.HybridSearch + "," +
                                     documents._QueryFeature.CountIf + "," +
-                                    documents._QueryFeature.WeightedRankFusion)
+                                    documents._QueryFeature.WeightedRankFusion + "," +
+                                    documents._QueryFeature.HybridSearchSkipOrderByReWrite)
         if os.environ.get(Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG,
                           Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG_DEFAULT) == "True":
             supported_query_features = (documents._QueryFeature.Aggregate + "," +

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3197,8 +3197,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                                     documents._QueryFeature.NonStreamingOrderBy + "," +
                                     documents._QueryFeature.HybridSearch + "," +
                                     documents._QueryFeature.CountIf + "," +
-                                    documents._QueryFeature.WeightedRankFusion + "," +
-                                    documents._QueryFeature.HybridSearchSkipOrderByReWrite)
+                                    documents._QueryFeature.WeightedRankFusion)
         if os.environ.get(Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG,
                           Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG_DEFAULT) == "True":
             supported_query_features = (documents._QueryFeature.Aggregate + "," +

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
@@ -59,7 +59,7 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         self._document_producer_comparator = None
         self._response_hook = response_hook
 
-    async def _run_hybrid_search(self):  # pylint: disable=cell-var-from-loop, too-many-branches, too-many-statements
+    async def _run_hybrid_search(self):  # pylint: disable=too-many-branches, too-many-statements
         # Check if we need to run global statistics queries, and if so do for every partition in the container
         if self._hybrid_search_query_info['requiresGlobalStatistics']:
             target_partition_key_ranges = await self._get_target_partition_key_range(target_all_ranges=True)
@@ -166,8 +166,9 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         for index, score_tuples in enumerate(component_scores):
             # Negative Weights will change sorting from Descending to Ascending
             ordering = self._hybrid_search_query_info['componentQueryInfos'][index]['orderBy'][0]
-            comparison_factor = not (ordering.lower() == 'ascending')
-            score_tuples.sort(key=lambda x: abs(component_weights[index]) * x[0], reverse=comparison_factor)
+            comparison_factor = not ordering.lower() == 'ascending'
+            #  pylint: disable=cell-var-from-loop
+            score_tuples.sort(key=lambda x: component_weights[index] * x[0], reverse=comparison_factor)
 
         # Compute the ranks
         ranks = _compute_ranks(component_scores)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
@@ -59,7 +59,7 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         self._document_producer_comparator = None
         self._response_hook = response_hook
 
-    async def _run_hybrid_search(self):
+    async def _run_hybrid_search(self):  # pylint: disable=cell-var-from-loop, too-many-branches, too-many-statements
         # Check if we need to run global statistics queries, and if so do for every partition in the container
         if self._hybrid_search_query_info['requiresGlobalStatistics']:
             target_partition_key_ranges = await self._get_target_partition_key_range(target_all_ranges=True)
@@ -166,7 +166,7 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         for index, score_tuples in enumerate(component_scores):
             # Negative Weights will change sorting from Descending to Ascending
             ordering = self._hybrid_search_query_info['componentQueryInfos'][index]['orderBy'][0]
-            comparison_factor = False if (ordering.lower() == 'ascending') else True
+            comparison_factor = not (ordering.lower() == 'ascending')
             score_tuples.sort(key=lambda x: abs(component_weights[index]) * x[0], reverse=comparison_factor)
 
         # Compute the ranks

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/hybrid_search_aggregator.py
@@ -151,9 +151,19 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         if self._hybrid_search_query_info.get('componentWeights'):
             component_weights = self._hybrid_search_query_info['componentWeights']
             component_count = len(self._hybrid_search_query_info['componentQueryInfos'])
-            component_weights = [component_weights[x] if x < len(component_weights)
-                                 else 1.0 for x in range(component_count)]
+            # If the number of weights is less than the number of components, we fill the rest with 1.0
+            # Unlikely to be the case since a bad request should be returned if weights are less than components,
+            # and any extra weights relative to components are ignored, but we handle it here anyway.
+            if len(component_weights) != component_count:
+                if len(component_weights) < component_count:
+                    # Fill the rest with 1.0
+                    component_weights = [component_weights[x] if x < len(component_weights)
+                                         else 1.0 for x in range(component_count)]
+                else:
+                    # Drop the excess values
+                    component_weights = component_weights[:component_count]
         else:
+            # If no weights are provided, we default to 1.0 for all components
             component_weights = [1.0] * len(self._hybrid_search_query_info['componentQueryInfos'])
 
         # Sort drained results by _rid

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
@@ -257,9 +257,19 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         if self._hybrid_search_query_info.get('componentWeights'):
             component_weights = self._hybrid_search_query_info['componentWeights']
             component_count = len(self._hybrid_search_query_info['componentQueryInfos'])
-            component_weights = [component_weights[x] if x < len(component_weights)
-                                 else 1.0 for x in range(component_count)]
+            # If the number of weights is less than the number of components, we fill the rest with 1.0
+            # Unlikely to be the case since a bad request should be returned if weights are less than components,
+            # and any extra weights relative to components are ignored, but we handle it here anyway.
+            if len(component_weights) != component_count:
+                if len(component_weights) < component_count:
+                    # Fill the rest with 1.0
+                    component_weights = [component_weights[x] if x < len(component_weights)
+                                         else 1.0 for x in range(component_count)]
+                else:
+                    # Drop the excess values
+                    component_weights = component_weights[:component_count]
         else:
+            # If no weights are provided, we assume all components have equal weight
             component_weights = [1.0] * len(self._hybrid_search_query_info['componentQueryInfos'])
 
         # Sort drained results by _rid

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
@@ -267,9 +267,6 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
         # Compose component scores matrix, where each tuple is (score, index)
         component_scores = _retrieve_component_scores(drained_results)
 
-        # # Sort by scores in descending order
-        # for score_tuples in component_scores:
-        #     score_tuples.sort(key=lambda x: x[0], reverse=True)
         # Sort by scores using component weights
         for index, score_tuples in enumerate(component_scores):
             ordering = self._hybrid_search_query_info['componentQueryInfos'][index]['orderBy'][0]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
@@ -3,12 +3,12 @@
 
 """Internal class for multi execution context aggregator implementation in the Azure Cosmos database service.
 """
-
+from typing import List, Union
 from azure.cosmos._execution_context.base_execution_context import _QueryExecutionContextBase
 from azure.cosmos._execution_context import document_producer
 from azure.cosmos._routing import routing_range
 from azure.cosmos import exceptions
-from typing import List, Union
+
 
 # pylint: disable=protected-access
 RRF_CONSTANT = 60

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/hybrid_search_aggregator.py
@@ -36,12 +36,13 @@ def _retrieve_component_scores(drained_results):
     return component_scores_list
 
 
-def _compute_rrf_scores(ranks, query_results):
+def _compute_rrf_scores(ranks, componentWeights, query_results):
     component_count = len(ranks)
     for index, result in enumerate(query_results):
         rrf_score = 0.0
         for component_index in range(component_count):
-            rrf_score += 1.0 / (RRF_CONSTANT + ranks[component_index][index])
+            rrf_score += componentWeights[component_index] / (RRF_CONSTANT + ranks[component_index][index])
+
         # Add the score to the item to be returned
         result['Score'] = rrf_score
 
@@ -54,7 +55,7 @@ def _compute_ranks(component_scores):
         rank = 1  # ranks are 1-based
         for index, score_tuple in enumerate(scores):
             # Identical scores should have the same rank
-            if index > 0 and score_tuple[0] < scores[index - 1][0]:
+            if index > 0 and score_tuple[0] != scores[index - 1][0]:
                 rank += 1
             ranks[component_index][score_tuple[1]] = rank
 
@@ -251,21 +252,35 @@ class _HybridSearchContextAggregator(_QueryExecutionContextBase):
             self._format_final_results(drained_results)
             return
 
+        # Get the Components weight if any
+        if self._hybrid_search_query_info.get('componentWeights'):
+            component_weights = self._hybrid_search_query_info['componentWeights']
+            component_count = len(self._hybrid_search_query_info['componentQueryInfos'])
+            component_weights = [component_weights[x] if x < len(component_weights)
+                                 else 1.0 for x in range(component_count)]
+        else:
+            component_weights = [1.0] * len(self._hybrid_search_query_info['componentQueryInfos'])
+
         # Sort drained results by _rid
         drained_results.sort(key=lambda x: x['_rid'])
 
         # Compose component scores matrix, where each tuple is (score, index)
         component_scores = _retrieve_component_scores(drained_results)
 
-        # Sort by scores in descending order
-        for score_tuples in component_scores:
-            score_tuples.sort(key=lambda x: x[0], reverse=True)
+        # # Sort by scores in descending order
+        # for score_tuples in component_scores:
+        #     score_tuples.sort(key=lambda x: x[0], reverse=True)
+        # Sort by scores using component weights
+        for index, score_tuples in enumerate(component_scores):
+            ordering = self._hybrid_search_query_info['componentQueryInfos'][index]['orderBy'][0]
+            comparison_factor = False if (ordering.lower() == 'ascending') else True
+            score_tuples.sort(key=lambda x: abs(component_weights[index]) * x[0], reverse=comparison_factor)
 
         # Compute the ranks
         ranks = _compute_ranks(component_scores)
 
         # Compute the RRF scores and add them to output
-        _compute_rrf_scores(ranks, drained_results)
+        _compute_rrf_scores(ranks, component_weights, drained_results)
 
         # Finally, sort on the RRF scores to build the final result to return
         drained_results.sort(key=lambda x: x['Score'], reverse=True)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -3207,7 +3207,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                                     documents._QueryFeature.Top + "," +
                                     documents._QueryFeature.NonStreamingOrderBy + "," +
                                     documents._QueryFeature.HybridSearch + "," +
-                                    documents._QueryFeature.CountIf)
+                                    documents._QueryFeature.CountIf + "," +
+                                    documents._QueryFeature.WeightedRankFusion)
         if os.environ.get(Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG,
                           Constants.NON_STREAMING_ORDER_BY_DISABLED_CONFIG_DEFAULT) == "True":
             supported_query_features = (documents._QueryFeature.Aggregate + "," +

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -439,7 +439,7 @@ class _QueryFeature:
     HybridSearch: Literal["HybridSearch"] = "HybridSearch"
     CountIf: Literal["CountIf"] = "CountIf"
     WeightedRankFusion: Literal["WeightedRankFusion"] = "WeightedRankFusion"
-
+    HybridSearchSkipOrderByReWrite: Literal["HybridSearchSkipOrderByReWrite"] = "HybridSearchSkipOrderByReWrite"
 
 class _DistinctType:
     NoneType: Literal["None"] = "None"

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -438,6 +438,7 @@ class _QueryFeature:
     NonStreamingOrderBy: Literal["NonStreamingOrderBy"] = "NonStreamingOrderBy"
     HybridSearch: Literal["HybridSearch"] = "HybridSearch"
     CountIf: Literal["CountIf"] = "CountIf"
+    WeightedRankFusion: Literal["WeightedRankFusion"] = "WeightedRankFusion"
 
 
 class _DistinctType:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -439,7 +439,6 @@ class _QueryFeature:
     HybridSearch: Literal["HybridSearch"] = "HybridSearch"
     CountIf: Literal["CountIf"] = "CountIf"
     WeightedRankFusion: Literal["WeightedRankFusion"] = "WeightedRankFusion"
-    HybridSearchSkipOrderByReWrite: Literal["HybridSearchSkipOrderByReWrite"] = "HybridSearchSkipOrderByReWrite"
 
 class _DistinctType:
     NoneType: Literal["None"] = "None"

--- a/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
@@ -280,6 +280,17 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
             [57, 85, 2, 66, 22, 25, 80, 76, 77, 24, 75, 54, 49, 51, 61]
         ]
 
+        # Test case 5
+        item_vector = self.test_container.read_item('50', '1')['vector']
+        query = "SELECT c.index, c.title FROM c " \
+                "ORDER BY RANK RRF(FullTextScore(c.text, ['United States']), VectorDistance(c.vector, {}), [1,1]) " \
+                "OFFSET 0 LIMIT 10".format(item_vector)
+        results = self.test_container.query_items(query, enable_cross_partition_query=True)
+        result_list = list(results)
+        assert len(result_list) == 10
+        result_list = [res['index'] for res in result_list]
+        assert result_list == [51, 54, 28, 70, 24, 61, 56, 26, 58, 77]
+
     def test_invalid_hybrid_search_queries_weighted_reciprocal_rank_fusion(self):
         try:
             query = "SELECT c.index, RRF(VectorDistance(c.vector, [1,2,3]), FullTextScore(c.text, 'test') FROM c"

--- a/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
@@ -280,7 +280,7 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
             [57, 85, 2, 66, 22, 25, 80, 76, 77, 24, 75, 54, 49, 51, 61]
         ]
 
-    def test_invalid_hybrid_search_queries_wrrf(self):
+    def test_invalid_hybrid_search_queries_weighted_reciprocal_rank_fusion(self):
         try:
             query = "SELECT c.index, RRF(VectorDistance(c.vector, [1,2,3]), FullTextScore(c.text, 'test') FROM c"
             results = self.test_container.query_items(query, enable_cross_partition_query=True)
@@ -289,7 +289,7 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
 
-    def test_weighted_vs_non_weighted_rrf(self):
+    def test_weighted_vs_non_weighted_reciprocal_rank_fusion(self):
         # Non-weighted RRF query
         query_non_weighted = """
             SELECT TOP 10 c.index, c.title FROM c
@@ -307,7 +307,7 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
                                                                  enable_cross_partition_query=True)
         result_list_weighted_equal = [res['index'] for res in results_weighted_equal]
 
-        # Weighted RRF query with different weights
+        # Weighted RRF query with different direction weights
         query_weighted_different = """
             SELECT TOP 10 c.index, c.title FROM c
             ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, -0.5])
@@ -320,7 +320,7 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
         assert result_list_non_weighted == result_list_weighted_equal, "Non-weighted and equally weighted RRF results should match."
         assert result_list_non_weighted != result_list_weighted_different, "Non-weighted and differently weighted RRF results should not match."
 
-    def test_rrf_with_missing_weights(self):
+    def test_weighted_reciprocal_rank_fusion_with_missing_weights(self):
         try:
             # Weighted RRF query with one weight missing
             query_missing_weight = """
@@ -333,7 +333,7 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
 
-    def test_weighted_rrf_with_response_hook(self):
+    def test_weighted_reciprocal_rank_fusion_with_response_hook(self):
         response_hook = test_config.ResponseHookCaller()
         query_weighted_rrf = """
             SELECT TOP 10 c.index, c.title FROM c

--- a/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search.py
@@ -226,5 +226,126 @@ class TestFullTextHybridSearchQuery(unittest.TestCase):
         assert len(result_list) == 10
         assert response_hook.count == 1
 
+    def test_hybrid_search_weighted_reciprocal_rank_fusion(self):
+        # Test case 1
+        query = """
+                    SELECT TOP 15 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    WHERE FullTextContains(c.title, 'John') OR FullTextContains(c.text, 'John') OR FullTextContains(c.text, 'United States')
+                    ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, 1])
+                """
+        results = self.test_container.query_items(query, enable_cross_partition_query=True)
+        result_list = [res['Index'] for res in results]
+        assert result_list in [
+            [61, 51, 49, 54, 75, 24, 77, 76, 80, 25, 22, 2, 66, 57, 85],
+            [61, 51, 49, 54, 75, 24, 77, 76, 80, 25, 22, 2, 66, 85, 57]
+        ]
+
+        # Test case 2
+        query = """
+                    SELECT TOP 15 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    WHERE FullTextContains(c.title, 'John') OR FullTextContains(c.text, 'John') OR FullTextContains(c.text, 'United States')
+                    ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [10, 10])
+                """
+        results = self.test_container.query_items(query, enable_cross_partition_query=True)
+        result_list = [res['Index'] for res in results]
+        assert result_list in [
+            [61, 51, 49, 54, 75, 24, 77, 76, 80, 25, 22, 2, 66, 57, 85],
+            [61, 51, 49, 54, 75, 24, 77, 76, 80, 25, 22, 2, 66, 85, 57]
+        ]
+
+        # Test case 3
+        query = """
+                    SELECT TOP 10 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    WHERE FullTextContains(c.title, 'John') OR FullTextContains(c.text, 'John') OR FullTextContains(c.text, 'United States')
+                    ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [0.1, 0.1])
+                """
+        results = self.test_container.query_items(query, enable_cross_partition_query=True)
+        result_list = [res['Index'] for res in results]
+        assert result_list == [61, 51, 49, 54, 75, 24, 77, 76, 80, 25]
+
+        # Test case 4
+        query = """
+                    SELECT TOP 15 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    WHERE FullTextContains(c.title, 'John') OR FullTextContains(c.text, 'John') OR FullTextContains(c.text, 'United States')
+                    ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [-1, -1])
+                """
+        results = self.test_container.query_items(query, enable_cross_partition_query=True)
+        result_list = [res['Index'] for res in results]
+        assert result_list in [
+            [85, 57, 66, 2, 22, 25, 77, 76, 80, 75, 24, 49, 54, 51, 81],
+            [57, 85, 2, 66, 22, 25, 80, 76, 77, 24, 75, 54, 49, 51, 61]
+        ]
+
+    def test_invalid_hybrid_search_queries_wrrf(self):
+        try:
+            query = "SELECT c.index, RRF(VectorDistance(c.vector, [1,2,3]), FullTextScore(c.text, 'test') FROM c"
+            results = self.test_container.query_items(query, enable_cross_partition_query=True)
+            list(results)
+            pytest.fail("Attempting to project RRF in a query should fail.")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+
+    def test_weighted_vs_non_weighted_rrf(self):
+        # Non-weighted RRF query
+        query_non_weighted = """
+            SELECT TOP 10 c.index, c.title FROM c
+            ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']))
+        """
+        results_non_weighted = self.test_container.query_items(query_non_weighted, enable_cross_partition_query=True)
+        result_list_non_weighted = [res['index'] for res in results_non_weighted]
+
+        # Weighted RRF query with equal weights
+        query_weighted_equal = """
+            SELECT TOP 10 c.index, c.title FROM c
+            ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, 1])
+        """
+        results_weighted_equal = self.test_container.query_items(query_weighted_equal,
+                                                                 enable_cross_partition_query=True)
+        result_list_weighted_equal = [res['index'] for res in results_weighted_equal]
+
+        # Weighted RRF query with different weights
+        query_weighted_different = """
+            SELECT TOP 10 c.index, c.title FROM c
+            ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, -0.5])
+        """
+        results_weighted_different = self.test_container.query_items(query_weighted_different,
+                                                                     enable_cross_partition_query=True)
+        result_list_weighted_different = [res['index'] for res in results_weighted_different]
+
+        # Assertions
+        assert result_list_non_weighted == result_list_weighted_equal, "Non-weighted and equally weighted RRF results should match."
+        assert result_list_non_weighted != result_list_weighted_different, "Non-weighted and differently weighted RRF results should not match."
+
+    def test_rrf_with_missing_weights(self):
+        try:
+            # Weighted RRF query with one weight missing
+            query_missing_weight = """
+                SELECT TOP 10 c.index, c.title FROM c
+                ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1])
+            """
+            res = self.test_container.query_items(query_missing_weight, enable_cross_partition_query=True)
+            list(res)
+            pytest.fail("Query with missing weights should fail.")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+
+    def test_weighted_rrf_with_response_hook(self):
+        response_hook = test_config.ResponseHookCaller()
+        query_weighted_rrf = """
+            SELECT TOP 10 c.index, c.title FROM c
+            ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, 0.5])
+        """
+        results = self.test_container.query_items(query_weighted_rrf, enable_cross_partition_query=True,
+                                                  response_hook=response_hook)
+        result_list = list(results)
+        assert len(result_list) == 10
+        assert response_hook.count > 0  # Ensure the response hook was called
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_hybrid_search_async.py
@@ -286,7 +286,7 @@ class TestFullTextHybridSearchQueryAsync(unittest.IsolatedAsyncioTestCase):
             [57, 85, 2, 66, 22, 25, 80, 76, 77, 24, 75, 54, 49, 51, 61]
         ]
 
-    async def test_invalid_hybrid_search_queries_wrrf_async(self):
+    async def test_invalid_hybrid_search_queries_weighted_reciprocal_rank_fusion_async(self):
         try:
             query = "SELECT c.index, RRF(VectorDistance(c.vector, [1,2,3]), FullTextScore(c.text, 'test') FROM c"
             results = self.test_container.query_items(query)
@@ -295,7 +295,7 @@ class TestFullTextHybridSearchQueryAsync(unittest.IsolatedAsyncioTestCase):
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
 
-    async def test_weighted_vs_non_weighted_rrf_async(self):
+    async def test_weighted_vs_non_weighted_reciprocal_rank_fusion_async(self):
         # Non-weighted RRF query
         query_non_weighted = """
             SELECT TOP 10 c.index, c.title FROM c
@@ -324,7 +324,7 @@ class TestFullTextHybridSearchQueryAsync(unittest.IsolatedAsyncioTestCase):
         assert result_list_non_weighted == result_list_weighted_equal, "Non-weighted and equally weighted RRF results should match."
         assert result_list_non_weighted != result_list_weighted_different, "Non-weighted and differently direction weighted RRF results should not match."
 
-    async def test_rrf_with_missing_weights_async(self):
+    async def test_weighted_reciprocal_rank_fusion_with_missing_weights_async(self):
         try:
             # Weighted RRF query with one weight missing
             query_missing_weight = """
@@ -337,7 +337,7 @@ class TestFullTextHybridSearchQueryAsync(unittest.IsolatedAsyncioTestCase):
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
 
-    async def test_weighted_rrf_with_response_hook_async(self):
+    async def test_weighted_reciprocal_rank_fusion_with_response_hook_async(self):
         response_hook = test_config.ResponseHookCaller()
         query_weighted_rrf = """
             SELECT TOP 10 c.index, c.title FROM c


### PR DESCRIPTION
# Description
** Adds this feature to the WRRF Feature Branch**
This PR adds Weighted RRF to the python cosmos db sdk. Weights can be added to the end of the RRF function of a Hybrid Full Text Query. The number of weights need to match the number of components passed into the RRF Function.  A positive weight will order by descending order and a negative weight will order by ascending order for that particular component/rank. 

some examples of WRRF:
```python
query = "SELECT TOP 10 c.index, c.title FROM c ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [1, 1])"
    
    results = container.query_items(query, enable_cross_partition_query=True)
    result_list = list(results)

 query = "SELECT TOP 10 c.index, c.title FROM c " \
            "ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [0.1, 0.1])"
    results = container.query_items(query, enable_cross_partition_query=True)
    result_list = list(results)
    
 query = "SELECT TOP 10 c.index, c.title FROM c " \
            "ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), [-1, -1])"
    results = container.query_items(query, enable_cross_partition_query=True)
    result_list = list(results)
```