### PR TITLE
Pin older aiohttp to check cosmos timeouts

### DIFF
--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.8.5
+aiohttp<=3.12.2
 -e ../../core/azure-core
 -e ../../identity/azure-identity
 -e ../../../tools/azure-sdk-tools


### PR DESCRIPTION
I installed the `whl` environment locally on windows 313 and compared it to last known not-timing-out in CI. Found this difference. Let's see if it makes an actual material difference in the run time.