### PR TITLE
Add client id to all request headers

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bugs Fixed
 
 #### Other Changes
+* Client ID will now be included in headers for all requests. See [PR #####]().
 
 ### 4.14.0b1 (2025-07-14)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -2067,7 +2067,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             options = {}
 
         headers = base.GetHeaders(self, self.default_headers, "patch", path, document_id, resource_type,
-                                  documents._OperationType.Patch, options)
+                                  documents._OperationType.Patch, options, client_id=self.client_id)
         # Patch will use WriteEndpoint since it uses PUT operation
         request_params = RequestObject(resource_type,
                                        documents._OperationType.Patch,
@@ -2161,7 +2161,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         base._populate_batch_headers(initial_headers)
         headers = base.GetHeaders(self, initial_headers, "post", path, collection_id,
                                   http_constants.ResourceType.Document,
-                                  documents._OperationType.Batch, options)
+                                  documents._OperationType.Batch, options, client_id=self.client_id)
         request_params = RequestObject(http_constants.ResourceType.Document,
                                        documents._OperationType.Batch,
                                        headers)
@@ -2224,7 +2224,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         path = '{}{}/{}'.format(path, "operations", "partitionkeydelete")
         collection_id = base.GetResourceIdOrFullNameFromLink(collection_link)
         headers = base.GetHeaders(self, self.default_headers, "post", path, collection_id,
-                                  http_constants.ResourceType.PartitionKey, documents._OperationType.Delete, options)
+                                  http_constants.ResourceType.PartitionKey, documents._OperationType.Delete, options,
+                                  client_id=self.client_id)
         request_params = RequestObject(http_constants.ResourceType.PartitionKey,
                                        documents._OperationType.Delete,
                                        headers)
@@ -2397,7 +2398,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         sproc_id = base.GetResourceIdOrFullNameFromLink(sproc_link)
         headers = base.GetHeaders(self, initial_headers, "post", path, sproc_id,
                                   http_constants.ResourceType.StoredProcedure,
-                                  documents._OperationType.ExecuteJavaScript, options)
+                                  documents._OperationType.ExecuteJavaScript, options,
+                                  client_id=self.client_id)
 
         # ExecuteStoredProcedure will use WriteEndpoint since it uses POST operation
         request_params = RequestObject(http_constants.ResourceType.StoredProcedure,
@@ -2688,7 +2690,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "post", path, id, typ, documents._OperationType.Create,
-                                  options)
+                                  options, client_id=self.client_id)
         # Create will use WriteEndpoint since it uses POST operation
 
         request_params = RequestObject(typ, documents._OperationType.Create, headers)
@@ -2735,7 +2737,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "post", path, id, typ, documents._OperationType.Upsert,
-                                  options)
+                                  options, client_id=self.client_id)
         headers[http_constants.HttpHeaders.IsUpsert] = True
 
         # Upsert will use WriteEndpoint since it uses POST operation
@@ -2782,7 +2784,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "put", path, id, typ, documents._OperationType.Replace,
-                                  options)
+                                  options, client_id=self.client_id)
         # Replace will use WriteEndpoint since it uses PUT operation
         request_params = RequestObject(typ, documents._OperationType.Replace, headers)
         request_params.set_excluded_location_from_options(options)
@@ -2825,7 +2827,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             options = {}
 
         initial_headers = initial_headers or self.default_headers
-        headers = base.GetHeaders(self, initial_headers, "get", path, id, typ, documents._OperationType.Read, options)
+        headers = base.GetHeaders(self, initial_headers, "get", path, id, typ, documents._OperationType.Read,
+                                  options, client_id=self.client_id)
         # Read will use ReadEndpoint since it uses GET operation
         request_params = RequestObject(typ, documents._OperationType.Read, headers)
         request_params.set_excluded_location_from_options(options)
@@ -2865,7 +2868,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "delete", path, id, typ, documents._OperationType.Delete,
-                                  options)
+                                  options, client_id=self.client_id)
         # Delete will use WriteEndpoint since it uses DELETE operation
         request_params = RequestObject(typ, documents._OperationType.Delete, headers)
         request_params.set_excluded_location_from_options(options)
@@ -3112,7 +3115,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                 resource_type,
                 op_typ,
                 options,
