### PR TITLE
update remaining image versions

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -27,8 +27,8 @@ stages:
   - job: Run
     timeoutInMinutes: 120
     pool:
-      name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: ubuntu-22.04
+      name: azsdk-pool
+      demands: ImageOverride -equals ubuntu-24.04
 
     variables:
       CodeownersLinterVersion: '1.0.0-dev.20240926.2'

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -27,8 +27,8 @@ stages:
   - job: Run
     timeoutInMinutes: 120
     pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals ubuntu-24.04
+      name: azsdk-pool-mms-ubuntu-2204-general
+      vmImage: ubuntu-22.04
 
     variables:
       CodeownersLinterVersion: '1.0.0-dev.20240926.2'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -9,8 +9,8 @@ pr:
       - eng/pipelines/aggregate-reports.yml
 
 pool:
-  name: azsdk-pool-mms-win-2022-general
-  vmImage: MMS2022
+  name: azsdk-pool
+  demands: ImageOverride -equals windows-2022
 
 variables:
   - template: ./templates/variables/globals.yml

--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -12,8 +12,8 @@ jobs:
     timeoutInMinutes: 120
 
     pool:
-      name: azsdk-pool-mms-ubuntu-2004-general
-      vmImage: 'ubuntu-20.04'
+      name: azsdk-pool
+      demands: ImageOverride -equals 'ubuntu-24.04'
 
     steps:
       - task: UsePythonVersion@0

--- a/eng/pipelines/templates/jobs/build-conda-dependencies.yml
+++ b/eng/pipelines/templates/jobs/build-conda-dependencies.yml
@@ -8,8 +8,8 @@ jobs:
   displayName: 'Build Windows Dependencies'
   timeoutInMinutes: 90
   pool:
-    name: azsdk-pool-mms-win-2022-general
-    image: azsdk-pool-mms-win-2022-1espt
+    name: azsdk-pool
+    image: windows-2022
     os: windows
   variables:
     VS_INSTALLER_URL: "https://aka.ms/vs/17/release/vs_enterprise.exe"
@@ -84,8 +84,8 @@ jobs:
   displayName: 'Build Linux Dependencies'
   timeoutInMinutes: 90
   pool:
-    name: azsdk-pool-mms-ubuntu-2004-general
-    image: azsdk-pool-mms-ubuntu-2004-1espt
+    name: azsdk-pool
+    image: ubuntu-24.04
     os: linux
 
   steps:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -237,8 +237,8 @@ jobs:
   - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
     parameters:
       JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-      OsVmImage: azsdk-pool-mms-ubuntu-2004-1espt
-      Pool: azsdk-pool-mms-ubuntu-2004-general
+      OsVmImage: ubuntu-24.04
+      Pool: azsdk-pool
       DependsOn:
         - 'Build_Linux'
         - 'Build_Windows'
@@ -286,8 +286,8 @@ jobs:
   - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
     parameters:
       JobTemplatePath: /eng/pipelines/templates/jobs/regression.yml
-      OsVmImage: azsdk-pool-mms-ubuntu-2004-1espt
-      Pool: azsdk-pool-mms-ubuntu-2004-general
+      OsVmImage: ubuntu-24.04
+      Pool: azsdk-pool
       GenerateJobName: generate_regression_matrix
       SparseCheckoutPaths: [ "scripts/", "sdk/", "tools/azure-sdk-tools/" ]
       MatrixConfigs:

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -34,17 +34,17 @@ jobs:
     strategy:
       matrix:
         linux:
-          imageName: 'ubuntu-20.04'
-          poolName: 'azsdk-pool-mms-ubuntu-2004-general'
+          imageName: 'ubuntu-24.04'
+          poolName: 'azsdk-pool'
         # windows:
         #   imageName: 'windows-2022'
-        #   poolName: 'azsdk-pool-mms-win-2022-general'
+        #   poolName: 'azsdk-pool'
         # mac:
         #   imageName: 'macos-latest'
         #   poolName: 'Azure Pipelines'
 
     pool:
-      vmImage: $(imageName)
+      demands: ImageOverride -equals $(imageName)
       name: '$(poolName)'
 
     steps:

--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -21,7 +21,8 @@ jobs:
     timeoutInMinutes: 90
 
     pool:
-      name: 'azsdk-pool-mms-ubuntu-2004-general'
+      name: 'azsdk-pool'
+      demands: ImageOverride -equals 'ubuntu-24.04'
 
     steps:
       - template: ../steps/release-candidate-steps.yml
@@ -35,7 +36,8 @@ jobs:
       timeoutInMinutes: 90
 
       pool:
