### PR TITLE
Resolve Crashing `VerifyChangeLogs`

### DIFF
--- a/eng/pipelines/templates/jobs/regression.yml
+++ b/eng/pipelines/templates/jobs/regression.yml
@@ -86,7 +86,7 @@ jobs:
 
       - pwsh: |
           mkdir -p $(TEST_PROXY_FOLDER)
-          python -m pip install -r eng/regression_tools.txt
+          $(PIP_EXE) install -r eng/regression_tools.txt
         displayName: 'Prep Environment'
 
       - template: /eng/common/testproxy/test-proxy-tool.yml

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -161,15 +161,16 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
   $allPkgPropLines = $null
   try
   {
+    $pathToBuild = (Join-Path $RepoRoot "tools" "azure-sdk-tools[build]")
     # Use ‘uv pip install’ if uv is on PATH, otherwise fall back to python -m pip
     if (Get-Command uv -ErrorAction SilentlyContinue) {
       Write-Host "Using uv pip install"
-      $null = uv pip install "./tools/azure-sdk-tools[build]"
+      $null = uv pip install "$pathToBuild"
       $freezeOutput = uv pip freeze
       Write-Host "Pip freeze output: $freezeOutput"
     } else {
       Write-Host "Using python -m pip install"
-      $null = python -m pip install "./tools/azure-sdk-tools[build]" -q -I
+      $null = python -m pip install "$pathToBuild" -q -I
     }
 
     Write-Host "Running get_package_properties.py to retrieve package properties"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -175,7 +175,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 
     $scriptLoc = Join-path $RepoRoot eng scripts get_package_properties.py
     Write-Host "Running '$scriptLoc' to retrieve package properties"
-    $allPkgPropLines = python $scriptLoc -s (Join-Path $RepoRoot $searchPath)
+    $allPkgPropLines = python "$scriptLoc" -s "$(Join-Path $RepoRoot $searchPath)"
   }
   catch
   {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -173,7 +173,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
     }
 
     Write-Host "Running get_package_properties.py to retrieve package properties"
-    $allPkgPropLines = python (Join-path eng scripts get_package_properties.py) -s $searchPath
+    $allPkgPropLines = python (Join-path $RepoRoot eng scripts get_package_properties.py) -s $searchPath
   }
   catch
   {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -173,8 +173,9 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
       $null = python -m pip install "$pathToBuild" -q -I
     }
 
-    Write-Host "Running get_package_properties.py to retrieve package properties"
-    $allPkgPropLines = python (Join-path $RepoRoot eng scripts get_package_properties.py) -s $searchPath
+    $scriptLoc = Join-path $RepoRoot eng scripts get_package_properties.py
+    Write-Host "Running '$scriptLoc' to retrieve package properties"
+    $allPkgPropLines = python $scriptLoc -s $searchPath
   }
   catch
   {
@@ -189,6 +190,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 
   foreach ($line in $allPkgPropLines)
   {
+    Write-Host "Parsing: '$line'"
     $pkgInfo = ($line -Split " ")
     $packageName = $pkgInfo[0]
     $packageVersion = $pkgInfo[1]

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -175,7 +175,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 
     $scriptLoc = Join-path $RepoRoot eng scripts get_package_properties.py
     Write-Host "Running '$scriptLoc' to retrieve package properties"
-    $allPkgPropLines = python $scriptLoc -s $searchPath
+    $allPkgPropLines = python $scriptLoc -s (Join-Path $RepoRoot $searchPath)
   }
   catch
   {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -190,7 +190,6 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 
   foreach ($line in $allPkgPropLines)
   {
-    Write-Host "Parsing: '$line'"
     $pkgInfo = ($line -Split " ")
     $packageName = $pkgInfo[0]
     $packageVersion = $pkgInfo[1]


### PR DESCRIPTION
This PR:

- [x] Fixes [this changelog error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5223254&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=f9225e1d-2076-5416-8677-0c051f71d13b)
- [x] Fixes this [regression error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5223254&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=b172d6a4-e9a5-568b-11c8-65af86dbe8ec) 

Sorry folks, I actually [ran an internal build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5215687&view=results) on the changeset that caused this break, ~~so I'm not certain how I managed to break _the world_ on verify changelog in the way I did.~~ This is because I ran it against the refs/pull/42545/merge, it resolved to run `verify-changelogs`, NOT the version that crashes on internal.

[test build proving out the fix on a service that was hitting this on their scheduled build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5224919&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=57f096e1-36e2-50f7-6e90-7a231ead9f90)

