### PR TITLE
CI Disabled for this package at some point in history

### DIFF
--- a/sdk/digitaltwins/azure-digitaltwins-core/pyproject.toml
+++ b/sdk/digitaltwins/azure-digitaltwins-core/pyproject.toml
@@ -1,3 +1,2 @@
 [tool.azure-sdk-build]
 pyright = false
-ci_enabled = false


### PR DESCRIPTION
Occurred with [this](https://github.com/Azure/azure-sdk-for-python/blob/2219c7dc57b5fee6dccd2a78e5b505156886c3a1/sdk/digitaltwins/azure-digitaltwins-core/pyproject.toml) mass update.

