### PR TITLE
Allow psutil spelling in azure monitor sdks

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1087,6 +1087,7 @@
         "otlp",
         "speced",
         "pkgutils",
+        "psutil",
         "psycopg",
         "uninstrument",
         "uninstrumented"


### PR DESCRIPTION
# Description

Allow psutil spelling to unblock https://github.com/Azure/azure-sdk-for-python/pull/41356/files

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
