### PR TITLE
Use paramtype for keyword params

### DIFF
--- a/sdk/ai/azure-ai-agents/azure/ai/agents/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/_patch.py
@@ -1,4 +1,4 @@
-# pylint: disable=line-too-long,useless-suppression,too-many-lines
+﻿# pylint: disable=line-too-long,useless-suppression,too-many-lines
 # ------------------------------------
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
@@ -140,7 +140,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -205,7 +205,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -295,7 +295,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -392,7 +392,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -458,7 +458,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -569,7 +569,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -701,45 +701,45 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         Creates a new agent thread and immediately starts a run using that new thread.
 
         :keyword agent_id: The ID of the agent for which the thread should be created. Required.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword content_type: Body Parameter content-type for JSON body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :keyword thread: The details used to create the new thread. If none provided, an empty thread is
                        created.
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Override the model the agent uses for this run.
-        :type model: str
+        :paramtype model: str
         :keyword instructions: Override the system instructions for this run.
-        :type instructions: str
+        :paramtype instructions: str
         :keyword tools: Override the list of enabled tools for this run.
-        :type tools: list[~azure.ai.agents.models.ToolDefinition]
+        :paramtype tools: list[~azure.ai.agents.models.ToolDefinition]
         :keyword tool_resources: Override the tools the agent can use for this run.
-        :type tool_resources: ~azure.ai.agents.models.ToolResources
+        :paramtype tool_resources: ~azure.ai.agents.models.ToolResources
         :keyword temperature: Sampling temperature between 0 and 2. Higher = more random.
-        :type temperature: float
+        :paramtype temperature: float
         :keyword top_p: Nucleus sampling parameter between 0 and 1.
-        :type top_p: float
+        :paramtype top_p: float
         :keyword max_prompt_tokens: Max prompt tokens to use across the run.
-        :type max_prompt_tokens: int
+        :paramtype max_prompt_tokens: int
         :keyword max_completion_tokens: Max completion tokens to use across the run.
-        :type max_completion_tokens: int
+        :paramtype max_completion_tokens: int
         :keyword truncation_strategy: Strategy for dropping old messages as context grows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls which tool the model will call.
-        :type tool_choice: str or
+        :paramtype tool_choice: str or
                           ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
                           ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, tools will be invoked in parallel.
-        :type parallel_tool_calls: bool
+        :paramtype parallel_tool_calls: bool
         :keyword metadata: Up to 16 key/value pairs for structured metadata on the run.
-        :type metadata: dict[str, str]
+        :paramtype metadata: dict[str, str]
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -755,7 +755,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :param body: The request payload as a JSON-serializable dict.
         :type body: JSON
         :keyword content_type: Body Parameter content-type for JSON body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -771,7 +771,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :param body: The request payload as a byte-stream.
         :type body: IO[bytes]
         :keyword content_type: Body Parameter content-type for binary body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -807,43 +807,43 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :type body: JSON or IO[bytes]
         :keyword agent_id: The ID of the agent for which the thread should be created.
                          Required when not using the JSON/body overload.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword thread: The details used to create the new thread. If none provided, an empty thread is
                        created.
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Override the model the agent uses for this run.
-        :type model: str
+        :paramtype model: str
         :keyword instructions: Override the system instructions for this run.
-        :type instructions: str
+        :paramtype instructions: str
         :keyword tools: Override the list of enabled tools for this run.
-        :type tools: list[~azure.ai.agents.models.ToolDefinition]
+        :paramtype tools: list[~azure.ai.agents.models.ToolDefinition]
         :keyword tool_resources: Override the tools the agent can use for this run.
-        :type tool_resources: ~azure.ai.agents.models.ToolResources
+        :paramtype tool_resources: ~azure.ai.agents.models.ToolResources
         :keyword temperature: Sampling temperature between 0 and 2. Higher = more random.
-        :type temperature: float
+        :paramtype temperature: float
         :keyword top_p: Nucleus sampling parameter between 0 and 1.
-        :type top_p: float
+        :paramtype top_p: float
         :keyword max_prompt_tokens: Max prompt tokens to use across the run.
-        :type max_prompt_tokens: int
+        :paramtype max_prompt_tokens: int
         :keyword max_completion_tokens: Max completion tokens to use across the run.
-        :type max_completion_tokens: int
+        :paramtype max_completion_tokens: int
         :keyword truncation_strategy: Strategy for dropping old messages as context grows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls which tool the model will call.
