### PR TITLE
[Identity] Add brokered auth to async DAC

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/broker.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/broker.py
@@ -1,0 +1,70 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import asyncio  # pylint: disable=do-not-import-asyncio
+from types import TracebackType
+from typing import Any, Optional, Type
+
+from azure.core.credentials import AccessToken, AccessTokenInfo
+from ..._credentials.broker import BrokerCredential as SyncBrokerCredential
+from .._internal import AsyncContextManager
+
+
+class BrokerCredential(AsyncContextManager):
+    """An async broker credential that wraps the synchronous BrokerCredential.
+
+    This credential wraps the synchronous BrokerCredential and provides an async interface.
+    It handles prerequisite checking and falls back appropriately through the sync credential.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._sync_credential = SyncBrokerCredential(**kwargs)
+
+    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        """Asynchronously request an access token for `scopes`.
+
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
+            For more information about scopes, see
+            https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
+
+        :return: An access token with the desired scopes.
+        :rtype: ~azure.core.credentials.AccessToken
+
+        :raises CredentialUnavailableError: when the broker credential is unavailable
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: self._sync_credential.get_token(*scopes, **kwargs))
+
+    async def get_token_info(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:
+        """Asynchronously request an access token for `scopes`.
+
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
+            For more information about scopes, see
+            https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
+
+        :return: An AccessTokenInfo instance with information about the token.
+        :rtype: ~azure.core.credentials.AccessTokenInfo
+
+        :raises CredentialUnavailableError: when the broker credential is unavailable
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: self._sync_credential.get_token_info(*scopes, **kwargs))
+
+    async def __aenter__(self) -> "BrokerCredential":
+        await asyncio.get_event_loop().run_in_executor(None, self._sync_credential.__enter__)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self._sync_credential.__exit__(exc_type, exc_value, traceback)
+        )
+
+    async def close(self) -> None:
+        """Close the credential's transport session."""
+        await asyncio.get_event_loop().run_in_executor(None, self._sync_credential.close)

--- a/sdk/identity/azure-identity/tests/conftest.py
+++ b/sdk/identity/azure-identity/tests/conftest.py
@@ -179,27 +179,6 @@ def live_user_details():
         return user_details
 
 
-@pytest.fixture()
-def event_loop():
-    """Ensure the event loop used by pytest-asyncio on Windows is ProactorEventLoop, which supports subprocesses.
-
-    This is necessary because SelectorEventLoop, which does not support subprocesses, is the default on Python < 3.8.
-    """
-
-    try:
-        import asyncio
-    except:
-        return
-
-    if sys.platform.startswith("win"):
-        loop = asyncio.ProactorEventLoop()
-    else:
-        loop = asyncio.new_event_loop()
-
-    yield loop
-    loop.close()
-
-
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy, environment_variables):
     set_custom_default_matcher(

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -16,6 +16,7 @@ from azure.identity import (
     SharedTokenCacheCredential,
     VisualStudioCodeCredential,
 )
+from azure.identity._credentials.broker import BrokerCredential
 from azure.identity._constants import EnvironmentVariables
 from azure.identity._credentials.azure_cli import AzureCliCredential
 from azure.identity._credentials.azd_cli import AzureDeveloperCliCredential
@@ -177,10 +178,7 @@ def test_exclude_options():
     credential = DefaultAzureCredential(exclude_developer_cli_credential=True)
     assert_credentials_not_present(credential, AzureDeveloperCliCredential)
 
-    # test excluding broker credential
     credential = DefaultAzureCredential(exclude_broker_credential=True)
-    from azure.identity._credentials.broker import BrokerCredential
-
     assert_credentials_not_present(credential, BrokerCredential)
 
     # interactive auth is excluded by default
@@ -188,13 +186,6 @@ def test_exclude_options():
     actual = {c.__class__ for c in credential.credentials}
     default = {c.__class__ for c in DefaultAzureCredential().credentials}
     assert actual - default == {InteractiveBrowserCredential}
-
-    # broker credential is included by default
-    credential = DefaultAzureCredential()
-    from azure.identity._credentials.broker import BrokerCredential
-
-    actual = {c.__class__ for c in credential.credentials}
-    assert BrokerCredential in actual, "BrokerCredential should be included in DefaultAzureCredential by default"
 
 
 @pytest.mark.parametrize("get_token_method", GET_TOKEN_METHODS)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+import sys
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
@@ -17,7 +18,9 @@ from azure.identity.aio import (
     SharedTokenCacheCredential,
     VisualStudioCodeCredential,
 )
+from azure.identity.aio._credentials.broker import BrokerCredential
 from azure.identity._constants import EnvironmentVariables
+from azure.identity._internal.utils import is_wsl
 import pytest
 
 from helpers import mock_response, Request, GET_TOKEN_METHODS
@@ -136,6 +139,9 @@ def test_exclude_options():
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
         assert_credentials_not_present(credential, SharedTokenCacheCredential)
+
+    credential = DefaultAzureCredential(exclude_broker_credential=True)
+    assert_credentials_not_present(credential, BrokerCredential)
 
     credential = DefaultAzureCredential(exclude_cli_credential=True)
     assert_credentials_not_present(credential, AzureCliCredential)
@@ -344,3 +350,78 @@ def test_validate_cloud_shell_credential_in_dac():
         DefaultAzureCredential(identity_config={"client_id": "foo"})
         DefaultAzureCredential(identity_config={"object_id": "foo"})
         DefaultAzureCredential(identity_config={"resource_id": "foo"})
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win") and not is_wsl(), reason="tests Windows-specific behavior")
+@pytest.mark.asyncio
+async def test_broker_credential():
+    """Test that DefaultAzureCredential uses the broker credential when available"""
+    with patch("azure.identity.broker.InteractiveBrowserBrokerCredential") as mock_credential:
+        credential = DefaultAzureCredential()
+        # The broker credential should be in the chain
+        broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+        assert len(broker_credentials) == 1, "BrokerCredential should be in the chain"
+    # InteractiveBrowserBrokerCredential should be instantiated by BrokerCredential
+    assert mock_credential.call_count >= 1, "InteractiveBrowserBrokerCredential should be instantiated"
+
+
+@pytest.mark.asyncio
+async def test_broker_credential_client_id():
+    """Test that DefaultAzureCredential allows configuring a client ID for BrokerCredential"""
+
+    client_id = "broker-client-id"
+    credential = DefaultAzureCredential(broker_client_id=client_id)
+    broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+    assert (
+        len(broker_credentials) == 1
+    ), "BrokerCredential should be in the chain even when broker package is not installed"
+    broker_credential = broker_credentials[0]
+    # Check that the broker credential was created with proper parameters by testing the sync credential
+    # We can access the sync credential since this is a test and we control the implementation
+    sync_credential = getattr(broker_credential, "_sync_credential", None)
+    assert sync_credential is not None, "BrokerCredential should have _sync_credential"
+    assert (
+        getattr(sync_credential, "_client_id", None) == client_id
+    ), "Credential should be instantiated with the specified client ID"
+
+
+@pytest.mark.asyncio
+async def test_broker_credential_tenant_id():
+    """Test that DefaultAzureCredential allows configuring a tenant ID for BrokerCredential"""
+
+    tenant_id = "broker-tenant-id"
+
+    credential = DefaultAzureCredential(broker_tenant_id=tenant_id)
+    broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+    assert (
+        len(broker_credentials) == 1
+    ), "BrokerCredential should be in the chain even when broker package is not installed"
+    broker_credential = broker_credentials[0]
+    # Check that the broker credential was created with proper parameters by testing the sync credential
+    sync_credential = getattr(broker_credential, "_sync_credential", None)
+    assert sync_credential is not None, "BrokerCredential should have _sync_credential"
+    assert (
+        getattr(sync_credential, "_tenant_id", None) == tenant_id
+    ), "Credential should be instantiated with the specified tenant ID"
+
+
+@pytest.mark.asyncio
+async def test_broker_credential_requirements_not_installed():
+    """Test that DefaultAzureCredential includes BrokerCredential even when broker package is not installed"""
+
+    # Mock the get_broker_credential function to return None (simulating package not installed)
+    with patch.dict("sys.modules", {"azure.identity.broker": None}):
+        credential = DefaultAzureCredential()
+        # The broker credential should still be in the chain
+        broker_credentials = [c for c in credential.credentials if c.__class__.__name__ == "BrokerCredential"]
+        assert (
+            len(broker_credentials) == 1
+        ), "BrokerCredential should be in the chain even when broker package is not installed"
+
+        # Test that the broker credential raises CredentialUnavailableError using the async get_token method
+        broker_cred = broker_credentials[0]
+        with pytest.raises(CredentialUnavailableError):
+            # Use getattr to handle typing issues
+            get_token_method = getattr(broker_cred, "get_token_info", None)
+            assert get_token_method is not None
+            await get_token_method("https://management.azure.com/.default")


### PR DESCRIPTION
Here, we wrap the synchronous broker credential and provide an async interface to allow for the async DefaultAzureCredential to use brokered auth, improving parity with sync DAC.