### PR TITLE
[Cosmos] Fix Service Request Retry Policy

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Bugs Fixed
 * Fixed bug where replacing manual throughput using `ThroughputProperties` would not work. See [PR 41564](https://github.com/Azure/azure-sdk-for-python/pull/41564)
+* Fixed bug where constantly raising Service Request Error Exceptions would cause the Service Request Retry Policy to indefinitely retry the request during a query or when a request was sent without a request object. See [PR #####]()
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_service_request_retry_policy.py
@@ -87,6 +87,11 @@ class ServiceRequestRetryPolicy(object):
                     location_endpoint = self.resolve_next_region_service_endpoint()
 
             self.request.route_to_location(location_endpoint)
+            return True
+        # Check if the next retry about to be done is safe
+        if (self.failover_retry_count + 1) >= self.total_retries:
+            return False
+        self.failover_retry_count += 1
         return True
 
     # This function prepares the request to go to the second endpoint in the same region


### PR DESCRIPTION
# Description
When a Service Request Error was constantly raised in a request, it would result in the Service Request Retry Policy to always retry indefinitely when there was not request object sent in a request. This would affect when fetching the items from a Query. This would affect the tests that specifically test this retry policy. This PR adds a similar max retry count to that of the Service Response Retry Policy. If there is no Request object, then we retry equal to the number of regions in the Read regions. This scenario is unlikely to happen outside of testing, but this fix guarantees the sdk won't retry indefinitely. 