### PR TITLE
Fix failing release job for azure-ai-agents

### DIFF
--- a/sdk/ai/azure-ai-agents/tsp-location.yaml
+++ b/sdk/ai/azure-ai-agents/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/Azure.AI.Agents
-commit: 9cfa4c5aa42ef81a9f7d1d324402427f2507d61d
+commit: c9027a3432fbeead6d375d6089c9bce41755a622
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Fix failing release job "Verify REST API spec location for "azure-ai-agents"" by using latest commit from azure-rest-api-specs