### PR TITLE
[SDK generation pipeline] fix apiview for missing depependency

### DIFF
--- a/scripts/auto_release/requirement.txt
+++ b/scripts/auto_release/requirement.txt
@@ -6,5 +6,5 @@ packaging==24.1
 pytest==6.2.5
 fastcore==1.3.25
 tox==4.15.0
-wheel==0.46.1
+wheel==0.45.1
 setuptools==78.1.0

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -4,7 +4,7 @@
 python -m pip install -U pip > /dev/null
 python scripts/dev_setup.py -p azure-core > /dev/null
 pip install tox==4.15.0 > /dev/null
-pip install wheel==0.46.1 > /dev/null
+pip install wheel==0.45.1 > /dev/null
 pip install setuptools==78.1.0 > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)


### PR DESCRIPTION
for https://github.com/Azure/azure-sdk-tools/issues/10553

![image](https://github.com/user-attachments/assets/87f4f04a-83a7-4358-845a-3954b77a57e5)

wheel==0.46.1 is yanked.