### PR TITLE
[Storage] Fix Entra ID support in Blob perf tests, update other packages

### DIFF
--- a/sdk/storage/azure-storage-blob/perf-resources.bicep
+++ b/sdk/storage/azure-storage-blob/perf-resources.bicep
@@ -1,7 +1,7 @@
 param baseName string = resourceGroup().name
 param location string = resourceGroup().location
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: '${baseName}blob'
   location: location
   kind: 'BlockBlobStorage'
@@ -17,5 +17,3 @@ var connectionString = 'DefaultEndpointsProtocol=https;AccountName=${name};Accou
 output AZURE_STORAGE_ACCOUNT_NAME string = name
 output AZURE_STORAGE_ACCOUNT_KEY string = key
 output AZURE_STORAGE_CONNECTION_STRING string = connectionString
-output STANDARD_STORAGE_CONNECTION_STRING string = connectionString
-output STORAGE_CONNECTION_STRING string = connectionString

--- a/sdk/storage/azure-storage-blob/perf-tests.yml
+++ b/sdk/storage/azure-storage-blob/perf-tests.yml
@@ -14,8 +14,8 @@ Tests:
 - Test: download
   Class: DownloadTest
   Arguments: &sizes
-  - --size 10240 --parallel 64
-  - --size 10240 --parallel 64 --use-entra-id
+  - --size 10240 --parallel 1
+  - --size 10240 --parallel 1 --use-entra-id
   - --size 10485760 --parallel 32
   - --size 1073741824 --parallel 1 --warmup 60 --duration 60
   - --size 1073741824 --parallel 8 --warmup 60 --duration 60

--- a/sdk/storage/azure-storage-blob/perf-tests.yml
+++ b/sdk/storage/azure-storage-blob/perf-tests.yml
@@ -17,6 +17,7 @@ Tests:
   - --size 10240 --parallel 64
   - --size 10240 --parallel 64 --use-entra-id
   - --size 10485760 --parallel 32
+  - --size 1073741824 --parallel 1 --warmup 60 --duration 60
   - --size 1073741824 --parallel 8 --warmup 60 --duration 60
 
 - Test: upload

--- a/sdk/storage/azure-storage-blob/perf-tests.yml
+++ b/sdk/storage/azure-storage-blob/perf-tests.yml
@@ -5,8 +5,8 @@ Project: sdk/storage/azure-storage-blob
 PrimaryPackage: azure-storage-blob
 
 PackageVersions:
-- azure-core: 1.31.0
-  azure-storage-blob: 12.18.3
+- azure-core: 1.35.0
+  azure-storage-blob: 12.26.0
 - azure-core: source
   azure-storage-blob: source
 
@@ -14,10 +14,9 @@ Tests:
 - Test: download
   Class: DownloadTest
   Arguments: &sizes
-  - --size 10240 --parallel 1
-  - --size 10240 --parallel 1 --use-entra-id
+  - --size 10240 --parallel 64
+  - --size 10240 --parallel 64 --use-entra-id
   - --size 10485760 --parallel 32
-  - --size 1073741824 --parallel 1 --warmup 60 --duration 60
   - --size 1073741824 --parallel 8 --warmup 60 --duration 60
 
 - Test: upload

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -34,20 +34,10 @@ class _ServiceTest(PerfStressTest):
 
         if not _ServiceTest.service_client or self.args.no_client_share:
             if self.args.use_entra_id:
-                tenant_id = self.get_from_env("AZURE-STORAGE-BLOB_TENANT_ID")
-                client_id = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_ID")
-                client_secret = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_SECRET")
-                sync_token_credential = SyncClientSecretCredential(
-                    tenant_id,
-                    client_id,
-                    client_secret
-                )
-                async_token_credential = AsyncClientSecretCredential(
-                    tenant_id,
-                    client_id,
-                    client_secret
-                )
                 account_name = self.get_from_env("AZURE_STORAGE_ACCOUNT_NAME")
+                sync_token_credential = self.get_credential(is_async=False)
+                async_token_credential = self.get_credential(is_async=True)
+
                 # We assume these tests will only be run on the Azure public cloud for now.
                 url = f"https://{account_name}.blob.core.windows.net"
                 _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=sync_token_credential, **self._client_kwargs)

