### PR TITLE
[Identity] Update AzurePowerShellCredential script

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue with `AzurePowerShellCredential` not working correctly for users still using older versions of PowerShell (e.g., Windows PowerShell 5.1) where `-AsPlainText` is not supported in the `ConvertFrom-SecureString` cmdlet.  ([#41675](https://github.com/Azure/azure-sdk-for-python/pull/41675))
+
 ### Other Changes
 
 ## 1.23.0 (2025-05-13)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -41,15 +41,25 @@ if ($tenantId.Length -gt 0) {{
     $params['TenantId'] = $tenantId
 }}
 
-$useSecureString = $m.Version -ge [version]'2.17.0'
-if ($useSecureString) {{
+if ($m.Version -ge [version]'2.17.0' -and $m.Version -lt [version]'5.0.0') {{
     $params['AsSecureString'] = $true
 }}
 
 $token = Get-AzAccessToken @params
 $tokenValue = $token.Token
-if ($useSecureString) {{
-    $tokenValue = $tokenValue | ConvertFrom-SecureString -AsPlainText
+if ($tokenValue -is [System.Security.SecureString]) {{
+    if ($PSVersionTable.PSVersion.Major -lt 7) {{
+        try {{
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenValue)
+            $tokenValue = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        }}
+        finally {{
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }}
+    }}
+    else {{
+        $tokenValue = $tokenValue | ConvertFrom-SecureString -AsPlainText
+    }}
 }}
 Write-Output "`nazsdk%$($tokenValue)%$($token.ExpiresOn.ToUnixTimeSeconds())`n"
 """

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -49,8 +49,8 @@ $token = Get-AzAccessToken @params
 $tokenValue = $token.Token
 if ($tokenValue -is [System.Security.SecureString]) {{
     if ($PSVersionTable.PSVersion.Major -lt 7) {{
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenValue)
         try {{
-            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenValue)
             $tokenValue = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
         }}
         finally {{

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -5,7 +5,6 @@
 import base64
 from itertools import product
 import logging
-from platform import python_version
 import re
 import subprocess
 import sys
@@ -121,11 +120,10 @@ def test_get_token(stderr, get_token_method):
     decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
     assert "tenantId = ''" in decoded_script
     assert f"'ResourceUrl' = '{scope}'" in decoded_script
+    assert "-is [System.Security.SecureString]" in decoded_script
 
     assert Popen().communicate.call_count == 1
     args, kwargs = Popen().communicate.call_args
-    if python_version() >= "3.3":
-        assert "timeout" in kwargs
 
 
 @pytest.mark.parametrize("stderr,get_token_method", product(("", PREPARING_MODULES), GET_TOKEN_METHODS))

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -115,6 +115,7 @@ async def test_get_token(stderr, get_token_method):
     decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
     assert "tenantId = ''" in decoded_script
     assert f"'ResourceUrl' = '{scope}'" in decoded_script
+    assert "-is [System.Security.SecureString]" in decoded_script
 
     assert mock_exec().result().communicate.call_count == 1
 


### PR DESCRIPTION
- Only add the `-AsSecureString` argument when available and needed. This argument is no longer needed for `Az.Accounts` versions 5.0.0 and above.
- Update secure string parsing logic to allow it to work if a user is using Windows PowerShell instead of PowerShell 7+. Alternative parsing logic pulled from https://learn.microsoft.com/en-us/powershell/azure/migrate-az-14.0.0?view=azps-14.1.0#azaccounts. 

Closes: https://github.com/Azure/azure-sdk-for-python/issues/41508

