### PR TITLE
Add sync and async methods `.connections.get_default()`

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -208,28 +208,31 @@ folder in the [package samples][samples].
 <!-- SNIPPET:sample_connections.connections_sample-->
 
 ```python
-print("List the properties of all connections:")
+print("List all connections:")
 for connection in project_client.connections.list():
     print(connection)
 
-print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections):")
+print("List all connections of a particular type:")
 for connection in project_client.connections.list(
     connection_type=ConnectionType.AZURE_OPEN_AI,
 ):
     print(connection)
 
-print("To list the default connection of a particular type  (in this case, Azure Store Account):")
-for connection in project_client.connections.list(
-    connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
-    default_connection=True,
-):
-    print(connection)
+print("Get the default connection of a particular type, without its credentials:")
+connection = project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+print(connection)
 
-print(f"Get the properties of a connection named `{connection_name}`, without its credentials:")
+print("Get the default connection of a particular type, with its credentials:")
+connection = project_client.connections.get_default(
+    connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True
+)
+print(connection)
+
+print(f"Get the connection named `{connection_name}`, without its credentials:")
 connection = project_client.connections.get(connection_name)
 print(connection)
 
-print(f"Get the properties of a connection named `{connection_name}`, with its credentials:")
+print(f"Get the connection named `{connection_name}`, with its credentials:")
 connection = project_client.connections.get(connection_name, include_credentials=True)
 print(connection)
 ```
@@ -267,6 +270,16 @@ print(dataset)
 print(f"Get an existing Dataset version `{dataset_version_1}`:")
 dataset = project_client.datasets.get(name=dataset_name, version=dataset_version_1)
 print(dataset)
+
+""" 
+TODO: TypeSpec needs to be fixed for this to work. "body" should be removed.
+print(f"Get credentials of an existing Dataset version `{dataset_version_1}`:")
+asset_credential = project_client.datasets.get_credentials(
+    name=dataset_name,
+    version=dataset_version_1,
+    body=None)
+print(asset_credential)
+"""
 
 print("List latest versions of all Datasets:")
 for dataset in project_client.datasets.list():

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_connections_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_connections_async.py
@@ -7,11 +7,12 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from ._operations import ConnectionsOperations as ConnectionsOperationsGenerated
 from ...models._models import Connection
+from ...models._enums import ConnectionType
 
 
 class ConnectionsOperations(ConnectionsOperationsGenerated):
@@ -41,3 +42,27 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
             return await super()._get_with_credentials(name, **kwargs)
 
         return await super()._get(name, **kwargs)
+
+    @distributed_trace_async
+    async def get_default(
+        self, connection_type: Union[str, ConnectionType], *, include_credentials: Optional[bool] = False, **kwargs: Any
+    ) -> Connection:
+        """Get the default connection for a given connection type.
+
+        :param connection_type: The type of the connection. Required.
+        :type connection_type: str or ~azure.ai.projects.models.ConnectionType
+        :keyword include_credentials: Whether to include credentials in the response. Default is False.
+        :paramtype include_credentials: bool
+        :return: Connection. The Connection is compatible with MutableMapping
+        :rtype: ~azure.ai.projects.models.Connection
+        :raises ValueError: If no default connection is found for the given type.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        connections = super().list(connection_type=connection_type, default_connection=True, **kwargs)
+        async for connection in connections:
+            if include_credentials:
+                connection = await super()._get_with_credentials(connection.name, **kwargs)
+                return connection
+            else:
+                return connection
+        raise ValueError(f"No default connection found for type: {connection_type}.")

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -558,8 +558,7 @@ class BlobReference(_Model):
     """
 
     blob_uri: str = rest_field(name="blobUri", visibility=["read", "create", "update", "delete", "query"])
-    """Blob URI path for client to upload data. Example: `https://blob.windows.core.net/Container/Path
-     <https://blob.windows.core.net/Container/Path>`_. Required."""
+    """Blob URI path for client to upload data. Example: ``https://blob.windows.core.net/Container/Path``. Required."""
     storage_account_arm_id: str = rest_field(
         name="storageAccountArmId", visibility=["read", "create", "update", "delete", "query"]
     )
@@ -741,8 +740,7 @@ class DatasetVersion(_Model):
 
     __mapping__: Dict[str, _Model] = {}
     data_uri: str = rest_field(name="dataUri", visibility=["read", "create"])