--- a/sdk/storage/azure-storage-file-datalake/perf-resources.bicep
+++ b/sdk/storage/azure-storage-file-datalake/perf-resources.bicep
@@ -1,7 +1,7 @@
 param baseName string = resourceGroup().name
 param location string = resourceGroup().location
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: '${baseName}dlake'
   location: location
   kind: 'BlockBlobStorage'
@@ -19,12 +19,4 @@ var key = storageAccount.listKeys().keys[0].value
 // EndpointSuffix is required by azure-storage-file-datalake 12.7.0 and earlier (fixed in #24779)
 var connectionString = 'DefaultEndpointsProtocol=https;AccountName=${name};AccountKey=${key};EndpointSuffix=core.windows.net'
 
-// .NET
-output DATALAKE_STORAGE_ACCOUNT_NAME string = name
-output DATALAKE_STORAGE_ACCOUNT_KEY string = key
-
-// Java, JS
-output STORAGE_CONNECTION_STRING string = connectionString
-
-// Python
 output AZURE_STORAGE_CONNECTION_STRING string = connectionString

--- a/sdk/storage/azure-storage-file-datalake/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-datalake/perf-tests.yml
@@ -5,8 +5,8 @@ Project: sdk/storage/azure-storage-file-datalake
 PrimaryPackage: azure-storage-file-datalake
 
 PackageVersions:
-- azure-core: 1.31.0
-  azure-storage-file-datalake: 12.18.0
+- azure-core: 1.35.0
+  azure-storage-file-datalake: 12.21.0
 - azure-core: source
   azure-storage-file-datalake: source
 

--- a/sdk/storage/azure-storage-file-share/perf-resources.bicep
+++ b/sdk/storage/azure-storage-file-share/perf-resources.bicep
@@ -1,7 +1,7 @@
 param baseName string = resourceGroup().name
 param location string = resourceGroup().location
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: '${baseName}files'
   location: location
   kind: 'FileStorage'
@@ -26,5 +26,3 @@ var connectionString = 'DefaultEndpointsProtocol=https;AccountName=${name};Accou
 output AZURE_STORAGE_ACCOUNT_NAME string = name
 output AZURE_STORAGE_ACCOUNT_KEY string = key
 output AZURE_STORAGE_CONNECTION_STRING string = connectionString
-output STANDARD_STORAGE_CONNECTION_STRING string = connectionString
-output STORAGE_CONNECTION_STRING string = connectionString

--- a/sdk/storage/azure-storage-file-share/perf-tests.yml
+++ b/sdk/storage/azure-storage-file-share/perf-tests.yml
@@ -5,8 +5,8 @@ Project: sdk/storage/azure-storage-file-share
 PrimaryPackage: azure-storage-file-share
 
 PackageVersions:
-- azure-core: 1.31.0
-  azure-storage-file-share: 12.20.0
+- azure-core: 1.35.0
+  azure-storage-file-share: 12.22.0
 - azure-core: source
   azure-storage-file-share: source
 

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_base.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_base.py
@@ -240,16 +240,6 @@ class _PerfTestBase(_PerfTestABC):
                 service_connection_id=service_connection_id,
                 system_access_token=system_access_token,
             )
-        # This is for testing purposes only, to ensure that the AzurePipelinesCredential is used when available
-        else:
-            force_fallback_dac = os.environ.get("AZURE_TEST_FORCE_FALLBACK_DAC", "false")
-            if service_connection_id and not (force_fallback_dac):
-                # if service_connection_id is set, we believe it is running in CI
-                system_access_token = "Sanitized" if system_access_token else None
-                raise ValueError(
-                    "Running in Azure Pipelines. Environment variables not set for service principal authentication. "
-                    f"service_connection_id: {service_connection_id}, client_id: {client_id}, tenant_id: {tenant_id}, system_access_token: {system_access_token}"
-                )
 
         # Fall back to DefaultAzureCredential
         from azure.identity import DefaultAzureCredential


### PR DESCRIPTION
This change fixes Entra ID support in Blob perf tests by adding a `get_credential` method, similar to that of the Live tests, which can be used to get a `DefaultAzureCredential` or a `PipelinesCredential` if running in a pipeline. Used this to replace the client secret credential that no longer worked.

Also update the baseline for all Storage perf tests as well as cleaned up the bicep files.