### PR TITLE
[Storage] Pin earlier working version of crypto library in `azure-storage-blob-changefeed`

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
@@ -3,4 +3,4 @@
 -e ../../identity/azure-identity
 -e ../azure-storage-blob
 aiohttp>=3.0
-cryptography==44.0.3
+cryptography==44.0.3  # TODO: Pinned due to cryptography compatibility issue in CI. Revisit once resolved.

--- a/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
@@ -3,3 +3,4 @@
 -e ../../identity/azure-identity
 -e ../azure-storage-blob
 aiohttp>=3.0
+cryptography==44.0.3

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.27.0b1 (2025-06-11)
+## 12.27.0b1 (2025-06-12)
 
 This version and all future versions will require Python 3.9+. Python 3.8 is no longer supported.
 

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.22.0b1 (2025-06-11)
+## 12.22.0b1 (2025-06-12)
 
 This version and all future versions will require Python 3.9+. Python 3.8 is no longer supported.
 

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.23.0b1 (2025-06-11)
+## 12.23.0b1 (2025-06-12)
 
 This version and all future versions will require Python 3.9+. Python 3.8 is no longer supported.
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.14.0b1 (2025-06-11)
+## 12.14.0b1 (2025-06-12)
 
 This version and all future versions will require Python 3.9+. Python 3.8 is no longer supported.
 


### PR DESCRIPTION
The new `cryptography` library released in Python 3.9 has been causing collection failures in our CI/live tests. For now, we will use `cryptography==44.0.03` instead of `cryptography==45.0.02`.

Here's some examples of runs:
- [Failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4883932&view=logs&j=f8949c67-9d21-53bc-b8db-079dc324f468&t=6c8776a1-7c0d-50cf-7256-992fb2bc9724&l=34208)
- [Passing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4877772&view=logs&j=f8949c67-9d21-53bc-b8db-079dc324f468&t=6c8776a1-7c0d-50cf-7256-992fb2bc9724&l=34197)