### PR TITLE
Require base dependencies in pylint for pyproject

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -105,6 +105,7 @@ setenv =
   {[testenv:pylint]setuptools_enable}
   PROXY_URL=http://localhost:5002
 deps =
+  {[base]deps}
   -rdev_requirements.txt
 commands =
     {[tox]pip_command} install pylint=={[testenv:pylint]pylint_version}
@@ -129,6 +130,7 @@ setenv =
   {[testenv:pylint]setuptools_enable}
   PROXY_URL=http://localhost:5002
 deps =
+  {[base]deps}
   -rdev_requirements.txt
   PyGitHub>=1.59.0
 commands =


### PR DESCRIPTION
# Description

Now that `azure-keyvault-keys` is migrated to `pyproject.toml`, I found that `next-pylint` and `pylint` environments were failing because of a missing `build` dependency. Other environments that already require `[base]deps`, like `next-mypy`, run fine -- this PR adds the requirement to the two pylint environments to support pyproject.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
