### PR TITLE
Disable transformation of non-ascii characters on storing to CosmosDB

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
@@ -59,7 +59,7 @@ def _request_body_from_data(data):
     if data is None or isinstance(data, str) or _is_readable_stream(data):
         return data
     if isinstance(data, (dict, list, tuple)):
-        json_dumped = json.dumps(data, separators=(",", ":"))
+        json_dumped = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
 
         return json_dumped
     return None


### PR DESCRIPTION
# Description

This PR is to update the `json.dumps()` function to accept the `ensure_ascii=False` parameter so we can properly send unicode characters to CosmosDB, which it does support storing. If this parameter is disabled, trying to send strings with a unicode character results in the string being converted to an escaped unicode sequence to comply with being an ASCII character, and that results in transformations like `\\ud83d\\udf1f` for 🌟, which results in an error in Cosmos when trying to store these values: 
```
Code: InternalServerError
Message: unsupported Unicode escape sequence
```

I'm assuming it's because of the [escape sequence and Python interpreter do not play nice](https://www.perplexity.ai/search/storing-unicode-characters-in-wy5f4yJ9Q2ijPO9ALOKpWw). I stumbled upon this [issue](https://github.com/Azure/azure-sdk-for-python/issues/40373) when looking for answers, and decided to try implementing the solution proposed by @lidingshan in my local run, and it seems to work. To avoid an indefinite monkeypatch for my team, I am creating this PR to get this investigated/fixed.

Not sure if this is the best/long term solution for properly ensuring the unicode characters are stored in Cosmos, but it seems that Cosmos supports that storage, so idk why we would try and force the ASCII conversion here.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
