### PR TITLE
Remove the 3 methods `get_chat_completions_client()`, `get_embeddings_client()` and `get_image_embeddings_client()` 

### DIFF
--- a/sdk/ai/azure-ai-projects/AGENTS_MIGRATION_GUIDE.md
+++ b/sdk/ai/azure-ai-projects/AGENTS_MIGRATION_GUIDE.md
@@ -1,5 +1,6 @@
-# Agents migration guide from Hub-based projects to Endpoint-based projects.
-This guide describes migration from hub-based to Endpoint-based projects. To create a Endpoint-based project, please use one of the deployment scripts on [foundry samples repository](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup) appropriate for your scenario, also you can use Azure AI Foundry UI. The support of hub-based projects was dropped in `azure-ai-projects` version `1.0.0b11`. In this document, we show the operation implementation of before `1.0.0b11` in **Hub-based** secion, followed by code for `azure-ai-projects` version `1.0.0b11` or later in **Endpoint-based**.
+# Agents migration guide from Hub-based projects to Endpoint-based projects
+
+This guide describes migration from hub-based to Endpoint-based projects. To create a Endpoint-based project, please use one of the deployment scripts on [foundry samples repository](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup) appropriate for your scenario, also you can use Azure AI Foundry UI. The support of hub-based projects was dropped in `azure-ai-projects` version `1.0.0b11`. In this document, we show the operation implementation of before `1.0.0b11` in **Hub-based** section, followed by code for `azure-ai-projects` version `1.0.0b11` or later in **Endpoint-based**.
 
 ## Import changes
 
@@ -109,9 +110,11 @@ Files Operations
 | `project_client.agents.delete_file` | `project_client.agents.files.delete` |
 
 ## API changes
+
 1. Create project. The connection string is replaced by the endpoint. The project endpoint URL has the form https://\<your-ai-services-account-name\>.services.ai.azure.com/api/projects/\<your-project-name\>. It can be found in your Azure AI Foundry Project overview page.
 
     **Hub-based**
+
     ```python
     project_client = AIProjectClient.from_connection_string(
         credential=DefaultAzureCredential(),
@@ -120,12 +123,15 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     project_client = AIProjectClient(endpoint=endpoint, credential=DefaultAzureCredential())
     ```
+
 2. Crate an agent. In the new versions of SDK, the agent can be created using project client or directly created by using `AgentsClient` constructor. In the code below, `project_client.agents`is an `AgentsClient` instance so `project_client.agents` and `agents_client` can be used interchangeably. For simplicity we will use ` project_client.agents `.
 
     **Hub-based**
+
     ```python
     agent = project_client.agents.create_agent(
         model= "gpt-4o",
@@ -133,9 +139,11 @@ Files Operations
         instructions="You are helpful assistant",
     )
     ```
-    **Endpoint-based** 
 
-    Agent is instantiated using `AIProjectClient `
+    **Endpoint-based**
+
+    Agent is instantiated using `AIProjectClient`
+
     ```python
     agent = project_client.agents.create_agent(
         model="gpt-4o",
@@ -145,6 +153,7 @@ Files Operations
     ```
 
     Agent is instantiated using `AgentsClient` constructor:
+
     ```python
     from azure.ai.agents import AgentsClient
 
@@ -158,9 +167,11 @@ Files Operations
         instructions="You are helpful agent",
     )
     ```
+
 3. List agents. New version of SDK allows more convenient ways of listing threads, messages and agents by returning `ItemPaged` and `AsyncItemPaged`. The list of returned items is split by pages, which may be consequently returned to user. Below we will demonstrate this mechanism for agents. The `limit` parameter defines the number of items on the page. This example is also applicable for listing threads, runs, run steps, vector stores, files in vector store, and messages.
 
     **Hub-based**
+
     ```python
     has_more = True
     last_id = None
@@ -173,6 +184,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     agents = project_client.agents.list_agents(limit=2)
      # Iterate items by page. Each page will be limited by two items.
@@ -190,12 +202,14 @@ Files Operations
 4. Delete agent. In versions azure-ai-projects 1.0.0b11, all deletion operations used to return deletion status, for example, deletion of agent was returning `AgentDeletionStatus`. In 1.0.0b11 and later, these operations do not return a value.
 
     **Hub-based**
+
     ```python
     deletion_status = project_client.agents.delete_agent(agent.id)
     print(deletion_status.deleted)
     ```
 
     **Endpoint-based**
+
     ```python
     project_client.agents.delete_agent(agent.id)
     ```
@@ -203,16 +217,21 @@ Files Operations
 5. Create a thread.
 
     **Hub-based**
+
     ```python
     thread = project_client.agents.create_thread()
     ```
+
     **Endpoint-based**
+
     ```python
     thread = project_client.agents.threads.create()
     ```
+
 6. List threads.
 
     **Hub-based**
+
     ```python
     with project_client:
         last_id = None
