### PR TITLE
Fix sdk\ai release pipeline

### DIFF
--- a/sdk/ai/ci.yml
+++ b/sdk/ai/ci.yml
@@ -50,16 +50,14 @@ extends:
     #    Selection: sparse
     #    GenerateVMJobs: true
     Artifacts:
-    # Uncommentbefore merging to main branch
-    # - name: azure-ai-projects
-    #  safeName: azureaiprojects
+    - name: azure-ai-projects
+      safeName: azureaiprojects
     - name: azure-ai-inference
       safeName: azureaiinference
-    #######################################
     - name: azure-ai-agents
       safeName: azureaiagents
     # These packages are deprecated: 
     # - name: azure-ai-generative
     #   safeName: azureaigenerative
-    - name: azure-ai-resources
-      safeName: azureairesources
+    # - name: azure-ai-resources
+    # safeName: azureairesources


### PR DESCRIPTION
Following feedback from "Azure SDK Onboarding" Teams channel, azure-ai-resources needs to be removed from ci.yaml since it's now deprecated. Also bring back azure-ai-projects.