### PR TITLE
remove package check

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -141,7 +141,6 @@ def _aggregate_content_safety_metrics(
             module = inspect.getmodule(evaluators[evaluator_name])
             if (
                 module
-                and module.__name__.startswith("azure.ai.evaluation.")
                 and metric_name.endswith("_score")
                 and metric_name.replace("_score", "") in content_safety_metrics
             ):


### PR DESCRIPTION
Removes the package check on defect rate metric creation for content safety evaluators. This technically means that if someone were to create a custom evaluator that produced the exact same output columns, they'd have a defect rate metric automatically replace their score metric, but i doubt this is likely to happen.

This is needed to fix a bug in our remote evaluation system that doesn't properly produce defect rates from these evals due to class wrapping.
