### PR TITLE
Allow for publishing to DevOps feed instead of PyPi

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -95,7 +95,7 @@ stages:
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
-              displayName: "Publish to ${{ parameters.Public Feed }}"
+              displayName: "Publish to ${{ parameters.PublicFeed }}"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
               environment: ${{ parameters.PublicPublishEnvironment }}
               dependsOn: TagRepository

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -6,6 +6,8 @@ parameters:
   DependsOn: Build
   DocArtifact: 'documentation'
   DevFeedName: 'public/azure-sdk-for-python'
+  PublicFeed: PyPi
+  PublicPublishEnvironment: package-publish
   TargetDocRepoOwner: ''
   TargetDocRepoName: ''
   PackageSourceOverride: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
@@ -95,7 +97,7 @@ stages:
             - deployment: PublishPackage
               displayName: "Publish to PyPI"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-              environment: package-publish
+              environment: ${{ parameters.PublicPublishEnvironment }}
               dependsOn: TagRepository
 
               templateContext:
@@ -127,39 +129,54 @@ stages:
                           python -m pip install -r $(Pipeline.Workspace)/release_artifact/release_requirements.txt
                         displayName: Install Release Dependencies
 
+                      - ${{ if eq(parameters.PublicFeed, 'PyPi') }}:
+                        - pwsh: |
+                            $esrpDirectory = "$(Pipeline.Workspace)/esrp-release/${{parameters.ArtifactName}}/${{artifact.name}}"
+                            New-Item -ItemType Directory -Force -Path $esrpDirectory
+  
+                            Get-ChildItem -Path "$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}" `
+                              | Where-Object { ($_.Name -like "*.tar.gz" -or $_.Name -like "*.whl") } `
+                              | Copy-Item -Destination $esrpDirectory
+  
+                            Get-ChildItem $esrpDirectory
+                          displayName: Isolate files for ESRP Publish
+  
+                        - task: EsrpRelease@9
+                          displayName: 'Publish to ESRP'
+                          inputs:
+                            ConnectedServiceName: 'Azure SDK PME Managed Identity'
+                            ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+                            DomainTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+                            UseManagedIdentity: true
+                            KeyVaultName: 'kv-azuresdk-codesign'
+                            SignCertName: 'azure-sdk-esrp-release-certificate'
+                            Intent: 'PackageDistribution'
+                            ContentType: 'PyPI'
+                            FolderLocation: $(Pipeline.Workspace)/esrp-release/${{parameters.ArtifactName}}/${{artifact.name}}
+                            Owners: $(Build.RequestedForEmail)
+                            Approvers: $(Build.RequestedForEmail)
+                            ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                            MainPublisher: 'ESRPRELPACMANTEST'
+                            
+                      - ${{ if ne(parameters.PublicFeed, 'PyPi') }}:
+                        - task: TwineAuthenticate@0
+                          displayName: 'Authenticate to feed: ${{parameters.PublicFeed}}'
+                          inputs:
+                            artifactFeeds: ${{parameters.PublicFeed}}
+                            
+                        - script: |
+                            set -e
+                            twine upload --repository ${{parameters.PublicFeed}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl
+                            echo "Uploaded whl to devops feed"
+                            twine upload --repository ${{parameters.PublicFeed}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tar.gz
+                            echo "Uploaded sdist to devops feed"
+                          displayName: 'Publish package to feed: ${{parameters.PublicFeed}}'
+
                       - task: TwineAuthenticate@0
                         displayName: 'Authenticate to feed: ${{parameters.DevFeedName}}'
                         inputs:
                           artifactFeeds: ${{parameters.DevFeedName}}
-
-                      - pwsh: |
-                          $esrpDirectory = "$(Pipeline.Workspace)/esrp-release/${{parameters.ArtifactName}}/${{artifact.name}}"
-                          New-Item -ItemType Directory -Force -Path $esrpDirectory
-
-                          Get-ChildItem -Path "$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}" `
-                            | Where-Object { ($_.Name -like "*.tar.gz" -or $_.Name -like "*.whl") } `
-                            | Copy-Item -Destination $esrpDirectory
-
-                          Get-ChildItem $esrpDirectory
-                        displayName: Isolate files for ESRP Publish
-
-                      - task: EsrpRelease@9
-                        displayName: 'Publish to ESRP'
-                        inputs:
-                          ConnectedServiceName: 'Azure SDK PME Managed Identity'
-                          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-                          DomainTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'
-                          UseManagedIdentity: true
-                          KeyVaultName: 'kv-azuresdk-codesign'
-                          SignCertName: 'azure-sdk-esrp-release-certificate'
-                          Intent: 'PackageDistribution'
-                          ContentType: 'PyPI'
-                          FolderLocation: $(Pipeline.Workspace)/esrp-release/${{parameters.ArtifactName}}/${{artifact.name}}
-                          Owners: $(Build.RequestedForEmail)
-                          Approvers: $(Build.RequestedForEmail)
-                          ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                          MainPublisher: 'ESRPRELPACMANTEST'
-
+                          
                       - script: |
                           set -e
                           twine upload --repository ${{parameters.DevFeedName}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -95,7 +95,7 @@ stages:
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
-              displayName: "Publish to PyPI"
+              displayName: "Publish to ${{ parameters.Public Feed }}"
               condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
               environment: ${{ parameters.PublicPublishEnvironment }}
               dependsOn: TagRepository

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -41,6 +41,12 @@ parameters:
   - name: DevFeedName
     type: string
     default: public/azure-sdk-for-python
+  - name: PublicFeed
+    type: string
+    default: 'PyPi'
+  - name: PublicPublishEnvironment
+    type: string
+    default: package-publish
   - name: TargetDocRepoOwner
     type: string
     default: MicrosoftDocs
@@ -127,4 +133,5 @@ extends:
           TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
           TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
           DevFeedName: ${{ parameters.DevFeedName }}
-
+          PublicFeed: ${{ parameters.PublicFeed }}
+          PublicPublishEnvironment: ${{ parameters.PublicPublishEnvironment }}

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -1,5 +1,11 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
+parameters:
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -28,6 +34,8 @@ pr:
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, 'true') }}:
+      PublicFeed: 'public/storage-staging'
     ServiceDirectory: storage
     TestProxy: true
     TestTimeoutInMinutes: 120

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -2,7 +2,7 @@
 
 parameters:
   - name: ReleaseToDevOpsOnly
