### PR TITLE
[Key Vault] Reintroduce activation skipping in security domain upload

### DIFF
--- a/sdk/keyvault/azure-keyvault-securitydomain/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-securitydomain/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b1 (2025-05-06)
+## 1.0.0b1 (2025-05-07)
 
 ### Features Added
 

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/__init__.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/__init__.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from .async_polling import (
     AsyncSecurityDomainDownloadNoPolling,
     AsyncSecurityDomainDownloadPollingMethod,
+    AsyncSecurityDomainUploadNoPolling,
     AsyncSecurityDomainUploadPollingMethod,
 )
 from .challenge_auth_policy import ChallengeAuthPolicy
@@ -18,6 +19,7 @@ from .polling import (
     SecurityDomainDownloadNoPolling,
     SecurityDomainDownloadPolling,
     SecurityDomainDownloadPollingMethod,
+    SecurityDomainUploadNoPolling,
     SecurityDomainUploadPolling,
     SecurityDomainUploadPollingMethod,
 )
@@ -27,6 +29,7 @@ HttpChallengeCache = http_challenge_cache  # to avoid aliasing pylint error (C47
 __all__ = [
     "AsyncSecurityDomainDownloadNoPolling",
     "AsyncSecurityDomainDownloadPollingMethod",
+    "AsyncSecurityDomainUploadNoPolling",
     "AsyncSecurityDomainUploadPollingMethod",
     "ChallengeAuthPolicy",
     "HttpChallenge",
@@ -34,6 +37,7 @@ __all__ = [
     "SecurityDomainDownloadNoPolling",
     "SecurityDomainDownloadPolling",
     "SecurityDomainDownloadPollingMethod",
+    "SecurityDomainUploadNoPolling",
     "SecurityDomainUploadPolling",
     "SecurityDomainUploadPollingMethod",
 ]

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/async_polling.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/async_polling.py
@@ -158,3 +158,6 @@ class AsyncSecurityDomainUploadPollingMethod(AsyncPollingTerminationMixin, Async
         :return: The built resource.
         """
         return None
+
+class AsyncSecurityDomainUploadNoPolling(AsyncSecurityDomainUploadPollingMethod, AsyncNoPollingMixin):
+    pass

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/polling.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/polling.py
@@ -198,3 +198,6 @@ class SecurityDomainUploadPollingMethod(PollingTerminationMixin, LROBasePolling)
         :return: The built resource.
         """
         return None
+
+class SecurityDomainUploadNoPolling(SecurityDomainUploadPollingMethod, NoPollingMixin):
+    pass

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_patch.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_patch.py
@@ -179,7 +179,7 @@ class SecurityDomainClient(KeyVaultClient):
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
         polling_method = (
             SecurityDomainDownloadNoPolling()
-            if skip_activation_polling is True
+            if skip_activation_polling
             else SecurityDomainDownloadPollingMethod(lro_algorithms=[SecurityDomainDownloadPolling()], timeout=delay)
         )
         return super()._begin_download(  # type: ignore[return-value]
@@ -250,7 +250,7 @@ class SecurityDomainClient(KeyVaultClient):
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
         polling_method = (
             SecurityDomainUploadNoPolling()
-            if skip_activation_polling is True
+            if skip_activation_polling
             else SecurityDomainUploadPollingMethod(lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay)
         )
         return super()._begin_upload(  # type: ignore[return-value]

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_patch.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_patch.py
@@ -25,6 +25,7 @@ from ._internal import (
     SecurityDomainDownloadNoPolling,
     SecurityDomainDownloadPolling,
     SecurityDomainDownloadPollingMethod,
+    SecurityDomainUploadNoPolling,
     SecurityDomainUploadPolling,
     SecurityDomainUploadPollingMethod,
 )
@@ -195,6 +196,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: SecurityDomain,
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> LROPoller[None]: ...
 
@@ -205,6 +207,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: JSON,
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> LROPoller[None]: ...
 
@@ -215,6 +218,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: IO[bytes],
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> LROPoller[None]: ...
 
@@ -224,6 +228,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: Union[SecurityDomain, JSON, IO[bytes]],
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> LROPoller[None]:
         """Restore the provided Security Domain.
@@ -234,14 +239,19 @@ class SecurityDomainClient(KeyVaultClient):
          IO[bytes]
         :keyword str content_type: Body Parameter content-type. Content type parameter for JSON body.
          Default value is "application/json".
+        :keyword bool skip_activation_polling: If set to True, the operation will not poll for HSM activation to
+         complete and calling `.result()` on the poller will return None immediately, or raise an exception in case of
+         an error. Default value is False.
 
         :return: An instance of LROPoller that returns None.
         :rtype: ~azure.core.polling.LROPoller[None]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
-        polling_method = SecurityDomainUploadPollingMethod(
-            lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay
+        polling_method = (
+            SecurityDomainUploadNoPolling()
+            if skip_activation_polling is True
+            else SecurityDomainUploadPollingMethod(lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay)
         )
         return super()._begin_upload(  # type: ignore[return-value]
             security_domain,

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/aio/_patch.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/aio/_patch.py
@@ -137,7 +137,7 @@ class SecurityDomainClient(KeyVaultClient):
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
         polling_method = (
             AsyncSecurityDomainDownloadNoPolling()
-            if skip_activation_polling is True
+            if skip_activation_polling
             else AsyncSecurityDomainDownloadPollingMethod(
                 lro_algorithms=[SecurityDomainDownloadPolling()], timeout=delay
             )
@@ -210,7 +210,7 @@ class SecurityDomainClient(KeyVaultClient):
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
         polling_method = (
             AsyncSecurityDomainUploadNoPolling()
-            if skip_activation_polling is True
+            if skip_activation_polling
             else AsyncSecurityDomainUploadPollingMethod(lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay)
         )
         return await super()._begin_upload(  # type: ignore[return-value]

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/aio/_patch.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/aio/_patch.py
@@ -20,6 +20,7 @@ from .._internal import (
     AsyncChallengeAuthPolicy,
     AsyncSecurityDomainDownloadNoPolling,
     AsyncSecurityDomainDownloadPollingMethod,
+    AsyncSecurityDomainUploadNoPolling,
     AsyncSecurityDomainUploadPollingMethod,
     SecurityDomainDownloadPolling,
     SecurityDomainUploadPolling,
@@ -155,6 +156,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: SecurityDomain,
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> AsyncLROPoller[None]: ...
 
@@ -165,6 +167,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: JSON,
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> AsyncLROPoller[None]: ...
 
@@ -175,6 +178,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: IO[bytes],
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> AsyncLROPoller[None]: ...
 
@@ -184,6 +188,7 @@ class SecurityDomainClient(KeyVaultClient):
         security_domain: Union[SecurityDomain, JSON, IO[bytes]],
         *,
         content_type: str = "application/json",
+        skip_activation_polling: bool = False,
         **kwargs: Any,
     ) -> AsyncLROPoller[None]:
         """Restore the provided Security Domain.
@@ -194,14 +199,19 @@ class SecurityDomainClient(KeyVaultClient):
          IO[bytes]
         :keyword str content_type: Body Parameter content-type. Content type parameter for JSON body.
          Default value is "application/json".
+        :keyword bool skip_activation_polling: If set to True, the operation will not poll for HSM activation to
+         complete and calling `.result()` on the poller will return None immediately, or raise an exception in case of
+         an error. Default value is False.
 
         :return: An instance of AsyncLROPoller that returns None.
         :rtype: ~azure.core.polling.AsyncLROPoller[None]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         delay = kwargs.pop("polling_interval", self._config.polling_interval)
-        polling_method = AsyncSecurityDomainUploadPollingMethod(
-            lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay
+        polling_method = (
+            AsyncSecurityDomainUploadNoPolling()
+            if skip_activation_polling is True
+            else AsyncSecurityDomainUploadPollingMethod(lro_algorithms=[SecurityDomainUploadPolling()], timeout=delay)
         )
         return await super()._begin_upload(  # type: ignore[return-value]
             security_domain,


### PR DESCRIPTION
# Description

The Azure CLI's [security domain `upload` command](https://learn.microsoft.com/cli/azure/keyvault/security-domain?view=azure-cli-latest#az-keyvault-security-domain-upload) accepts a `--no-wait` option to skip activation polling. Our `begin_upload` method needs to support this as well to enable this scenario.

This was already supported in the version of this library that's vendored by the CLI today, but was accidentally removed during recent refactoring while renaming `polling` to `skip_activation_polling`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
