### PR TITLE
bump typespec-python 0.47.2

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,14 +6,14 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.47.1"
+        "@azure-tools/typespec-python": "0.47.2"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "~0.58.0",
+        "@azure-tools/typespec-autorest": "~0.58.1",
         "@azure-tools/typespec-azure-core": "~0.58.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.58.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.58.1",
         "@azure-tools/typespec-azure-rulesets": "~0.58.0",
-        "@azure-tools/typespec-client-generator-core": "~0.58.0",
+        "@azure-tools/typespec-client-generator-core": "0.58.0",
         "@azure-tools/typespec-liftr-base": "0.8.0",
         "@typespec/compiler": "^1.2.1",
         "@typespec/events": "~0.72.1",
@@ -128,13 +128,13 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.47.1.tgz",
-      "integrity": "sha512-8oph1/RwznRfB83iCvhXGJ2Zxf/c7/2ofC6TEdAD0BChW1kVfE+lYOmG78n+rINLjJ/C+IhztaGJ7cL638MLKQ==",
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.47.2.tgz",
+      "integrity": "sha512-9BAAcdn+sFvyaJsfDMo9RC8nubWglHxPx0f/cYOiw1kr7U7rB4EZ1KPpej8UosHuYG8ChF1IXEwqxWEOIIECdA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.14.1",
+        "@typespec/http-client-python": "~0.14.2",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.14.1.tgz",
-      "integrity": "sha512-XCBstfoOFPdAZ9479hb6vwtA1h+mkROjo3bBtCh5ITcy9gECvQK6vOLkjrGywmsaBBFRJhHrUI94MxWFAfJwOQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.14.2.tgz",
+      "integrity": "sha512-5G8uCugt6FNW8pvxog5/oWTdN6SXXhVRu8OBOf6QoPy8gNkeTsNraQz6vRYkyR/VpxnFatUbXfdPmE/vuFKABA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.47.1"
+    "@azure-tools/typespec-python": "0.47.2"
   },
   "devDependencies": {
     "@typespec/compiler": "^1.2.1",
@@ -14,10 +14,10 @@
     "@typespec/streams": "~0.72.1",
     "@typespec/xml": "~0.72.1",
     "@azure-tools/typespec-azure-core": "~0.58.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.58.0",
-    "@azure-tools/typespec-autorest": "~0.58.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.58.1",
+    "@azure-tools/typespec-autorest": "~0.58.1",
     "@azure-tools/typespec-azure-rulesets": "~0.58.0",
-    "@azure-tools/typespec-client-generator-core": "~0.58.0",
+    "@azure-tools/typespec-client-generator-core": "0.58.0",
     "@azure-tools/typespec-liftr-base": "0.8.0"
   }
 }


### PR DESCRIPTION
This PR bumps the typespec-python version from 0.47.1 to 0.47.2 in the emitter package configuration.

## Changes
- Updated `@azure-tools/typespec-python` from `0.47.1` to `0.47.2`
- Updated related Azure TypeSpec dependencies to their latest patch versions
- Regenerated `emitter-package-lock.json` with the new dependency versions

## Files Modified
- `eng/emitter-package.json`
- `eng/emitter-package-lock.json`