### PR TITLE
[evaluation] Remove _InternalRiskCategory from type hint

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.10.0 (2025-07-29)
+## 1.10.0 (2025-07-31)
 
 ### Breaking Changes
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
@@ -280,7 +280,7 @@ class RedTeam:
         application_scenario: Optional[str] = None,
         custom_attack_seed_prompts: Optional[str] = None,
         output_dir=".",
-        attack_success_thresholds: Optional[Dict[Union[RiskCategory, _InternalRiskCategory], int]] = None,
+        attack_success_thresholds: Optional[Dict[RiskCategory, int]] = None,
     ):
         """Initialize a new Red Team agent for AI model evaluation.
 
@@ -307,7 +307,7 @@ class RedTeam:
             Should be a dictionary mapping risk categories (RiskCategory enum values) to threshold values,
             or None to use default binary evaluation (evaluation results determine success).
             When using thresholds, scores >= threshold are considered successful attacks.
-        :type attack_success_thresholds: Optional[Dict[Union[RiskCategory, _InternalRiskCategory], int]]
+        :type attack_success_thresholds: Optional[Dict[RiskCategory, int]]
         """
 
         self.azure_ai_project = validate_azure_ai_project(azure_ai_project)


### PR DESCRIPTION

# Description

This pull request addresses feedback from the 1.10.0 ApiVIEW review, and removes an internal type from a public
facing type hint.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
