### PR TITLE
Suprress console stdout output from adding file permissions in local storage

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Suppress stdout side effect of add permissions to file for local storage on Windows
-  ([#41410](https://github.com/Azure/azure-sdk-for-python/pull/41410))
+  ([#41727](https://github.com/Azure/azure-sdk-for-python/pull/41727))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Suppress stdout side effect of add permissions to file for local storage on Windows
+  ([#41410](https://github.com/Azure/azure-sdk-for-python/pull/41410))
+
 ### Other Changes
 
 ## 1.0.0b38 (2025-06-17)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -226,6 +226,8 @@ class LocalFileStorage:
                         "/inheritance:r",
                     ],
                     check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                 )
                 if result.returncode == 0:
                     return True


### PR DESCRIPTION
Following this pr: https://github.com/Azure/azure-sdk-for-python/pull/41384,
introduced running a subprocess to add folder permissions to enable local storage.

Running the subprocess produces output to stdout like:

![image](https://github.com/user-attachments/assets/39237265-e173-42d8-b0a0-7cf8cb13e17b)

This pr suppresses those outputs.