-                partition_key_range_id
+                partition_key_range_id,
+                client_id=self.client_id
             )
 
             request_params = RequestObject(
@@ -3159,7 +3163,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             resource_type,
             documents._OperationType.SqlQuery,
             options,
-            partition_key_range_id
+            partition_key_range_id,
+            client_id=self.client_id
         )
 
         request_params = RequestObject(resource_type, documents._OperationType.SqlQuery, req_headers)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -743,7 +743,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         sproc_id = base.GetResourceIdOrFullNameFromLink(sproc_link)
         headers = base.GetHeaders(self, initial_headers, "post", path, sproc_id,
                                   http_constants.ResourceType.StoredProcedure,
-                                  documents._OperationType.ExecuteJavaScript, options)
+                                  documents._OperationType.ExecuteJavaScript, options, client_id=self.client_id)
 
         # ExecuteStoredProcedure will use WriteEndpoint since it uses POST operation
         request_params = _request_object.RequestObject(http_constants.ResourceType.StoredProcedure,
@@ -783,7 +783,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "post", path, id, typ,
-                                  documents._OperationType.Create, options)
+                                  documents._OperationType.Create, options, client_id=self.client_id)
         # Create will use WriteEndpoint since it uses POST operation
 
         request_params = _request_object.RequestObject(typ, documents._OperationType.Create, headers)
@@ -923,7 +923,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "post", path, id, typ, documents._OperationType.Upsert,
-                                  options)
+                                  options, client_id=self.client_id)
 
         headers[http_constants.HttpHeaders.IsUpsert] = True
 
@@ -1229,7 +1229,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "get", path, id, typ, documents._OperationType.Read,
-                                  options)
+                                  options, client_id=self.client_id)
         # Read will use ReadEndpoint since it uses GET operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Read, headers)
         request_params.set_excluded_location_from_options(options)
@@ -1492,7 +1492,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = self.default_headers
         headers = base.GetHeaders(self, initial_headers, "patch", path, document_id, typ,
-                                  documents._OperationType.Patch, options)
+                                  documents._OperationType.Patch, options, client_id=self.client_id)
         # Patch will use WriteEndpoint since it uses PUT operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Patch, headers)
         request_params.set_excluded_location_from_options(options)
@@ -1599,7 +1599,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "put", path, id, typ, documents._OperationType.Replace,
-                                  options)
+                                  options, client_id=self.client_id)
         # Replace will use WriteEndpoint since it uses PUT operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Replace, headers)
         request_params.set_excluded_location_from_options(options)
@@ -1925,7 +1925,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         initial_headers = initial_headers or self.default_headers
         headers = base.GetHeaders(self, initial_headers, "delete", path, id, typ, documents._OperationType.Delete,
-                                  options)
+                                  options, client_id=self.client_id)
         # Delete will use WriteEndpoint since it uses DELETE operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Delete, headers)
         request_params.set_excluded_location_from_options(options)
@@ -2042,7 +2042,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         base._populate_batch_headers(initial_headers)
         headers = base.GetHeaders(self, initial_headers, "post", path, collection_id,
                                   http_constants.ResourceType.Document,
-                                  documents._OperationType.Batch, options)
+                                  documents._OperationType.Batch, options, client_id=self.client_id)
         request_params = _request_object.RequestObject(http_constants.ResourceType.Document,
                                                        documents._OperationType.Batch, headers)
         request_params.set_excluded_location_from_options(options)
@@ -2912,7 +2912,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             op_typ = documents._OperationType.QueryPlan if is_query_plan else documents._OperationType.ReadFeed
             # Query operations will use ReadEndpoint even though it uses GET(for feed requests)
             headers = base.GetHeaders(self, initial_headers, "get", path, id_, typ, op_typ,
-                                      options, partition_key_range_id)
+                                      options, partition_key_range_id, client_id=self.client_id)
             request_params = _request_object.RequestObject(
                 typ,
                 op_typ,
@@ -2951,7 +2951,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         # Query operations will use ReadEndpoint even though it uses POST(for regular query operations)
         req_headers = base.GetHeaders(self, initial_headers, "post", path, id_, typ,
                                       documents._OperationType.SqlQuery,
-                                      options, partition_key_range_id)
+                                      options, partition_key_range_id, client_id=self.client_id)
         request_params = _request_object.RequestObject(typ, documents._OperationType.SqlQuery, req_headers)
         request_params.set_excluded_location_from_options(options)
 
@@ -3321,7 +3321,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         collection_id = base.GetResourceIdOrFullNameFromLink(collection_link)
         initial_headers = dict(self.default_headers)
         headers = base.GetHeaders(self, initial_headers, "post", path, collection_id, "partitionkey",
-                                  documents._OperationType.Delete, options)
+                                  documents._OperationType.Delete, options, client_id=self.client_id)
         request_params = _request_object.RequestObject("partitionkey", documents._OperationType.Delete,
                                                        headers)
         request_params.set_excluded_location_from_options(options)


### PR DESCRIPTION
# Description

Previously, Client ID was only included in the headers when doing database account operations. It will now be included in every request/response. 