### PR TITLE
Test `core` mindependency indirect build

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -252,4 +252,3 @@ def get_installed_packages(paths=None):
     # if paths is set then find installed packages from given paths
     ws = WorkingSet(paths) if paths else working_set
     return ["{0}=={1}".format(p.project_name, p.version) for p in ws]
-


### PR DESCRIPTION
Trying to understand what is actually going wrong in #41973 

Locally the code from above PR works, but it's crashing with the wrong version of typing-extensions being detected.

I'm trying to understand if it's actually the new code or just unreached code in my previous detection pr.

EDIT: It _must_ be the pkg_resources change causing a different version of `typing-extensions` to pop up.