### PR TITLE
[Core] Add start_time kwargs to start_span methods

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added a `start_time` keyword argument to the `start_span` and `start_as_current_span` methods in the `OpenTelemetryTracer` class. This allows users to specify a custom start time for created spans. #41106
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/tracing/opentelemetry.py
+++ b/sdk/core/azure-core/azure/core/tracing/opentelemetry.py
@@ -81,6 +81,7 @@ class OpenTelemetryTracer:
         kind: SpanKind = _SpanKind.INTERNAL,
         attributes: Optional[Attributes] = None,
         links: Optional[Sequence[Link]] = None,
+        start_time: Optional[int] = None,
     ) -> Span:
         """Starts a span without setting it as the current span in the context.
 
@@ -92,6 +93,8 @@ class OpenTelemetryTracer:
         :paramtype attributes: Mapping[str, AttributeValue]
         :keyword links: Links to add to the span.
         :paramtype links: list[~azure.core.tracing.Link]
+        :keyword start_time: The start time of the span in nanoseconds since the epoch.
+        :paramtype start_time: Optional[int]
         :return: The span that was started
         :rtype: ~opentelemetry.trace.Span
         """
@@ -103,6 +106,7 @@ class OpenTelemetryTracer:
             kind=otel_kind,
             attributes=attributes,
             links=otel_links,
+            start_time=start_time,
             record_exception=False,
         )
 
@@ -116,6 +120,7 @@ class OpenTelemetryTracer:
         kind: SpanKind = _SpanKind.INTERNAL,
         attributes: Optional[Attributes] = None,
         links: Optional[Sequence[Link]] = None,
+        start_time: Optional[int] = None,
         end_on_exit: bool = True,
     ) -> Iterator[Span]:
         """Context manager that starts a span and sets it as the current span in the context.
@@ -134,12 +139,14 @@ class OpenTelemetryTracer:
         :paramtype attributes: Optional[Attributes]
         :keyword links: Links to add to the span.
         :paramtype links: Optional[Sequence[Link]]
+        :keyword start_time: The start time of the span in nanoseconds since the epoch.
+        :paramtype start_time: Optional[int]
         :keyword end_on_exit: Whether to end the span when exiting the context manager. Defaults to True.
         :paramtype end_on_exit: bool
         :return: The span that was started
         :rtype: Iterator[~opentelemetry.trace.Span]
         """
-        span = self.start_span(name, kind=kind, attributes=attributes, links=links)
+        span = self.start_span(name, kind=kind, attributes=attributes, links=links, start_time=start_time)
         with trace.use_span(  # pylint: disable=not-context-manager
             span, record_exception=False, end_on_exit=end_on_exit
         ) as span:

--- a/sdk/core/azure-core/tests/test_tracer_otel.py
+++ b/sdk/core/azure-core/tests/test_tracer_otel.py
@@ -376,3 +376,22 @@ def test_tracer_set_span_error(tracing_helper):
 
     assert finished_spans[1].status.status_code == OtelStatusCode.ERROR
     assert finished_spans[1].status.description == "This is an error"
+
+
+def test_start_span_with_start_time(tracing_helper):
+    """Test that a span can be started with a custom start time."""
+    tracer = get_tracer()
+    assert tracer
+    start_time = 1234567890
+    with tracer.start_as_current_span(name="foo-span", start_time=start_time) as span:
+        assert span.start_time == start_time
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 1
+    assert finished_spans[0].start_time == start_time
+
+    span = tracer.start_span(name="foo-span", start_time=start_time)
+    assert span.start_time == start_time
+    span.end()
+    finished_spans = tracing_helper.exporter.get_finished_spans()
+    assert len(finished_spans) == 2
+    assert finished_spans[1].start_time == start_time


### PR DESCRIPTION
We should expose a `start_time` keyword argument in the `start_span` methods to allow users to specify the start time of the span. This is useful in scenarios like in SB, where you want to create a span for a receive operation, but also want to add links to the messages that are received, so we want to create the span after the receive operation, but still portray a more accurate duration for the span.