-        :type tool_choice: str or
+        :paramtype tool_choice: str or
                           ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
                           ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, tools will be invoked in parallel.
-        :type parallel_tool_calls: bool
+        :paramtype parallel_tool_calls: bool
         :keyword metadata: Up to 16 key/value pairs for structured metadata on the run.
-        :type metadata: dict[str, str]
+        :paramtype metadata: dict[str, str]
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ValueError: If the combination of arguments is invalid.
@@ -913,41 +913,41 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         state, executing any required tool calls via the provided ToolSet.
 
         :keyword agent_id: The unique identifier of the agent to run. Required if `body` is unset.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword thread: Options for creating the new thread (initial messages, metadata, tool resources).
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Optional override of the model deployment name to use for this run.
-        :type model: str, optional
+        :paramtype model: str, optional
         :keyword instructions: Optional override of the system instructions for this run.
-        :type instructions: str, optional
+        :paramtype instructions: str, optional
         :keyword toolset: A ToolSet instance containing both `.definitions` and `.resources` for tools.
                         If provided, its definitions/resources are used; otherwise no tools are passed.
-        :type toolset: azure.ai.agents._tools.ToolSet, optional
+        :paramtype toolset: azure.ai.agents._tools.ToolSet, optional
         :keyword temperature: Sampling temperature for the model (0.0-2.0), higher is more random.
-        :type temperature: float, optional
+        :paramtype temperature: float, optional
         :keyword top_p: Nucleus sampling value (0.0-1.0), alternative to temperature.
-        :type top_p: float, optional
+        :paramtype top_p: float, optional
         :keyword max_prompt_tokens: Maximum total prompt tokens across turns; run ends “incomplete” if exceeded.
-        :type max_prompt_tokens: int, optional
+        :paramtype max_prompt_tokens: int, optional
         :keyword max_completion_tokens: Maximum total completion tokens across turns; run ends “incomplete” if exceeded.
-        :type max_completion_tokens: int, optional
+        :paramtype max_completion_tokens: int, optional
         :keyword truncation_strategy: Strategy for dropping old messages when context window overflows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject, optional
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject, optional
         :keyword tool_choice: Controls which tool (if any) the model is allowed to call.
-        :type tool_choice: str or ~azure.ai.agents.models.AgentsToolChoiceOption, optional
+        :paramtype tool_choice: str or ~azure.ai.agents.models.AgentsToolChoiceOption, optional
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, allows tool calls to be executed in parallel.
-        :type parallel_tool_calls: bool, optional
+        :paramtype parallel_tool_calls: bool, optional
         :keyword metadata: Optional metadata (up to 16 key/value pairs) to attach to the run.
-        :type metadata: dict[str, str], optional
+        :paramtype metadata: dict[str, str], optional
         :keyword polling_interval: Seconds to wait between polling attempts for run status. Default is 1.
-        :type polling_interval: int, optional
+        :paramtype polling_interval: int, optional
         :return: The final ThreadRun object, in a terminal state (succeeded, failed, or cancelled).
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/aio/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/aio/_patch.py
@@ -141,7 +141,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -206,7 +206,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -297,7 +297,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -392,7 +392,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -457,7 +457,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -567,7 +567,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
@@ -699,45 +699,45 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         Creates a new agent thread and immediately starts a run using that new thread.
 
         :keyword agent_id: The ID of the agent for which the thread should be created. Required.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword content_type: Body Parameter content-type for JSON body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :keyword thread: The details used to create the new thread. If none provided, an empty thread is
                        created.
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Override the model the agent uses for this run.
-        :type model: str
+        :paramtype model: str
         :keyword instructions: Override the system instructions for this run.
-        :type instructions: str
+        :paramtype instructions: str
         :keyword tools: Override the list of enabled tools for this run.
-        :type tools: list[~azure.ai.agents.models.ToolDefinition]
+        :paramtype tools: list[~azure.ai.agents.models.ToolDefinition]
         :keyword tool_resources: Override the tools the agent can use for this run.
-        :type tool_resources: ~azure.ai.agents.models.ToolResources
+        :paramtype tool_resources: ~azure.ai.agents.models.ToolResources
         :keyword temperature: Sampling temperature between 0 and 2. Higher = more random.
-        :type temperature: float
+        :paramtype temperature: float
         :keyword top_p: Nucleus sampling parameter between 0 and 1.
-        :type top_p: float
+        :paramtype top_p: float
         :keyword max_prompt_tokens: Max prompt tokens to use across the run.
