### PR TITLE
[sdk generation pipeline] Fix for apiview

### DIFF
--- a/scripts/auto_release/requirement.txt
+++ b/scripts/auto_release/requirement.txt
@@ -6,5 +6,5 @@ packaging==24.1
 pytest==6.2.5
 fastcore==1.3.25
 tox==4.15.0
-wheel==0.45.1
+wheel==0.43.0
 setuptools==78.1.0

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -4,8 +4,9 @@
 python -m pip install -U pip > /dev/null
 python scripts/dev_setup.py -p azure-core > /dev/null
 pip install tox==4.15.0 > /dev/null
-pip install wheel==0.45.1 > /dev/null
+pip install wheel==0.43.0 > /dev/null
 pip install setuptools==78.1.0 > /dev/null
+pip install ssetuptools-scm>8.3.0 > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)
 echo Install tsp-client

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -6,7 +6,7 @@ python scripts/dev_setup.py -p azure-core > /dev/null
 pip install tox==4.15.0 > /dev/null
 pip install wheel==0.43.0 > /dev/null
 pip install setuptools==78.1.0 > /dev/null
-pip install ssetuptools-scm>8.3.0 > /dev/null
+pip install setuptools-scm>8.3.0 > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)
 echo Install tsp-client

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -6,7 +6,7 @@ python scripts/dev_setup.py -p azure-core > /dev/null
 pip install tox==4.15.0 > /dev/null
 pip install wheel==0.43.0 > /dev/null
 pip install setuptools==78.1.0 > /dev/null
-pip install setuptools-scm>8.3.0 > /dev/null
+pip install setuptools-scm==8.3.0 > /dev/null
 
 # install tsp-client globally (local install may interfere with tooling)
 echo Install tsp-client


### PR DESCRIPTION
for https://github.com/Azure/azure-sdk-tools/issues/10553

According to [log](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4885592&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692), the root cause may be missing dependencies `setuptools_scm`:

![image](https://github.com/user-attachments/assets/7427ec0f-4e24-4870-928e-efae2aef665f)
