### PR TITLE
Honor MWR config in client

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed bug where `multiple_write_locations` option in client was not being honored. See [PR 40999](https://github.com/Azure/azure-sdk-for-python/pull/40999).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -58,9 +58,6 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
         self.last_refresh_time = 0
         self._database_account_cache = None
 
-    def get_use_multiple_write_locations(self):
-        return self.location_cache.can_use_multiple_write_locations()
-
     def get_refresh_time_interval_in_ms_stub(self):
         return constants._Constants.DefaultEndpointsRefreshTime
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
@@ -58,7 +58,7 @@ class ServiceRequestRetryPolicy(object):
 
             self.request.last_routed_location_endpoint_within_region = self.request.location_endpoint_to_route
             if (_OperationType.IsReadOnlyOperation(self.request.operation_type)
-                    or self.global_endpoint_manager.get_use_multiple_write_locations()):
+                    or self.global_endpoint_manager.can_use_multiple_write_locations_for_request(self.request)):
                 self.update_location_cache()
                 # We just directly got to the next location in case of read requests
                 # We don't retry again on the same region for regional endpoint

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
@@ -58,7 +58,7 @@ class ServiceRequestRetryPolicy(object):
 
             self.request.last_routed_location_endpoint_within_region = self.request.location_endpoint_to_route
             if (_OperationType.IsReadOnlyOperation(self.request.operation_type)
-                    or self.global_endpoint_manager.can_use_multiple_write_locations_for_request(self.request)):
+                    or self.global_endpoint_manager.can_use_multiple_write_locations(self.request)):
                 self.update_location_cache()
                 # We just directly got to the next location in case of read requests
                 # We don't retry again on the same region for regional endpoint

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -62,9 +62,6 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
         self.last_refresh_time = 0
         self._database_account_cache = None
 
-    def get_use_multiple_write_locations(self):
-        return self.location_cache.can_use_multiple_write_locations()
-
     def get_refresh_time_interval_in_ms_stub(self):
         return constants._Constants.DefaultEndpointsRefreshTime
 

--- a/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport.py
@@ -297,7 +297,9 @@ class TestFaultInjectionTransport:
 
         initialized_objects = self.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         container: ContainerProxy = initialized_objects["col"]
 
         created_document = container.create_item(body=document_definition)
@@ -347,7 +349,9 @@ class TestFaultInjectionTransport:
 
         initialized_objects = self.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         container: ContainerProxy = initialized_objects["col"]
 
         start:float = time.perf_counter()
@@ -466,7 +470,9 @@ class TestFaultInjectionTransport:
 
         initialized_objects = self.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         container: ContainerProxy = initialized_objects["col"]
         with pytest.raises(ServiceRequestError):
             container.upsert_item(body=document_definition)

--- a/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_fault_injection_transport_async.py
@@ -330,7 +330,9 @@ class TestFaultInjectionTransportAsync(IsolatedAsyncioTestCase):
 
         initialized_objects = await TestFaultInjectionTransportAsync.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         try:
             container: ContainerProxy = initialized_objects["col"]
 
@@ -383,7 +385,9 @@ class TestFaultInjectionTransportAsync(IsolatedAsyncioTestCase):
 
         initialized_objects = await TestFaultInjectionTransportAsync.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         try:
             container: ContainerProxy = initialized_objects["col"]
 
@@ -508,7 +512,9 @@ class TestFaultInjectionTransportAsync(IsolatedAsyncioTestCase):
 
         initialized_objects = await TestFaultInjectionTransportAsync.setup_method_with_custom_transport(
             custom_transport,
-            preferred_locations=["First Region", "Second Region"])
+            preferred_locations=["First Region", "Second Region"],
+            multiple_write_locations=True
+        )
         try:
             container: ContainerProxy = initialized_objects["col"]
             with pytest.raises(ServiceRequestError):


### PR DESCRIPTION
# Description
The multiple_write_locations option on the cosmos client was not being honored when a request is retrying due to a service request error.