### PR TITLE
[Keyvault] KV Keys add back changelog to pyproject.toml

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/pyproject.toml
+++ b/sdk/keyvault/azure-keyvault-keys/pyproject.toml
@@ -36,7 +36,7 @@ repository = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk"
 
 [tool.setuptools.dynamic]
 version = {attr = "azure.keyvault.keys._version.VERSION"}
-readme = {file = ["README.md"], content-type = "text/markdown"}
+readme = {file = ["README.md", "CHANGELOG.md"], content-type = "text/markdown"}
 
 [tool.setuptools.packages.find]
 exclude = ["samples*", "tests*", "azure", "azure.keyvault"]


### PR DESCRIPTION
Accidentally removed the changelog from the readme description when converting from setup.py to pyproject.toml. Adding it back in. (Even though PEP 621 doesn't allow multiple files to be passed in for readme, setuptools does, so this should be fine.)