-        name: 'azsdk-pool-mms-ubuntu-2004-general'
+        name: 'azsdk-pool'
+        demands: ImageOverride -equals 'ubuntu-24.04'
 
       steps:
         - task: UsePythonVersion@0

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -42,8 +42,8 @@ extends:
           isMainPipeline: true
           enableForGitHub: true
       sourceAnalysisPool:
-        name: azsdk-pool-mms-win-2022-general
-        image: azsdk-pool-mms-win-2022-1espt
+        name: azsdk-pool
+        image: windows-2022
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false

--- a/eng/pipelines/templates/stages/archetype-conda-release.yml
+++ b/eng/pipelines/templates/stages/archetype-conda-release.yml
@@ -17,8 +17,8 @@ stages:
         # environment: pypi
 
         pool:
-          name: azsdk-pool-mms-ubuntu-2004-general
-          vmImage: 'ubuntu-20.04'
+          name: 'azsdk-pool'
+          demands: ImageOverride -equals 'ubuntu-24.04'
 
         strategy:
           runOnce:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -27,8 +27,8 @@ stages:
             condition: ne(variables['Skip.TagRepository'], 'true')
 
             pool:
-              image: azsdk-pool-mms-ubuntu-2004-1espt
-              name: azsdk-pool-mms-ubuntu-2004-general
+              image: ubuntu-24.04
+              name: azsdk-pool
               os: linux
 
             steps:
@@ -112,8 +112,8 @@ stages:
                   targetPath: $(Pipeline.Workspace)/packages_extended
 
               pool:
-                image: azsdk-pool-mms-ubuntu-2004-1espt
-                name: azsdk-pool-mms-ubuntu-2004-general
+                image: ubuntu-24.04
+                name: azsdk-pool
                 os: linux
 
               strategy:
@@ -133,14 +133,14 @@ stages:
                         - pwsh: |
                             $esrpDirectory = "$(Pipeline.Workspace)/esrp-release/${{parameters.ArtifactName}}/${{artifact.name}}"
                             New-Item -ItemType Directory -Force -Path $esrpDirectory
-  
+
                             Get-ChildItem -Path "$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}" `
                               | Where-Object { ($_.Name -like "*.tar.gz" -or $_.Name -like "*.whl") } `
                               | Copy-Item -Destination $esrpDirectory
-  
+
                             Get-ChildItem $esrpDirectory
                           displayName: Isolate files for ESRP Publish
-  
+
                         - task: EsrpRelease@9
                           displayName: 'Publish to ESRP'
                           inputs:
@@ -157,13 +157,13 @@ stages:
                             Approvers: $(Build.RequestedForEmail)
                             ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
                             MainPublisher: 'ESRPRELPACMANTEST'
-                            
+
                       - ${{ if ne(parameters.PublicFeed, 'PyPi') }}:
                         - task: TwineAuthenticate@0
                           displayName: 'Authenticate to feed: ${{parameters.PublicFeed}}'
                           inputs:
                             artifactFeeds: ${{parameters.PublicFeed}}
-                            
+
                         - script: |
                             set -e
                             twine upload --repository ${{parameters.PublicFeed}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl
@@ -176,7 +176,7 @@ stages:
                         displayName: 'Authenticate to feed: ${{parameters.DevFeedName}}'
                         inputs:
                           artifactFeeds: ${{parameters.DevFeedName}}
-                          
+
                       - script: |
                           set -e
                           twine upload --repository ${{parameters.DevFeedName}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl
@@ -190,8 +190,8 @@ stages:
             dependsOn: PublishPackage
 
             pool:
-              image: azsdk-pool-mms-ubuntu-2004-1espt
-              name: azsdk-pool-mms-ubuntu-2004-general
+              image: ubuntu-24.04
+              name: azsdk-pool
               os: linux
 
             steps:
@@ -221,8 +221,8 @@ stages:
               dependsOn: PublishPackage
 
               pool:
-                name: azsdk-pool-mms-win-2022-general
-                image: azsdk-pool-mms-win-2022-1espt
+                name: azsdk-pool
+                image: windows-2022
                 os: windows
 
               steps:
@@ -259,8 +259,8 @@ stages:
               dependsOn: PublishPackage
 
               pool:
-                image: azsdk-pool-mms-ubuntu-2004-1espt
-                name: azsdk-pool-mms-ubuntu-2004-general
+                image: ubuntu-24.04
+                name: azsdk-pool
                 os: linux
 
               steps:
@@ -299,8 +299,8 @@ stages:
             dependsOn: PublishPackage
 
             pool:
-              image: azsdk-pool-mms-ubuntu-2004-1espt
-              name: azsdk-pool-mms-ubuntu-2004-general
+              image: azsdk-pool
+              name: ubuntu-24.04
               os: linux
 
             steps:
@@ -342,8 +342,8 @@ stages:
         displayName: "Publish package to daily feed"
         condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
         pool:
-          image: azsdk-pool-mms-ubuntu-2004-1espt
-          name: azsdk-pool-mms-ubuntu-2004-general
+          image: ubuntu-240.04
+          name: azsdk-pool
           os: linux
         steps:
         - download: current
@@ -380,8 +380,8 @@ stages:
         dependsOn: PublishPackages
         condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))
         pool:
