### PR TITLE
[Identity] Fix MI live test deployment

### DIFF
--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -64,6 +64,7 @@ $MIName = $DeploymentOutputs['IDENTITY_USER_DEFINED_IDENTITY_NAME']
 $SaAccountName = 'workload-identity-sa'
 $PodName = $DeploymentOutputs['IDENTITY_AKS_POD_NAME']
 $storageName = $DeploymentOutputs['IDENTITY_STORAGE_NAME_2']
+$FICAudience = 'api://AzureADTokenExchange'
 
 # Get the aks cluster credentials
 Write-Host "Getting AKS credentials"
@@ -75,7 +76,7 @@ $AKS_OIDC_ISSUER = az aks show -n $DeploymentOutputs['IDENTITY_AKS_CLUSTER_NAME'
 
 # Create the federated identity
 Write-Host "Creating federated identity"
-az identity federated-credential create --name $MIName --identity-name $MIName --resource-group $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:default:workload-identity-sa
+az identity federated-credential create --name $MIName --identity-name $MIName --resource-group $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:default:workload-identity-sa  --audiences $FICAudience
 
 # Build the kubernetes deployment yaml
 $kubeConfig = @"


### PR DESCRIPTION
When creating a federated identity using the Azure CLI in our test-resources-post.ps1 script, specifying an audience is now required.

This adds the intended audience to the respective command.
