### PR TITLE
[bct] Fix ignore logic

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -619,7 +619,8 @@ class BreakingChangesTracker:
         if bc == ignored:
             return True
         for b, i in zip(bc, ignored):
-            if i == "*":
+            if i == "*" or i is None:
+                # If the ignore rule is a wildcard or None, we skip this part of the check
                 continue
             if isinstance(i, RegexSuppression) and b is not None:
                 if i.match(b):


### PR DESCRIPTION
This fixes the issue where ignored checks in this format where actually not getting ignored due to a discrepancy in the number of elements in the tuples to compare: `("AddedMethodOverload", "*")`

This PR removed the extra overload checks reported for mgmt plane migration specs