### PR TITLE
Fix HTTP suppression in AI SDKs

### DIFF
--- a/sdk/ai/azure-ai-agents/azure/ai/agents/telemetry/_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/telemetry/_ai_agents_instrumentor.py
@@ -1197,7 +1197,7 @@ class _AIAgentsInstrumentorPreview:
         if span is None:
             return function(*args, **kwargs)
 
-        with span.change_context(span.span_instance):
+        with span.change_context(span):
             try:
                 result = function(*args, **kwargs)
             except Exception as exc:
@@ -1215,7 +1215,7 @@ class _AIAgentsInstrumentorPreview:
         if span is None:
             return await function(*args, **kwargs)
 
-        with span.change_context(span.span_instance):
+        with span.change_context(span):
             try:
                 result = await function(*args, **kwargs)
             except Exception as exc:
@@ -1261,7 +1261,7 @@ class _AIAgentsInstrumentorPreview:
         if span is None:
             return function(*args, **kwargs)
 
-        with span.change_context(span.span_instance):
+        with span.change_context(span):
             try:
                 kwargs["event_handler"] = self.wrap_handler(event_handler, span)
                 result = function(*args, **kwargs)
@@ -1308,9 +1308,8 @@ class _AIAgentsInstrumentorPreview:
         if span is None:
             return await function(*args, **kwargs)
 
-        # TODO: how to keep span active in the current context without existing?
         # TODO: dummy span for none
-        with span.change_context(span.span_instance):
+        with span.change_context(span):
             try:
                 kwargs["event_handler"] = self.wrap_async_handler(event_handler, span)
                 result = await function(*args, **kwargs)

--- a/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
@@ -611,7 +611,7 @@ class _AIInferenceInstrumentorPreview:
                 try:
                     # tracing events not supported in azure-core-tracing-opentelemetry
                     # so need to access the span instance directly
-                    with span_impl_type.change_context(span.span_instance):
+                    with span_impl_type.change_context(span):
                         last_event_timestamp_ns = self._add_request_details(span, args, kwargs)
                         result = function(*args, **kwargs)
                         if kwargs.get("stream") is True:
@@ -685,7 +685,7 @@ class _AIInferenceInstrumentorPreview:
                 try:
                     # tracing events not supported in azure-core-tracing-opentelemetry
                     # so need to access the span instance directly
-                    with span_impl_type.change_context(span.span_instance):
+                    with span_impl_type.change_context(span):
                         last_event_timestamp_ns = self._add_request_details(span, args, kwargs)
                         result = await function(*args, **kwargs)
                         if kwargs.get("stream") is True:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -128,7 +128,7 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
                 for attr, value in span_attributes.items():
                     span.add_attribute(attr, value)  # type: ignore
 
-                with change_context(span.span_instance):
+                with change_context(span):
                     headers = span.to_header()
                     request.http_request.headers.update(headers)
                 request.context[self.TRACING_CONTEXT] = span

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -128,7 +128,7 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
                 for attr, value in span_attributes.items():
                     span.add_attribute(attr, value)  # type: ignore
 
-                with change_context(span):
+                with change_context(span.span_instance):
                     headers = span.to_header()
                     request.http_request.headers.update(headers)
                 request.context[self.TRACING_CONTEXT] = span


### PR DESCRIPTION
we currently produce duplicate HTTP spans when tracing inference and agents SDKs

<img width="944" alt="image" src="https://github.com/user-attachments/assets/2f987310-e4d5-4fa7-94fb-d9b0011030db" />

It's caused by incorrect context propagation that in its turn leads to Azure SDK HTTP instrumentation being enabled along with underlying generic `requests` instrumentation.

Fixing it.