### PR TITLE
[tools] Update resource_testcase.py

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
@@ -10,7 +10,7 @@ import datetime
 import logging
 
 try:
-    from azure.mgmt.resource import ResourceManagementClient
+    from azure.mgmt.resource.resources import ResourceManagementClient
 except ImportError:
     pass
 


### PR DESCRIPTION
It is more explicit to import `ResourceManagementClient` from `azure.mgmt.resource.resources` since `azure.mgmt.resource.__init__` may change in the future.