### PR TITLE
Fix the issue with `corehttp` not being set to nightly alpha version

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -427,9 +427,8 @@ def get_version_py(setup_path: str) -> Optional[str]:
     Given the path to pyproject.toml or setup.py, attempts to find a (_)version.py file and return its location.
     """
     file_path, _ = os.path.split(setup_path)
-    # Find path to _version.py recursively in azure folder of package
-    azure_root_path = os.path.join(file_path, "azure")
-    for root, _, files in os.walk(azure_root_path):
+    # Find path to _version.py recursively
+    for root, _, files in os.walk(file_path):
         if VERSION_PY in files:
             return os.path.join(root, VERSION_PY)
         elif OLD_VERSION_PY in files:


### PR DESCRIPTION
See title!

The failure is visible [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4981864&view=logs&s=cc1c0c38-0f79-5da2-c09f-847e3abdf9ce&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b).

This has been failing for a while now and I just never did the digging to understand why. If you check the `PackageInfo` for the build I linked above, you will find all the packages have been dev versioned _except_ for `corehttp`. Due to the bug in set dev version, we are building/publishing the `1.0.0b7` version that's in the repo. Because we don't publish that version until _after_ pypi release, the nightly doc publishing is failing to build docs for `corehttp` because it's going after a package version that _doesn't exist on the feed yet_ instead of the `nightly alpha` version that the docs build is intended to work with.

This PR fixes the set_dev_version and ensures everything is in alignment.
