### PR TITLE
Remove pinned MCP server version

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -14,7 +14,7 @@
         "azure-sdk-mcp": {
             "type": "stdio",
             "command": "pwsh",        
-            "args": ["${workspaceFolder}/eng/common/mcp/azure-sdk-mcp.ps1", "-Run", "-Version","1.0.0-dev.20250630.3"]
+            "args": ["${workspaceFolder}/eng/common/mcp/azure-sdk-mcp.ps1", "-Run"]
         }
     }
 }


### PR DESCRIPTION
Remove MCP server version pinning for DevEx MCP server. This was causing version conflict when DevEX MCP server is running a different version on rest api specs repo. We are working on a different solution to support global version pinning instead of pinning at individual repos.