### PR TITLE
Replace Throughput Bugfix

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -795,10 +795,10 @@ def _replace_throughput(
             increment_percent = throughput.auto_scale_increment_percent
             if max_throughput is not None:
                 new_throughput_properties['content']['offerAutopilotSettings']['maxThroughput'] = max_throughput
-                if increment_percent:
-                    new_throughput_properties['content']['offerAutopilotSettings']['autoUpgradePolicy']['throughputPolicy']['incrementPercent'] = increment_percent  # pylint: disable=line-too-long
-                if throughput.offer_throughput:
-                    new_throughput_properties["content"]["offerThroughput"] = throughput.offer_throughput
+            if increment_percent:
+                new_throughput_properties['content']['offerAutopilotSettings']['autoUpgradePolicy']['throughputPolicy']['incrementPercent'] = increment_percent  # pylint: disable=line-too-long
+            if throughput.offer_throughput:
+                new_throughput_properties["content"]["offerThroughput"] = throughput.offer_throughput
         except AttributeError as e:
             raise TypeError("offer_throughput must be int or an instance of ThroughputProperties") from e
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -795,8 +795,8 @@ def _replace_throughput(
             increment_percent = throughput.auto_scale_increment_percent
             if max_throughput is not None:
                 new_throughput_properties['content']['offerAutopilotSettings']['maxThroughput'] = max_throughput
-            if increment_percent:
-                new_throughput_properties['content']['offerAutopilotSettings']['autoUpgradePolicy']['throughputPolicy']['incrementPercent'] = increment_percent  # pylint: disable=line-too-long
+                if increment_percent:
+                    new_throughput_properties['content']['offerAutopilotSettings']['autoUpgradePolicy']['throughputPolicy']['incrementPercent'] = increment_percent  # pylint: disable=line-too-long
             if throughput.offer_throughput:
                 new_throughput_properties["content"]["offerThroughput"] = throughput.offer_throughput
         except AttributeError as e:

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
@@ -979,10 +979,9 @@ class TestCRUDContainerOperations(unittest.TestCase):
         collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
 
         new_throughput = ThroughputProperties(offer_throughput=2500, auto_scale_max_throughput=4000, auto_scale_increment_percent=5)
-        try:
+
+        with pytest.raises(KeyError):
             collection.replace_throughput(new_throughput)
-        except KeyError as e:
-            pass
 
     def _MockExecuteFunction(self, function, *args, **kwargs):
         if HttpHeaders.PartitionKey in args[4].headers:

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
@@ -958,10 +958,8 @@ class TestCRUDContainerOperations(unittest.TestCase):
         created_db = self.databaseForTest
         collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
 
-        # get current collection throughput settings
-        current_throughput = collection.get_throughput()
         new_throughput = ThroughputProperties(offer_throughput=2500)
-        update_throughput = collection.replace_throughput(new_throughput.offer_throughput)
+        collection.replace_throughput(new_throughput.offer_throughput)
 
         retrieve_throughput = collection.get_throughput()
         assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
@@ -970,10 +968,8 @@ class TestCRUDContainerOperations(unittest.TestCase):
         created_db = self.databaseForTest
         collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
 
-        # get current collection throughput settings
-        current_throughput = collection.get_throughput()
         new_throughput = ThroughputProperties(offer_throughput=2500)
-        update_throughput = collection.replace_throughput(new_throughput)
+        collection.replace_throughput(new_throughput)
 
         retrieve_throughput = collection.get_throughput()
         assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
@@ -24,7 +24,7 @@ import azure.cosmos.cosmos_client as cosmos_client
 import azure.cosmos.documents as documents
 import azure.cosmos.exceptions as exceptions
 import test_config
-from azure.cosmos import _retry_utility
+from azure.cosmos import _retry_utility, ThroughputProperties
 from azure.cosmos.http_constants import HttpHeaders, StatusCodes
 from azure.cosmos.partition_key import PartitionKey
 
@@ -954,7 +954,29 @@ class TestCRUDContainerOperations(unittest.TestCase):
 
         created_db.delete_container(none_coll)
 
+    def test_replace_throughput_offer_with_int(self):
+        created_db = self.databaseForTest
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
 
+        # get current collection throughput settings
+        current_throughput = collection.get_throughput()
+        new_throughput = ThroughputProperties(offer_throughput=2500)
+        update_throughput = collection.replace_throughput(new_throughput.offer_throughput)
+
+        retrieve_throughput = collection.get_throughput()
+        assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
+
+    def test_replace_throughput_offer_with_object(self):
+        created_db = self.databaseForTest
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
+
+        # get current collection throughput settings
+        current_throughput = collection.get_throughput()
+        new_throughput = ThroughputProperties(offer_throughput=2500)
+        update_throughput = collection.replace_throughput(new_throughput)
+
+        retrieve_throughput = collection.get_throughput()
+        assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
 
     def _MockExecuteFunction(self, function, *args, **kwargs):
         if HttpHeaders.PartitionKey in args[4].headers:

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container.py
@@ -974,6 +974,16 @@ class TestCRUDContainerOperations(unittest.TestCase):
         retrieve_throughput = collection.get_throughput()
         assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
 
+    def test_negative_replace_throughput_with_all_configs_set(self):
+        created_db = self.databaseForTest
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
+
+        new_throughput = ThroughputProperties(offer_throughput=2500, auto_scale_max_throughput=4000, auto_scale_increment_percent=5)
+        try:
+            collection.replace_throughput(new_throughput)
+        except KeyError as e:
+            pass
+
     def _MockExecuteFunction(self, function, *args, **kwargs):
         if HttpHeaders.PartitionKey in args[4].headers:
             self.last_headers.append(args[4].headers[HttpHeaders.PartitionKey])

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container_async.py
@@ -25,6 +25,7 @@ import test_config
 from azure.cosmos.aio import CosmosClient, _retry_utility_async, DatabaseProxy
 from azure.cosmos.http_constants import HttpHeaders, StatusCodes
 from azure.cosmos.partition_key import PartitionKey
+from azure.cosmos import ThroughputProperties
 
 
 class TimeoutTransport(AsyncioRequestsTransport):
@@ -956,7 +957,6 @@ class TestCRUDContainerOperationsAsync(unittest.IsolatedAsyncioTestCase):
             assert expected_offer_type == offer.properties.get('offerType')
 
     async def test_offer_read_and_query_async(self):
-
         # Create database.
         db = self.database_for_test
 
@@ -968,7 +968,6 @@ class TestCRUDContainerOperationsAsync(unittest.IsolatedAsyncioTestCase):
         self.__validate_offer_response_body(expected_offer, collection_properties.get('_self'), None)
 
     async def test_offer_replace_async(self):
-
         collection = self.database_for_test.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
         # Read Offer
         expected_offer = await collection.get_throughput()
@@ -984,7 +983,6 @@ class TestCRUDContainerOperationsAsync(unittest.IsolatedAsyncioTestCase):
         assert expected_offer.offer_throughput + 100 == replaced_offer.offer_throughput
 
     async def test_index_progress_headers_async(self):
-
         created_db = self.database_for_test
         consistent_coll = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
         created_container = created_db.get_container_client(container=consistent_coll)
@@ -1006,6 +1004,36 @@ class TestCRUDContainerOperationsAsync(unittest.IsolatedAsyncioTestCase):
         assert HttpHeaders.IndexTransformationProgress in created_db.client_connection.last_response_headers
 
         await created_db.delete_container(none_coll)
+
+    async def test_replace_throughput_offer_with_int(self):
+        created_db = self.database_for_test
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
+
+        new_throughput = ThroughputProperties(offer_throughput=2500)
+        await collection.replace_throughput(new_throughput.offer_throughput)
+
+        retrieve_throughput = await collection.get_throughput()
+        assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
+
+    async def test_replace_throughput_offer_with_object(self):
+        created_db = self.database_for_test
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
+
+        new_throughput = ThroughputProperties(offer_throughput=2500)
+        await collection.replace_throughput(new_throughput)
+
+        retrieve_throughput = await collection.get_throughput()
+        assert getattr(retrieve_throughput, "offer_throughput") == getattr(new_throughput, "offer_throughput")
+
+    async def test_negative_replace_throughput_with_all_configs_set(self):
+        created_db = self.database_for_test
+        collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
+
+        new_throughput = ThroughputProperties(offer_throughput=2500, auto_scale_max_throughput=4000, auto_scale_increment_percent=5)
+        try:
+            await collection.replace_throughput(new_throughput)
+        except KeyError as e:
+            pass
 
     async def _mock_execute_function(self, function, *args, **kwargs):
         if HttpHeaders.PartitionKey in args[4].headers:

--- a/sdk/cosmos/azure-cosmos/tests/test_crud_container_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_crud_container_async.py
@@ -1030,10 +1030,9 @@ class TestCRUDContainerOperationsAsync(unittest.IsolatedAsyncioTestCase):
         collection = created_db.get_container_client(self.configs.TEST_MULTI_PARTITION_CONTAINER_ID)
 
         new_throughput = ThroughputProperties(offer_throughput=2500, auto_scale_max_throughput=4000, auto_scale_increment_percent=5)
-        try:
+
+        with pytest.raises(KeyError):
             await collection.replace_throughput(new_throughput)
-        except KeyError as e:
-            pass
 
     async def _mock_execute_function(self, function, *args, **kwargs):
         if HttpHeaders.PartitionKey in args[4].headers:


### PR DESCRIPTION
# Description

Un-indented two if statements from being under the max throughput if statement logic. 
This is to address a bug where users could only manually replace throughput by passing an int. 
Now users can pass the following successfully:
```python
new_throughput = ThroughputProperties(offer_throughput=2500)
update_throughput = collection.replace_throughput(new_throughput)
```