-        :type max_prompt_tokens: int
+        :paramtype max_prompt_tokens: int
         :keyword max_completion_tokens: Max completion tokens to use across the run.
-        :type max_completion_tokens: int
+        :paramtype max_completion_tokens: int
         :keyword truncation_strategy: Strategy for dropping old messages as context grows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls which tool the model will call.
-        :type tool_choice: str or
+        :paramtype tool_choice: str or
                           ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
                           ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, tools will be invoked in parallel.
-        :type parallel_tool_calls: bool
+        :paramtype parallel_tool_calls: bool
         :keyword metadata: Up to 16 key/value pairs for structured metadata on the run.
-        :type metadata: dict[str, str]
+        :paramtype metadata: dict[str, str]
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -753,7 +753,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :param body: The request payload as a JSON-serializable dict.
         :type body: JSON
         :keyword content_type: Body Parameter content-type for JSON body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -769,7 +769,7 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :param body: The request payload as a byte-stream.
         :type body: IO[bytes]
         :keyword content_type: Body Parameter content-type for binary body. Default is "application/json".
-        :type content_type: str
+        :paramtype content_type: str
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -805,43 +805,43 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         :type body: JSON or IO[bytes]
         :keyword agent_id: The ID of the agent for which the thread should be created.
                          Required when not using the JSON/body overload.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword thread: The details used to create the new thread. If none provided, an empty thread is
                        created.
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Override the model the agent uses for this run.
-        :type model: str
+        :paramtype model: str
         :keyword instructions: Override the system instructions for this run.
-        :type instructions: str
+        :paramtype instructions: str
         :keyword tools: Override the list of enabled tools for this run.
-        :type tools: list[~azure.ai.agents.models.ToolDefinition]
+        :paramtype tools: list[~azure.ai.agents.models.ToolDefinition]
         :keyword tool_resources: Override the tools the agent can use for this run.
-        :type tool_resources: ~azure.ai.agents.models.ToolResources
+        :paramtype tool_resources: ~azure.ai.agents.models.ToolResources
         :keyword temperature: Sampling temperature between 0 and 2. Higher = more random.
-        :type temperature: float
+        :paramtype temperature: float
         :keyword top_p: Nucleus sampling parameter between 0 and 1.
-        :type top_p: float
+        :paramtype top_p: float
         :keyword max_prompt_tokens: Max prompt tokens to use across the run.
-        :type max_prompt_tokens: int
+        :paramtype max_prompt_tokens: int
         :keyword max_completion_tokens: Max completion tokens to use across the run.
-        :type max_completion_tokens: int
+        :paramtype max_completion_tokens: int
         :keyword truncation_strategy: Strategy for dropping old messages as context grows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls which tool the model will call.
-        :type tool_choice: str or
+        :paramtype tool_choice: str or
                           ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
                           ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, tools will be invoked in parallel.
-        :type parallel_tool_calls: bool
+        :paramtype parallel_tool_calls: bool
         :keyword metadata: Up to 16 key/value pairs for structured metadata on the run.
-        :type metadata: dict[str, str]
+        :paramtype metadata: dict[str, str]
         :return: ThreadRun. The ThreadRun is compatible with MutableMapping.
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ValueError: If the combination of arguments is invalid.
@@ -912,41 +912,41 @@ class AgentsClient(AgentsClientGenerated):  # pylint: disable=client-accepts-api
         state, executing any required tool calls via the provided ToolSet.
 
         :keyword agent_id: The unique identifier of the agent to run. Required if `body` is unset.
-        :type agent_id: str
+        :paramtype agent_id: str
         :keyword thread: Options for creating the new thread (initial messages, metadata, tool resources).
-        :type thread: ~azure.ai.agents.models.AgentThreadCreationOptions
+        :paramtype thread: ~azure.ai.agents.models.AgentThreadCreationOptions
         :keyword model: Optional override of the model deployment name to use for this run.
-        :type model: str, optional
+        :paramtype model: str, optional
         :keyword instructions: Optional override of the system instructions for this run.
-        :type instructions: str, optional
+        :paramtype instructions: str, optional
         :keyword toolset: A ToolSet instance containing both `.definitions` and `.resources` for tools.
                         If provided, its definitions/resources are used; otherwise no tools are passed.
-        :type toolset: azure.ai.agents._tools.ToolSet, optional
+        :paramtype toolset: azure.ai.agents._tools.ToolSet, optional
         :keyword temperature: Sampling temperature for the model (0.0-2.0), higher is more random.
