### PR TITLE
[perfstress] Add support for per-operation latency tracking and results file output

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_proc.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_proc.py
@@ -133,7 +133,7 @@ async def _run_tests(duration: int, args, tests, results, status, *, with_profil
 
         # Add final test results to the results queue to be accumulated by the parent process.
         for test in tests:
-            results.put((test._parallel_index, test.completed_operations, test.last_completion_time))
+            results.put((test._parallel_index, test.completed_operations, test.last_completion_time, test._latencies))
     finally:
         # Clean up status reporting thread.
         stop_status.set()

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_runner.py
@@ -114,6 +114,9 @@ class _PerfStressRunner:
         per_test_arg_parser.add_argument(
             "--insecure", action="store_true", help="Disable SSL validation. Default is False.", default=False
         )
+        per_test_arg_parser.add_argument(
+            "-l", "--latency", action="store_true", help="Track per-operation latency statistics.", default=False
+        )
 
         # Per-test args
         self._test_class_to_run.add_arguments(per_test_arg_parser)
@@ -264,13 +267,16 @@ class _PerfStressRunner:
 
     def _report_results(self):
         """Calculate and log the test run results across all child processes"""
-        operations = []
+        total_operations = 0
+        operations_per_second = 0.0
+        latencies = []
         while not self.results.empty():
-            operations.append(self.results.get())
+            result: Tuple[int, int, float, List[float]] = self.results.get()
+            total_operations += result[1]
+            operations_per_second += result[1] / result[2] if result[2] else 0
+            latencies.extend(result[3])
 
-        total_operations = self._get_completed_operations(operations)
         self.logger.info("")
-        operations_per_second = self._get_operations_per_second(operations)
         if operations_per_second:
             seconds_per_operation = 1 / operations_per_second
             weighted_average_seconds = total_operations / operations_per_second
@@ -282,6 +288,10 @@ class _PerfStressRunner:
                     self._format_number(seconds_per_operation, 4),
                 )
             )
+
+            if self.per_test_args.latency and len(latencies) > 0:
+                self.logger.info("")
+                self._print_latencies(latencies)
         else:
             self.logger.info("Completed without generating operation statistics.")
         self.logger.info("")
@@ -335,3 +345,12 @@ class _PerfStressRunner:
         decimals = max(0, significant_digits - math.floor(log) - 1)
 
         return ("{:,." + str(decimals) + "f}").format(rounded)
+
+    def _print_latencies(self, latencies: List[float]):
+        self.logger.info("=== Latency Distribution ===")
+        latencies.sort()
+
+        percentiles = [50.0, 75.0, 90.0, 95.0, 99.0, 99.9, 100.0]
+        for p in percentiles:
+            index = math.ceil(p / 100 * len(latencies)) - 1
+            self.logger.info(f"{p:5.1f}% {latencies[index]:10.2f}ms")

--- a/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-sdk-tools/devtools_testutils/perfstress_tests/_perf_stress_runner.py
@@ -300,7 +300,7 @@ class _PerfStressRunner:
                 self._print_latencies(latencies)
                 if self.per_test_args.results_file:
                     # Not all tests will have a size argument
-                    size = self.per_test_args.size if hasattr(self.per_test_args, "size") else None
+                    size = getattr(self.per_test_args, "size", None)
                     self._write_results_file(self.per_test_args.results_file, latencies, size)
         else:
             self.logger.info("Completed without generating operation statistics.")


### PR DESCRIPTION
Introduces two new flags:

- `--latency` - Enables tracking the latency of each individual operation and printing out metrics at the end of the test run.
- `--results-file` - Specifying a file path, indicates that the per-operation latency results should be written to a results file. This requires the `--latency` flag also be enabled to track per-operation latency.
  - This is mostly intended to be used by the PerfAutomation tool to calculate latency metrics.