### PR TITLE
force default aoai version

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_d585f1f45d"
+  "Tag": "python/evaluation/azure-ai-evaluation_2b7d360048"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/aoai_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/aoai_grader.py
@@ -77,7 +77,7 @@ class AzureOpenAIGrader():
            return AzureOpenAI(
                 azure_endpoint=self._model_config["azure_endpoint"],
                 api_key=self._model_config.get("api_key", None), # Default-style access to appease linters.
-                api_version=self._model_config.get("api_version", DEFAULT_AOAI_API_VERSION),
+                api_version=DEFAULT_AOAI_API_VERSION, # Force a known working version
                 azure_deployment=self._model_config.get("azure_deployment", ""),
             )
         from openai import OpenAI


### PR DESCRIPTION
Ignore user-supplied aoai versions for now when defining graders, and only use a known-to-work default.
