### PR TITLE
Fix ml-samples-repo

### DIFF
--- a/eng/pipelines/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/trigger-ml-sample-pipeline.yml
@@ -23,7 +23,6 @@ jobs:
 
     pool:
       name: azsdk-pool
-      demands: ImageOverride -equals 'ubuntu-24.04'
 
     steps:
     - template: /eng/pipelines/templates/steps/resolve-package-targeting.yml


### PR DESCRIPTION
For some reason targeting `ubuntu-24.04` errors out. It shouldn't, but the default agent in `azsdk-pool` is `ubuntu-24.04` so I don't really care.