### PR TITLE
[Identity] Update MI live test resources

### DIFF
--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -52,7 +52,9 @@ Start-Sleep -s 45
 $az_version = az version
 Write-Host "Azure CLI version: $az_version"
 az cloud set --name $Environment
-az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
+if ($CI) {
+    az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
+}
 az account set --subscription $SubscriptionId
 $versions = az aks get-versions -l $Location -o json | ConvertFrom-Json
 Write-Host "AKS versions for ${Location}: $($versions | ConvertTo-Json -Depth 100)"

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -337,7 +337,18 @@ resource kubernetesCluster 'Microsoft.ContainerService/managedClusters@2023-06-0
   }
 }
 
-resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = if (provisionLiveResources) {
+resource publicIP 'Microsoft.Network/publicIPAddresses@2023-05-01' = {
+  name: '${baseName}PublicIP'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2024-07-01' = if (provisionLiveResources) {
   name: '${baseName}vnet'
   location: location
   properties: {
@@ -351,13 +362,14 @@ resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = if (provisionLive
         name: '${baseName}subnet'
         properties: {
           addressPrefix: '10.0.0.0/24'
+          defaultOutboundAccess: false
         }
       }
     ]
   }
 }
 
-resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' = if (provisionLiveResources) {
+resource networkInterface 'Microsoft.Network/networkInterfaces@2024-07-01' = if (provisionLiveResources) {
   name: '${baseName}NIC'
   location: location
   properties: {
@@ -369,13 +381,16 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' = if 
           subnet: {
             id: provisionLiveResources ? vnet.properties.subnets[0].id : ''
           }
+          publicIPAddress: {
+            id: provisionLiveResources ? publicIP.id : ''
+          }
         }
       }
     ]
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-06-01' = if (provisionLiveResources) {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-07-01' = if (provisionLiveResources) {
   name: '${baseName}vm'
   location: location
   identity: {

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -337,7 +337,7 @@ resource kubernetesCluster 'Microsoft.ContainerService/managedClusters@2023-06-0
   }
 }
 
-resource publicIP 'Microsoft.Network/publicIPAddresses@2023-05-01' = {
+resource publicIP 'Microsoft.Network/publicIPAddresses@2023-05-01' = if (provisionLiveResources) {
   name: '${baseName}PublicIP'
   location: location
   sku: {


### PR DESCRIPTION
Test resource provisioning has been failing in the TME tenant for the weekly managed identity tests. This updates the bicep to allow provisioning to succeed again. 