### PR TITLE
[Storage] [STG 99] Made invalid `x-ms-version` error message more user-friendly

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -174,6 +174,11 @@ def process_storage_error(storage_error) -> NoReturn:  # type: ignore [misc] # p
     for name, info in additional_data.items():
         error_message += f"\n{name}:{info}"
 
+    if additional_data.get('headername') == 'x-ms-version':
+        sv_docs_url = "https://learn.microsoft.com/rest/api/storageservices/versioning-for-the-azure-storage-service"
+        error_message += ("\nThe provided service version is not enabled on this storage account. " +
+                          f"Please see {sv_docs_url} for additional information.\n")
+
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:
         storage_error.message = error_message


### PR DESCRIPTION
From manually testing by setting the service version date to `2099-11-05`:

```
E   azure.core.exceptions.HttpResponseError: The value for one of the HTTP headers is not in the correct format.
E   RequestId:254c550c-801e-006a-4b86-c4797a000000
E   Time:2025-05-14T04:11:30.5028648Z
E   ErrorCode:InvalidHeaderValue
E   headername:x-ms-version
E   headervalue:2099-11-05
E   The provided service version is not enabled on this storage account.Please see https://learn.microsoft.com/rest/api/storageservices/versioning-for-the-azure-storage-service for additional information.
E   
E   Content: <?xml version="1.0" encoding="utf-8"?>
E   <Error><Code>InvalidHeaderValue</Code><Message>The value for one of the HTTP headers is not in the correct format.
E   RequestId:254c550c-801e-006a-4b86-c4797a000000
E   Time:2025-05-14T04:11:30.5028648Z</Message><HeaderName>x-ms-version</HeaderName><HeaderValue>2099-11-05</HeaderValue></Error>
```

Let me know your thoughts before propagating to other packages :)