-          image: azsdk-pool-mms-ubuntu-2004-1espt
-          name: azsdk-pool-mms-ubuntu-2004-general
+          image: ubuntu-24.04
+          name: azsdk-pool
           os: linux
         steps:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -342,7 +342,7 @@ stages:
         displayName: "Publish package to daily feed"
         condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
         pool:
-          image: ubuntu-240.04
+          image: ubuntu-24.04
           name: azsdk-pool
           os: linux
         steps:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -299,8 +299,8 @@ stages:
             dependsOn: PublishPackage
 
             pool:
-              image: azsdk-pool
-              name: ubuntu-24.04
+              image: ubuntu-24.04
+              name: azsdk-pool
               os: linux
 
             steps:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -115,8 +115,8 @@ extends:
                     SparseCheckoutPaths:
                       - sdk/${{ parameters.ServiceDirectory }}/**/*.json
                     JobTemplatePath: /eng/pipelines/templates/jobs/live.tests.yml
-                    OsVmImage: azsdk-pool-mms-ubuntu-2004-1espt
-                    Pool: azsdk-pool-mms-ubuntu-2004-general
+                    OsVmImage: ubuntu-24.04
+                    Pool: azsdk-pool
                     AdditionalParameters:
                       ServiceDirectory: ${{ parameters.ServiceDirectory }}
                       TestResourceDirectories: ${{ parameters.TestResourceDirectories }}

--- a/eng/pipelines/templates/stages/conda-sdk-client.yml
+++ b/eng/pipelines/templates/stages/conda-sdk-client.yml
@@ -182,8 +182,8 @@ extends:
             timeoutInMinutes: 240
 
             pool:
-              name: azsdk-pool-mms-ubuntu-2004-general
-              image: azsdk-pool-mms-ubuntu-2004-1espt
+              name: azsdk-pool
+              image: ubuntu-24.04
               os: linux
 
             steps:

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -62,8 +62,8 @@ extends:
               artifactName: artifacts-for-release
               targetPath: $(Artifacts)
           pool:
-            image: azsdk-pool-mms-ubuntu-2004-1espt
-            name: azsdk-pool-mms-ubuntu-2004-general
+            image: ubuntu-24.04
+            name: azsdk-pool
             os: linux
           strategy:
             runOnce:

--- a/eng/pipelines/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/trigger-ml-sample-pipeline.yml
@@ -22,8 +22,8 @@ jobs:
       - template: /eng/pipelines/templates/variables/globals.yml
 
     pool:
-      name: azsdk-pool-mms-ubuntu-2004-general
-      vmImage: MMSUbuntu20.04
+      name: azsdk-pool
+      demands: ImageOverride -equals 'ubuntu-24.04'
 
     steps:
     - template: /eng/pipelines/templates/steps/resolve-package-targeting.yml

--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -6,7 +6,7 @@
   },
   "matrix": {
     "Agent": {
-      "ubuntu-22.04": {
+      "ubuntu-24.04": {
         "OSVmImage": "env:LINUXVMIMAGE",
         "Pool": "env:LINUXPOOL",
         "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "true"
@@ -31,20 +31,20 @@
   "include": [
     {
       "CoverageConfig": {
-        "ubuntu2004_39_coverage": {
+        "ubuntu2404_39_coverage": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
           "PythonVersion": "3.9",
           "CoverageArg": "",
           "TestSamples": "false",
-          "AZURE_TEST_AGENT": "UBUNTU_2004_PYTHON39",
+          "AZURE_TEST_AGENT": "UBUNTU_2404_PYTHON39",
           "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
         }
       }
     },
     {
       "Config": {
-        "Ubuntu2004_3120": {
+        "Ubuntu2404_3120": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
           "PythonVersion": "3.12",


### PR DESCRIPTION
This PR updates any remaining `ubuntu 20.04` images to `24.04`. For a lot of this these are just labelling updates. Other than that, this PR also ensures that we are running solely on the new pool, versus any of our old platform-specific ones.

Of the changes that are made, we just need to validate a few of them to be certain of the rest. Along that vein:

- [x] [A template release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4995494&view=results)
- [x] [A livetest run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4995375&view=results)
- [x] PR build triggered from this PR.
- [x] [Aggregate reports](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4995493&view=results)