### PR TITLE
[sdk generation pipeline] update logic about outdated code removal

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -236,7 +236,8 @@ def main(generate_input, generate_output):
         try:
             code_generation_start_time = time.time()
             if input_type == "relatedTypeSpecProjectFolder":
-                del_outdated_generated_files(str(Path(spec_folder, readme_or_tsp)))
+                if run_in_pipeline:
+                    del_outdated_generated_files(str(Path(spec_folder, readme_or_tsp)))
                 config = gen_typespec(
                     readme_or_tsp,
                     spec_folder,


### PR DESCRIPTION
If users run the script locally, they may not want to delete the existing files in advance, especial for data-plane sdk which contains much customized code.