### PR TITLE
Distinguish Azure AI SDKs in statsbeats

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -194,6 +194,8 @@ class _RP_Names(Enum):
 # Special constant for azure-sdk opentelemetry instrumentation
 _AZURE_SDK_OPENTELEMETRY_NAME = "azure-sdk-opentelemetry"
 _AZURE_SDK_NAMESPACE_NAME = "az.namespace"
+# TODO: do we need -opentelemetry suffix?
+_AZURE_AI_SDK_NAME = "azure-ai"
 
 _BASE = 2
 
@@ -253,6 +255,7 @@ _INSTRUMENTATIONS_LIST = [
     "openai_v2",
     "vertexai",
     # Instrumentations below this line have not been added to statsbeat report yet
+    _AZURE_AI_SDK_NAME
 ]
 
 _INSTRUMENTATIONS_BIT_MAP = {_INSTRUMENTATIONS_LIST[i]: _BASE**i for i in range(len(_INSTRUMENTATIONS_LIST))}

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -194,8 +194,7 @@ class _RP_Names(Enum):
 # Special constant for azure-sdk opentelemetry instrumentation
 _AZURE_SDK_OPENTELEMETRY_NAME = "azure-sdk-opentelemetry"
 _AZURE_SDK_NAMESPACE_NAME = "az.namespace"
-# TODO: do we need -opentelemetry suffix?
-_AZURE_AI_SDK_NAME = "azure-ai"
+_AZURE_AI_SDK_NAME = "azure-ai-opentelemetry"
 
 _BASE = 2
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -124,6 +124,7 @@ def _getlocale():
             # by continuing to use getdefaultlocale() even though it has been deprecated.
             # we ignore the deprecation warnings to reduce noise
             warnings.simplefilter("ignore", category=DeprecationWarning)
+            # pylint: disable=deprecated-method
             return locale.getdefaultlocale()[0]
     except AttributeError:
         # locale.getlocal() has issues on Windows: https://github.com/python/cpython/issues/82986

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -533,7 +533,7 @@ def _check_instrumentation_span(span: ReadableSpan) -> None:
     # `azure-` or `azure.` is a prefix
     if span.instrumentation_scope.name.startswith("azure"):
         # spec-case for Azure AI SDKs - identified by `az.namespace` attribute
-        if (span.attributes.get(_AZURE_SDK_NAMESPACE_NAME) == "Microsoft.CognitiveServices"):
+        if (span.attributes and span.attributes.get(_AZURE_SDK_NAMESPACE_NAME) == "Microsoft.CognitiveServices"):
             _utils.add_instrumentation(_AZURE_AI_SDK_NAME)
         else:
             _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -23,6 +23,7 @@ from azure.monitor.opentelemetry.exporter._constants import (
     _APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED,
     _AZURE_SDK_NAMESPACE_NAME,
     _AZURE_SDK_OPENTELEMETRY_NAME,
+    _AZURE_AI_SDK_NAME,
     _INSTRUMENTATION_SUPPORTING_METRICS_LIST,
     _SAMPLE_RATE_KEY,
     _METRIC_ENVELOPE_NAME,
@@ -525,12 +526,17 @@ def _convert_span_events_to_envelopes(span: ReadableSpan) -> Sequence[TelemetryI
 
 
 def _check_instrumentation_span(span: ReadableSpan) -> None:
-    # Special use-case for spans generated from azure-sdk services
-    # Identified by having az.namespace as a span attribute
-    if span.attributes and _AZURE_SDK_NAMESPACE_NAME in span.attributes:
-        _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)
-        return
     if span.instrumentation_scope is None:
+        return
+
+    # Special use-case for spans generated from azure-sdk services
+    # `azure-` or `azure.` is a prefix
+    if span.instrumentation_scope.name.startswith("azure"):
+        # spec-case for Azure AI SDKs - identified by `az.namespace` attribute
+        if (span.attributes.get(_AZURE_SDK_NAMESPACE_NAME or None) == "Microsoft.CognitiveServices"):
+            _utils.add_instrumentation(_AZURE_AI_SDK_NAME)
+        else:
+            _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)
         return
     # All instrumentation scope names from OpenTelemetry instrumentations have
     # `opentelemetry.instrumentation.` as a prefix

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -533,7 +533,7 @@ def _check_instrumentation_span(span: ReadableSpan) -> None:
     # `azure-` or `azure.` is a prefix
     if span.instrumentation_scope.name.startswith("azure"):
         # spec-case for Azure AI SDKs - identified by `az.namespace` attribute
-        if (span.attributes.get(_AZURE_SDK_NAMESPACE_NAME or None) == "Microsoft.CognitiveServices"):
+        if (span.attributes.get(_AZURE_SDK_NAMESPACE_NAME) == "Microsoft.CognitiveServices"):
             _utils.add_instrumentation(_AZURE_AI_SDK_NAME)
         else:
             _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -533,7 +533,7 @@ def _check_instrumentation_span(span: ReadableSpan) -> None:
     # `azure-` or `azure.` is a prefix
     if span.instrumentation_scope.name.startswith("azure"):
         # spec-case for Azure AI SDKs - identified by `az.namespace` attribute
-        if (span.attributes and span.attributes.get(_AZURE_SDK_NAMESPACE_NAME) == "Microsoft.CognitiveServices"):
+        if span.attributes and span.attributes.get(_AZURE_SDK_NAMESPACE_NAME) == "Microsoft.CognitiveServices":
             _utils.add_instrumentation(_AZURE_AI_SDK_NAME)
         else:
             _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/dev_requirements.txt
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/dev_requirements.txt
@@ -1,4 +1,5 @@
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
+../../core/azure-core-tracing-opentelemetry
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.7'

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_processor.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_processor.py
@@ -23,7 +23,7 @@ class TestQuickpulseLogRecordProcessor(unittest.TestCase):
     def test_emit(self):
         processor = _QuickpulseLogRecordProcessor()
         log_data = mock.Mock()
