### PR TITLE
[sdk generation pipeline] fix for "service-dir"

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -37,8 +37,11 @@ def del_outdated_generated_files(tsp: str):
     with open(tspconfig, "r") as file_in:
         content = yaml.safe_load(file_in)
     # tspconfig.yaml example: https://github.com/Azure/azure-rest-api-specs/pull/29080/files
-    service_dir = content.get("parameters", {}).get("service-dir", {}).get("default", "")
-    package_dir = content.get("options", {}).get("@azure-tools/typespec-python", {}).get("package-dir", "")
+    typespec_python_config = content.get("options", {}).get("@azure-tools/typespec-python", {})
+    service_dir = typespec_python_config.get("service-dir") or content.get("parameters", {}).get("service-dir", {}).get(
+        "default", ""
+    )
+    package_dir = typespec_python_config.get("package-dir", "")
     if not service_dir or not package_dir:
         _LOGGER.info(f"do not find service-dir or package-dir in tspconfig.yaml: {tspconfig}")
         return


### PR DESCRIPTION
priority of "service-dir" in language specific configuration is higher than default configuration.