### PR TITLE
Handle git_props pop keyerror in job operations create_or_update

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -62,10 +62,10 @@ from azure.ai.ml.constants._common import (
     TID_FMT,
     AssetTypes,
     AzureMLResourceType,
+    GitProperties,
     WorkspaceDiscoveryUrlKey,
 )
 from azure.ai.ml.constants._compute import ComputeType
-from azure.ai.ml.constants._common import GitProperties
 from azure.ai.ml.constants._job.pipeline import PipelineConstants
 from azure.ai.ml.entities import Compute, Job, PipelineJob, ServiceInstance, ValidationResult
 from azure.ai.ml.entities._assets._artifacts.code import Code
@@ -690,10 +690,10 @@ class JobOperations(_ScopeDependentOperations):
             repo_url = git_props.get(GitProperties.PROP_MLFLOW_GIT_REPO_URL)
 
             if has_pat_token(repo_url):
-                git_props.pop(GitProperties.PROP_MLFLOW_GIT_REPO_URL)
-                git_props.pop(GitProperties.PROP_MLFLOW_GIT_BRANCH)
-                git_props.pop(GitProperties.PROP_MLFLOW_GIT_COMMIT)
-                git_props.pop(GitProperties.PROP_DIRTY)
+                git_props.pop(GitProperties.PROP_MLFLOW_GIT_REPO_URL, None)
+                git_props.pop(GitProperties.PROP_MLFLOW_GIT_BRANCH, None)
+                git_props.pop(GitProperties.PROP_MLFLOW_GIT_COMMIT, None)
+                git_props.pop(GitProperties.PROP_DIRTY, None)
                 module_logger.warning("Git properties are removed because the repository URL contains a secret.")
 
             if git_props:


### PR DESCRIPTION
# Description

Fix for this GH issue - https://github.com/Azure/azure-sdk-for-python/issues/40948
If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
