### PR TITLE
Fix `azure-digitaltwins-core` dependencies

### DIFF
--- a/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated service API version to use API version 2023-10-31 by default.
 - Updated internal implementation while maintaining API compatibility.
 - Improved type annotations throughout the library.
+- Added `isodate` dependency
 
 ## 1.2.0 (2022-05-31)
  - GA release
@@ -45,7 +46,7 @@
 - User Agent value updated according to guidelines.
 - Updated JSON patch parameter typehints to `List[Dict[str, object]]`.
 - Updated constructor credential typehint to `azure.core.credentials.TokenCredential`
-- Samples and documentation updated. 
+- Samples and documentation updated.
 
 
 ## 1.0.0b1 (2020-10-31)

--- a/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Updated service API version to use API version 2023-10-31 by default.
 - Updated internal implementation while maintaining API compatibility.
 - Improved type annotations throughout the library.
-- Added `isodate` dependency
+- Added `isodate` dependency.
 
 ## 1.2.0 (2022-05-31)
  - GA release

--- a/sdk/digitaltwins/azure-digitaltwins-core/setup.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/setup.py
@@ -70,5 +70,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.29.0",
+        "isodate>=0.6.1",
     ],
 )

--- a/sdk/digitaltwins/azure-digitaltwins-core/setup.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/setup.py
@@ -70,6 +70,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.29.0",
-        "isodate>=0.6.1",
+        "isodate<1.0.0,>=0.6.1"
     ],
 )

--- a/sdk/digitaltwins/azure-digitaltwins-core/setup.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/setup.py
@@ -70,6 +70,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.29.0",
-        "isodate<1.0.0,>=0.6.1"
+        "isodate>=0.6.1",
     ],
 )


### PR DESCRIPTION
`depends` check was failing due to missing dep.

Before:

```
semick@CPC-scbed-QJJWS:~/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core$ main|>python
Python 3.13.3 (main, Apr  9 2025, 08:55:02) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from azure.digitaltwins.core import *
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from azure.digitaltwins.core import *
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/__init__.py", line 9, in <module>
    from ._digitaltwins_client import DigitalTwinsClient
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py", line 17, in <module>
    from ._generated.models._models_py3 import DigitalTwinsEventRoute, IncomingRelationship
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/__init__.py", line 15, in <module>
    from ._azure_digital_twins_api import AzureDigitalTwinsAPI  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/_azure_digital_twins_api.py", line 17, in <module>
    from . import models as _models
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/models/__init__.py", line 16, in <module>
    from ._models_py3 import (  # type: ignore
    ...<48 lines>...
    )
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/models/_models_py3.py", line 14, in <module>
    from .._utils import serialization as _serialization
  File "/home/semick/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/_utils/serialization.py", line 43, in <module>
    import isodate  # type: ignore
    ^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'isodate'
>>>
```

after, correctly silently imports

```
semick@CPC-scbed-QJJWS:~/repo/azure-sdk-for-python/sdk/digitaltwins/azure-digitaltwins-core$ main|>python
Python 3.13.3 (main, Apr  9 2025, 08:55:02) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from azure.digitaltwins.core import *
>>> quit()
```