### PR TITLE
[auto release] add packages which shall skip check for flatten

### DIFF
--- a/scripts/auto_release/main.py
+++ b/scripts/auto_release/main.py
@@ -223,6 +223,9 @@ class CodegenTestPR:
         if self.whole_package_name in [
             "azure-mgmt-mysqlflexibleservers",
             "azure-mgmt-postgresqlflexibleservers",
+            "azure-mgmt-kubernetesconfiguration-extensiontypes",
+            "azure-mgmt-kubernetesconfiguration-extensions",
+            "azure-mgmt-kubernetesconfiguration-fluxconfigurations",
         ]:
             return
         if self.from_swagger:


### PR DESCRIPTION
These 3 new packages are split from existing package `azure-mgmt-kubernetesconfiguration` so if we disable flatten, CLI will be broken.

for https://github.com/Azure/azure-rest-api-specs/pull/34670/