### PR TITLE
Customer Facing Statsbeat: Refactored logic for tracking dropped item from storage

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 - Customer Facing Statsbeat: Added remaining drop codes to base
   ([#42382](https://github.com/Azure/azure-sdk-for-python/pull/42382))
+- Refactored the put methods in storage.py for LocalFileBlob and LocalFileStorage
+  ([#42502](https://github.com/Azure/azure-sdk-for-python/pull/42502))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -223,7 +223,7 @@ class BaseExporter:
                         # For any exceptions occurred in put method of either LocalFileStorage or LocalFileBlob, track dropped item with reason
                         _track_dropped_items(self._customer_statsbeat_metrics, envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put)
                     else:
-                        # LocalFileBlob.put returns StorageExportResult.LOCAL_FILE_BLOB_SUCCESS here. Since self, does not return anything, this is captured in else.
+                        # LocalFileBlob.put returns StorageExportResult.LOCAL_FILE_BLOB_SUCCESS here. Don't need to track anything in this case.
                         pass
             elif result == ExportResult.SUCCESS:
                 # Try to send any cached events

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -223,7 +223,7 @@ class BaseExporter:
                         # For any exceptions occurred in put method of either LocalFileStorage or LocalFileBlob, track dropped item with reason
                         _track_dropped_items(self._customer_statsbeat_metrics, envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put)
                     else:
-                        # LocalFileBlob.put returns either an exception(failure, handled above) or the file path(success), eventually that will be removed since this value is not being utilized elsewhere
+                        # LocalFileBlob.put returns StorageExportResult.LOCAL_FILE_BLOB_SUCCESS here. Since self, does not return anything, this is captured in else.
                         pass
             elif result == ExportResult.SUCCESS:
                 # Try to send any cached events


### PR DESCRIPTION
# Description

Refactored logic for tracking dropped item from storage. When storage.put is called the new tracking method is called after that.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
