### PR TITLE
[Core] Chain challenge responses with token exceptions

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` will now properly surface credential exceptions when handling claims challenges. Previously, exceptions from credential token requests were suppressed; now they are raised and chained with the original 401 `HttpResponseError` response for better debugging visibility. #42536
+
 ## 1.35.0 (2025-07-02)
 
 ### Features Added

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -13,6 +13,7 @@ from azure.core.credentials_async import (
     AsyncSupportsTokenInfo,
     AsyncTokenProvider,
 )
+from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
 from azure.core.pipeline.policies._authentication import (
@@ -110,7 +111,12 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
         if response.http_response.status_code == 401:
             self._token = None  # any cached token is invalid
             if "WWW-Authenticate" in response.http_response.headers:
-                request_authorized = await self.on_challenge(request, response)
+                try:
+                    request_authorized = await self.on_challenge(request, response)
+                except Exception as ex:
+                    # Raise the exception from the token request with the original 401 response
+                    raise ex from HttpResponseError(response=response.http_response)
+
                 if request_authorized:
                     # if we receive a challenge response, we retrieve a new token
                     # which matches the new target. In this case, we don't want to remove
@@ -145,14 +151,11 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
             encoded_claims = get_challenge_parameter(headers, "Bearer", "claims")
             if not encoded_claims:
                 return False
-            try:
-                padding_needed = -len(encoded_claims) % 4
-                claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode("utf-8")
-                if claims:
-                    await self.authorize_request(request, *self._scopes, claims=claims)
-                    return True
-            except Exception:  # pylint:disable=broad-except
-                return False
+            padding_needed = -len(encoded_claims) % 4
+            claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode("utf-8")
+            if claims:
+                await self.authorize_request(request, *self._scopes, claims=claims)
+                return True
         return False
 
     def on_response(

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -16,7 +16,7 @@ from azure.core.credentials import (
     AzureNamedKeyCredential,
     AccessTokenInfo,
 )
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import ServiceRequestError, HttpResponseError, ClientAuthenticationError
 from azure.core.pipeline import Pipeline, PipelineRequest, PipelineContext, PipelineResponse
 from azure.core.pipeline.transport import HttpTransport, HttpRequest
 from azure.core.pipeline.policies import (
@@ -837,3 +837,51 @@ def test_bearer_policy_on_challenge_caches_token_with_claims(http_request):
 
     # Verify the Authorization header was set correctly
     assert request.http_request.headers["Authorization"] == "Bearer claims_token"
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+def test_bearer_policy_on_challenge_exception_chaining(http_request):
+    """Test that exceptions during on_challenge are chained with HttpResponseError"""
+
+    # Mock credential that raises an exception during get_token_info with claims
+    def mock_get_token_info(*scopes, options=None):
+        if options and "claims" in options:
+            raise ClientAuthenticationError("Failed to request token info with claims")
+        return AccessTokenInfo("initial_token", int(time.time()) + 3600)
+
+    fake_credential = Mock(
+        spec_set=["get_token", "get_token_info"],
+        get_token=Mock(return_value=AccessToken("fallback", int(time.time()) + 3600)),
+        get_token_info=mock_get_token_info,
+    )
+    policy = BearerTokenCredentialPolicy(fake_credential, "scope")
+
+    # Create a 401 response with insufficient_claims challenge
+    test_claims = '{"access_token":{"foo":"bar"}}'
+    encoded_claims = base64.urlsafe_b64encode(test_claims.encode()).decode().rstrip("=")
+    challenge_header = f'Bearer error="insufficient_claims", claims="{encoded_claims}"'
+
+    response_mock = Mock(status_code=401, headers={"WWW-Authenticate": challenge_header})
+
+    # Mock transport that returns the 401 response
+    def mock_transport_send(request):
+        return response_mock
+
+    transport = Mock(send=mock_transport_send)
+    pipeline = Pipeline(transport=transport, policies=[policy])
+
+    # Execute the request and verify exception chaining
+    with pytest.raises(ClientAuthenticationError) as exc_info:
+        pipeline.run(http_request("GET", "https://example.com"))
+
+    # Verify the original exception is preserved
+    original_exception = exc_info.value
+    assert original_exception.message == "Failed to request token info with claims"
+
+    # Verify the exception is chained with HttpResponseError
+    assert original_exception.__cause__ is not None
+    assert isinstance(original_exception.__cause__, HttpResponseError)
+
+    # Verify the HttpResponseError contains the original 401 response
+    http_response_error = original_exception.__cause__
+    assert http_response_error.response is response_mock


### PR DESCRIPTION
## Motivation

In `BearerTokenCredentialPolicy`, if a 401 HTTP response is received with a claims challenge from a service, the policy will attempt to acquire a new token using the claims provided in the challenge.

Currently, if a claims token request fails, the `BearerTokenCredentialPolicy` will only surface the **401 response** and not the error details from the claims token request. The claims token request error is just caught and swallowed. This means that users may not have all the information they need to resolve authentication issues.

## Changes

When a claims token request fails, the policy will now raise the associated error and chain the original 401 response error to it using `raise ... from ...` syntax. This provides users with immediate access to all relevant error information. Programmatically, the caller can now access the token request error and can access the original 401 response through the `__cause__` attribute on the exception.

## Notes

- In both cases, current and proposed, the user will be unable to proceed regardless because of insufficient auth. An Error should be raised.
- Keyvault's implementation of challenge policies raises any error from the claims token request already.

## Example error output

```shell
azure.core.exceptions.HttpResponseError: (RequestDisallowedByPolicy) Resource 'example' was disallowed by policy. Policy identifiers: {policyAssignment: {name: 'Users must use MFA for Create/Update oeprations'}}
Code: RequestDisallowedByPolicy
Message: Resource 'example' was disallowed by policy. Policy identifiers: {policyAssignment: {name: 'Users must use MFA for Create/Update oeprations'}}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/paul/paul_pipeline.py", line 102, in <module>
    main()
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/paul/paul_pipeline.py", line 70, in main
    response = client.send_request(request)
...
...
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py", line 239, in on_challenge
    self.authorize_request(request, *self._scopes, claims=claims)
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py", line 148, in authorize_request
    self._request_token(*scopes, **kwargs)
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py", line 111, in _request_token
    self._token = self._get_token(*scopes, **kwargs)
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py", line 101, in _get_token
    return cast(SupportsTokenInfo, self._credential).get_token_info(*scopes, options=options)
  File "/home/pvaneck/azure-sdk-for-python/sdk/core/azure-core/paul/paul_pipeline.py", line 37, in get_token_info
    raise ClientAuthenticationError("Claims failure. ADSTS123: Some additional info. Please run the following: az login --claims-challenge 1234abc")
azure.core.exceptions.ClientAuthenticationError: Claims failure. ADSTS123: Some additional info. Please run the following: az login --claims-challenge 1234abc
```


Ref: https://github.com/Azure/azure-sdk-for-python/issues/41739