### PR TITLE
[Monitor OpenTelemetry Exporter] Remove the Device OS Setting

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 - Fix for issue #41470. Added back exception message, removed earlier due to linting errors
   ([#41512] https://github.com/Azure/azure-sdk-for-python/pull/41512)
+- Should not populate device OS tag in the exporter.
+  ([#41549] https://github.com/Azure/azure-sdk-for-python/pull/41549)
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 - Fix for issue #41470. Added back exception message, removed earlier due to linting errors
   ([#41512] https://github.com/Azure/azure-sdk-for-python/pull/41512)
-- Should not populate device OS tag in the exporter.
+- Should leave ingestion to populate Device OS from User Agent
   ([#41549] https://github.com/Azure/azure-sdk-for-python/pull/41549)
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -130,7 +130,6 @@ def _getlocale():
 azure_monitor_context = {
     ContextTagKeys.AI_DEVICE_ID: platform.node(),
     ContextTagKeys.AI_DEVICE_LOCALE: _getlocale(),
-    ContextTagKeys.AI_DEVICE_OS_VERSION: platform.version(),
     ContextTagKeys.AI_DEVICE_TYPE: "Other",
     ContextTagKeys.AI_INTERNAL_SDK_VERSION: _get_sdk_version(),
 }

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -363,10 +363,6 @@ class TestAzureLogExporter(unittest.TestCase):
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
         )
         self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
-        )
-        self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]
         )
         self.assertEqual(

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
@@ -188,10 +188,6 @@ class TestAzureMetricExporter(unittest.TestCase):
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
         )
         self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
-        )
-        self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]
         )
         self.assertEqual(

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -15,12 +15,10 @@ from unittest.mock import patch
 
 TEST_AI_DEVICE_ID = "TEST_AI_DEVICE_ID"
 TEST_AI_DEVICE_LOCALE = "TEST_AI_DEVICE_LOCALE"
-TEST_OS_VERSION = "TEST_OS_VERSION"
 TEST_SDK_VERSION_PREFIX = "TEST_AZURE_SDK_VERSION_PREFIX"
 TEST_AZURE_MONITOR_CONTEXT = {
     "ai.device.id": TEST_AI_DEVICE_ID,
     "ai.device.locale": TEST_AI_DEVICE_LOCALE,
-    "ai.device.osVersion": TEST_OS_VERSION,
     "ai.device.type": "Other",
     "ai.internal.sdkVersion": "{}py1.2.3:otel4.5.6:ext7.8.9".format(
         TEST_SDK_VERSION_PREFIX,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -291,10 +291,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
         )
         self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
-        )
-        self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]
         )
         self.assertEqual(
@@ -1449,10 +1445,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
         )
         self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
-        )
-        self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]
         )
         self.assertEqual(
@@ -1509,10 +1501,6 @@ class TestAzureTraceExporter(unittest.TestCase):
         )
         self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
-        )
-        self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
         )
         self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]
@@ -1573,10 +1561,6 @@ class TestAzureTraceExporter(unittest.TestCase):
         )
         self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_LOCALE), azure_monitor_context[ContextTagKeys.AI_DEVICE_LOCALE]
-        )
-        self.assertEqual(
-            envelope.tags.get(ContextTagKeys.AI_DEVICE_OS_VERSION),
-            azure_monitor_context[ContextTagKeys.AI_DEVICE_OS_VERSION],
         )
         self.assertEqual(
             envelope.tags.get(ContextTagKeys.AI_DEVICE_TYPE), azure_monitor_context[ContextTagKeys.AI_DEVICE_TYPE]


### PR DESCRIPTION
# Description

We should not send device OS from the exporter as it should be set on the ingestion side.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
