### PR TITLE
Update CODEOWNERS for Monitor Query Logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,7 +179,7 @@
 /sdk/monitor/azure-monitor-ingestion/                                @pvaneck @Azure/azure-sdk-write-monitor-data-plane
 
 # PRLabel: %Monitor
-/sdk/monitor/azure-monitor-query/                                    @pvaneck @Azure/azure-sdk-write-monitor-data-plane
+/sdk/monitor/azure-monitor-query/                                    @Azure/azure-sdk-write-monitor-query-logs
 
 # PRLabel: %Monitor
 /sdk/monitor/azure-monitor-querymetrics/                             @Azure/azure-sdk-write-monitor-query-metrics


### PR DESCRIPTION
The Monitor Query Logs library is now owned by the service team. Update the corresponding CODEOWNERS entry with their GitHub team.