### PR TITLE
Remove non-existing instrumentor

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -322,7 +322,6 @@ def _setup_additional_azure_sdk_instrumentations(configurations: Dict[str, Confi
 
     instrumentors = [
         ("azure.ai.inference.tracing", "AIInferenceInstrumentor"),
-        ("azure.ai.projects.telemetry.agents", "AIAgentsInstrumentor"),
         ("azure.ai.agents.telemetry", "AIAgentsInstrumentor"),
     ]
 


### PR DESCRIPTION
# Description

When running one of the Azure AI Projects samples that uses OTel tracing, I saw the below error in the console. Removing this old instrumentor, as it no longer exists (it existed in older preview versions of azure-ai-projects package, before Agents was split to its own package azure-ai-agents).

```
Failed to import AIAgentsInstrumentor from azure.ai.projects.telemetry.agents
Traceback (most recent call last):
  File "C:\Users\dcohen\AppData\Local\Programs\Python\Python312\Lib\site-packages\azure\monitor\opentelemetry\_configure.py", line 332, in _setup_additional_azure_sdk_instrumentations
    module = __import__(module_path, fromlist=[class_name])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'azure.ai.projects.telemetry'
```