### PR TITLE
[Key Vault] Move wrap algo emums

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -10,7 +10,15 @@
   [#37507](https://github.com/Azure/azure-sdk-for-python/pull/37507)
 
 ### Bugs Fixed
+
 - Fixed a bug where `KeyVaultRSAPublicKey` and `KeyVaultRSAPrivateKey` were not correctly implementing the `cryptography` library's `RSAPublicKey` and `RSAPrivateKey` interfaces, causing instantiation errors. ([#41205](https://github.com/Azure/azure-sdk-for-python/pull/41205))
+
+### Breaking Changes
+
+> These changes do not impact the API of stable versions such as 4.10.0. Only code written against a beta version such as 4.11.0b1 may be affected.
+- The following enums have been moved:
+  - `EncryptionAlgorithm.ckm_aes_key_wrap` -> `KeyWrapAlgorithm.ckm_aes_key_wrap`
+  - `EncryptionAlgorithm.ckm_aes_key_wrap_pad` -> `KeyWrapAlgorithm.ckm_aes_key_wrap_pad`
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_enums.py
@@ -21,6 +21,8 @@ class KeyWrapAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     # Microsoft does *not* recommend RSA_1_5, which is included solely for backwards compatibility.
     # Cryptographic standards no longer consider RSA with the PKCS#1 v1.5 padding scheme secure for encryption.
     rsa1_5 = "RSA1_5"
+    ckm_aes_key_wrap = "CKM_AES_KEY_WRAP"
+    ckm_aes_key_wrap_pad = "CKM_AES_KEY_WRAP_PAD"
 
 
 class EncryptionAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -44,8 +46,6 @@ class EncryptionAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     a128_cbcpad = "A128CBCPAD"
     a192_cbcpad = "A192CBCPAD"
     a256_cbcpad = "A256CBCPAD"
-    ckm_aes_key_wrap = "CKM_AES_KEY_WRAP"
-    ckm_aes_key_wrap_pad = "CKM_AES_KEY_WRAP_PAD"
 
 
 class SignatureAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):


### PR DESCRIPTION
The enums for `CKM_AES_KEY_WRAP` and `CKM_AES_KEY_WRAP_PAD` belong in the `KeyWrapAlgorithm` enum class.