### PR TITLE
Update method name to get Application Insights connection string

### DIFF
--- a/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_basics_async_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_basics_async_with_azure_monitor_tracing.py
@@ -17,16 +17,14 @@ USAGE:
     pip install azure-ai-projects azure-ai-agents azure-identity opentelemetry-sdk azure-monitor-opentelemetry aiohttp
 
     Set these environment variables with your own values:
-    * PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
-                          page of your Azure AI Foundry portal.
-    * AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
-      messages, which may contain personal data. False by default.
-    * AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
-      messages, which may contain personal data. False by default.
-    * APPLICATIONINSIGHTS_CONNECTION_STRING - Set to the connection string of your Application Insights resource.
-      This is used to send telemetry data to Azure Monitor. You can also get the connection string programmatically
-      from AIProjectClient using the `telemetry.get_connection_string` method. A code sample showing how to do this
-      can be found in the `sample_telemetry_async.py` file in the azure-ai-projects telemetry samples.
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
+       page of your Azure AI Foundry portal.
+    2) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
+       messages, which may contain personal data. False by default.
+    3) APPLICATIONINSIGHTS_CONNECTION_STRING - Set to the connection string of your Application Insights resource.
+       This is used to send telemetry data to Azure Monitor. You can also get the connection string programmatically
+       from AIProjectClient using the `telemetry.get_application_insights_connection_string()` method. A code sample showing
+       how to do this can be found in the `sample_telemetry_async.py` file in the azure-ai-projects telemetry samples.
 """
 import asyncio
 import time

--- a/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_basics_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_basics_with_azure_monitor_tracing.py
@@ -18,15 +18,15 @@ USAGE:
 
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
-                          page of your Azure AI Foundry portal.
+       page of your Azure AI Foundry portal.
     2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
     4) APPLICATIONINSIGHTS_CONNECTION_STRING - Set to the connection string of your Application Insights resource.
        This is used to send telemetry data to Azure Monitor. You can also get the connection string programmatically
-       from AIProjectClient using the `telemetry.get_connection_string` method. A code sample showing how to do this
-       can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
+       from AIProjectClient using the `telemetry.get_application_insights_connection_string()` method. A code sample showing
+       how to do this can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
 """
 
 import os

--- a/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_stream_eventhandler_with_azure_monitor_tracing.py
@@ -18,15 +18,15 @@ USAGE:
 
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
-                          page of your Azure AI Foundry portal.
+       page of your Azure AI Foundry portal.
     2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
     4) APPLICATIONINSIGHTS_CONNECTION_STRING - Set to the connection string of your Application Insights resource.
        This is used to send telemetry data to Azure Monitor. You can also get the connection string programmatically
-       from AIProjectClient using the `telemetry.get_connection_string` method. A code sample showing how to do this
-       can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
+       from AIProjectClient using the `telemetry.get_application_insights_connection_string()` method. A code sample showing
+       how to do this can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
 """
 
 import os

--- a/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_toolset_with_azure_monitor_tracing.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_telemetry/sample_agents_toolset_with_azure_monitor_tracing.py
@@ -18,15 +18,15 @@ USAGE:
 
     Set these environment variables with your own values:
     1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
-                          page of your Azure AI Foundry portal.
+       page of your Azure AI Foundry portal.
     2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
        the "Models + endpoints" tab in your Azure AI Foundry project.
     3) AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED - Optional. Set to `true` to trace the content of chat
        messages, which may contain personal data. False by default.
     4) APPLICATIONINSIGHTS_CONNECTION_STRING - Set to the connection string of your Application Insights resource.
        This is used to send telemetry data to Azure Monitor. You can also get the connection string programmatically
-       from AIProjectClient using the `telemetry.get_connection_string` method. A code sample showing how to do this
-       can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
+       from AIProjectClient using the `telemetry.get_application_insights_connection_string()` method. A code sample showing
+       how to do this can be found in the `sample_telemetry.py` file in the azure-ai-projects telemetry samples.
 """
 from typing import Any, Callable, Set
 


### PR DESCRIPTION
With the stable release of azure-ai-projects client library, the method named `.telemetry.get_connection_string` has changed to `.telemetry.get_application_insights_connection_string`. 

Also other minor updates in the comments of the telemetry samples.