### PR TITLE
Remove duplicate redacted/unredacted console logs

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -33,12 +33,18 @@ _console_logging_enabled: bool = os.environ.get("ENABLE_AZURE_AI_PROJECTS_CONSOL
 )
 if _console_logging_enabled:
     import sys
-
+    # Enable detailed console logs across Azure libraries
     azure_logger = logging.getLogger("azure")
     azure_logger.setLevel(logging.DEBUG)
     azure_logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+    # Exclude detailed logs for network calls associated with getting Entra ID token.
     identity_logger = logging.getLogger("azure.identity")
     identity_logger.setLevel(logging.ERROR)
+    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to 
+    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor 
+    # (which are implemented as a separate logging policy)
+    logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
+    logger.setLevel(logging.ERROR)
 
 
 def _patch_user_agent(user_agent: Optional[str]) -> str:

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -40,8 +40,8 @@ if _console_logging_enabled:
     # Exclude detailed logs for network calls associated with getting Entra ID token.
     identity_logger = logging.getLogger("azure.identity")
     identity_logger.setLevel(logging.ERROR)
-    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to 
-    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor 
+    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to
+    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor
     # (which are implemented as a separate logging policy)
     logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
     logger.setLevel(logging.ERROR)

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -41,8 +41,8 @@ if _console_logging_enabled:
     # Exclude detailed logs for network calls associated with getting Entra ID token.
     identity_logger = logging.getLogger("azure.identity")
     identity_logger.setLevel(logging.ERROR)
-    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to 
-    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor 
+    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to
+    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor
     # (which are implemented as a separate logging policy)
     logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
     logger.setLevel(logging.ERROR)

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -34,12 +34,18 @@ _console_logging_enabled: bool = os.environ.get("ENABLE_AZURE_AI_PROJECTS_CONSOL
 )
 if _console_logging_enabled:
     import sys
-
+    # Enable detailed console logs across Azure libraries
     azure_logger = logging.getLogger("azure")
     azure_logger.setLevel(logging.DEBUG)
     azure_logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+    # Exclude detailed logs for network calls associated with getting Entra ID token.
     identity_logger = logging.getLogger("azure.identity")
     identity_logger.setLevel(logging.ERROR)
+    # Make sure regular (redacted) detailed azure.core logs are not shown, as we are about to 
+    # turn on non-redacted logs by passing 'logging_enable=True' to the client constructor 
+    # (which are implemented as a separate logging policy)
+    logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
+    logger.setLevel(logging.ERROR)
 
 
 class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
## Background

Python Projects SDK has an internal switch to turn on un-redacted console logging, based on env variable ENABLE_AZURE_AI_PROJECTS_CONSOLE_LOGGING. The same thing can be done in code by the developer, per ["Configure logging in the Azure libraries for Python"](https://learn.microsoft.com/en-us/azure/developer/python/sdk/azure-sdk-logging). However, I found it very easy to just turn on/off an env variable, instead of constantly adding and removing a few lines of code to my tests and samples, every time I need to investigate an issue. 

## What does this PR do?

Up until now, when this environment variable is set, the logs included both redacted and unredacted logs. This made is hard to read console logs. Following discussion with the Azure SDK Python team, I learned how to suppress redacted logs. This PR makes the change to make sure that only unredacted console logs are shown.