### PR TITLE
[Monitor] Remove unused envvar from test resources output

### DIFF
--- a/sdk/monitor/test-resources.bicep
+++ b/sdk/monitor/test-resources.bicep
@@ -233,7 +233,6 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2021-09-01-p
   ]
 }
 
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsightsComponent.properties.ConnectionString
 output METRICS_RESOURCE_ID string = applicationInsightsComponent.id
 output AZURE_MONITOR_WORKSPACE_ID string = primaryWorkspace.properties.customerId
 output AZURE_MONITOR_SECONDARY_WORKSPACE_ID string = secondaryWorkspace.properties.customerId


### PR DESCRIPTION
This env var isn't used by any tests. Removing it as it can cause issues with exporter live tests.