### PR TITLE
Users/bambriz/feedrangehotfix0

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Release History
 
+### 4.12.0b2 (2025-06-18)
+
+#### Features Added
+
+#### Bugs Fixed
+* Fixed issue where Query Change Feed did not return items if the container uses legacy Hash V1 Partition Keys. This also fixes issues with not being able to change feed query for Specific Partition Key Values for HPK. See [PR #####]()
+
+#### Other Changes
+
 ### 4.12.0b1 (2025-05-19)
 
 #### Features Added

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3118,10 +3118,11 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         # check if query has prefix partition key
         isPrefixPartitionQuery = kwargs.pop("isPrefixPartitionQuery", None)
-        if isPrefixPartitionQuery:
+        if isPrefixPartitionQuery and "partitionKeyDefinition" in kwargs:
             last_response_headers = CaseInsensitiveDict()
             # here get the over lapping ranges
-            pk_properties: Optional[PartitionKey] = kwargs.pop("partitionKeyDefinition", None)
+            # Default to empty Dictionary, but unlikely to be empty as we first check if we have it in kwargs
+            pk_properties: Union[PartitionKey, Dict] = kwargs.pop("partitionKeyDefinition", {})
             partition_key_definition = PartitionKey(
                 path=pk_properties["paths"],
                 kind=pk_properties["kind"],

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3121,9 +3121,11 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         if isPrefixPartitionQuery:
             last_response_headers = CaseInsensitiveDict()
             # here get the over lapping ranges
-            partition_key_definition = kwargs.pop("partitionKeyDefinition", None)
-            pk_properties = partition_key_definition
-            partition_key_definition = PartitionKey(path=pk_properties["paths"], kind=pk_properties["kind"])
+            pk_properties: Optional[PartitionKey] = kwargs.pop("partitionKeyDefinition", None)
+            partition_key_definition = PartitionKey(
+                path=pk_properties["paths"],
+                kind=pk_properties["kind"],
+                version=pk_properties["version"])
             partition_key_value = pk_properties["partition_key"]
             feedrangeEPK = partition_key_definition._get_epk_range_for_prefix_partition_key(
                 partition_key_value

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
@@ -22,6 +22,97 @@ import struct
 from typing import NoReturn, Tuple, Union
 
 
+class _UInt32:
+    def __init__(self, value: int) -> None:
+        self._value: int = value & 0xFFFFFFFF
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    @value.setter
+    def value(self, new_value: int) -> None:
+        self._value = new_value & 0xFFFFFFFF
+
+    def __add__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value + (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __sub__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value - (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __mul__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value * (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __xor__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value ^ (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __lshift__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value << (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __ilshift__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        self._value = (self.value << (other.value if isinstance(other, _UInt32) else other)) & 0xFFFFFFFF
+        return self
+
+    def __rshift__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value >> (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __irshift__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        self._value = (self.value >> (other.value if isinstance(other, _UInt32) else other)) & 0xFFFFFFFF
+        return self
+
+    def __and__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        result = self.value & (other.value if isinstance(other, _UInt32) else other)
+        return _UInt32(result & 0xFFFFFFFF)
+
+    def __or__(self, other: Union[int, '_UInt32']) -> '_UInt32':
+        if isinstance(other, _UInt32):
+            return _UInt32(self.value | other.value)
+        if isinstance(other, int):
+            return _UInt32(self.value | other)
+        raise TypeError("Unsupported type for OR operation")
+
+    def __invert__(self) -> '_UInt32':
+        return _UInt32(~self.value & 0xFFFFFFFF)
+
+    def __eq__(self, other: Union[int, '_UInt32', object]) -> bool:
+        return self.value == (other.value if isinstance(other, _UInt32) else other)
+
+    def __ne__(self, other: Union[int, '_UInt32', object]) -> bool:
+        return not self.__eq__(other)
+
+    def __lt__(self, other: Union[int, '_UInt32']) -> bool:
+        return self.value < (other.value if isinstance(other, _UInt32) else other)
+
+    def __gt__(self, other: Union[int, '_UInt32']) -> bool:
+        return self.value > (other.value if isinstance(other, _UInt32) else other)
+
+    def __le__(self, other: Union[int, '_UInt32']) -> bool:
+        return self.value <= (other.value if isinstance(other, _UInt32) else other)
+
+    def __ge__(self, other: Union[int, '_UInt32']) -> bool:
+        return self.value >= (other.value if isinstance(other, _UInt32) else other)
+
+    @staticmethod
+    def encode_double_as_uint32(value: float) -> int:
+        value_in_uint32 = struct.unpack('<I', struct.pack('<f', value))[0]
+        mask = 0x80000000
+        return (value_in_uint32 ^ mask) if value_in_uint32 < mask else (~value_in_uint32) + 1
+
+    @staticmethod
+    def decode_double_from_uint32(value: int) -> int:
+        mask = 0x80000000
+        value = ~(value - 1) if value < mask else value ^ mask
+        return struct.unpack('<f', struct.pack('<I', value))[0]
+
+    def __int__(self) -> int:
+        return self.value
+
 class _UInt64:
     def __init__(self, value: int) -> None:
         self._value: int = value & 0xFFFFFFFFFFFFFFFF
@@ -71,6 +162,32 @@ class _UInt64:
 
     def __invert__(self) -> '_UInt64':
         return _UInt64(~self.value & 0xFFFFFFFFFFFFFFFF)
+
+    def __eq__(self, other: Union[int, '_UInt64', object]) -> bool:
+        return self.value == (other.value if isinstance(other, _UInt64) else other)
+
+    def __ne__(self, other: Union[int, '_UInt64', object]) -> bool:
+        return not self.__eq__(other)
+
+    def __irshift__(self, other: Union[int, '_UInt64']) -> '_UInt64':
+        self._value = (self.value >> (other.value if isinstance(other, _UInt64) else other)) & 0xFFFFFFFFFFFFFFFF
+        return self
+
+    def __ilshift__(self, other: Union[int, '_UInt64']) -> '_UInt64':
+        self._value = (self.value << (other.value if isinstance(other, _UInt64) else other)) & 0xFFFFFFFFFFFFFFFF
+        return self
+
+    def __lt__(self, other: Union[int, '_UInt64']) -> bool:
+        return self.value < (other.value if isinstance(other, _UInt64) else other)
+
+    def __gt__(self, other: Union[int, '_UInt64']) -> bool:
+        return self.value > (other.value if isinstance(other, _UInt64) else other)
+
+    def __le__(self, other: Union[int, '_UInt64']) -> bool:
+        return self.value <= (other.value if isinstance(other, _UInt64) else other)
+
+    def __ge__(self, other: Union[int, '_UInt64']) -> bool:
+        return self.value >= (other.value if isinstance(other, _UInt64) else other)
 
     @staticmethod
     def encode_double_as_uint64(value: float) -> int:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
@@ -30,7 +30,7 @@
 # This is public domain code with no copyrights. From home page of
 # <a href="https://github.com/aappleby/smhasher">SMHasher</a>:
 #  "All MurmurHash versions are public domain software, and the author disclaims all copyright to their code."
-from ._cosmos_integers import _UInt128, _UInt64
+from ._cosmos_integers import _UInt128, _UInt64, _UInt32
 
 
 def rotate_left_64(val: int, shift: int) -> int:
@@ -148,44 +148,47 @@ def murmurhash3_128(span: bytearray, seed: _UInt128) -> _UInt128:  # pylint: dis
 
     return _UInt128(int(h1.value), int(h2.value))
 
-def murmurhash3_32(data: bytearray, length: int, seed: int) -> int:
-        c1: int = 0xcc9e2d51
-        c2: int = 0x1b873593
 
-        h1: int = seed
-        rounded_end: int = (length & 0xfffffffc)  # round down to 4 byte block
+def murmurhash3_32(data: bytearray, seed: int) -> _UInt32:
+    c1: _UInt32 = _UInt32(0xcc9e2d51)
+    c2: _UInt32 = _UInt32(0x1b873593)
+    length: _UInt32 = _UInt32(len(data))
+    h1: _UInt32 = _UInt32(seed)
+    rounded_end: _UInt32 = _UInt32(length.value & 0xfffffffc)  # round down to 4 byte block
 
-        for i in range(0, rounded_end, 4):
-            # little endian load order
-            k1: int = (data[i] & 0xff) | ((data[i + 1] & 0xff) << 8) | ((data[i + 2] & 0xff) << 16) | (
-                        data[i + 3] << 24)
-            k1 *= c1
-            k1 = (k1 << 15) | (k1 >> 17)  # ROTL32(k1,15)
-            k1 *= c2
+    for i in range(0, rounded_end.value, 4):
+        # little endian load order
+        k1: _UInt32 = _UInt32(
+            (data[i] & 0xff) | ((data[i + 1] & 0xff) << 8) | ((data[i + 2] & 0xff) << 16) | (data[i + 3] << 24)
+        )
+        k1 *= c1
+        k1.value = (k1.value << 15) | (k1.value >> 17)  # ROTL32(k1,15)
+        k1 *= c2
 
-            h1 ^= k1
-            h1 = (h1 << 13) | (h1 >> 19)  # ROTL32(h1,13)
-            h1 = h1 * 5 + 0xe6546b64
+        h1 ^= k1
+        h1.value = (h1.value << 13) | (h1.value >> 19)  # ROTL32(h1,13)
+        h1 = h1 * _UInt32(5) + _UInt32(0xe6546b64)
 
-        # tail
-        k1: int = 0
-        if length & 0x03 == 3:
-            k1 = (data[rounded_end + 2] & 0xff) << 16
-        if length & 0x03 >= 2:
-            k1 |= (data[rounded_end + 1] & 0xff) << 8
-        if length & 0x03 >= 1:
-            k1 |= (data[rounded_end] & 0xff)
-            k1 *= c1
-            k1 = (k1 << 15) | (k1 >> 17)
-            k1 *= c2
-            h1 ^= k1
+    # tail
+    k1: _UInt32 = _UInt32(0)
+    if length.value & 0x03 == 3:
+        k1 ^= _UInt32((data[rounded_end.value + 2] & 0xff) << 16)
+    if length.value & 0x03 >= 2:
+        k1 ^= _UInt32((data[rounded_end.value + 1] & 0xff) << 8)
+    if length.value & 0x03 >= 1:
+        k1 ^= _UInt32(data[rounded_end.value] & 0xff)
+        k1 *= c1
+        k1.value = (k1.value << 15) | (k1.value >> 17)
+        k1 *= c2
+        h1 ^= k1
 
-        # finalization
-        h1 ^= length
-        h1 ^= h1 >> 16
-        h1 *= 0x85ebca6b
-        h1 ^= h1 >> 13
-        h1 *= 0xc2b2ae35
-        h1 ^= h1 >> 16
+    # finalization
+    h1 ^= length
+    h1.value ^= h1.value >> 16
+    h1 *= _UInt32(0x85ebca6b)
+    h1.value ^= h1.value >> 13
+    h1 *= _UInt32(0xc2b2ae35)
+    h1.value ^= h1.value >> 16
 
-        return h1
+    return h1
+

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -144,7 +144,10 @@ class ContainerProxy:
 
         container_properties = await self._get_properties()
         partition_key_definition = container_properties["partitionKey"]
-        partition_key = PartitionKey(path=partition_key_definition["paths"], kind=partition_key_definition["kind"])
+        partition_key = PartitionKey(
+            path=partition_key_definition["paths"],
+            kind=partition_key_definition["kind"],
+            version=partition_key_definition["version"])
 
         return partition_key._get_epk_range_for_partition_key(partition_key_value)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2914,7 +2914,10 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         if cont_prop:
             cont_prop = await cont_prop()
             pk_properties = cont_prop["partitionKey"]
-            partition_key_definition = PartitionKey(path=pk_properties["paths"], kind=pk_properties["kind"])
+            partition_key_definition = PartitionKey(
+                path=pk_properties["paths"],
+                kind=pk_properties["kind"],
+                version=pk_properties["version"])
             if partition_key_definition.kind == "MultiHash" and \
                     (isinstance(partition_key, List) and \
                      len(partition_key_definition['paths']) != len(partition_key)):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -138,7 +138,10 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
     def _get_epk_range_for_partition_key( self, partition_key_value: PartitionKeyType) -> Range:
         container_properties = self._get_properties()
         partition_key_definition = container_properties["partitionKey"]
-        partition_key = PartitionKey(path=partition_key_definition["paths"], kind=partition_key_definition["kind"])
+        partition_key = PartitionKey(
+            path=partition_key_definition["paths"],
+            kind=partition_key_definition["kind"],
+            version=partition_key_definition["version"])
 
         return partition_key._get_epk_range_for_partition_key(partition_key_value)
 
@@ -715,7 +718,10 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
         self, partition_key: PartitionKeyType) -> bool:
         properties = self._get_properties()
         pk_properties = properties["partitionKey"]
-        partition_key_definition = PartitionKey(path=pk_properties["paths"], kind=pk_properties["kind"])
+        partition_key_definition = PartitionKey(
+            path=pk_properties["paths"],
+            kind=pk_properties["kind"],
+            version=pk_properties["version"])
         return partition_key_definition._is_prefix_partition_key(partition_key)
 
 

--- a/sdk/cosmos/azure-cosmos/tests/test_changefeed_partition_key_variation.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_changefeed_partition_key_variation.py
@@ -1,0 +1,179 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+import unittest
+import uuid
+import pytest
+
+import azure.cosmos.cosmos_client as cosmos_client
+import test_config
+from azure.cosmos.partition_key import PartitionKey
+
+
+@pytest.mark.cosmosEmulator
+@pytest.mark.cosmosQuery
+class TestChangeFeedPKVariation(unittest.TestCase):
+    """Test change feed with different partition key variations."""
+
+    configs = test_config.TestConfig
+    host = configs.host
+    masterKey = configs.masterKey
+    connectionPolicy = configs.connectionPolicy
+    client: cosmos_client.CosmosClient = None
+    # Items for Hash V1 partition key
+    single_hash_items = [
+                        {"id": str(i), "pk": f"short_string"} for i in range(1, 101)
+                    ] + [
+                        {"id": str(i), "pk": f"long_string_" + "a" * 251} for i in range(101, 201)
+                    ] + [
+                        {"id": str(i), "pk": 1000} for i in range(201, 301)
+                    ] + [
+                        {"id": str(i), "pk": 1000 * 1.1111} for i in range(301, 401)
+                    ] + [
+                        {"id": str(i), "pk": True} for i in range(401, 501)
+                    ]
+
+    # Items for Hierarchical Partition Keys
+    hpk_items = [
+                    {"id": str(i), "pk1": "level1_", "pk2": "level2_"} for i in range(1, 101)
+                ] + [
+                    {"id": str(i), "pk1": "level1_", "pk2": f"level2_long__" + "c" * 101} for i in range(101, 201)
+                ] + [
+                    {"id": str(i), "pk1": 10, "pk2": 1000} for i in range(201, 301)
+                ] + [
+                    {"id": str(i), "pk1": 10 * 1.1, "pk2": 10 * 2.2} for i in range(301, 401)
+                ] + [
+                        {"id": str(i), "pk1": True, 'pk2': False} for i in range(401, 501)
+                    ]
+
+    test_data_hash = [
+        {
+            "version": 1,
+            "expected_epk": (
+                "05C1DD5D8149640862636465666768696A6B6C6D6E6F70717273747576"
+                "7778797A7B62636465666768696A6B6C6D6E6F70717273747576777879"
+                "7A7B62636465666768696A6B6C6D6E6F707172737475767778797A7B62636465666768696A6B6C6D6E6F707172737475767700"
+            ),
+        },
+        {
+            "version": 2,
+            "expected_epk": (
+                "2032D236DA8678BFB900E866D7EBCE76"  # Replace with the actual expected value for Hash V2
+            ),
+        },
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = test_config.TestConfig()
+        if (cls.config.masterKey == '[YOUR_KEY_HERE]' or
+                cls.config.host == '[YOUR_ENDPOINT_HERE]'):
+            raise Exception(
+                "You must specify your Azure Cosmos account values for "
+                "'masterKey' and 'host' at the top of this class to run the "
+                "tests.")
+        cls.client = cosmos_client.CosmosClient(cls.config.host, cls.config.masterKey)
+        cls.db = cls.client.get_database_client(cls.config.TEST_DATABASE_ID)
+
+    def create_container(self, db, container_id, partition_key, version=None):
+        """Helper to create a container with a specific partition key definition."""
+        if isinstance(partition_key, list):
+            # Assume multihash (hierarchical partition key) for the container
+            pk_definition = PartitionKey(path=partition_key, kind='MultiHash')
+        else:
+            pk_definition = PartitionKey(path=partition_key, kind='Hash', version=version)
+        return db.create_container(id=container_id, partition_key=pk_definition)
+
+    def insert_items(self, container, items):
+        """Helper to insert items into a container."""
+        for item in items:
+            container.create_item(body=item)
+
+    def validate_changefeed(self, container):
+        """Helper to validate changefeed results."""
+        partition_keys = ["short_string", "long_string_" + "a" * 251, 1000, 1000 * 1.1111, True]
+        for pk in partition_keys:
+            changefeed = container.query_items_change_feed(is_start_from_beginning=True, partition_key=pk)
+            changefeed_items = [item for item in changefeed]
+
+            # Perform a regular query
+            regular_query = container.query_items(query="SELECT * FROM c", partition_key=pk)
+            regular_query_items = [item for item in regular_query]
+
+            # Compare the number of documents returned
+            assert len(changefeed_items) == len(regular_query_items), (
+                f"Mismatch in document count for partition key {pk}: Changefeed returned {len(changefeed_items)} items,"
+                f"while regular query returned {len(regular_query_items)} items."
+            )
+
+    def validate_changefeed_hpk(self, container):
+        """Helper to validate changefeed results for hierarchical partition keys."""
+        partition_keys = [
+            ["level1_", "level2_"],
+            ["level1_", "level2_long__" + "c" * 101],
+            [10, 1000],
+            [10 * 1.1, 10 * 2.2],
+            [True, False]
+        ]
+        for pk in partition_keys:
+            # Perform a change feed query
+            changefeed = container.query_items_change_feed(is_start_from_beginning=True, partition_key=pk)
+            changefeed_items = [item for item in changefeed]
+
+            # Perform a regular query
+            regular_query = container.query_items(query="SELECT * FROM c", partition_key=pk)
+            regular_query_items = [item for item in regular_query]
+
+            # Compare the number of documents returned
+            assert len(changefeed_items) == len(regular_query_items), (
+                f"Mismatch in document count for partition key {pk}: Changefeed returned {len(changefeed_items)} items,"
+                f"while regular query returned {len(regular_query_items)} items."
+            )
+
+    def test_partition_key_hashing(self):
+        """Test effective partition key string generation for different hash versions."""
+        for hash_data in self.test_data_hash:
+            version = hash_data["version"]
+            expected_epk = hash_data["expected_epk"]
+            part_k = ("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"
+                      "klmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
+            partition_key = PartitionKey(
+                path="/field1",
+                kind="Hash",
+                version=version
+            )
+            epk_str = partition_key._get_effective_partition_key_string(part_k)
+            assert epk_str.upper() == expected_epk
+
+    def test_hash_v1_partition_key(self):
+        """Test changefeed with Hash V1 partition key."""
+        db = self.db
+        container = self.create_container(db, f"container_test_hash_V1_{uuid.uuid4()}",
+                                          "/pk", version=1)
+        items = self.single_hash_items
+        self.insert_items(container, items)
+        self.validate_changefeed(container)
+        self.db.delete_container(container.id)
+
+    def test_hash_v2_partition_key(self):
+        """Test changefeed with Hash V2 partition key."""
+        db = self.db
+        container = self.create_container(db, f"container_test_hash_V2_{uuid.uuid4()}",
+                                          "/pk", version=2)
+        items = self.single_hash_items
+        self.insert_items(container, items)
+        self.validate_changefeed(container)
+        self.db.delete_container(container.id)
+
+    def test_hpk_partition_key(self):
+        """Test changefeed with hierarchical partition key."""
+        db = self.db
+        container = self.create_container(db, f"container_test_hpk_{uuid.uuid4()}",
+                                          ["/pk1", "/pk2"])
+        items = self.hpk_items
+        self.insert_items(container, items)
+        self.validate_changefeed_hpk(container)
+        self.db.delete_container(container.id)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/test_changefeed_partition_key_variation_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_changefeed_partition_key_variation_async.py
@@ -1,0 +1,178 @@
+import unittest
+import uuid
+import pytest
+from azure.cosmos.aio import CosmosClient
+import test_config
+from azure.cosmos.partition_key import PartitionKey
+
+@pytest.mark.cosmosEmulator
+@pytest.mark.asyncio
+class TestChangeFeedPKVariationAsync(unittest.IsolatedAsyncioTestCase):
+    """Test change feed with different partition key variations (async version)."""
+
+    configs = test_config.TestConfig
+    host = configs.host
+    masterKey = configs.masterKey
+    connectionPolicy = configs.connectionPolicy
+    client: CosmosClient = None
+
+    # Items for Hash V1 partition key
+    single_hash_items = [
+                        {"id": str(i), "pk": f"short_string"} for i in range(1, 101)
+                    ] + [
+                        {"id": str(i), "pk": f"long_string_" + "a" * 251} for i in range(101, 201)
+                    ] + [
+                        {"id": str(i), "pk": 1000} for i in range(201, 301)
+                    ] + [
+                        {"id": str(i), "pk": 1000 * 1.1111} for i in range(301, 401)
+                    ] + [
+                        {"id": str(i), "pk": True} for i in range(401, 501)
+                    ]
+
+    # Items for Hierarchical Partition Keys
+    hpk_items = [
+                    {"id": str(i), "pk1": "level1_", "pk2": "level2_"} for i in range(1, 101)
+                ] + [
+                    {"id": str(i), "pk1": "level1_", "pk2": f"level2_long__" + "c" * 101} for i in range(101, 201)
+                ] + [
+                    {"id": str(i), "pk1": 10, "pk2": 1000} for i in range(201, 301)
+                ] + [
+                    {"id": str(i), "pk1": 10 * 1.1, "pk2": 10 * 2.2} for i in range(301, 401)
+                ] + [
+                        {"id": str(i), "pk1": True, 'pk2': False} for i in range(401, 501)
+                    ]
+
+    test_data_hash = [
+        {
+            "version": 1,
+            "expected_epk": (
+                "05C1DD5D8149640862636465666768696A6B6C6D6E6F70717273747576"
+                "7778797A7B62636465666768696A6B6C6D6E6F70717273747576777879"
+                "7A7B62636465666768696A6B6C6D6E6F707172737475767778797A7B62636465666768696A6B6C6D6E6F707172737475767700"
+            ),
+        },
+        {
+            "version": 2,
+            "expected_epk": (
+                "2032D236DA8678BFB900E866D7EBCE76"  # Replace with the actual expected value for Hash V2
+            ),
+        },
+    ]
+
+    @classmethod
+    async def asyncSetUpClass(cls):
+        cls.config = test_config.TestConfig()
+        if (cls.config.masterKey == '[YOUR_KEY_HERE]' or
+                cls.config.host == '[YOUR_ENDPOINT_HERE]'):
+            raise Exception(
+                "You must specify your Azure Cosmos account values for "
+                "'masterKey' and 'host' at the top of this class to run the "
+                "tests.")
+
+
+    async def asyncSetUp(self):
+        self.client = CosmosClient(self.host, self.masterKey)
+        self.db = await self.client.create_database_if_not_exists(self.configs.TEST_DATABASE_ID)
+
+    async def asyncTearDown(self):
+        await self.client.close()
+
+    async def create_container(self, db, container_id, partition_key, version=None):
+        """Helper to create a container with a specific partition key definition."""
+        if isinstance(partition_key, list):
+            # Assume multihash (hierarchical partition key) for the container
+            pk_definition = PartitionKey(path=partition_key, kind='MultiHash')
+        else:
+            pk_definition = PartitionKey(path=partition_key, kind='Hash', version=version)
+        return await db.create_container(container_id, pk_definition)
+
+    async def insert_items(self, container, items):
+        """Helper to insert items into a container."""
+        for item in items:
+            await container.create_item(body=item)
+
+    async def validate_changefeed(self, container):
+        """Helper to validate changefeed results."""
+        partition_keys = ["short_string", "long_string_" + "a" * 251, 1000, 1000 * 1.1111, True]
+        for pk in partition_keys:
+            changefeed = container.query_items_change_feed(is_start_from_beginning=True, partition_key=pk)
+            changefeed_items = [item async for item in changefeed]
+
+            # Perform a regular query
+            regular_query = container.query_items(query="SELECT * FROM c", partition_key=pk)
+            regular_query_items = [item async for item in regular_query]
+
+            # Compare the number of documents returned
+            assert len(changefeed_items) == len(regular_query_items), (
+                f"Mismatch in document count for partition key {pk}: Changefeed returned {len(changefeed_items)} items, "
+                f"while regular query returned {len(regular_query_items)} items."
+            )
+
+    async def validate_changefeed_hpk(self, container):
+        """Helper to validate changefeed results for hierarchical partition keys."""
+        partition_keys = [
+            ["level1_", "level2_"],
+            ["level1_", "level2_long__" + "c" * 101],
+            [10, 1000],
+            [10 * 1.1, 10 * 2.2],
+            [True, False]
+        ]
+        for pk in partition_keys:
+            # Perform a change feed query
+            changefeed = container.query_items_change_feed(is_start_from_beginning=True, partition_key=pk)
+            changefeed_items = [item async for item in changefeed]
+
+            # Perform a regular query
+            regular_query = container.query_items(query="SELECT * FROM c", partition_key=pk)
+            regular_query_items = [item async for item in regular_query]
+
+            # Compare the number of documents returned
+            assert len(changefeed_items) == len(regular_query_items), (
+                f"Mismatch in document count for partition key {pk}: Changefeed returned {len(changefeed_items)} items, "
+                f"while regular query returned {len(regular_query_items)} items."
+            )
+
+    async def test_partition_key_hashing(self):
+        """Test effective partition key string generation for different hash versions."""
+        for hash_data in self.test_data_hash:
+            version = hash_data["version"]
+            expected_epk = hash_data["expected_epk"]
+            part_k = ("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"
+                      "klmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
+            partition_key = PartitionKey(
+                path="/field1",
+                kind="Hash",
+                version=version
+            )
+            epk_str = partition_key._get_effective_partition_key_string(part_k)
+            assert epk_str.upper() == expected_epk
+
+    async def test_hash_v1_partition_key(self):
+        """Test changefeed with Hash V1 partition key."""
+        db = self.db
+        container = await self.create_container(db, f"container_test_hash_V1_{uuid.uuid4()}", "/pk", version=1)
+        items = self.single_hash_items
+        await self.insert_items(container, items)
+        await self.validate_changefeed(container)
+        await self.db.delete_container(container.id)
+
+    async def test_hash_v2_partition_key(self):
+        """Test changefeed with Hash V2 partition key."""
+        db = self.db
+        container = await self.create_container(db, f"container_test_hash_V2_{uuid.uuid4()}", "/pk", version=2)
+        items = self.single_hash_items
+        await self.insert_items(container, items)
+        await self.validate_changefeed(container)
+        await self.db.delete_container(container.id)
+
+    async def test_hpk_partition_key(self):
+        """Test changefeed with hierarchical partition key."""
+        db = self.db
+        container = await self.create_container(db, f"container_test_hpk_{uuid.uuid4()}", ["/pk1", "/pk2"])
+        items = self.hpk_items
+        await self.insert_items(container, items)
+        await self.validate_changefeed_hpk(container)
+        await self.db.delete_container(container.id)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

This PR fixes an issue where querychangefeed doesn't return items that have PartitionKey Values that use Hash V1. This also fixes issue where one couldn't query changefeed for specific HPK PK values that weren't prefix pks. A Murmurhash3 32bit x86 algorithm was implemented and made to match what backend expects for the EPK of Hash V1 Partition Key Values. 