-    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    displayName: 'Release package to DevOps feed instead of PyPi'
     type: boolean
     default: false
 

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,5 +1,15 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
+parameters:
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    type: boolean
+    default: false
+  - name: AutoApproveRelease
+    displayName: 'Automatically approve the release stage'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -43,6 +53,10 @@ parameters:
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, 'true') }}:
+      PublicFeed: 'public/storage-staging'
+    ${{ if eq(parameters.AutoApproveRelease, 'true') }}:
+      PublicPublishEnvironment: none
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     ServiceDirectory: template
     TestProxy: true

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -32,7 +32,7 @@ pr:
 
 parameters:
   - name: ReleaseToDevOpsOnly
-    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    displayName: 'Release package to DevOps feed instead of PyPi'
     type: boolean
     default: false
   - name: AutoApproveRelease

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,15 +1,5 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
-parameters:
-  - name: ReleaseToDevOpsOnly
-    displayName: 'Release package to DevOps feed instead of Nuget.org'
-    type: boolean
-    default: false
-  - name: AutoApproveRelease
-    displayName: 'Automatically approve the release stage'
-    type: boolean
-    default: false
-
 trigger:
   branches:
     include:
@@ -41,6 +31,14 @@ pr:
     - eng/common/
 
 parameters:
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    type: boolean
+    default: false
+  - name: AutoApproveRelease
+    displayName: 'Automatically approve the release stage'
+    type: boolean
+    default: false
   # Switch to canary to test canary 1es branch. 1es template validation will set this parameter
   # to canary on run.
   - name: oneESTemplateTag


### PR DESCRIPTION
Add feature to enable the Storage team to release to a devops feed instead of public nuget.org for releases. This allows them to do a soft GA where consumers can use the latest GA from the Devops feed if they know their regions have the new storage features. The GA will get published to nuget.org once all the regions have the new features.