### PR TITLE
[Key Vault] Correctly return CertificateOperation when creating certificate with unknown issuer

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- When creating a certificate with an unknown issuer, `CertificateClient.(begin_)create_certificate` now returns a
+  `CertificateOperation` instead of `None`
+
 ### Other Changes
 
 ## 4.10.0 (2025-06-16)

--- a/sdk/keyvault/azure-keyvault-certificates/assets.json
+++ b/sdk/keyvault/azure-keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-certificates",
-  "Tag": "python/keyvault/azure-keyvault-certificates_d160d7cd76"
+  "Tag": "python/keyvault/azure-keyvault-certificates_d281d3c6c6"
 }

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -44,6 +44,8 @@ class CreateCertificatePoller(PollingMethod):
     def finished(self) -> bool:
         operation = self._pending_certificate_op
         if operation and operation.issuer_name and operation.issuer_name.lower() == "unknown":
+            # Because we've finished, self._resource won't be set by the run method; set it here so we don't return None
+            self._resource = self._pending_certificate_op
             return True
         return self._pending_certificate_op.status.lower() != "inprogress"  # type: ignore
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_polling_async.py
@@ -45,6 +45,8 @@ class CreateCertificatePollerAsync(AsyncPollingMethod):
     def finished(self) -> bool:
         operation = self._pending_certificate_op
         if operation and operation.issuer_name and operation.issuer_name.lower() == "unknown":
+            # Because we've finished, self._resource won't be set by the run method; set it here so we don't return None
+            self._resource = self._pending_certificate_op
             return True
         return self._pending_certificate_op.status.lower() != "inprogress"  # type: ignore
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -16,6 +16,7 @@ from azure.keyvault.certificates import (
     ApiVersion,
     CertificateClient,
     CertificateContact,
+    CertificateOperation,
     CertificatePolicyAction,
     CertificatePolicy,
     CertificateProperties,
@@ -757,6 +758,34 @@ class TestCertificateClient(KeyVaultTestCase):
         with patch.object(client._client._client._pipeline, "run", run):
             with pytest.raises(ResourceExistsError):
                 client.begin_create_certificate("...", CertificatePolicy.get_default())
+
+    @pytest.mark.parametrize("api_version", only_latest)
+    @CertificatesClientPreparer()
+    @recorded_by_proxy
+    def test_unknown_issuer_response(self, client, **kwargs):
+        """When a certificate is created with an unknown issuer, the poller result should be a CertificateOperation"""
+        cert_name = self.get_resource_name("unknownIssuer")
+
+        # create certificate with unknown issuer
+        cert_policy = CertificatePolicy(
+            issuer_name=WellKnownIssuerNames.unknown,
+            subject="CN=*.microsoft.com",
+            san_dns_names=["sdk.azure-int.net"],
+            exportable=True,
+            key_type="RSA",
+            key_size=2048,
+            reuse_key=False,
+            content_type=CertificateContentType.pkcs12,
+            validity_in_months=24,
+        )
+        create_certificate_poller = client.begin_create_certificate(
+            certificate_name=cert_name, policy=cert_policy
+        )
+        result = create_certificate_poller.result()
+        # The operation should indicate that certificate creation is in progress and requires a merge to complete
+        assert isinstance(result, CertificateOperation)
+        assert result.status and result.status.lower() == "inprogress"
+        assert result.status_details and "merge" in result.status_details.lower()
 
 
 def test_policy_expected_errors_for_create_cert():


### PR DESCRIPTION
# Description

Our certificate creation methods, `CertificateClient.begin_create_certificate` (sync) and `CertificateClient.create_certificate` (async), are meant to return either a `KeyVaultCertificate` when creation is successful or a `CertificateOperation` when creation is interrupted or pending.

When the certificate's issuer is unknown, certificate creation can't complete until `merge_certificate` is used. Since we know this, our creation poller immediately finishes when the issuer is unknown -- however, the final result wasn't being set, so the return value has been `None` in this scenario. This PR fixes this bug, setting the poller result to the certificate operation before finishing so that the correct return type is yielded.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
