### PR TITLE
account for OAI breaking changes

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_2b7d360048"
+  "Tag": "python/evaluation/azure-ai-evaluation_4e58349bd2"
 }

--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_b49370f3b2"
+  "Tag": "python/evaluation/azure-ai-evaluation_64eea0ea34"
 }

--- a/sdk/evaluation/azure-ai-evaluation/assets.json
+++ b/sdk/evaluation/azure-ai-evaluation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/evaluation/azure-ai-evaluation",
-  "Tag": "python/evaluation/azure-ai-evaluation_4e58349bd2"
+  "Tag": "python/evaluation/azure-ai-evaluation_b49370f3b2"
 }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/label_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/label_grader.py
@@ -4,7 +4,7 @@
 from typing import Any, Dict, Union, List
 
 from azure.ai.evaluation._model_configurations import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
-from openai.types.eval_create_params import TestingCriterionLabelModel
+from openai.types.graders import LabelModelGrader
 from azure.ai.evaluation._common._experimental import experimental
 
 from .aoai_grader import AzureOpenAIGrader
@@ -55,7 +55,7 @@ class AzureOpenAILabelGrader(AzureOpenAIGrader):
         passing_labels: List[str],
         **kwargs: Any
     ):
-        grader = TestingCriterionLabelModel(
+        grader = LabelModelGrader(
             input=input,
             labels=labels,
             model=model,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/string_check_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/string_check_grader.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Union
 from typing_extensions import Literal
 
 from azure.ai.evaluation._model_configurations import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
-from openai.types.eval_string_check_grader import EvalStringCheckGrader
+from openai.types.graders import StringCheckGrader
 from azure.ai.evaluation._common._experimental import experimental
 
 from .aoai_grader import AzureOpenAIGrader
@@ -55,7 +55,7 @@ class AzureOpenAIStringCheckGrader(AzureOpenAIGrader):
         reference: str,
         **kwargs: Any
     ):
-        grader = EvalStringCheckGrader(
+        grader = StringCheckGrader(
             input=input,
             name=name,
             operation=operation,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/text_similarity_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/text_similarity_grader.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Union
 from typing_extensions import Literal
 
 from azure.ai.evaluation._model_configurations import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
-from openai.types.eval_text_similarity_grader import EvalTextSimilarityGrader
+from openai.types.graders import TextSimilarityGrader
 from azure.ai.evaluation._common._experimental import experimental
 
 from .aoai_grader import AzureOpenAIGrader
@@ -76,7 +76,7 @@ class AzureOpenAITextSimilarityGrader(AzureOpenAIGrader):
         name: str,
         **kwargs: Any
     ):
-        grader = EvalTextSimilarityGrader(
+        grader = TextSimilarityGrader(
             evaluation_metric=evaluation_metric,
             input=input,
             pass_threshold=pass_threshold,

--- a/sdk/evaluation/azure-ai-evaluation/dev_requirements.txt
+++ b/sdk/evaluation/azure-ai-evaluation/dev_requirements.txt
@@ -9,5 +9,4 @@ pytest-xdist
 azure-ai-inference>=1.0.0b4
 azure-ai-projects
 aiohttp
-openai>=1.73.0
 -e ../azure-ai-evaluation

--- a/sdk/evaluation/azure-ai-evaluation/setup.py
+++ b/sdk/evaluation/azure-ai-evaluation/setup.py
@@ -77,7 +77,7 @@ setup(
         "httpx>=0.25.1",
         # Dependencies added since Promptflow will soon be made optional
         "pandas>=2.1.2,<3.0.0",
-        "openai>=1.73.0",
+        "openai>=1.78.0",
         "ruamel.yaml>=0.17.10,<1.0.0",
         "msrest>=0.6.21",
         "Jinja2>=3.1.6",

--- a/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_aoai_graders.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/e2etests/test_aoai_graders.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from devtools_testutils import is_live
 
-from openai.types.eval_string_check_grader import EvalStringCheckGrader
+from openai.types.graders import StringCheckGrader
 from azure.ai.evaluation import (
     F1ScoreEvaluator,
     evaluate,
@@ -66,7 +66,7 @@ class TestAoaiEvaluation:
         # ---- General Grader Initialization ----
 
         # Define an string check grader config directly using the OAI SDK
-        oai_string_check_grader = EvalStringCheckGrader(
+        oai_string_check_grader = StringCheckGrader(
             input="{{item.query}}",
             name="contains hello",
             operation="like",


### PR DESCRIPTION
The OAI SDK decided to move around a bunch of public(?) classes. We need to fix the SDK to account for that, and pin the setup version to ensure that users don't use a too-early version.