### PR TITLE
Check for pyproject when parsing library dependencies

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -58,22 +58,24 @@ def record_dep(dependencies: Dict[str, Dict[str, Any]], req_name: str, spec: str
 def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
     packages = {}
     dependencies = {}
-
     for lib_dir in discover_targeted_packages("azure*", base_dir):
-        parsed = ParsedSetup.from_path(lib_dir)
-        lib_name, version, requires = parsed.name, parsed.version, parsed.requires
+        try:
+            parsed = ParsedSetup.from_path(lib_dir)
+            lib_name, version, requires = parsed.name, parsed.version, parsed.requires
 
-        packages[lib_name] = {"version": version, "source": lib_dir, "deps": []}
+            packages[lib_name] = {"version": version, "source": lib_dir, "deps": []}
 
-        for req in requires:
-            req_obj = parse_require(req)
-            req_name = req_obj.name
-            spec = req_obj.specifier if len(req_obj.specifier) else None
-            if spec is None:
-                spec = ""
+            for req in requires:
+                req_obj = parse_require(req)
+                req_name = req_obj.name
+                spec = req_obj.specifier if len(req_obj.specifier) else None
+                if spec is None:
+                    spec = ""
 
-            packages[lib_name]["deps"].append({"name": req_name, "version": str(spec)})
-            record_dep(dependencies, req_name, str(spec), lib_name)
+                packages[lib_name]["deps"].append({"name": req_name, "version": str(spec)})
+                record_dep(dependencies, req_name, str(spec), lib_name)
+        except:
+            print(f"Failed to parse setup.py or pyproject.toml at {lib_dir}")
     return packages, dependencies
 
 

--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -59,9 +59,8 @@ def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Di
     packages = {}
     dependencies = {}
 
-    def parse_setup(setup_path: str) -> None:
-        """Attempts to parse either a setup.py or pyproject.toml file to extract package information."""
-        parsed = ParsedSetup.from_path(setup_path)
+    for lib_dir in discover_targeted_packages("azure*", base_dir):
+        parsed = ParsedSetup.from_path(lib_dir)
         lib_name, version, requires = parsed.name, parsed.version, parsed.requires
 
         packages[lib_name] = {"version": version, "source": lib_dir, "deps": []}
@@ -75,19 +74,6 @@ def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Di
 
             packages[lib_name]["deps"].append({"name": req_name, "version": str(spec)})
             record_dep(dependencies, req_name, str(spec), lib_name)
-
-    for lib_dir in discover_targeted_packages("azure*", base_dir):
-        setup_path = os.path.join(lib_dir, "setup.py")
-        try:
-            parse_setup(setup_path)
-        # If we can't parse setup.py, we try to parse pyproject.toml
-        except:
-            pyproject_path = os.path.join(lib_dir, "pyproject.toml")
-            try:
-                parse_setup(pyproject_path)
-            # If we can't parse pyproject.toml either, we print an error message with attempted paths
-            except:
-                print(f"Failed to parse {setup_path} or {pyproject_path}")
     return packages, dependencies
 
 

--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -60,6 +60,7 @@ def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Di
     dependencies = {}
 
     def parse_setup(setup_path: str) -> None:
+        """Attempts to parse either a setup.py or pyproject.toml file to extract package information."""
         parsed = ParsedSetup.from_path(setup_path)
         lib_name, version, requires = parsed.name, parsed.version, parsed.requires
 
@@ -79,10 +80,12 @@ def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Di
         setup_path = os.path.join(lib_dir, "setup.py")
         try:
             parse_setup(setup_path)
+        # If we can't parse setup.py, we try to parse pyproject.toml
         except:
             pyproject_path = os.path.join(lib_dir, "pyproject.toml")
             try:
                 parse_setup(pyproject_path)
+            # If we can't parse pyproject.toml either, we print an error message with attempted paths
             except:
                 print(f"Failed to parse {setup_path} or {pyproject_path}")
     return packages, dependencies

--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -80,12 +80,11 @@ def get_lib_deps(base_dir: str) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Di
         try:
             parse_setup(setup_path)
         except:
-            pass
-        pyproject_path = os.path.join(lib_dir, "pyproject.toml")
-        try:
-            parse_setup(pyproject_path)
-        except:
-            print(f"Failed to parse {setup_path} or {pyproject_path}")
+            pyproject_path = os.path.join(lib_dir, "pyproject.toml")
+            try:
+                parse_setup(pyproject_path)
+            except:
+                print(f"Failed to parse {setup_path} or {pyproject_path}")
     return packages, dependencies
 
 

--- a/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
+++ b/tools/azure-sdk-tools/tests/test_pyproject_interactions.py
@@ -3,8 +3,10 @@ import os, tempfile, shutil
 
 import pytest
 
+from ci_tools.dependency_analysis import get_lib_deps
 from ci_tools.parsing import update_build_config, get_build_config, get_config_setting
 from ci_tools.environment_exclusions import is_check_enabled
+from ci_tools.variables import discover_repo_root
 
 integration_folder = os.path.join(os.path.dirname(__file__), "integration")
 pyproject_folder = os.path.join(integration_folder, "scenarios", "pyproject_build_config")
@@ -89,3 +91,12 @@ def test_pyproject_update_check_override():
 
         reloaded_build_config = get_build_config(temp_dir)
         assert reloaded_build_config == update_result
+
+
+def test_pyproject_get_lib_deps():
+    all_packages, _ = get_lib_deps(discover_repo_root())
+    # Ensure that libraries with pyproject.toml files are fetched correctly; azure-keyvault-keys is an example
+    pyproject_info = all_packages["azure-keyvault-keys"]
+    assert pyproject_info["version"]
+    assert pyproject_info["source"]
+    assert len(pyproject_info["deps"]) > 0


### PR DESCRIPTION
# Description

Resolves #42013. This updates `dependency_analysis.get_lib_deps` to attempt parsing a `pyproject.toml` file for a library by calling `ParsedSetup.from_path` with the library path instead of the library's presumed `setup.py` location. Pipeline runs [show](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5103036&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=c9190431-7417-53a5-3fc1-7c7e026cd79d&l=1175) that this now works for `azure-keyvault-keys`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