-        :type temperature: float, optional
+        :paramtype temperature: float, optional
         :keyword top_p: Nucleus sampling value (0.0-1.0), alternative to temperature.
-        :type top_p: float, optional
+        :paramtype top_p: float, optional
         :keyword max_prompt_tokens: Maximum total prompt tokens across turns; run ends "incomplete" if exceeded.
-        :type max_prompt_tokens: int, optional
+        :paramtype max_prompt_tokens: int, optional
         :keyword max_completion_tokens: Maximum total completion tokens across turns; run ends "incomplete" if exceeded.
-        :type max_completion_tokens: int, optional
+        :paramtype max_completion_tokens: int, optional
         :keyword truncation_strategy: Strategy for dropping old messages when context window overflows.
-        :type truncation_strategy: ~azure.ai.agents.models.TruncationObject, optional
+        :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject, optional
         :keyword tool_choice: Controls which tool (if any) the model is allowed to call.
-        :type tool_choice: str or ~azure.ai.agents.models.AgentsToolChoiceOption, optional
+        :paramtype tool_choice: str or ~azure.ai.agents.models.AgentsToolChoiceOption, optional
         :keyword response_format: Specifies the format for the responses, particularly for tool calls.
          Can be a string, response format mode, or structured response format object that defines how
          the agent should structure its outputs.
-        :type response_format: Optional[Union[str,
+        :paramtype response_format: Optional[Union[str,
                                ~azure.ai.agents.models.AgentsApiResponseFormatMode,
                                ~azure.ai.agents.models.AgentsApiResponseFormat,
                                ~azure.ai.agents.models.ResponseFormatJsonSchemaType]]
         :keyword parallel_tool_calls: If True, allows tool calls to be executed in parallel.
-        :type parallel_tool_calls: bool, optional
+        :paramtype parallel_tool_calls: bool, optional
         :keyword metadata: Optional metadata (up to 16 key/value pairs) to attach to the run.
-        :type metadata: dict[str, str], optional
+        :paramtype metadata: dict[str, str], optional
         :keyword polling_interval: Seconds to wait between polling attempts for run status. Default is 1.
-        :type polling_interval: int, optional
+        :paramtype polling_interval: int, optional
         :return: The final ThreadRun object, in a terminal state (succeeded, failed, or cancelled).
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
@@ -1350,7 +1350,7 @@ class FilesOperations(FilesOperationsGenerated):
         """Uploads a file for use by other operations.
 
         :keyword file_path: The path to the file to upload.
-        :type file_path: str
+        :paramtype file_path: str
         :keyword purpose: The intended purpose of the uploaded file. Known values are: "assistants", "assistants_output", and "vision".
         :paramtype purpose: str or ~azure.ai.agents.models.FilePurpose
         :return: FileInfo. The FileInfo is compatible with MutableMapping
@@ -1511,7 +1511,7 @@ class FilesOperations(FilesOperationsGenerated):
         """Uploads a file for use by other operations.
 
         :keyword file_path: The path to the file to upload.
-        :type file_path: str
+        :paramtype file_path: str
         :keyword purpose: Known values are: "assistants", "assistants_output", and "vision".
         :paramtype purpose: str or ~azure.ai.agents.models.FilePurpose
         :keyword polling_interval: Time to wait before polling for the status of the uploaded file. Default value

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
@@ -1383,7 +1383,7 @@ class FilesOperations(FilesOperationsGenerated):
         """Uploads a file for use by other operations.
 
         :keyword file_path: The path to the file to upload.
-        :type file_path: str
+        :paramtype file_path: str
         :keyword purpose: Known values are: "assistants", "assistants_output", and "vision".
         :paramtype purpose: str or ~azure.ai.agents.models.FilePurpose
         :return: FileInfo. The FileInfo is compatible with MutableMapping
@@ -1544,7 +1544,7 @@ class FilesOperations(FilesOperationsGenerated):
         """Uploads a file for use by other operations.
 
         :keyword file_path: The path to the file on the local filesystem to upload.
-        :type file_path: str
+        :paramtype file_path: str
         :keyword purpose: Known values are: "assistants", "assistants_output", and "vision".
         :paramtype purpose: str or ~azure.ai.agents.models.FilePurpose
         :keyword polling_interval: Time to wait before polling for the status of the uploaded file. Default value


### PR DESCRIPTION
Did one thing only - change to paramtype to type for keyword parameters.
I use AI in VSCode to help me and I asked it to run 7 times to make sure nothing missing.   On the 6th times, it still have some missing and I found that AI never tried to change for positional parameters.