### PR TITLE
[Identity Broker] Allow default account usage in WSL

### DIFF
--- a/sdk/identity/azure-identity-broker/README.md
+++ b/sdk/identity/azure-identity-broker/README.md
@@ -7,7 +7,7 @@ This package extends the [Azure Identity][azure_identity] library by providing s
 | Web Account Manager (WAM) on Windows 10+  | 1.0.0                   |
 | [Company Portal][company_portal] on macOS | 1.3.0b1                 |
 | Web Account Manager (WAM) on WSL 2.4.13+  | 1.3.0b2                 |
-| Broker on Linux                           | 1.3.0b2                 |
+| Microsoft Identity Broker on Linux        | 1.3.0b2                 |
 
 [Source code][source_code] | [Package (PyPI)][azure_identity_broker] | [API reference documentation][ref_docs] | [Microsoft Entra ID documentation][entra_id]
 

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import socket
 import sys
-from typing import Dict, Any, Mapping, Union
+from typing import Dict, Any, Mapping, Union, cast
 import msal
 
 from azure.core.exceptions import ClientAuthenticationError
@@ -14,7 +14,7 @@ from azure.identity._credentials import (
 )  # pylint:disable=protected-access
 from azure.identity._exceptions import CredentialUnavailableError  # pylint:disable=protected-access
 from azure.identity._internal.utils import within_dac  # pylint:disable=protected-access
-from ._utils import wrap_exceptions, resolve_tenant
+from ._utils import wrap_exceptions, resolve_tenant, is_wsl
 
 
 class PopTokenRequestOptions(TokenRequestOptions):
@@ -50,6 +50,8 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         unspecified, users will authenticate to an Azure development application.
     :keyword str login_hint: a username suggestion to pre-fill the login page's username/email address field. A user
         may still log in with a different username.
+    :keyword cache_persistence_options: configuration for persistent token caching. If unspecified, the credential
+        will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
     :keyword int parent_window_handle: If your app is a GUI app running on Windows 10+ or macOS, you
@@ -80,21 +82,21 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
 
     @wrap_exceptions
     def _request_token(self, *scopes: str, **kwargs: Any) -> Dict:
-        scopes = list(scopes)  # type: ignore
+        scopes_list = list(scopes)
         claims = kwargs.get("claims")
         pop = kwargs.get("pop")
-        app = self._get_app(**kwargs)
+        app = cast(msal.PublicClientApplication, self._get_app(**kwargs))
         port = self._parsed_url.port if self._parsed_url else None
         auth_scheme = None
         if pop:
             auth_scheme = msal.PopAuthScheme(
                 http_method=pop["resource_request_method"], url=pop["resource_request_url"], nonce=pop["nonce"]
             )
-        if sys.platform.startswith("win"):
+        if sys.platform.startswith("win") or is_wsl():
             if self._use_default_broker_account:
                 try:
                     result = app.acquire_token_interactive(
-                        scopes=scopes,
+                        scopes=scopes_list,
                         login_hint=self._login_hint,
                         claims_challenge=claims,
                         timeout=self._timeout,
@@ -110,7 +112,7 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
                     pass
             try:
                 result = app.acquire_token_interactive(
-                    scopes=scopes,
+                    scopes=scopes_list,
                     login_hint=self._login_hint,
                     claims_challenge=claims,
                     timeout=self._timeout,
@@ -133,7 +135,7 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         else:
             try:
                 result = app.acquire_token_interactive(
-                    scopes=scopes,
+                    scopes=scopes_list,
                     login_hint=self._login_hint,
                     claims_challenge=claims,
                     timeout=self._timeout,
@@ -144,9 +146,9 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
                     auth_scheme=auth_scheme,
                 )
             except Exception:  # pylint: disable=broad-except
-                app = self._disable_broker_on_app(**kwargs)
+                app = cast(msal.PublicClientApplication, self._disable_broker_on_app(**kwargs))
                 result = app.acquire_token_interactive(
-                    scopes=scopes,
+                    scopes=scopes_list,
                     login_hint=self._login_hint,
                     claims_challenge=claims,
                     timeout=self._timeout,

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_utils.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_utils.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import os
 import functools
 import logging
+import platform
 from azure.core.exceptions import ClientAuthenticationError
 
 
@@ -80,3 +81,11 @@ def resolve_tenant(
         'when creating the credential, or add "*" to additionally_allowed_tenants to allow '
         "acquiring tokens for any tenant.".format(tenant_id)
     )
+
+
+def is_wsl():
+    # This is how MSAL checks for WSL.
+    uname = platform.uname()
+    platform_name = getattr(uname, "system", uname[0]).lower()
+    release = getattr(uname, "release", uname[2]).lower()
+    return platform_name == "linux" and "microsoft" in release


### PR DESCRIPTION
WSL supports logging in with the default broker account.