### PR TITLE
Update CODEOWNERS for Monitor Query Metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,6 +182,9 @@
 /sdk/monitor/azure-monitor-query/                                    @pvaneck @Azure/azure-sdk-write-monitor-data-plane
 
 # PRLabel: %Monitor
+/sdk/monitor/azure-monitor-querymetrics/                             @Azure/azure-sdk-write-monitor-query-metrics
+
+# PRLabel: %Monitor
 /sdk/monitor/*                                                       @pvaneck
 
 # PRLabel: %Monitor - ApplicationInsights


### PR DESCRIPTION
Adds a new entry for the Monitor Query Metrics SDK, which is owned by the service team. A new team is assigned to it, and that team contains the service team engineers.