### PR TITLE
Run codeql only in aggregate-reports

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -77,10 +77,6 @@ jobs:
         sdl:
           componentgovernance:
             enabled: true
-          codeql:
-            binaryLanguages: python # Need to specify the language because we clone after the codeql initialize step
-            compiled:
-              enabled: true
 
     steps:
     - template: /eng/pipelines/templates/steps/build-package-artifacts.yml


### PR DESCRIPTION
I missed merging a change in https://github.com/Azure/azure-sdk-for-python/pull/42431/files.

https://github.com/Azure/azure-sdk-for-python/pull/42431/files

My goal was to only run codeql during the aggregate-reports pipeline because we don't want to destabilize the normal builds with extra-long times when codeql decides to run (like https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5221610&view=logs&j=1dca5ef1-3811-5712-152d-1052a5815ba2&t=e6c03388-c5c2-5478-daae-7f3d61ba4c18).