### PR TITLE
[sdk generation pipeline] find client name in __all__ from __init__.py

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -174,15 +174,15 @@ class CheckFile:
         if self._next_version is None:
             self._next_version = self.calculate_next_version()
         return self._next_version
-    
+
     @property
     def extract_client_title_from_init(self) -> str:
         """
         Extract the client title from a package's __init__.py file.
-        
+
         Args:
             package_name (str): The package name (e.g., "azure-mgmt-compute")
-            
+
         Returns:
             str: The client title if found, empty string otherwise
         """
@@ -203,7 +203,7 @@ class CheckFile:
                                     return elt.value
         except Exception as e:
             _LOGGER.info(f"Failed to extract title from {init_file}: {e}")
-        
+
         return ""
 
     # Use the template to update readme and setup by packaging_tools

--- a/tools/azure-sdk-tools/packaging_tools/sdk_package.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_package.py
@@ -51,9 +51,9 @@ def main(generate_input, generate_output):
         try:
             md_output = execute_func_with_timeout(change_log_func)
         except multiprocessing.TimeoutError:
-            md_output = "change log generation was timeout!!!"
+            md_output = "change log generation was timeout!!! You need to write it manually!!!"
         except:
-            md_output = "change log generation failed!!!"
+            md_output = "change log generation failed!!! You need to write it manually!!!"
         finally:
             for file in ["stable.json", "current.json"]:
                 file_path = Path(sdk_folder, prefolder, package_name, file)


### PR DESCRIPTION
For https://github.com/Azure/azure-sdk-for-python/issues/41529
To make the script work in mcp tool, we can't assume the package is installed. So the better way is to find client name from source .py file.