### PR TITLE
Fix issue for skip tests with split timeout

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_config.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_config.py
@@ -26,6 +26,8 @@ try:
 except:
     print("no urllib3")
 
+SPLIT_TIMEOUT = 60*25 # timeout test at 25 minutes
+SLEEP_TIME = 60 # sleep for 1 minutes
 
 class TestConfig(object):
     local_host = 'https://localhost:8081/'
@@ -204,7 +206,7 @@ class TestConfig(object):
     def trigger_split(container, throughput):
         print("Triggering a split in session token helpers")
         container.replace_throughput(throughput)
-        print("changed offer to 11k")
+        print(f"changed offer to {throughput}")
         print("--------------------------------")
         print("Waiting for split to complete")
         start_time = time.time()
@@ -212,11 +214,11 @@ class TestConfig(object):
         while True:
             offer = container.get_throughput()
             if offer.properties['content'].get('isOfferReplacePending', False):
-                if time.time() - start_time > 60 * 25:  # timeout test at 25 minutes
-                    unittest.skip("Partition split didn't complete in time.")
+                if time.time() - start_time > SPLIT_TIMEOUT:  # timeout test at 25 minutes
+                    raise unittest.SkipTest("Partition split didn't complete in time")
                 else:
                     print("Waiting for split to complete")
-                    time.sleep(60)
+                    time.sleep(SLEEP_TIME)
             else:
                 break
         print("Split in session token helpers has completed")
@@ -225,7 +227,7 @@ class TestConfig(object):
     async def trigger_split_async(container, throughput):
         print("Triggering a split in session token helpers")
         await container.replace_throughput(throughput)
-        print("changed offer to 11k")
+        print(f"changed offer to {throughput}")
         print("--------------------------------")
         print("Waiting for split to complete")
         start_time = time.time()
@@ -233,11 +235,11 @@ class TestConfig(object):
         while True:
             offer = await container.get_throughput()
             if offer.properties['content'].get('isOfferReplacePending', False):
-                if time.time() - start_time > 60 * 25:  # timeout test at 25 minutes
-                    unittest.skip("Partition split didn't complete in time.")
+                if time.time() - start_time > SPLIT_TIMEOUT:  # timeout test at 25 minutes
+                    raise unittest.SkipTest("Partition split didn't complete in time")
                 else:
                     print("Waiting for split to complete")
-                    time.sleep(60)
+                    time.sleep(SLEEP_TIME)
             else:
                 break
         print("Split in session token helpers has completed")

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
@@ -88,7 +88,7 @@ class TestPartitionSplitQuery(unittest.TestCase):
         offer = self.database.get_throughput()
         while True:
             if time.time() - start_time > 60 * 25:  # timeout test at 25 minutes
-                unittest.skip("Partition split didn't complete in time.")
+                raise unittest.SkipTest("Partition split didn't complete in time")
             if offer.properties['content'].get('isOfferReplacePending', False):
                 time.sleep(10)
                 offer = self.database.get_throughput()


### PR DESCRIPTION
# Description

Some of our tests were running too long and caused the issue with release pipeline.

## Root cause
The root cause was the timeout mechanism added were not working as expected. The tests were stuck in a infinite loop: https://github.com/Azure/azure-sdk-for-python/pull/36555/files#diff-afc2704bae74e066b90af9635aebb85767f20223aa73731f6ea6f1565507c4beR88

```
unittest.skip()
```

## Fix
The fix was to use the following to stop the tests instantly:
```
raise unittest.SkipTest()
```

This fix will timeout split tests with 25 minutes timeout.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
