### PR TITLE
patch: ModuleNotFoundError: No module named 'azure.ai.agents.tracing'

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_telemetry.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_telemetry.py
@@ -72,7 +72,7 @@ def enable_telemetry(
         )
 
     try:
-        from azure.ai.agents.tracing import AIAgentsInstrumentor  # pylint: disable=import-error,no-name-in-module
+        from azure.ai.agents.telemetry import AIAgentsInstrumentor  # pylint: disable=import-error,no-name-in-module
 
         agents_instrumentor = AIAgentsInstrumentor()
         if not agents_instrumentor.is_instrumented():


### PR DESCRIPTION
# Description
When calling enable_telemetry() currently the old import leads to:
````
WARNING:azure.ai.projects._patch_telemetry:Could not call `AIAgentsInstrumentor().instrument()`
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/azure/ai/projects/_patch_telemetry.py", line 75, in enable_telemetry
    from azure.ai.agents.tracing import AIAgentsInstrumentor  # pylint: disable=import-error,no-name-in-module
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'azure.ai.agents.tracing'
Calling LangchainInstrumentor().instrument()
````

Steps to reproduce:
```
import sys
from azure.ai.projects import enable_telemetry
endpoint = "https://example.com"

enable_telemetry(destination=endpoint)
```

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
