### PR TITLE
[Storage] Documented `results_per_page` keyword for `list_blobs` and `list_blob_names` APIs

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -864,6 +864,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         :keyword str name_starts_with:
             Filters the results to return only blobs whose names
             begin with the specified prefix.
+        :keyword int results_per_page:
+            Controls the maximum number of Blobs that will be included in each page of results if using
+            :func: `ItemPaged.by_page()`.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -812,6 +812,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
             Options include: 'snapshots', 'metadata', 'uncommittedblobs', 'copy', 'deleted', 'deletedwithversions',
             'tags', 'versions', 'immutabilitypolicy', 'legalhold'.
         :type include: list[str] or str
+        :keyword int results_per_page:
+            Controls the maximum number of Blobs that will be included in each page of results if using
+            :func: `ItemPaged.by_page()`.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -798,6 +798,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, S
             Options include: 'snapshots', 'metadata', 'uncommittedblobs', 'copy', 'deleted', 'deletedwithversions',
             'tags', 'versions', 'immutabilitypolicy', 'legalhold'.
         :type include: list[str] or str
+        :keyword int results_per_page:
+            Controls the maximum number of Blobs that will be included in each page of results if using
+            :func: `ItemPaged.by_page()`.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.
@@ -851,6 +854,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, S
         :keyword str name_starts_with:
             Filters the results to return only blobs whose names
             begin with the specified prefix.
+        :keyword int results_per_page:
+            Controls the maximum number of Blobs that will be included in each page of results if using
+            :func: `ItemPaged.by_page()`.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.


### PR DESCRIPTION
Solves #41968

Need to double check `by_page` function link...