### PR TITLE
Take setup dependency on azure-ai-agents. Update inference route to /models

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -7,7 +7,7 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import os
-from typing import List, Any, Optional, TYPE_CHECKING
+from typing import List, Any, Optional
 from typing_extensions import Self
 from azure.core.credentials import TokenCredential
 from azure.ai.agents import AgentsClient
@@ -94,10 +94,10 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
         self.telemetry = TelemetryOperations(self)  # type: ignore
         self.inference = InferenceOperations(self)  # type: ignore
-        self._agents = None
+        self._agents: Optional[AgentsClient] = None
 
     @property
-    def agents(self) -> "AgentsClient":  # type: ignore[name-defined]
+    def agents(self) -> AgentsClient:  # type: ignore[name-defined]
         """Get the AgentsClient associated with this AIProjectClient.
         The package azure.ai.agents must be installed to use this property.
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -10,14 +10,11 @@ import os
 from typing import List, Any, Optional, TYPE_CHECKING
 from typing_extensions import Self
 from azure.core.credentials import TokenCredential
+from azure.ai.agents import AgentsClient
 from ._client import AIProjectClient as AIProjectClientGenerated
 from .operations import TelemetryOperations, InferenceOperations
 from ._patch_prompts import PromptTemplate
 from ._patch_telemetry import enable_telemetry
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import,ungrouped-imports
-    from azure.ai.agents import AgentsClient
 
 _console_logging_enabled: bool = os.environ.get("ENABLE_AZURE_AI_PROJECTS_CONSOLE_LOGGING", "False").lower() in (
     "true",
@@ -108,13 +105,6 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         :rtype: azure.ai.agents.AgentsClient
         """
         if self._agents is None:
-            # Lazy import of AgentsClient only when this property is accessed
-            try:
-                from azure.ai.agents import AgentsClient
-            except ModuleNotFoundError as e:
-                raise ModuleNotFoundError(
-                    "Failed to import AgentsClient. Please run 'pip install azure.ai.agents'"
-                ) from e
             self._agents = AgentsClient(
                 endpoint=self._config.endpoint,
                 credential=self._config.credential,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -7,7 +7,7 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import os
-from typing import List, Any, TYPE_CHECKING
+from typing import List, Any, Optional
 from typing_extensions import Self
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.ai.agents.aio import AgentsClient
@@ -77,10 +77,10 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
         self.telemetry = TelemetryOperations(self)  # type: ignore
         self.inference = InferenceOperations(self)  # type: ignore
-        self._agents = None
+        self._agents: Optional[AgentsClient] = None
 
     @property
-    def agents(self) -> "AgentsClient":  # type: ignore[name-defined]
+    def agents(self) -> AgentsClient:  # type: ignore[name-defined]
         """Get the asynchronous AgentsClient associated with this AIProjectClient.
         The package azure.ai.agents must be installed to use this property.
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -10,13 +10,10 @@ import os
 from typing import List, Any, TYPE_CHECKING
 from typing_extensions import Self
 from azure.core.credentials_async import AsyncTokenCredential
+from azure.ai.agents.aio import AgentsClient
 from ._client import AIProjectClient as AIProjectClientGenerated
 from .._patch import _patch_user_agent
 from .operations import InferenceOperations, TelemetryOperations
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import,ungrouped-imports
-    from azure.ai.agents.aio import AgentsClient
 
 _console_logging_enabled: bool = os.environ.get("ENABLE_AZURE_AI_PROJECTS_CONSOLE_LOGGING", "False").lower() in (
     "true",
@@ -91,13 +88,6 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         :rtype: azure.ai.agents.aio.AgentsClient
         """
         if self._agents is None:
-            # Lazy import of AgentsClient only when this property is accessed
-            try:
-                from azure.ai.agents.aio import AgentsClient
-            except ModuleNotFoundError as e:
-                raise ModuleNotFoundError(
-                    "Failed to import AgentsClient. Please run 'pip install azure.ai.agents'"
-                ) from e
             self._agents = AgentsClient(
                 endpoint=self._config.endpoint,
                 credential=self._config.credential,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -49,7 +49,7 @@ class InferenceOperations:
         Converts an input URL in the format:
         https://<host-name>/<some-path>
         to:
-        https://<host-name>/api/models
+        https://<host-name>/models
 
         :param input_url: The input endpoint URL used to construct AIProjectClient.
         :type input_url: str
@@ -60,7 +60,7 @@ class InferenceOperations:
         parsed = urlparse(input_url)
         if parsed.scheme != "https" or not parsed.netloc:
             raise ValueError("Invalid endpoint URL format. Must be an https URL with a host.")
-        new_url = f"https://{parsed.netloc}/api/models"
+        new_url = f"https://{parsed.netloc}/models"
         return new_url
 
     @distributed_trace

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
@@ -42,7 +42,7 @@ class InferenceOperations:
         Converts an input URL in the format:
         https://<host-name>/<some-path>
         to:
-        https://<host-name>/api/models
+        https://<host-name>/models
 
         :param input_url: The input endpoint URL used to construct AIProjectClient.
         :type input_url: str
@@ -53,7 +53,7 @@ class InferenceOperations:
         parsed = urlparse(input_url)
         if parsed.scheme != "https" or not parsed.netloc:
             raise ValueError("Invalid endpoint URL format. Must be an https URL with a host.")
-        new_url = f"https://{parsed.netloc}/api/models"
+        new_url = f"https://{parsed.netloc}/models"
         return new_url
 
     @distributed_trace

--- a/sdk/ai/azure-ai-projects/dev_requirements.txt
+++ b/sdk/ai/azure-ai-projects/dev_requirements.txt
@@ -4,5 +4,6 @@
 aiohttp
 azure.storage.blob
 azure.ai.inference
+azure.ai.agents
 openai
 prompty

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents.py
@@ -15,7 +15,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-agents azure-identity
+    pip install azure-ai-projects azure-identity
 
     Set this environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your

--- a/sdk/ai/azure-ai-projects/samples/agents/sample_agents_async.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/sample_agents_async.py
@@ -15,7 +15,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install azure-ai-projects azure-ai-agents azure-identity aiohttp
+    pip install azure-ai-projects azure-identity aiohttp
 
     Set this environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your

--- a/sdk/ai/azure-ai-projects/setup.py
+++ b/sdk/ai/azure-ai-projects/setup.py
@@ -71,6 +71,7 @@ setup(
         "azure-core>=1.30.0",
         "typing-extensions>=4.12.2",
         "azure-storage-blob>=12.15.0",
+        "azure-ai-agents",
     ],
     python_requires=">=3.9",
     extras_require={


### PR DESCRIPTION
# Description

* Now that the first version of azure-ai-agents package was release, update azure-ai-projects to take a setup dependency on it, instead of "lazy import"
* Use `/models` route instead of `/api/models` route for inferencing, when constructing azure-ai-inference SDK.