### PR TITLE
Install azsdk mcp server in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,21 +12,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           cache: 'pip'
-      
+
       - name: Create and activate virtual environment
         run: |
           python -m venv .venv
           source .venv/bin/activate
           echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
           echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
-      
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r eng/ci_tools.txt
+
+      - name: Install azsdk mcp server
+        run: |
+          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,5 +32,6 @@ jobs:
           python -m pip install -r eng/ci_tools.txt
 
       - name: Install azsdk mcp server
+        shell: pwsh
         run: |
           ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin


### PR DESCRIPTION
Install azsdk mcp server in copilot setup steps.

This pairs with the coding agent config in the repo settings:

```
{
  "mcpServers": {
    "azure-sdk-mcp": {
      "type": "local",
      "command": "/home/runner/bin/azsdk",
      "tools": [
        "AnalyzePipeline",
        "GetFailedTestCaseData",
        "CheckPackageReleaseReadiness"
      ],
      "args": [
        "start"
      ]
    }
  }
}
```