### PR TITLE
Customer Facing Statsbeat: Added remaining drop codes to base

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_customer_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_customer_statsbeat.py
@@ -37,6 +37,11 @@ from azure.monitor.opentelemetry.exporter.statsbeat._utils import (
 )
 from azure.monitor.opentelemetry.exporter import VERSION
 
+from azure.monitor.opentelemetry.exporter.statsbeat._state import (
+    _CUSTOMER_STATSBEAT_STATE,
+    _CUSTOMER_STATSBEAT_STATE_LOCK,
+)
+
 _CUSTOMER_STATSBEAT_MAP_LOCK = threading.Lock()
 
 class _CustomerStatsbeatTelemetryCounters:
@@ -256,10 +261,6 @@ def collect_customer_statsbeat(exporter):
     if hasattr(exporter, 'storage') and exporter.storage:
         exporter.storage._customer_statsbeat_metrics = _CUSTOMER_STATSBEAT_METRICS
 
-_CUSTOMER_STATSBEAT_STATE = {
-    "SHUTDOWN": False,
-}
-_CUSTOMER_STATSBEAT_STATE_LOCK = threading.Lock()
 
 def shutdown_customer_statsbeat_metrics() -> None:
     global _CUSTOMER_STATSBEAT_METRICS
@@ -276,6 +277,3 @@ def shutdown_customer_statsbeat_metrics() -> None:
         if shutdown_success:
             with _CUSTOMER_STATSBEAT_STATE_LOCK:
                 _CUSTOMER_STATSBEAT_STATE["SHUTDOWN"] = True
-
-def get_customer_statsbeat_shutdown():
-    return _CUSTOMER_STATSBEAT_STATE["SHUTDOWN"]

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
@@ -19,6 +19,10 @@ _STATSBEAT_STATE = {
 _STATSBEAT_STATE_LOCK = threading.Lock()
 _STATSBEAT_FAILURE_COUNT_THRESHOLD = 3
 
+_CUSTOMER_STATSBEAT_STATE = {
+    "SHUTDOWN": False,
+}
+_CUSTOMER_STATSBEAT_STATE_LOCK = threading.Lock()
 
 def is_statsbeat_enabled():
     disabled = os.environ.get(_APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL)
@@ -68,3 +72,6 @@ def get_statsbeat_live_metrics_feature_set():
 def set_statsbeat_live_metrics_feature_set():
     with _STATSBEAT_STATE_LOCK:
         _STATSBEAT_STATE["LIVE_METRICS_FEATURE_SET"] = True
+
+def get_customer_statsbeat_shutdown():
+    return _CUSTOMER_STATSBEAT_STATE["SHUTDOWN"]


### PR DESCRIPTION
# Description

Added the logic for remaining drop codes and moved them from storage to base.py. This PR also includes changes that refactor the `get_customer_statsbeat_shutdown` method, customer_statsbeat state and state lock variables and moved them from customer_statsbeat to state.py, just like regular statsbeat.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
