### PR TITLE
[auto release] add packages which shall skip check for flatten

### DIFF
--- a/scripts/auto_release/main.py
+++ b/scripts/auto_release/main.py
@@ -226,6 +226,7 @@ class CodegenTestPR:
             "azure-mgmt-kubernetesconfiguration-extensiontypes",
             "azure-mgmt-kubernetesconfiguration-extensions",
             "azure-mgmt-kubernetesconfiguration-fluxconfigurations",
+            "azure-mgmt-kubernetesconfiguration-privatelinkscopes",
         ]:
             return
         if self.from_swagger:


### PR DESCRIPTION
Skip flatten check for packages split from existing package azure-mgmt-kubernetesconfiguration

for https://github.com/Azure/azure-rest-api-specs/pull/34982