### PR TITLE
Update Python Projects SDK version, and set dependency on beta versions of azure-ai-agents instead of stable

### DIFF
--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0b3 (Unreleased)
+
+### Features added
+
+### Breaking changes
+
+### Bugs Fixed
+
+### Sample updates
+
 ## 1.1.0b2 (2025-08-05)
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_version.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "1.1.0b2"
+VERSION = "1.1.0b3"

--- a/sdk/ai/azure-ai-projects/setup.py
+++ b/sdk/ai/azure-ai-projects/setup.py
@@ -71,7 +71,7 @@ setup(
         "azure-core>=1.30.0",
         "typing-extensions>=4.12.2",
         "azure-storage-blob>=12.15.0",
-        "azure-ai-agents>=1.0.0",
+        "azure-ai-agents>=1.2.0b1",
     ],
     python_requires=">=3.9",
 )


### PR DESCRIPTION
Increment version for a next beta release. Nothing is planned at the moment.

Update dependency to "azure-ai-agents>=1.2.0b1" so when you start from a clean environment, latest beta version of Agents SDK will be installed when azure-ai-projects is installed. This is okay for a beta release of azure-ai-projects. The stable release of azure-ai-projects has the dependency "azure-ai-agents>=1.0.0", which installs the latest stable release of azure-ai-agents (and you don't get any of the preview features).