-    """URI of the data. Example: `https://go.microsoft.com/fwlink/?linkid=2202330
-     <https://go.microsoft.com/fwlink/?linkid=2202330>`_. Required."""
+    """URI of the data. Example: ``https://go.microsoft.com/fwlink/?linkid=2202330``. Required."""
     type: str = rest_discriminator(name="type", visibility=["read", "create", "update", "delete", "query"])
     """Dataset type. Required. Known values are: \"uri_file\" and \"uri_folder\"."""
     is_reference: Optional[bool] = rest_field(name="isReference", visibility=["read"])

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -549,8 +549,7 @@ class BlobReference(_Model):
     """Blob reference details.
 
     :ivar blob_uri: Blob URI path for client to upload data. Example:
-     `https://blob.windows.core.net/Container/Path <https://blob.windows.core.net/Container/Path>`_.
-     Required.
+     ``https://blob.windows.core.net/Container/Path``. Required.
     :vartype blob_uri: str
     :ivar storage_account_arm_id: ARM ID of the storage account to use. Required.
     :vartype storage_account_arm_id: str
@@ -721,8 +720,7 @@ class DatasetVersion(_Model):
     You probably want to use the sub-classes and not this class directly. Known sub-classes are:
     FileDatasetVersion, FolderDatasetVersion
 
-    :ivar data_uri: URI of the data. Example: `https://go.microsoft.com/fwlink/?linkid=2202330
-     <https://go.microsoft.com/fwlink/?linkid=2202330>`_. Required.
+    :ivar data_uri: URI of the data. Example: ``https://go.microsoft.com/fwlink/?linkid=2202330``. Required.
     :vartype data_uri: str
     :ivar type: Dataset type. Required. Known values are: "uri_file" and "uri_folder".
     :vartype type: str or ~azure.ai.projects.models.DatasetType
@@ -995,8 +993,7 @@ class EvaluatorConfiguration(_Model):
 class FileDatasetVersion(DatasetVersion, discriminator="uri_file"):
     """FileDatasetVersion Definition.
 
-    :ivar data_uri: URI of the data. Example: `https://go.microsoft.com/fwlink/?linkid=2202330
-     <https://go.microsoft.com/fwlink/?linkid=2202330>`_. Required.
+    :ivar data_uri: URI of the data. Example: ``https://go.microsoft.com/fwlink/?linkid=2202330``. Required.
     :vartype data_uri: str
     :ivar is_reference: Indicates if dataset is reference only or managed by dataset service. If
      true, the underlying data will be deleted when the dataset version is deleted.
@@ -1041,8 +1038,7 @@ class FileDatasetVersion(DatasetVersion, discriminator="uri_file"):
 class FolderDatasetVersion(DatasetVersion, discriminator="uri_folder"):
     """FileDatasetVersion Definition.
 
-    :ivar data_uri: URI of the data. Example: `https://go.microsoft.com/fwlink/?linkid=2202330
-     <https://go.microsoft.com/fwlink/?linkid=2202330>`_. Required.
+    :ivar data_uri: URI of the data. Example: ``https://go.microsoft.com/fwlink/?linkid=2202330``. Required.
     :vartype data_uri: str
     :ivar is_reference: Indicates if dataset is reference only or managed by dataset service. If
      true, the underlying data will be deleted when the dataset version is deleted.

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_connections.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_connections.py
@@ -7,10 +7,11 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import Optional, Any
+from typing import Optional, Any, Union
 from azure.core.tracing.decorator import distributed_trace
 from ._operations import ConnectionsOperations as ConnectionsOperationsGenerated
 from ..models._models import Connection
+from ..models._enums import ConnectionType
 
 
 class ConnectionsOperations(ConnectionsOperationsGenerated):
@@ -39,3 +40,27 @@ class ConnectionsOperations(ConnectionsOperationsGenerated):
             return super()._get_with_credentials(name, **kwargs)
 
         return super()._get(name, **kwargs)
+
+    @distributed_trace
+    def get_default(
+        self, connection_type: Union[str, ConnectionType], *, include_credentials: Optional[bool] = False, **kwargs: Any
+    ) -> Connection:
+        """Get the default connection for a given connection type.
+
+        :param connection_type: The type of the connection. Required.
+        :type connection_type: str or ~azure.ai.projects.models.ConnectionType
+        :keyword include_credentials: Whether to include credentials in the response. Default is False.
+        :paramtype include_credentials: bool
+        :return: Connection. The Connection is compatible with MutableMapping
+        :rtype: ~azure.ai.projects.models.Connection
+        :raises ValueError: If no default connection is found for the given type.
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        connections = super().list(connection_type=connection_type, default_connection=True, **kwargs)
+        for connection in connections:
+            if include_credentials:
+                connection = super()._get_with_credentials(connection.name, **kwargs)
+                return connection
+            else:
+                return connection
+        raise ValueError(f"No default connection found for type: {connection_type}.")

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections.py
@@ -36,28 +36,31 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
     with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
 
         # [START connections_sample]
-        print("List the properties of all connections:")
+        print("List all connections:")
         for connection in project_client.connections.list():
             print(connection)
 
