### PR TITLE
Update implementation of .inference.get_azure_openai_client()

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -127,7 +127,29 @@ You also have the option (not shown) to explicitly specify the Azure OpenAI conn
 <!-- SNIPPET:sample_chat_completions_with_azure_openai_client.aoai_sample-->
 
 ```python
+print(
+    "Get an authenticated Azure OpenAI client for the parent AI Services resource, and perform a chat completion operation:"
+)
 with project_client.inference.get_azure_openai_client(api_version="2024-10-21") as client:
+
+    response = client.chat.completions.create(
+        model=model_deployment_name,
+        messages=[
+            {
+                "role": "user",
+                "content": "How many feet are in a mile?",
+            },
+        ],
+    )
+
+    print(response.choices[0].message.content)
+
+print(
+    "Get an authenticated Azure OpenAI client for a connected Azure OpenAI service, and perform a chat completion operation:"
+)
+with project_client.inference.get_azure_openai_client(
+    api_version="2024-10-21", connection_name=connection_name
+) as client:
 
     response = client.chat.completions.create(
         model=model_deployment_name,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -63,6 +63,27 @@ class InferenceOperations:
         new_url = f"https://{parsed.netloc}/models"
         return new_url
 
+    # TODO: Use a common method for both the sync and async operations
+    @classmethod
+    def _get_aoai_inference_url(cls, input_url: str) -> str:
+        """
+        Converts an input URL in the format:
+        https://<host-name>/<some-path>
+        to:
+        https://<host-name>
+
+        :param input_url: The input endpoint URL used to construct AIProjectClient.
+        :type input_url: str
+
+        :return: The endpoint URL required to construct an AzureOpenAI client from the `openai` package.
+        :rtype: str
+        """
+        parsed = urlparse(input_url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise ValueError("Invalid endpoint URL format. Must be an https URL with a host.")
+        new_url = f"https://{parsed.netloc}"
+        return new_url
+
     @distributed_trace
     def get_chat_completions_client(self, **kwargs: Any) -> "ChatCompletionsClient":  # type: ignore[name-defined]
         """Get an authenticated asynchronous ChatCompletionsClient (from the package azure-ai-inference) to use with
@@ -184,9 +205,8 @@ class InferenceOperations:
     async def get_azure_openai_client(
         self, *, api_version: Optional[str] = None, connection_name: Optional[str] = None, **kwargs
     ) -> "AsyncAzureOpenAI":  # type: ignore[name-defined]
-        """Get an authenticated AsyncAzureOpenAI client (from the `openai` package) for the default
-        Azure OpenAI connection (if `connection_name` is not specified), or from the Azure OpenAI
-        resource given by its connection name.
+        """Get an authenticated AsyncAzureOpenAI client (from the `openai` package) to use with
+        AI models deployed to your AI Foundry Project or connected Azure OpenAI services.
 
         .. note:: The package `openai` must be installed prior to calling this method.
 
@@ -194,13 +214,16 @@ class InferenceOperations:
          See "Data plane - Inference" row in the table at
          https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs. If this keyword
          is not specified, you must set the environment variable `OPENAI_API_VERSION` instead.
-        :paramtype api_version: str
-        :keyword connection_name: The name of a connection to an Azure OpenAI resource in your AI Foundry project.
-         resource. Optional. If not provided, the default Azure OpenAI connection will be used.
-        :type connection_name: str
+        :paramtype api_version: Optional[str]
+        :keyword connection_name: Optional. If specified, the connection named here must be of type Azure OpenAI.
+         The returned AzureOpenAI client will use the inference URL specified by the connected Azure OpenAI
+         service, and can be used with AI models deployed to that service. If not specified, the returned
+         AzureOpenAI client will use the inference URL of the parent AI Services resource, and can be used
+         with AI models deployed directly to your AI Foundry project.
+        :paramtype connection_name: Optional[str]
 
         :return: An authenticated AsyncAzureOpenAI client
-        :rtype: ~openai.AzureAsyncAzureOpenAIOpenAI
+        :rtype: ~openai.AsyncAzureOpenAI
 
         :raises ~azure.core.exceptions.ResourceNotFoundError: if an Azure OpenAI connection
          does not exist.
@@ -219,71 +242,84 @@ class InferenceOperations:
                 "OpenAI SDK is not installed. Please install it using 'pip install openai'"
             ) from e
 
-        connection = Connection()
         if connection_name:
-            connection = await self._outer_instance.connections.get(name=connection_name, **kwargs)
-            if connection.type != ConnectionType.AZURE_OPEN_AI:
-                raise ValueError(f"Connection `{connection_name}` is not of type Azure OpenAI.")
-        else:
-            # If connection name was not specified, try to get the default Azure OpenAI connection.
-            connections: AsyncIterable[Connection] = self._outer_instance.connections.list(
-                connection_type=ConnectionType.AZURE_OPEN_AI, default_connection=True, **kwargs
-            )
-            try:
-                connection = await connections.__aiter__().__anext__()
-            except StopAsyncIteration as exc:
-                raise ResourceNotFoundError("No default Azure OpenAI connection found.") from exc
-            connection_name = connection.name
-
-            # TODO: if there isn't a default openai connection, we would have to by convention
-            # use https://{resource-name}.openai.azure.com where {resource-name} is the same as the
-            # foundry API endpoint (https://{resource-name}.services.ai.azure.com)
-
-        # If the connection uses API key authentication, we need to make another service call to get
-        # the connection with API key populated.
-        if connection.credentials.type == CredentialType.API_KEY:
             connection = (
                 await self._outer_instance.connections._get_with_credentials(  # pylint: disable=protected-access
                     name=connection_name, **kwargs
                 )
             )
+            if connection.type != ConnectionType.AZURE_OPEN_AI:
+                raise ValueError(f"Connection `{connection_name}` is not of type Azure OpenAI.")
 
-        logger.debug("[InferenceOperations.get_azure_openai_client] connection = %s", str(connection))
+            azure_endpoint = connection.target[:-1] if connection.target.endswith("/") else connection.target
 
-        azure_endpoint = connection.target[:-1] if connection.target.endswith("/") else connection.target
+            if isinstance(connection.credentials, ApiKeyCredentials):
 
-        if isinstance(connection.credentials, ApiKeyCredentials):
+                logger.debug(
+                    "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI client using API key authentication, on connection `%s`, endpoint `%s`, api_version `%s`",
+                    connection_name,
+                    azure_endpoint,
+                    api_version,
+                )
+                api_key = connection.credentials.api_key
+                client = AsyncAzureOpenAI(api_key=api_key, azure_endpoint=azure_endpoint, api_version=api_version)
 
-            logger.debug(
-                "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI using API key authentication"
-            )
-            api_key = connection.credentials.api_key
-            client = AsyncAzureOpenAI(api_key=api_key, azure_endpoint=azure_endpoint, api_version=api_version)
+            elif isinstance(connection.credentials, EntraIDCredentials):
 
-        elif isinstance(connection.credentials, EntraIDCredentials):
+                logger.debug(
+                    "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI using Entra ID authentication, on connection `%s`, endpoint `%s`, api_version `%s`",
+                    connection_name,
+                    azure_endpoint,
+                    api_version,
+                )
 
-            logger.debug(
-                "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI using Entra ID authentication"
-            )
+                try:
+                    from azure.identity import get_bearer_token_provider
+                except ModuleNotFoundError as e:
+                    raise ModuleNotFoundError(
+                        "azure.identity package not installed. Please install it using 'pip install azure.identity'"
+                    ) from e
 
-            try:
-                from azure.identity.aio import get_bearer_token_provider
-            except ModuleNotFoundError as e:
-                raise ModuleNotFoundError(
-                    "azure.identity package not installed. Please install it using 'pip install azure.identity'"
-                ) from e
+                client = AsyncAzureOpenAI(
+                    # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider # pylint: disable=line-too-long
+                    azure_ad_token_provider=get_bearer_token_provider(
+                        self._outer_instance._config.credential,  # pylint: disable=protected-access
+                        "https://cognitiveservices.azure.com/.default",  # pylint: disable=protected-access
+                    ),
+                    azure_endpoint=azure_endpoint,
+                    api_version=api_version,
+                )
 
-            client = AsyncAzureOpenAI(
-                # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider # pylint: disable=line-too-long
-                azure_ad_token_provider=get_bearer_token_provider(
-                    self._outer_instance._config.credential,  # pylint: disable=protected-access
-                    "https://cognitiveservices.azure.com/.default",  # pylint: disable=protected-access
-                ),
-                azure_endpoint=azure_endpoint,
-                api_version=api_version,
-            )
+            else:
+                raise ValueError("Unsupported authentication type {connection.type}")
 
-        else:
-            raise ValueError("Unsupported authentication type {connection.type}")
+            return client
+
+        try:
+            from azure.identity.aio import get_bearer_token_provider
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "azure.identity package not installed. Please install it using 'pip install azure.identity'"
+            ) from e
+
+        azure_endpoint = self._get_aoai_inference_url(
+            self._outer_instance._config.endpoint
+        )  # pylint: disable=protected-access
+
+        logger.debug(
+            "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI client using Entra ID authentication, on parent AI Services resource, endpoint `%s`, api_version `%s`",
+            azure_endpoint,
+            api_version,
+        )
+
+        client = AsyncAzureOpenAI(
+            # See https://learn.microsoft.com/python/api/azure-identity/azure.identity?view=azure-python#azure-identity-get-bearer-token-provider # pylint: disable=line-too-long
+            azure_ad_token_provider=get_bearer_token_provider(
+                self._outer_instance._config.credential,  # pylint: disable=protected-access
+                "https://cognitiveservices.azure.com/.default",  # pylint: disable=protected-access
+            ),
+            azure_endpoint=azure_endpoint,
+            api_version=api_version,
+        )
 
         return client

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -8,18 +8,16 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import logging
-from typing import Optional, AsyncIterable, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING, Any
 from urllib.parse import urlparse
-from azure.core.exceptions import ResourceNotFoundError
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.tracing.decorator import distributed_trace
 
 from ...models._models import (
-    Connection,
     ApiKeyCredentials,
     EntraIDCredentials,
 )
-from ...models._enums import CredentialType, ConnectionType
+from ...models._enums import ConnectionType
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -274,7 +272,7 @@ class InferenceOperations:
                 )
 
                 try:
-                    from azure.identity import get_bearer_token_provider
+                    from azure.identity.aio import get_bearer_token_provider
                 except ModuleNotFoundError as e:
                     raise ModuleNotFoundError(
                         "azure.identity package not installed. Please install it using 'pip install azure.identity'"
@@ -303,8 +301,8 @@ class InferenceOperations:
             ) from e
 
         azure_endpoint = self._get_aoai_inference_url(
-            self._outer_instance._config.endpoint
-        )  # pylint: disable=protected-access
+            self._outer_instance._config.endpoint  # pylint: disable=protected-access
+        )
 
         logger.debug(
             "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI client using Entra ID authentication, on parent AI Services resource, endpoint `%s`, api_version `%s`",

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
@@ -8,12 +8,11 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import logging
-from typing import Optional, Iterable, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING, Any
 from urllib.parse import urlparse
-from azure.core.exceptions import ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
-from ..models._models import Connection, ApiKeyCredentials, EntraIDCredentials
-from ..models._enums import CredentialType, ConnectionType
+from ..models._models import ApiKeyCredentials, EntraIDCredentials
+from ..models._enums import ConnectionType
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -293,8 +292,8 @@ class InferenceOperations:
             ) from e
 
         azure_endpoint = self._get_aoai_inference_url(
-            self._outer_instance._config.endpoint
-        )  # pylint: disable=protected-access
+            self._outer_instance._config.endpoint  # pylint: disable=protected-access
+        )
 
         logger.debug(
             "[InferenceOperations.get_azure_openai_client] Creating AzureOpenAI client using Entra ID authentication, on parent AI Services resource, endpoint `%s`, api_version `%s`",

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_openai_client_async.py
@@ -18,8 +18,10 @@ USAGE:
 
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
-       Azure AI Foundry project.
-    2) MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project.
+       Azure AI Foundry project. Required.
+    2) MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project. Required.
+    3) CONNECTION_NAME - The name of an Azure OpenAI connection, as found in the "Connected resources" tab
+       in the Management Center of your AI Foundry project. Required.
 
     Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
     https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
@@ -35,13 +37,37 @@ async def main():
 
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+    connection_name = os.environ["CONNECTION_NAME"]
 
     async with DefaultAzureCredential() as credential:
 
         async with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
 
-            # Get an authenticated AsyncAzureOpenAI client for your default Azure OpenAI connection:
-            async with await project_client.inference.get_azure_openai_client(api_version="2024-10-21") as client:
+            print(
+                "Get an authenticated Azure OpenAI client for the parent AI Services resource, and perform a chat completion operation:"
+            )
+            async with await project_client.inference.get_azure_openai_client(
+                api_version="2024-10-21"
+            ) as client:
+
+                response = await client.chat.completions.create(
+                    model=model_deployment_name,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": "How many feet are in a mile?",
+                        },
+                    ],
+                )
+
+                print(response.choices[0].message.content)
+
+            print(
+                "Get an authenticated Azure OpenAI client for a connected Azure OpenAI service, and perform a chat completion operation:"
+            )
+            async with await project_client.inference.get_azure_openai_client(
+                api_version="2024-10-21", connection_name=connection_name
+            ) as client:
 
                 response = await client.chat.completions.create(
                     model=model_deployment_name,

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_openai_client.py
@@ -17,8 +17,10 @@ USAGE:
 
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the overview page of your
-       Azure AI Foundry project.
-    2) MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project.
+       Azure AI Foundry project. Required.
+    2) MODEL_DEPLOYMENT_NAME - The model deployment name, as found in your AI Foundry project. Required.
+    3) CONNECTION_NAME - The name of an Azure OpenAI connection, as found in the "Connected resources" tab
+       in the Management Center of your AI Foundry project. Required.
 
     Update the Azure OpenAI api-version as needed (see `api_version=` below). Values can be found here:
     https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs
@@ -30,13 +32,36 @@ from azure.identity import DefaultAzureCredential
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+connection_name = os.environ["CONNECTION_NAME"]
 
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
     with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
 
         # [START aoai_sample]
+        print(
+            "Get an authenticated Azure OpenAI client for the parent AI Services resource, and perform a chat completion operation:"
+        )
         with project_client.inference.get_azure_openai_client(api_version="2024-10-21") as client:
+
+            response = client.chat.completions.create(
+                model=model_deployment_name,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "How many feet are in a mile?",
+                    },
+                ],
+            )
+
+            print(response.choices[0].message.content)
+
+        print(
+            "Get an authenticated Azure OpenAI client for a connected Azure OpenAI service, and perform a chat completion operation:"
+        )
+        with project_client.inference.get_azure_openai_client(
+            api_version="2024-10-21", connection_name=connection_name
+        ) as client:
 
             response = client.chat.completions.create(
                 model=model_deployment_name,


### PR DESCRIPTION
Support either returning an AOAI client on the parent AI Services resource, or on a connected AOAI service. We are still debating which api_version to show in the sample code. 