### PR TITLE
Fix key error when getting version field in PartitionKey #41626

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_circuit_breaker.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_circuit_breaker.py
@@ -64,7 +64,7 @@ class _GlobalPartitionEndpointManagerForCircuitBreaker(_GlobalEndpointManager):
         partition_key_definition = properties["partitionKey"]
         partition_key = PartitionKey(path=partition_key_definition["paths"],
                                      kind=partition_key_definition["kind"],
-                                     version=partition_key_definition["version"])
+                                     version=partition_key_definition.get("version", 2))
 
         if HttpHeaders.PartitionKey in request.headers:
             partition_key_value = request.headers[HttpHeaders.PartitionKey]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -156,7 +156,7 @@ class ContainerProxy:
         partition_key = PartitionKey(
             path=partition_key_definition["paths"],
             kind=partition_key_definition["kind"],
-            version=partition_key_definition["version"])
+            version=partition_key_definition.get("version", 2))
 
         return partition_key._get_epk_range_for_partition_key(partition_key_value)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2958,7 +2958,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             partition_key_definition = cont_prop["partitionKey"]
             partition_key_obj = PartitionKey(path=partition_key_definition["paths"],
                                              kind=partition_key_definition["kind"],
-                                             version=partition_key_definition["version"])
+                                             version=partition_key_definition.get("version", 2))
             is_prefix_partition_query = partition_key_obj._is_prefix_partition_key(partition_key_value)
 
         if is_prefix_partition_query and partition_key_obj:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_circuit_breaker_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_circuit_breaker_async.py
@@ -62,7 +62,7 @@ class _GlobalPartitionEndpointManagerForCircuitBreakerAsync(_GlobalEndpointManag
         partition_key_definition = properties["partitionKey"]
         partition_key = PartitionKey(path=partition_key_definition["paths"],
                                      kind=partition_key_definition["kind"],
-                                     version=partition_key_definition["version"])
+                                     version=partition_key_definition.get("version", 2))
 
         if HttpHeaders.PartitionKey in request.headers:
             partition_key_value = request.headers[HttpHeaders.PartitionKey]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -67,7 +67,7 @@ def get_partition_key_from_properties(container_properties: Dict[str, Any]) -> P
     return PartitionKey(
         path=partition_key_definition["paths"],
         kind=partition_key_definition["kind"],
-        version=partition_key_definition["version"])
+        version=partition_key_definition.get("version", 2))
 
 def is_prefix_partition_key(container_properties: Dict[str, Any], partition_key: PartitionKeyType) -> bool:
     partition_key_obj: PartitionKey = get_partition_key_from_properties(container_properties)


### PR DESCRIPTION
# Description
The "version" key doesn't guaranteed to exist. using a default value of 2 instead. This will fix this issue. https://github.com/Azure/azure-sdk-for-python/issues/41626

**Why this change is safe?**
The implementation of [PartitionKey](https://github.com/Azure/azure-sdk-for-python/blob/32bef6d4f1ea6136e430de8890f2877b2f92ae90/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py#L115) is using a default value of 2 if version is not provided.
```
version = args[2] if len(args) > 2 else kwargs.get('version', 2)
```


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