-        print("List the properties of all connections of a particular type (in this case, Azure OpenAI connections):")
+        print("List all connections of a particular type:")
         for connection in project_client.connections.list(
             connection_type=ConnectionType.AZURE_OPEN_AI,
         ):
             print(connection)
 
-        print("To list the default connection of a particular type  (in this case, Azure Store Account):")
-        for connection in project_client.connections.list(
-            connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
-            default_connection=True,
-        ):
-            print(connection)
+        print("Get the default connection of a particular type, without its credentials:")
+        connection = project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+        print(connection)
 
-        print(f"Get the properties of a connection named `{connection_name}`, without its credentials:")
+        print("Get the default connection of a particular type, with its credentials:")
+        connection = project_client.connections.get_default(
+            connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True
+        )
+        print(connection)
+
+        print(f"Get the connection named `{connection_name}`, without its credentials:")
         connection = project_client.connections.get(connection_name)
         print(connection)
 
-        print(f"Get the properties of a connection named `{connection_name}`, with its credentials:")
+        print(f"Get the connection named `{connection_name}`, with its credentials:")
         connection = project_client.connections.get(connection_name, include_credentials=True)
         print(connection)
         # [END connection_sample]

--- a/sdk/ai/azure-ai-projects/samples/connections/sample_connections_async.py
+++ b/sdk/ai/azure-ai-projects/samples/connections/sample_connections_async.py
@@ -39,30 +39,31 @@ async def main() -> None:
 
         async with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
 
-            print("List the properties of all connections:")
+            print("List all connections:")
             async for connection in project_client.connections.list():
                 print(connection)
 
-            print(
-                "List the properties of all connections of a particular type (in this case, Azure OpenAI connections):"
-            )
+            print("List all connections of a particular type:")
             async for connection in project_client.connections.list(
                 connection_type=ConnectionType.AZURE_OPEN_AI,
             ):
                 print(connection)
 
-            print("To list the default connection of a particular type  (in this case, Azure Store Account):")
-            async for connection in project_client.connections.list(
-                connection_type=ConnectionType.AZURE_STORAGE_ACCOUNT,
-                default_connection=True,
-            ):
-                print(connection)
+            print("Get the default connection of a particular type, without its credentials:")
+            connection = await project_client.connections.get_default(connection_type=ConnectionType.AZURE_OPEN_AI)
+            print(connection)
 
-            print(f"Get the properties of a connection named `{connection_name}`, without its credentials:")
+            print("Get the default connection of a particular type, with its credentials:")
+            connection = await project_client.connections.get_default(
+                connection_type=ConnectionType.AZURE_OPEN_AI, include_credentials=True
+            )
+            print(connection)
+
+            print(f"Get the connection named `{connection_name}`, without its credentials:")
             connection = await project_client.connections.get(connection_name)
             print(connection)
 
-            print(f"Get the properties of a connection named `{connection_name}`, with its credentials:")
+            print(f"Get the connection named `{connection_name}`, with its credentials:")
             connection = await project_client.connections.get(connection_name, include_credentials=True)
             print(connection)
 

--- a/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets.py
+++ b/sdk/ai/azure-ai-projects/samples/datasets/sample_datasets.py
@@ -70,6 +70,16 @@ with DefaultAzureCredential(exclude_interactive_browser_credential=False) as cre
         dataset = project_client.datasets.get(name=dataset_name, version=dataset_version_1)
         print(dataset)
 
+        """ 
+        TODO: TypeSpec needs to be fixed for this to work. "body" should be removed.
+        print(f"Get credentials of an existing Dataset version `{dataset_version_1}`:")
+        asset_credential = project_client.datasets.get_credentials(
+            name=dataset_name,
+            version=dataset_version_1,
+            body=None)
+        print(asset_credential)
+        """
+
         print("List latest versions of all Datasets:")
         for dataset in project_client.datasets.list():
             print(dataset)

--- a/sdk/ai/azure-ai-projects/samples/evaluation/sample_agent_evaluations.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluation/sample_agent_evaluations.py
@@ -30,7 +30,7 @@ from azure.ai.projects.models import (
     InputDataset,
     EvaluatorIds,
     EvaluatorConfiguration,
-    AgentEvaluationSamplingConfiguration
+    AgentEvaluationSamplingConfiguration,
 )
 from dotenv import load_dotenv
 


### PR DESCRIPTION
Since those are available in the previous version, I'm adding them to the new Python version to minimize breaking changes. You can already get the default connection by calling `.connection.list()` with `default_connection=True` and accessing the single connection in the returned list. Having an explicit get_default makes sense to me since it's a common usage case.

Also fix failing Sphinx (doc string generation). This is a bug in the TypeSpec python emitter, there is no workaround for it at the moment, so I need to edit the auto-generated files.