-        processor.emit(log_data)
+        processor.on_emit(log_data)
         self.qpm._record_log_record.assert_called_once_with(log_data)
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -11,7 +11,11 @@ from unittest import mock
 # pylint: disable=import-error
 from opentelemetry.trace import get_tracer_provider, set_tracer_provider
 from opentelemetry.sdk import trace, resources
+from opentelemetry.sdk.trace import TracerProvider
+
 from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_ESCAPED,
@@ -22,6 +26,9 @@ from opentelemetry.semconv.attributes.exception_attributes import (
 from opentelemetry.trace import Link, SpanContext, SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 
+from azure.core.settings import settings
+from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+from azure.core.instrumentation import get_tracer as get_azure_sdk_tracer
 from azure.monitor.opentelemetry.exporter.export._base import ExportResult
 from azure.monitor.opentelemetry.exporter.export.trace._exporter import (
     AzureMonitorTraceExporter,
@@ -31,6 +38,7 @@ from azure.monitor.opentelemetry.exporter.export.trace._exporter import (
 from azure.monitor.opentelemetry.exporter._constants import (
     _AZURE_SDK_NAMESPACE_NAME,
     _AZURE_SDK_OPENTELEMETRY_NAME,
+    _AZURE_AI_SDK_NAME,
 )
 from azure.monitor.opentelemetry.exporter._generated.models import ContextTagKeys
 from azure.monitor.opentelemetry.exporter._utils import azure_monitor_context
@@ -1128,7 +1136,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             "url.path": "/path",
             "url.query": "query",
             "server.address": "www.example.org",
-            "server.port": "80"
+            "server.port": "80",
         }
         envelope = exporter._span_to_envelope(span)
         self.assertEqual(envelope.data.base_data.url, "https://www.example.org:80/path?query")
@@ -1687,8 +1695,86 @@ class TestAzureTraceExporterUtils(unittest.TestCase):
 
     def test_check_instrumentation_span_azure_sdk(self):
         span = mock.Mock()
-        span.attributes = {_AZURE_SDK_NAMESPACE_NAME: "Microsoft.EventHub"}
-        span.instrumentation_scope.name = "__main__"
+        span.attributes = {}
+        span.instrumentation_scope.name = "azure.foo.bar.__init__"
+
         with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
             _check_instrumentation_span(span)
             add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+    @mock.patch("opentelemetry.trace.get_tracer_provider")
+    def test_check_instrumentation_span_azure_sdk_otel_span(self, mock_get_tracer_provider):
+        mock_get_tracer_provider.return_value = self.get_tracer_provider()
+
+        with OpenTelemetrySpan() as azure_sdk_span:
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                azure_sdk_span.add_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.ServiceBus")
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                azure_sdk_span.add_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.CognitiveServices")
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_AI_SDK_NAME)
+
+    @mock.patch("opentelemetry.trace.get_tracer_provider")
+    def test_check_instrumentation_span_azure_sdk_span_impl(self, mock_get_tracer_provider):
+        mock_get_tracer_provider.return_value = self.get_tracer_provider()
+
+        settings.tracing_implementation = "opentelemetry"
+        try:
+            azure_sdk_span = settings.tracing_implementation()(name="test")
+
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                azure_sdk_span.add_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.ServiceBus")
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+            with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+                azure_sdk_span.add_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.CognitiveServices")
+                _check_instrumentation_span(azure_sdk_span.span_instance)
+                add.assert_called_once_with(_AZURE_AI_SDK_NAME)
+
+        finally:
+            settings.tracing_implementation = None
+
+    @mock.patch("opentelemetry.trace.get_tracer_provider")
+    def test_check_instrumentation_span_azure_sdk_get_tracer(self, mock_get_tracer_provider):
+        mock_get_tracer_provider.return_value = self.get_tracer_provider()
+
+        azure_sdk_tracer = get_azure_sdk_tracer(library_name="azure-foo-bar")
+        azure_sdk_span = azure_sdk_tracer.start_span(name="test")
+
+        with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+            _check_instrumentation_span(azure_sdk_span)
+            add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+        with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+            azure_sdk_span.set_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.ServiceBus")
+            _check_instrumentation_span(azure_sdk_span)
+            add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)
+
+        with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+            azure_sdk_span.set_attribute(_AZURE_SDK_NAMESPACE_NAME, "Microsoft.CognitiveServices")
+            _check_instrumentation_span(azure_sdk_span)
+            add.assert_called_once_with(_AZURE_AI_SDK_NAME)
+
+        not_azure_sdk_span = get_azure_sdk_tracer(library_name="not-azure-foo-bar").start_span(name="test")
+        with mock.patch("azure.monitor.opentelemetry.exporter._utils.add_instrumentation") as add:
+            _check_instrumentation_span(not_azure_sdk_span)
+            add.assert_not_called()
+
+    def get_tracer_provider(self):
+        tracer_provider = TracerProvider()
+        span_exporter = InMemorySpanExporter()
+        processor = SimpleSpanProcessor(span_exporter)
+        tracer_provider.add_span_processor(processor)
+        return tracer_provider


### PR DESCRIPTION
- separate Azure AI and the rest of Azure SDKs in statbeats
- detect azure sdk spans by scope name - it's consistent with other instrumentations and also would cover all existing Azure SDKs. `az.namespace` is set by very few of them


This works along with https://github.com/Azure/azure-sdk-for-python/pull/42015