### PR TITLE
Remove all usage of deprecating `pkg_resources`

### DIFF
--- a/eng/tox/prep_sphinx_env.py
+++ b/eng/tox/prep_sphinx_env.py
@@ -12,11 +12,7 @@ import glob
 import logging
 import shutil
 import argparse
-from pkg_resources import Requirement
-import ast
 import os
-import textwrap
-import io
 from tox_helper_tasks import (
     unzip_sdist_to_directory,
     move_and_rename
@@ -55,6 +51,7 @@ def should_build_docs(package_name):
 def create_index_file(readme_location, package_rst):
     readme_ext = os.path.splitext(readme_location)[1]
 
+    output = ""
     if readme_ext == ".md":
         with open(readme_location, "r") as file:
             output = file.read()

--- a/eng/tox/run_sphinx_build.py
+++ b/eng/tox/run_sphinx_build.py
@@ -12,14 +12,9 @@ from subprocess import check_call, CalledProcessError
 import argparse
 import os
 import logging
-import sys
 from prep_sphinx_env import should_build_docs
 from run_sphinx_apidoc import is_mgmt_package
-from pkg_resources import Requirement
-import ast
 import os
-import textwrap
-import io
 import shutil
 
 from ci_tools.parsing import ParsedSetup

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -7,7 +7,7 @@ import stat
 from ast import Not
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version, parse, InvalidVersion
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 import io
 
 from ci_tools.variables import discover_repo_root, DEV_BUILD_IDENTIFIER, str_to_bool
@@ -369,7 +369,7 @@ def process_requires(setup_py_path: str, is_dev_build: bool = False):
     """
 
     pkg_details = ParsedSetup.from_path(setup_py_path)
-    azure_requirements = [Requirement.parse(r) for r in pkg_details.requires if r.startswith("azure")]
+    azure_requirements = [Requirement(r) for r in pkg_details.requires if r.startswith("azure")]
 
     # Find package requirements that are not available on PyPI
     requirement_to_update = {}
@@ -673,7 +673,7 @@ def is_package_compatible(
 
     for immutable_requirement in immutable_requirements:
         for package_requirement in package_requirements:
-            if package_requirement.key == immutable_requirement.key:
+            if package_requirement.name == immutable_requirement.name:
                 # if the dev_req line has a requirement that conflicts with the immutable requirement,
                 # we need to resolve it. We KNOW that the immutable requirement will be of form package==version,
                 # so we can reliably pull out the version and check it against the specifier of the dev_req line.
@@ -743,7 +743,7 @@ def resolve_compatible_package(package_name: str, immutable_requirements: List[R
     """
 
     pypi = PyPIClient()
-    immovable_pkgs = {req.key: req for req in immutable_requirements}
+    immovable_pkgs = {req.name: req for req in immutable_requirements}
 
     # Let's use a real use-case to walk through this function. We're going to use the azure-ai-language-conversations
     # package as an example.
@@ -935,7 +935,7 @@ def get_pip_command(python_exe: Optional[str] = None) -> List[str]:
     :param str python_exe: The Python executable to use (if not using the default).
     :return: List of command arguments for pip.
     :rtype: List[str]
-    
+
     """
     # Check TOX_PIP_IMPL environment variable (aligns with tox.ini configuration)
     pip_impl = os.environ.get('TOX_PIP_IMPL', 'pip').lower()

--- a/tools/azure-sdk-tools/tests/test_conflict_resolution.py
+++ b/tools/azure-sdk-tools/tests/test_conflict_resolution.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 from ci_tools.functions import resolve_compatible_package, is_package_compatible
 from typing import Optional, List
 from packaging.version import Version
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We have a base dependency on `packaging` and we are leaning on that for the modules that are deprecating in `setuptools`. Resolves #41698 