### PR TITLE
[Key Vault] Handle missing inner certificate operation error

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - When creating a certificate with an unknown issuer, `CertificateClient.(begin_)create_certificate` now returns a
   `CertificateOperation` instead of `None`
+- When a certificate operation's error doesn't have an inner error, `CertificateOperationError` will be correctly
+  serialized instead of raising an exception
+  ([Azure/azure-cli #31764](https://github.com/Azure/azure-cli/issues/31764))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -86,10 +86,10 @@ class CertificateOperationError(object):
     :param str code: The error code.
     :param str message: The error message.
     :param inner_error: The error object itself
-    :type inner_error: ~azure.keyvault.certificates.CertificateOperationError
+    :type inner_error: ~azure.keyvault.certificates.CertificateOperationError or None
     """
 
-    def __init__(self, code: str, message: str, inner_error: "CertificateOperationError") -> None:
+    def __init__(self, code: str, message: str, inner_error: "Optional[CertificateOperationError]") -> None:
         self._code = code
         self._message = message
         self._inner_error = inner_error
@@ -102,7 +102,7 @@ class CertificateOperationError(object):
         return cls(
             code=error_bundle.code,  # type: ignore
             message=error_bundle.message,  # type: ignore
-            inner_error=cls._from_error_bundle(error_bundle.inner_error),  # type: ignore
+            inner_error=cls._from_error_bundle(error_bundle.inner_error) if error_bundle.inner_error else None,
         )
 
     @property
@@ -124,11 +124,11 @@ class CertificateOperationError(object):
         return self._message
 
     @property
-    def inner_error(self) -> "CertificateOperationError":
+    def inner_error(self) -> "Optional[CertificateOperationError]":
         """The error itself.
 
         :returns: The error itself.
-        :rtype: ~azure.keyvault.certificates.CertificateOperationError
+        :rtype: ~azure.keyvault.certificates.CertificateOperationError or None
         """
         return self._inner_error
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -31,6 +31,10 @@ from azure.keyvault.certificates import (
     WellKnownIssuerNames,
 )
 from azure.keyvault.certificates._client import NO_SAN_OR_SUBJECT
+from azure.keyvault.certificates._generated.models import (
+    CertificateOperation as _CertificateOperation,
+    KeyVaultErrorError,
+)
 from azure.keyvault.certificates._shared.client_base import DEFAULT_VERSION
 import pytest
 
@@ -834,3 +838,14 @@ def test_thumbprint_hex():
         x509_thumbprint=b"v\xe1\x81\x9f\xad\xf0jU\xefK\x12j.\xf7C\xc2\xba\xe8\xa1Q",
     )
     assert "76E1819FADF06A55EF4B126A2EF743C2BAE8A151" in str(properties)
+
+
+def test_certificate_operation_empty_inner_error():
+    """Ensure a CertificateOperation can be serialized when the generated model has no inner error.
+    See https://github.com/Azure/azure-cli/issues/31764.
+    """
+    error = KeyVaultErrorError(code="500", message="Bad Request", inner_error=None)
+    generated_operation = _CertificateOperation(error=error)
+    operation = CertificateOperation._from_certificate_operation_bundle(generated_operation)
+    assert operation._error
+    assert operation._error._inner_error is None

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -847,5 +847,5 @@ def test_certificate_operation_empty_inner_error():
     error = KeyVaultErrorError(code="500", message="Bad Request", inner_error=None)
     generated_operation = _CertificateOperation(error=error)
     operation = CertificateOperation._from_certificate_operation_bundle(generated_operation)
-    assert operation._error
-    assert operation._error._inner_error is None
+    assert operation.error
+    assert operation.error.inner_error is None


### PR DESCRIPTION
# Description

As https://github.com/Azure/azure-cli/issues/31764 shows, it's possible for a Key Vault error to contain an error message but no `inner_error`. We don't currently handle this case when serializing a `CertificateOperationError`, which can lead to an exception being raised when trying to access properties on the inner error. This PR adjusts the code to account for this scenario and adds a regression test, which I confirmed would fail with the existing implementation but passes with the new one.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
