### PR TITLE
Fix Health Insights links

### DIFF
--- a/sdk/healthinsights/azure-healthinsights-cancerprofiling/README.md
+++ b/sdk/healthinsights/azure-healthinsights-cancerprofiling/README.md
@@ -295,7 +295,7 @@ additional questions or comments.
 [azure_portal]: https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesHealthInsights
 [azure_cli]: https://learn.microsoft.com/cli/azure/
 [cancer_profiling_docs]: https://learn.microsoft.com/azure/azure-health-insights/oncophenotype/overview
-[cancer_profiling_api_documentation]: https://learn.microsoft.com/rest/api/cognitiveservices/healthinsights/onco-phenotype
+[cancer_profiling_api_documentation]: https://learn.microsoft.com/rest/api/healthinsights/onco-phenotype
 [hi_pypi]: https://pypi.org/project/azure-healthinsights-cancerprofiling/
 [product_docs]: https://learn.microsoft.com/azure/azure-health-insights/oncophenotype/
 [hi_samples]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/healthinsights/azure-healthinsights-cancerprofiling/samples

--- a/sdk/healthinsights/azure-healthinsights-clinicalmatching/README.md
+++ b/sdk/healthinsights/azure-healthinsights-clinicalmatching/README.md
@@ -227,6 +227,6 @@ additional questions or comments.
 [clinical_matching_docs]: https://learn.microsoft.com/azure/azure-health-insights/trial-matcher/overview
 [hi_pypi]: https://pypi.org/project/azure-healthinsights-clinicalmatching/
 [product_docs]: https://learn.microsoft.com/azure/azure-health-insights/trial-matcher/
-[clinical_matching_api_documentation]: https://learn.microsoft.com/rest/api/cognitiveservices/healthinsights/trial-matcher
+[clinical_matching_api_documentation]: https://learn.microsoft.com/rest/api/healthinsights/trial-matcher
 [hi_samples]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/healthinsights/azure-healthinsights-clinicalmatching/samples
 [hi_source_code]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/healthinsights/azure-healthinsights-clinicalmatching/azure/healthinsights/clinicalmatching


### PR DESCRIPTION
# Description

Resolves [nightly link check failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5032539&view=results). Links to REST API docs for Health Insights have dropped the `/cognitiveservices` portion of the URL.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