@@ -229,6 +248,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     threads = project_client.agents.threads.list(limit=2)
     # Iterate items by page. Each page will be limited by two items.
@@ -246,42 +266,52 @@ Files Operations
 7. Delete the thread. In previous SDK thread deletion used to return ` ThreadDeletionStatus` object, while in new version it does not return value.
 
     **Hub-based**
+
     ```python
     delete_status = project_client.agents.delete_thread(tread_id)
     print(delete_status.deleted)
     ```
 
     **Endpoint-based**
+
     ```python
     project_client.agents.threads.delete(tread_id)
     ```
+
 8. Create the message on a thread.
 
     **Hub-based**
+
     ```python
     message = project_client.agents.create_message(thread_id=thread.id, role="user", content="The message text.")
     ```
 
     **Endpoint-based**
+
     ```python
     message = agents_client.messages.create(thread_id=thread.id, role="user", content=" The message text."")
     ```
+
 9. Create and get the run.
 
     **Hub-based**
+
     ```python
     run = project_client.agents.runs.create(thread_id=thread.id, agent_id=agent.id)
     run = project_client.agents.get_run(thread_id=thread.id, run_id=run.id)
     ```
 
     **Endpoint-based**
+
     ```python
     run = project_client.agents.runs.create(thread_id=thread.id, agent_id=agent.id)
     run = project_client.agents.runs.get(thread_id=thread.id, run_id=run.id)
     ```
+
 10. List Runs.
 
     **Hub-based**
+
     ```python
     has_more = True
     last_id = None
@@ -294,6 +324,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     runs = project_client.agents.runs.list(thread.id)
     for one_run in runs:
@@ -303,6 +334,7 @@ Files Operations
 11. List Run steps.
 
     **Hub-based**
+
     ```python
     has_more = True
     last_id = None
@@ -315,6 +347,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     run_steps = project_client.agents.run_steps.list(thread.id, run.id)
     for one_run_step in run_steps:
@@ -324,6 +357,7 @@ Files Operations
 12. Using streams.
 
     **Hub-based**
+
     ```python
     with project_client.agents.create_stream(thread_id=thread.id, agent_id=agent.id) as stream:
         for event_type, event_data, func_return in stream:
@@ -334,6 +368,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     with project_client.agents.runs.stream(thread_id=thread.id, agent_id=agent.id, event_handler=MyEventHandler()) as stream:
             for event_type, event_data, func_return in stream:
@@ -346,6 +381,7 @@ Files Operations
 13. List messages.
 
     **Hub-based**
+
     ```python
     messages = project_client.agents.list_messages(thread_id=thread.id)
         # In code below we assume that the number of messages fits one page for brevity.
@@ -356,6 +392,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     messages = project_client.agents.messages.list(thread_id=thread.id)
         for msg in messages:
@@ -363,9 +400,11 @@ Files Operations
                 last_text = msg.text_messages[-1]
                 print(f"{msg.role}: {last_text.text.value}")
     ```
+
 14. Create, list and delete files are now handled by file operations, again, delete call in new SDK version does not return a value.
 
     **Hub-based**
+
     ```python
     # Create file
     file = project_client.agents.upload_file_and_poll(file_path="product_info_1.md", purpose=FilePurpose.AGENTS)
@@ -379,6 +418,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     # Create file
     file = project_client.agents.files.upload_and_poll(file_path=asset_file_path, purpose=FilePurpose.AGENTS)
@@ -389,9 +429,11 @@ Files Operations
     # Delete file.
     project_client.agents.files.delete(file_id=file.id)
     ```
+
 15. Create, list vector store files list and delete vector stores.
 
     **Hub-based**
+
     ```python
     # Create a vector store with no file and wait for it to be processed
         vector_store = project_client.agents.create_vector_store_and_poll(file_ids=[file.id], name="sample_vector_store")
@@ -421,6 +463,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     # Create a vector store with no file and wait for it to be processed
     vector_store = project_client.agents.vector_stores.create_and_poll(file_ids=[file.id], name="my_vectorstore")
