### PR TITLE
[bct] Add ignores for arm migrations

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_allowlist.py
+++ b/scripts/breaking_changes_checker/breaking_changes_allowlist.py
@@ -19,6 +19,7 @@ IGNORE_BREAKING_CHANGES = {
         # Changes due to latest dpg design + need to support overloads in this tool
         ("ChangedParameterOrdering", "*", "*", "__init__"),
         # Changes due to latest dpg design
+        ("RemovedOrRenamedInstanceAttribute", "*", "*", "additional_properties"),
         ("RemovedOrRenamedClass", "*", RegexSuppression(".*ListResult$")),
         ("ChangedParameterKind", "*", "*", "*", "top"),
         ("ChangedParameterKind", "*", "*", "*", "filter"),


### PR DESCRIPTION
- Ignore removal of additional properties since dpg models inherently support additional properties. 
- Ignore added new "properties" property reports. (Related to model flattening, we arent considering this breaking)