### PR TITLE
[EventHub] skip failing CI identity auth samples

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -54,8 +54,6 @@ TIMEOUT_SAMPLES = {
         "recv_with_checkpoint_store_async.py": (10),
         "recv_with_custom_starting_position_async.py": (10),
         "sample_code_eventhub_async.py": (10),
-        "send_and_receive_amqp_annotated_message.py": (10),
-        "send_and_receive_amqp_annotated_message_async.py": (10),
     },
     "azure-eventhub-checkpointstoreblob": {
         "receive_events_using_checkpoint_store.py": (10),
@@ -95,14 +93,21 @@ IGNORED_SAMPLES = {
         "sample_publish_events_to_a_topic_using_sas_credential_async.py"
     ],
     "azure-eventhub": [
-        "client_identity_authentication.py",    # TODO: remove after fixing issue #29177
-        "client_identity_authentication_async.py",    # TODO: remove after fixing issue #29177
+        "client_identity_authentication.py",
+        "client_identity_authentication_async.py",
         "connection_to_custom_endpoint_address.py",
         "proxy.py",
         "connection_to_custom_endpoint_address_async.py",
         "iot_hub_connection_string_receive_async.py",
         "proxy_async.py",
-        "send_stream.py",    # TODO: remove after fixing issue #29177
+        "send_stream.py",
+        "send_stream_async.py",
+        "send.py",
+        "send_async.py",
+        "send_buffered_mode.py",
+        "send_buffered_mode_async.py",
+        "send_and_receive_amqp_annotated_message.py",
+        "send_and_receive_amqp_annotated_message_async.py",
     ],
     "azure-eventhub-checkpointstoretable": ["receive_events_using_checkpoint_store.py"],
     "azure-servicebus": [

--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -102,8 +102,6 @@ IGNORED_SAMPLES = {
         "proxy_async.py",
         "send_stream.py",
         "send_stream_async.py",
-        "send.py",
-        "send_async.py",
         "send_buffered_mode.py",
         "send_buffered_mode_async.py",
         "send_and_receive_amqp_annotated_message.py",

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -6,7 +6,7 @@ from typing import Iterable, Dict, Any, Optional, Union, TYPE_CHECKING
 import logging
 import copy
 from collections import defaultdict
-import asyncio
+import asyncio # pylint:disable=do-not-import-asyncio
 from azure.eventhub.exceptions import OwnershipLostError  # type: ignore
 from azure.eventhub.aio import CheckpointStore  # type: ignore
 from azure.core.exceptions import ResourceModifiedError, ResourceExistsError, ResourceNotFoundError  # type: ignore

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -102,7 +102,7 @@ async def main():
     # Receive
     consumer = EventHubConsumerClient(
         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-        credential=AzureCliCredential(),
+        credential=DefaultAzureCredential(),
         consumer_group="$Default",
         eventhub_name=EVENTHUB_NAME,
         transport_type=TransportType.AmqpOverWebsocket,

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -14,7 +14,7 @@ import asyncio
 from azure.eventhub import TransportType
 from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient
 from azure.eventhub.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
-from azure.identity.aio import AzureCliCredential
+from azure.identity.aio import DefaultAzureCredential
 
 FULLY_QUALIFIED_NAMESPACE = os.environ["EVENT_HUB_HOSTNAME"]
 EVENTHUB_NAME = os.environ["EVENT_HUB_NAME"]
@@ -91,7 +91,7 @@ async def main():
     producer = EventHubProducerClient(
         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
         eventhub_name=EVENTHUB_NAME,
-        credential=AzureCliCredential(),
+        credential=DefaultAzureCredential(),
         transport_type=TransportType.AmqpOverWebsocket,
     )
     async with producer:

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_async.py
@@ -16,9 +16,8 @@ import os
 from azure.eventhub.aio import EventHubProducerClient
 from azure.eventhub.exceptions import EventHubError
 from azure.eventhub import EventData
-from azure.identity.aio import DefaultAzureCredential
 
-FULLY_QUALIFIED_NAMESPACE = os.environ["EVENT_HUB_HOSTNAME"]
+CONNECTION_STR = os.environ["EVENT_HUB_CONN_STR"]
 EVENTHUB_NAME = os.environ["EVENT_HUB_NAME"]
 
 
@@ -90,10 +89,9 @@ async def send_event_data_list(producer):
 
 async def run():
 
-    producer = EventHubProducerClient(
-        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+    producer = EventHubProducerClient.from_connection_string(
+        conn_str=CONNECTION_STR,
         eventhub_name=EVENTHUB_NAME,
-        credential=DefaultAzureCredential(),
     )
     async with producer:
         await send_event_data_batch(producer)

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/send.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/send.py
@@ -13,9 +13,8 @@ import time
 import os
 from azure.eventhub import EventHubProducerClient, EventData
 from azure.eventhub.exceptions import EventHubError
-from azure.identity import DefaultAzureCredential
 
-FULLY_QUALIFIED_NAMESPACE = os.environ["EVENT_HUB_HOSTNAME"]
+CONNECTION_STR = os.environ["EVENT_HUB_CONN_STR"]
 EVENTHUB_NAME = os.environ["EVENT_HUB_NAME"]
 
 
@@ -89,10 +88,9 @@ def send_event_data_list(producer):
         print("Sending error: ", eh_err)
 
 
-producer = EventHubProducerClient(
-    fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+producer = EventHubProducerClient.from_connection_string(
+    conn_str=CONNECTION_STR,
     eventhub_name=EVENTHUB_NAME,
-    credential=DefaultAzureCredential(),
 )
 
 start_time = time.time()


### PR DESCRIPTION
Skipping EH samples that are using Identity auth, since they suddenly started failing May 28 with:

azure.eventhub.exceptions.AuthenticationError: CBS Token authentication failed.
Status code: None
Error: client-error
CBS Token authentication failed.
Status code: None
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f3f11687130>

Updating the send.py samples to conn str auth for testing concurrent sending samples in CI.