@@ -441,6 +484,7 @@ Files Operations
 16. Vector store batch file search.
 
     **Hub-based**
+
     ```python
     # Batch upload files
     vector_store_file_batch = project_client.agents.create_vector_store_file_batch_and_poll(
@@ -460,6 +504,7 @@ Files Operations
     ```
 
     **Endpoint-based**
+
     ```python
     # Batch upload files
     vector_store_file_batch = project_client.agents.vector_store_file_batches.create_and_poll(

--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 * Fix for enable_telemetry to correctly instrument azure-ai-agents
 
+### Other
+
+* Set dependency on `azure-ai-agents` version `1.0.0` or above,
+now that we have a stable release of the Agents package.
+
 ### Sample updates
 
 ## 1.0.0b11 (2025-05-15)

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -9,7 +9,6 @@ resources in your Azure AI Foundry Project. Use it to:
 * **Enumerate connected Azure resources** in your Foundry project using the `.connections` operations.
 * **Upload documents and create Datasets** to reference them using the `.datasets` operations.
 * **Create and enumerate Search Indexes** using the `.indexes` operations.
-* **Get an Azure AI Inference client** for chat completions, text or image embeddings using the `.inference` operations.
 * **Read a Prompty file or string** and render messages for inference clients, using the `PromptTemplate` class.
 * **Run Evaluations** to assess the performance of generative AI applications, using the `evaluations` operations.
 * **Enable OpenTelemetry tracing** using the `enable_telemetry` function.
@@ -122,9 +121,13 @@ print("Deleted agent")
 
 ### Get an authenticated AzureOpenAI client
 
-Your Azure AI Foundry project may have one or more OpenAI models deployed that support chat completions. Use the code below to get an authenticated [AzureOpenAI](https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai) from the [openai](https://pypi.org/project/openai/) package, and execute a chat completions call.
+Your Azure AI Foundry project may have one or more AI models deployed that support chat completions.
+These could be OpenAI models, Microsoft models, or models from other providers.
+Use the code below to get an authenticated [AzureOpenAI](https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai)
+from the [openai](https://pypi.org/project/openai/) package, and execute a chat completions call.
 
-The code below assumes `model_deployment_name` (a string) is defined. It's the deployment name of an AI model in your Foundry Project, or a connected Azure OpenAI resource. As shown in the "Models + endpoints" tab, under the "Name" column.
+The code below assumes `model_deployment_name` (a string) is defined. It's the deployment name of an AI model in your
+Foundry Project, or a connected Azure OpenAI resource. As shown in the "Models + endpoints" tab, under the "Name" column.
 
 Update the `api_version` value with one found in the "Data plane - inference" row [in this table](https://learn.microsoft.com/azure/ai-services/openai/reference#api-specs).
 
@@ -171,34 +174,6 @@ with project_client.inference.get_azure_openai_client(
 <!-- END SNIPPET -->
 
 See the "inference" folder in the [package samples][samples] for additional samples.
-
-### Get an authenticated ChatCompletionsClient
-
-Your Azure AI Foundry project may have one or more AI models deployed that support chat completions. These could be OpenAI models, Microsoft models, or models from other providers. Use the code below to get an authenticated [ChatCompletionsClient](https://learn.microsoft.com/python/api/azure-ai-inference/azure.ai.inference.chatcompletionsclient) from the [azure-ai-inference](https://pypi.org/project/azure-ai-inference/) package, and execute a chat completions call.
-
-First, install the package:
-
-```bash
-pip install azure-ai-inference
-```
-
-Then run the code below. Here we assume `model_deployment_name` (a string) is defined. It's the deployment name of an AI model in your Foundry Project, as shown in the "Models + endpoints" tab, under the "Name" column.
-
-<!-- SNIPPET:sample_chat_completions_with_azure_ai_inference_client.inference_sample-->
-
-```python
-with project_client.inference.get_chat_completions_client() as client:
-
-    response = client.complete(
-        model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
-    )
-
-    print(response.choices[0].message.content)
-```
-
-<!-- END SNIPPET -->
-
-See the "inference" folder in the [package samples][samples] for additional samples, including getting an authenticated [EmbeddingsClient](https://learn.microsoft.com/python/api/azure-ai-inference/azure.ai.inference.embeddingsclient) and [ImageEmbeddingsClient](https://learn.microsoft.com/python/api/azure-ai-inference/azure.ai.inference.imageembeddingsclient).
 
 ### Deployments operations
 

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -97,7 +97,7 @@ project_client = AIProjectClient.from_connection_string(
 
 ### Performing Agent operations
 
-The `.agents` property on the `AIProjectsClient` gives you access to an authenticated `AgentsClient` from the `azure-ai-agents` package. Below we show how to create an Agent and delete it. To see what you can do with the `agent` you created, see the [many samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples) associated with the `azure-ai-agents` package.
+The `.agents` property on the `AIProjectsClient` gives you access to an authenticated `AgentsClient` from the `azure-ai-agents` package. Below we show how to create an Agent and delete it. To see what you can do with the Agent you created, see the [many samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples) and the [README.md](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents) file of the dependent `azure-ai-agents` package.
 
 The code below assumes `model_deployment_name` (a string) is defined. It's the deployment name of an AI model in your Foundry Project, as shown in the "Models + endpoints" tab, under the "Name" column.
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -18,7 +18,6 @@ from ...models._models import (
 )
 from ...models._enums import ConnectionType
 from ...operations._patch_inference import _get_aoai_inference_url
-from ...operations._patch_inference import _get_inference_url
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -40,123 +39,6 @@ class InferenceOperations:
 
     def __init__(self, outer_instance: "azure.ai.projects.aio.AIProjectClient") -> None:  # type: ignore[name-defined]
         self._outer_instance = outer_instance
-
-    @distributed_trace
-    def get_chat_completions_client(self, **kwargs: Any) -> "ChatCompletionsClient":  # type: ignore[name-defined]
-        """Get an authenticated asynchronous ChatCompletionsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports chat completions must be deployed.
-
-        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
-
-        :return: An authenticated chat completions client.
-        :rtype: ~azure.ai.inference.aio.ChatCompletionsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference.aio import ChatCompletionsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = ChatCompletionsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access,
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
-
-    @distributed_trace
-    def get_embeddings_client(self, **kwargs: Any) -> "EmbeddingsClient":  # type: ignore[name-defined]
-        """Get an authenticated asynchronous EmbeddingsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports text embeddings must be deployed.
-
-        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
-
-        :return: An authenticated Embeddings client.
-        :rtype: ~azure.ai.inference.aio.EmbeddingsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference.aio import EmbeddingsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = EmbeddingsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access,
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
-
-    @distributed_trace
-    def get_image_embeddings_client(self, **kwargs: Any) -> "ImageEmbeddingsClient":  # type: ignore[name-defined]
-        """Get an authenticated asynchronous ImageEmbeddingsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports image embeddings must be deployed.
-
-        .. note:: The package `azure-ai-inference` and `aiohttp` must be installed prior to calling this method.
-
-        :return: An authenticated Image Embeddings client.
-        :rtype: ~azure.ai.inference.aio.ImageEmbeddingsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference.aio import ImageEmbeddingsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = ImageEmbeddingsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access,
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
 
     @distributed_trace_async
     async def get_azure_openai_client(

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_inference_async.py
@@ -8,10 +8,8 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import logging
-from typing import Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING
 from azure.core.tracing.decorator_async import distributed_trace_async
-from azure.core.tracing.decorator import distributed_trace
-
 from ...models._models import (
     ApiKeyCredentials,
     EntraIDCredentials,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
@@ -17,29 +17,8 @@ from ..models._enums import ConnectionType
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
     from openai import AzureOpenAI
-    from azure.ai.inference import ChatCompletionsClient, EmbeddingsClient, ImageEmbeddingsClient
 
 logger = logging.getLogger(__name__)
-
-
-def _get_inference_url(input_url: str) -> str:
-    """
-    Converts an input URL in the format:
-    https://<host-name>/<some-path>
-    to:
-    https://<host-name>/models
-
-    :param input_url: The input endpoint URL used to construct AIProjectClient.
-    :type input_url: str
-
-    :return: The endpoint URL required to construct inference clients from the `azure-ai-inference` package.
-    :rtype: str
-    """
-    parsed = urlparse(input_url)
-    if parsed.scheme != "https" or not parsed.netloc:
-        raise ValueError("Invalid endpoint URL format. Must be an https URL with a host.")
-    new_url = f"https://{parsed.netloc}/models"
-    return new_url
 
 
 def _get_aoai_inference_url(input_url: str) -> str:
@@ -74,123 +53,6 @@ class InferenceOperations:
 
     def __init__(self, outer_instance: "azure.ai.projects.AIProjectClient") -> None:  # type: ignore[name-defined]
         self._outer_instance = outer_instance
-
-    @distributed_trace
-    def get_chat_completions_client(self, **kwargs: Any) -> "ChatCompletionsClient":  # type: ignore[name-defined]
-        """Get an authenticated ChatCompletionsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports chat completions must be deployed.
-
-        .. note:: The package `azure-ai-inference` must be installed prior to calling this method.
-
-        :return: An authenticated chat completions client.
-        :rtype: ~azure.ai.inference.ChatCompletionsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference import ChatCompletionsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = ChatCompletionsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
-
-    @distributed_trace
-    def get_embeddings_client(self, **kwargs: Any) -> "EmbeddingsClient":  # type: ignore[name-defined]
-        """Get an authenticated EmbeddingsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports text embeddings must be deployed.
-
-        .. note:: The package `azure-ai-inference` must be installed prior to calling this method.
-
-        :return: An authenticated Embeddings client.
-        :rtype: ~azure.ai.inference.EmbeddingsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference import EmbeddingsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = EmbeddingsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access,
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
-
-    @distributed_trace
-    def get_image_embeddings_client(self, **kwargs: Any) -> "ImageEmbeddingsClient":  # type: ignore[name-defined]
-        """Get an authenticated ImageEmbeddingsClient (from the package azure-ai-inference) to use with
-        AI models deployed to your AI Foundry Project. Keyword arguments are passed to the constructor of
-        ChatCompletionsClient.
-
-        At least one AI model that supports image embeddings must be deployed.
-
-        .. note:: The package `azure-ai-inference` must be installed prior to calling this method.
-
-        :return: An authenticated Image Embeddings client.
-        :rtype: ~azure.ai.inference.ImageEmbeddingsClient
-
-        :raises ~azure.core.exceptions.ModuleNotFoundError: if the `azure-ai-inference` package
-         is not installed.
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-        try:
-            from azure.ai.inference import ImageEmbeddingsClient
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "Azure AI Inference SDK is not installed. Please install it using 'pip install azure-ai-inference'"
-            ) from e
-
-        endpoint = _get_inference_url(self._outer_instance._config.endpoint)  # pylint: disable=protected-access
-
-        client = ImageEmbeddingsClient(
-            endpoint=endpoint,
-            credential=self._outer_instance._config.credential,  # pylint: disable=protected-access
-            credential_scopes=self._outer_instance._config.credential_scopes,  # pylint: disable=protected-access,
-            user_agent=kwargs.pop(
-                "user_agent", self._outer_instance._patched_user_agent  # pylint: disable=protected-access
-            ),
-            **kwargs,
-        )
-
-        return client
 
     @distributed_trace
     def get_azure_openai_client(

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_inference.py
@@ -8,7 +8,7 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 import logging
-from typing import Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 from azure.core.tracing.decorator import distributed_trace
 from ..models._models import ApiKeyCredentials, EntraIDCredentials

--- a/sdk/ai/azure-ai-projects/samples/agents/README.md
+++ b/sdk/ai/azure-ai-projects/samples/agents/README.md
@@ -1,6 +1,6 @@
 # Agents samples
 
-This directory intentionally contains one sample.
+This directory intentionally contains only one sample.
 
 The full set of Agent samples can be found in the [samples folder]((https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples)) of the `azure-ai-agents` package.
 

--- a/sdk/ai/azure-ai-projects/samples/agents/README.md
+++ b/sdk/ai/azure-ai-projects/samples/agents/README.md
@@ -2,7 +2,7 @@
 
 This directory intentionally contains only one sample.
 
-The full set of Agent samples can be found in the [samples folder]((https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples)) of the `azure-ai-agents` package.
+The full set of Agent samples can be found in the [samples folder](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples) of the `azure-ai-agents` package.
 
 See also `azure-ai-agents` package [README.md](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents).
 

--- a/sdk/ai/azure-ai-projects/samples/agents/README.md
+++ b/sdk/ai/azure-ai-projects/samples/agents/README.md
@@ -1,0 +1,8 @@
+# Agents samples
+
+This directory intentionally contains one sample.
+
+The full set of Agent samples can be found in the [samples folder]((https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents/samples)) of the `azure-ai-agents` package.
+
+See also `azure-ai-agents` package [README.md](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-agents).
+

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_chat_completions_with_azure_ai_inference_client_async.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AI Foundry Project endpoint, this sample demonstrates how to get an authenticated 
     async ChatCompletionsClient from the azure.ai.inference package, and perform one
     chat completions operation. For more information on the azure.ai.inference package see
     https://pypi.org/project/azure-ai-inference/.
@@ -25,8 +25,9 @@ USAGE:
 
 import os
 import asyncio
+from urllib.parse import urlparse
 from azure.identity.aio import DefaultAzureCredential
-from azure.ai.projects.aio import AIProjectClient
+from azure.ai.inference.aio import ChatCompletionsClient
 from azure.ai.inference.models import UserMessage
 
 
@@ -35,16 +36,23 @@ async def main():
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
+    # Project endpoint has the form:   https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>
+    # Inference endpoint has the form: https://<your-ai-services-account-name>.services.ai.azure.com/models
+    # Strip the "/api/projects/<your-project-name>" part and replace with "/models":
+    inference_endpoint = f"https://{urlparse(endpoint).netloc}/models"
+
     async with DefaultAzureCredential() as credential:
 
-        async with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+        async with ChatCompletionsClient(
+            endpoint=inference_endpoint,
+            credential=credential,
+            credential_scopes=["https://ai.azure.com/.default"],
+        ) as client:
 
-            async with project_client.inference.get_chat_completions_client() as client:
-
-                response = await client.complete(
-                    model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
-                )
-                print(response.choices[0].message.content)
+            response = await client.complete(
+                model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+            )
+            print(response.choices[0].message.content)
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/async_samples/sample_text_embeddings_with_azure_ai_inference_client_async.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AI Foundry Project endpoint, this sample demonstrates how to get an authenticated 
     async EmbeddingsClient from the azure.ai.inference package, and perform one text
     embeddings operation. For more information on the azure.ai.inference package see
     https://pypi.org/project/azure-ai-inference/.
@@ -25,8 +25,9 @@ USAGE:
 
 import os
 import asyncio
+from urllib.parse import urlparse
 from azure.identity.aio import DefaultAzureCredential
-from azure.ai.projects.aio import AIProjectClient
+from azure.ai.inference.aio import EmbeddingsClient
 
 
 async def main():
@@ -34,22 +35,29 @@ async def main():
     endpoint = os.environ["PROJECT_ENDPOINT"]
     model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
+    # Project endpoint has the form:   https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>
+    # Inference endpoint has the form: https://<your-ai-services-account-name>.services.ai.azure.com/models
+    # Strip the "/api/projects/<your-project-name>" part and replace with "/models":
+    inference_endpoint = f"https://{urlparse(endpoint).netloc}/models"
+
     async with DefaultAzureCredential() as credential:
 
-        async with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+        async with EmbeddingsClient(
+            endpoint=inference_endpoint,
+            credential=credential,
+            credential_scopes=["https://ai.azure.com/.default"],
+        ) as client:
 
-            async with project_client.inference.get_embeddings_client() as client:
+            response = await client.embed(
+                model=model_deployment_name, input=["first phrase", "second phrase", "third phrase"]
+            )
 
-                response = await client.embed(
-                    model=model_deployment_name, input=["first phrase", "second phrase", "third phrase"]
+            for item in response.data:
+                length = len(item.embedding)
+                print(
+                    f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                    f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
                 )
-
-                for item in response.data:
-                    length = len(item.embedding)
-                    print(
-                        f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
-                        f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
-                    )
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AI Foundry Project endpoint, this sample demonstrates how to get an authenticated 
     ChatCompletionsClient from the azure.ai.inference package and perform one chat completion
     operation. For more information on the azure.ai.inference package see
     https://pypi.org/project/azure-ai-inference/.
@@ -24,23 +24,29 @@ USAGE:
 """
 
 import os
+from urllib.parse import urlparse
 from azure.identity import DefaultAzureCredential
-from azure.ai.projects import AIProjectClient
+from azure.ai.inference import ChatCompletionsClient
 from azure.ai.inference.models import UserMessage
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
+# Project endpoint has the form:   https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>
+# Inference endpoint has the form: https://<your-ai-services-account-name>.services.ai.azure.com/models
+# Strip the "/api/projects/<your-project-name>" part and replace with "/models":
+inference_endpoint = f"https://{urlparse(endpoint).netloc}/models"
+
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
-    with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+    with ChatCompletionsClient(
+        endpoint=inference_endpoint,
+        credential=credential,
+        credential_scopes=["https://ai.azure.com/.default"],
+    ) as client:
 
-        # [START inference_sample]
-        with project_client.inference.get_chat_completions_client() as client:
+        response = client.complete(
+            model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
+        )
 
-            response = client.complete(
-                model=model_deployment_name, messages=[UserMessage(content="How many feet are in a mile?")]
-            )
-
-            print(response.choices[0].message.content)
-        # [END inference_sample]
+        print(response.choices[0].message.content)

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_prompt_string.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_chat_completions_with_azure_ai_inference_client_and_prompt_string.py
@@ -6,7 +6,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to
+    Given an AI Foundry Project endpoint, this sample demonstrates how to
     * Get an authenticated ChatCompletionsClient from the azure.ai.inference package
     * Define a Mustache template, and render the template with provided parameters to create a list of chat messages.
     * Perform one chat completion operation.
@@ -14,7 +14,7 @@ DESCRIPTION:
     Package prompty required. For more information see https://pypi.org/project/prompty/.
 
 USAGE:
-    sample_chat_completions_with_azure_ai_inference_client_and_prompt_string.py
+    python sample_chat_completions_with_azure_ai_inference_client_and_prompt_string.py
 
     Before running the sample:
 
@@ -27,50 +27,63 @@ USAGE:
 """
 
 import os
+from urllib.parse import urlparse
 from azure.identity import DefaultAzureCredential
-from azure.ai.projects import AIProjectClient, PromptTemplate
+from azure.ai.projects import PromptTemplate
+from azure.ai.inference import ChatCompletionsClient
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
 
+# Project endpoint has the form:   https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>
+# Inference endpoint has the form: https://<your-ai-services-account-name>.services.ai.azure.com/models
+# Strip the "/api/projects/<your-project-name>" part and replace with "/models":
+inference_endpoint = f"https://{urlparse(endpoint).netloc}/models"
+
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
-    with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+    prompt_template_str = """
+        system:
+        You are an AI assistant in a hotel. You help guests with their requests and provide information about the hotel and its services.
 
-        with project_client.inference.get_chat_completions_client() as client:
+        # context
+        {{#rules}}
+        {{rule}}
+        {{/rules}}
 
-            prompt_template_str = """
-                system:
-                You are an AI assistant in a hotel. You help guests with their requests and provide information about the hotel and its services.
+        {{#chat_history}}
+        {{role}}:
+        {{content}}
+        {{/chat_history}}
 
-                # context
-                {{#rules}}
-                {{rule}}
-                {{/rules}}
+        user:
+        {{input}}
+    """
 
-                {{#chat_history}}
-                {{role}}:
-                {{content}}
-                {{/chat_history}}
+    prompt_template = PromptTemplate.from_string(api="chat", prompt_template=prompt_template_str)
 
-                user:
-                {{input}}
-            """
-            prompt_template = PromptTemplate.from_string(api="chat", prompt_template=prompt_template_str)
+    input = "When I arrived, can I still have breakfast?"
 
-            input = "When I arrived, can I still have breakfast?"
-            rules = [
-                {"rule": "The check-in time is 3pm"},
-                {"rule": "The check-out time is 11am"},
-                {"rule": "Breakfast is served from 7am to 10am"},
-            ]
-            chat_history = [
-                {"role": "user", "content": "I'll arrive at 2pm. What's the check-in and check-out time?"},
-                {"role": "system", "content": "The check-in time is 3 PM, and the check-out time is 11 AM."},
-            ]
-            messages = prompt_template.create_messages(input=input, rules=rules, chat_history=chat_history)
-            print(messages)
+    rules = [
+        {"rule": "The check-in time is 3pm"},
+        {"rule": "The check-out time is 11am"},
+        {"rule": "Breakfast is served from 7am to 10am"},
+    ]
 
-            response = client.complete(model=model_deployment_name, messages=messages)
+    chat_history = [
+        {"role": "user", "content": "I'll arrive at 2pm. What's the check-in and check-out time?"},
+        {"role": "system", "content": "The check-in time is 3 PM, and the check-out time is 11 AM."},
+    ]
 
-            print(response.choices[0].message.content)
+    messages = prompt_template.create_messages(input=input, rules=rules, chat_history=chat_history)
+    print(messages)
+
+    with ChatCompletionsClient(
+        endpoint=inference_endpoint,
+        credential=credential,
+        credential_scopes=["https://ai.azure.com/.default"],
+    ) as client:
+
+        response = client.complete(model=model_deployment_name, messages=messages)
+
+        print(response.choices[0].message.content)

--- a/sdk/ai/azure-ai-projects/samples/inference/sample_image_embeddings_with_azure_ai_inference_client.py
+++ b/sdk/ai/azure-ai-projects/samples/inference/sample_image_embeddings_with_azure_ai_inference_client.py
@@ -5,7 +5,7 @@
 
 """
 DESCRIPTION:
-    Given an AIProjectClient, this sample demonstrates how to get an authenticated 
+    Given an AI Foundry Project endpoint, this sample demonstrates how to get an authenticated 
     ImageEmbeddingsClient from the azure.ai.inference package, and perform one image
     embeddings operation. For more information on the azure.ai.inference package see
     https://pypi.org/project/azure-ai-inference/.
@@ -25,12 +25,18 @@ USAGE:
 """
 
 import os
+from urllib.parse import urlparse
 from azure.identity import DefaultAzureCredential
-from azure.ai.projects import AIProjectClient
+from azure.ai.inference import ImageEmbeddingsClient
 from azure.ai.inference.models import ImageEmbeddingInput
 
 endpoint = os.environ["PROJECT_ENDPOINT"]
 model_deployment_name = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+# Project endpoint has the form:   https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>
+# Inference endpoint has the form: https://<your-ai-services-account-name>.services.ai.azure.com/models
+# Strip the "/api/projects/<your-project-name>" part and replace with "/models":
+inference_endpoint = f"https://{urlparse(endpoint).netloc}/models"
 
 # Construct the path to the image file used in this sample
 data_folder = os.environ.get("DATA_FOLDER", os.path.dirname(os.path.abspath(__file__)))
@@ -38,18 +44,20 @@ image_file = os.path.join(data_folder, "sample1.png")
 
 with DefaultAzureCredential(exclude_interactive_browser_credential=False) as credential:
 
-    with AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+    with ImageEmbeddingsClient(
+        endpoint=inference_endpoint,
+        credential=credential,
+        credential_scopes=["https://ai.azure.com/.default"],
+    ) as client:
 
-        with project_client.inference.get_image_embeddings_client() as client:
+        response = client.embed(
+            model=model_deployment_name,
+            input=[ImageEmbeddingInput.load(image_file=image_file, image_format="png")],
+        )
 
-            response = client.embed(
-                model=model_deployment_name,
-                input=[ImageEmbeddingInput.load(image_file=image_file, image_format="png")],
+        for item in response.data:
+            length = len(item.embedding)
+            print(
+                f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
+                f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
             )
-
-            for item in response.data:
-                length = len(item.embedding)
-                print(
-                    f"data[{item.index}]: length={length}, [{item.embedding[0]}, {item.embedding[1]}, "
-                    f"..., {item.embedding[length-2]}, {item.embedding[length-1]}]"
-                )

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
@@ -207,7 +207,7 @@ class TestSamples:
             ("samples\\telemetry\\sample_telemetry.py", "", "", ""),
         ],
     )
-    # @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
     def test_samples(
         self, sample_name: str, model_deployment_name: str, connection_name: str, data_folder: str
     ) -> None:
@@ -271,7 +271,7 @@ class TestSamples:
             ("samples\\telemetry\\sample_telemetry_async.py", "", "", ""),
         ],
     )
-    # @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
     async def test_samples_async(
         self, sample_name: str, model_deployment_name: str, connection_name: str, data_folder: str
     ) -> None:

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
@@ -207,7 +207,7 @@ class TestSamples:
             ("samples\\telemetry\\sample_telemetry.py", "", "", ""),
         ],
     )
-    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    # @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
     def test_samples(
         self, sample_name: str, model_deployment_name: str, connection_name: str, data_folder: str
     ) -> None:
@@ -271,7 +271,7 @@ class TestSamples:
             ("samples\\telemetry\\sample_telemetry_async.py", "", "", ""),
         ],
     )
-    @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
+    # @pytest.mark.skip(reason="This test should only run manually on your local machine, with live service calls.")
     async def test_samples_async(
         self, sample_name: str, model_deployment_name: str, connection_name: str, data_folder: str
     ) -> None:


### PR DESCRIPTION
# Changes related to the get inference methods
- Remove the 3 methods `get_chat_completions_client()`, `get_embeddings_client()` and `get_image_embeddings_client()` 
- Update all affected samples to show how to construct the azure-ai-inference client from a modified Project Endpoint URL, instead of calling the now-removed methods.
- Remove the relevant section from package README.md

# Other changes
- Fix all the squiggly line warnings the Microsoft Markdown extension is showing when you view the file AGENTS_MIGRATION_GUIDE.md. One typo fix, many space insert between a section title and the section body.
- Add a small README.md file in the \samples\agents folder, to direct developers to the azure-ai-agents samples
- Minor changes in package README.md text that talks about Agents