### PR TITLE
Explicitily fail instead of returning null if cannot parse resource link

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -346,7 +346,7 @@ def GetHeaders(  # pylint: disable=too-many-statements,too-many-branches
     return headers
 
 
-def GetResourceIdOrFullNameFromLink(resource_link: str) -> Optional[str]:
+def GetResourceIdOrFullNameFromLink(resource_link: str) -> str:
     """Gets resource id or full name from resource link.
 
     :param str resource_link:
@@ -379,7 +379,7 @@ def GetResourceIdOrFullNameFromLink(resource_link: str) -> Optional[str]:
         # request in form
         # /[resourceType]/[resourceId]/ .... /[resourceType]/[resourceId]/.
         return str(path_parts[-2])
-    return None
+    raise ValueError("Failed Parsing ResourceID from link: {0}".format(resource_link))
 
 
 def GenerateGuidId() -> str:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -61,7 +61,7 @@ class PartitionKeyRangeCache(object):
         :rtype: list
         """
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
-        await self.init_collection_routing_map_if_needed(collection_link, str(collection_id), feed_options, **kwargs)
+        await self.init_collection_routing_map_if_needed(collection_link, collection_id, feed_options, **kwargs)
 
         return self._collection_routing_map_by_item[collection_id].get_overlapping_ranges(partition_key_ranges)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -94,7 +94,7 @@ class PartitionKeyRangeCache(object):
             **kwargs: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
-        await self.init_collection_routing_map_if_needed(collection_link, str(collection_id), **kwargs)
+        await self.init_collection_routing_map_if_needed(collection_link, collection_id, **kwargs)
 
         return self._collection_routing_map_by_item[collection_id].get_range_by_partition_key_range_id(
             partition_key_range_id)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -83,7 +83,7 @@ class PartitionKeyRangeCache(object):
         :rtype: list
         """
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
-        self.init_collection_routing_map_if_needed(collection_link, str(collection_id), feed_options, **kwargs)
+        self.init_collection_routing_map_if_needed(collection_link, collection_id, feed_options, **kwargs)
 
         return self._collection_routing_map_by_item[collection_id].get_overlapping_ranges(partition_key_ranges)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -94,7 +94,7 @@ class PartitionKeyRangeCache(object):
             **kwargs: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
-        self.init_collection_routing_map_if_needed(collection_link, str(collection_id), **kwargs)
+        self.init_collection_routing_map_if_needed(collection_link, collection_id, **kwargs)
 
         return (self._collection_routing_map_by_item[collection_id]
                 .get_range_by_partition_key_range_id(partition_key_range_id))

--- a/sdk/cosmos/azure-cosmos/tests/test_base_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_base_unit.py
@@ -16,3 +16,10 @@ class TestIdAndNameBased(unittest.TestCase):
         # This is a database name that ran into 'Incorrect padding'
         # exception within base.IsNameBased function
         self.assertTrue(base.IsNameBased("dbs/paas_cmr"))
+
+    def test_collection_id(self):
+        # correctly formatted link
+        assert base.GetResourceIdOrFullNameFromLink("dbs/xjwmAA==/colls/1234") == "1234"
+        # incorrectly formatted link should raise ValueError
+        with pytest.raises(ValueError):
+            base.GetResourceIdOrFullNameFromLink("db/xjwmAA==/coll/")


### PR DESCRIPTION
# Description

Don't return None when parsing the collection id rather raise an error. If we return, none in the future it would break lots of parts of the sdk with a key error. 
