### PR TITLE
Resolve nightly `core` failure

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -52,7 +52,7 @@ class ParsedSetup:
         keywords: List[str],
         ext_package: str,
         ext_modules: List[Extension],
-        metapackage: bool
+        metapackage: bool,
     ):
         self.name: str = name
         self.version: str = version
@@ -109,7 +109,7 @@ class ParsedSetup:
             keywords,
             ext_package,
             ext_modules,
-            metapackage
+            metapackage,
         )
 
     def get_build_config(self) -> Optional[Dict[str, Any]]:
@@ -230,7 +230,9 @@ def read_setup_py_content(setup_filename: str) -> str:
 
 def parse_setup_py(
     setup_filename: str,
-) -> Tuple[str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], List[str], str, List[Extension], bool]:
+) -> Tuple[
+    str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], List[str], str, List[Extension], bool
+]:
     """
     Used to evaluate a setup.py (or a directory containing a setup.py) and return a tuple containing:
     (
@@ -305,8 +307,6 @@ def parse_setup_py(
     else:
         metapackage = True
 
-
-
     requires = kwargs.get("install_requires", [])
     package_data = kwargs.get("package_data", None)
     include_package_data = kwargs.get("include_package_data", None)
@@ -340,7 +340,9 @@ def parse_setup_py(
 
 def parse_pyproject(
     pyproject_filename: str,
-) -> Tuple[str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], List[str], str, List[Extension], bool]:
+) -> Tuple[
+    str, str, str, List[str], bool, str, str, Dict[str, Any], bool, List[str], List[str], str, List[Extension], bool
+]:
     """
     Used to evaluate a pyproject (or a directory containing a pyproject.toml) with a [project] configuration within.
     Returns a tuple containing:
@@ -383,7 +385,9 @@ def parse_pyproject(
                 else:
                     parsed_version = "0.0.0"
         else:
-            raise ValueError(f"Unable to find a version value directly set in \"{pyproject_filename}\", nor is it available in a \"version.py\" or \"_version.py.\"")
+            raise ValueError(
+                f'Unable to find a version value directly set in "{pyproject_filename}", nor is it available in a "version.py" or "_version.py."'
+            )
 
     name = project_config.get("name")
     version = parsed_version
@@ -426,9 +430,32 @@ def get_version_py(setup_path: str) -> Optional[str]:
     """
     Given the path to pyproject.toml or setup.py, attempts to find a (_)version.py file and return its location.
     """
+    # this list of directories will be excluded from the search for _version.py
+    # this is to avoid finding _version.py in the wrong place, such as in tests
+    # or in the venv directory or ANYWHERE ELSE that may mess with the parsing.
+    EXCLUDE = {
+        "venv",
+        "__pycache__",
+        "tests",
+        "test",
+        "generated_samples",
+        "generated_tests",
+        "samples",
+        "swagger",
+        "stress",
+        "docs",
+        "doc",
+        "local",
+        "scripts",
+        "images",
+    }
+
     file_path, _ = os.path.split(setup_path)
+
     # Find path to _version.py recursively
-    for root, _, files in os.walk(file_path):
+    for root, dirs, files in os.walk(file_path):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE and not d.endswith(".egg-info")]
+
         if VERSION_PY in files:
             return os.path.join(root, VERSION_PY)
         elif OLD_VERSION_PY in files:

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -68,12 +68,12 @@ def create_package_and_install(
     if cache_dir:
         commands_options.extend(["--cache-dir", cache_dir])
 
+    target_package = ParsedSetup.from_path(setup_py_path)
+    logging.info(f"At runtime, we got version {target_package.version} from the target package {target_package.name} on disk.")
+
     discovered_packages = discover_packages(
         setup_py_path, distribution_directory, target_setup, package_type, force_create
     )
-
-    target_package = ParsedSetup.from_path(setup_py_path)
-    logging.info(f"At runtime, we got version {target_package.version} from the target package {target_package.name} on disk.")
 
     # ensure that discovered packages are always copied to the distribution directory regardless of other factors
     for built_package in discovered_packages:

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -73,6 +73,7 @@ def create_package_and_install(
     )
 
     target_package = ParsedSetup.from_path(setup_py_path)
+    logging.info(f"At runtime, we got version {target_package.version} from the target package {target_package.name} on disk.")
 
     # ensure that discovered packages are always copied to the distribution directory regardless of other factors
     for built_package in discovered_packages:

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -69,7 +69,6 @@ def create_package_and_install(
         commands_options.extend(["--cache-dir", cache_dir])
 
     target_package = ParsedSetup.from_path(setup_py_path)
-    logging.info(f"At runtime, we got version {target_package.version} from the target package {target_package.name} on disk.")
 
     discovered_packages = discover_packages(
         setup_py_path, distribution_directory, target_setup, package_type, force_create

--- a/tools/azure-sdk-tools/ci_tools/versioning/version_set_dev.py
+++ b/tools/azure-sdk-tools/ci_tools/versioning/version_set_dev.py
@@ -90,10 +90,10 @@ def version_set_dev_main() -> None:
     for target_package in target_packages:
         try:
             new_version = get_dev_version(target_package.version, build_id)
-            print("{0}: {1} -> {2}".format(target_package.name, target_package.version, new_version))
-
+            print(f"Proccessing {target_package.name}.")
             process_requires(target_package.setup_filename, True)
             set_version_py(target_package.setup_filename, new_version)
             set_dev_classifier(target_package.setup_filename, new_version)
+            print("{0}: {1} -> {2}".format(target_package.name, target_package.version, new_version))
         except:
             print("Could not set dev version for package: {0}".format(target_package.name))

--- a/tools/azure-sdk-tools/ci_tools/versioning/version_shared.py
+++ b/tools/azure-sdk-tools/ci_tools/versioning/version_shared.py
@@ -79,6 +79,10 @@ def get_packages(
 def set_version_py(setup_path, new_version):
     version_py_location = get_version_py(setup_path)
 
+    if not version_py_location:
+        logging.error("No version.py file found in {}".format(setup_path))
+        sys.exit(1)
+
     version_contents = ""
     with open(version_py_location, "r") as version_py_file:
         version_contents = version_py_file.read()


### PR DESCRIPTION
Ok, so the failure this PR is fixing is one introduced by my previous PR #41629

Here is an example of the [failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4990331&view=logs&j=7b8caaf3-aec7-5f50-aa20-46d4a6342ac3&t=286a7ccb-1111-5827-fc90-5c974fed4202&l=5113)

You can see that it's something along the lines of

> the version of azure-core that was expected wasn't in the prebuilt wheel dir

And it would crop up in one of two ways:

1. We fail to find the `azure-core` wheel because we didn't update to expect the dev version of the package, so when we look for the GA version in the artifact directory where only nightly alpha exist, we can't find it.
2. We fail to find the `azure-core` wheel because we DO expect to find the dev version of the package, but something went wrong during generation and we didn't **produce** the dev version in the build phase.

This is because we use `os.walk` to traverse the package directory to find the `_version.py` file for `azure-core`. The issue was, we just looked at all folders beneath the package, and it is _nondeterministic_ by default for speed.

The issues were cropping up because the setting of the dev version was **targeting the wrong _version.py**.  [This one to be precise](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/tests/specs_sdk/modeltypes/modeltypes/_version.py).

This PR updates the traversal looking for the package version to exclude a few directories that I know will only be related to build/test, so we can ignore them.