### PR TITLE
Fix failing `mindependency` for `azure-core`

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -22,6 +22,7 @@ from ci_tools.parsing import ParsedSetup, parse_require
 from ci_tools.functions import compare_python_version, handle_incompatible_minimum_dev_reqs, get_pip_command
 
 from typing import List
+from subprocess import run, PIPE, CalledProcessError
 
 DEV_REQ_FILE = "dev_requirements.txt"
 NEW_DEV_REQ_FILE = "new_dev_requirements.txt"
@@ -376,7 +377,14 @@ def install_packages(packages, req_file):
         commands.extend(["-r", req_file])
 
     logging.info("Installing packages. Command: %s", commands)
-    check_call(commands)
+    try:
+        completed = run(commands, stdout=PIPE, stderr=PIPE, text=True, check=True)
+        logging.info("Command stdout:\n%s", completed.stdout)
+        if completed.stderr:
+            logging.warning("Command stderr:\n%s", completed.stderr)
+    except CalledProcessError as e:
+        logging.error("Command %r failed (exit code %d):\n%s", commands, e.returncode, e.stderr)
+        raise
 
 
 if __name__ == "__main__":

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -40,7 +40,7 @@ def create_package_and_install(
     force_create: bool,
     package_type: str,
     pre_download_disabled: bool,
-    python_executable: str = None,
+    python_executable: Optional[str] = None,
 ) -> None:
     """
     Workhorse for singular package installation given a package and a possible prebuilt wheel directory. Handles installation of both package AND dependencies, handling compatibility


### PR DESCRIPTION
FYI @xiangyan99

I'm seeing `azure-core` fail mindependency in the pullrequest pipeline due to the wrong version of `typing-extensions` being installed. I'm running down exactly why that is with this PR.
