### PR TITLE
[Test proxy] Update troubleshooting guide, link to it in failure messages

### DIFF
--- a/doc/dev/test_proxy_troubleshooting.md
+++ b/doc/dev/test_proxy_troubleshooting.md
@@ -7,21 +7,19 @@ GitHub repository, but this isn't necessary to read for Python testing.
 
 ## Table of contents
 
-- [Guide for test proxy troubleshooting](#guide-for-test-proxy-troubleshooting)
-  - [Table of contents](#table-of-contents)
-  - [Debugging tip](#debugging-tip)
-  - [Test collection failure](#test-collection-failure)
-  - [Errors in tests using resource preparers](#errors-in-tests-using-resource-preparers)
-  - [Test failure during `record/start` or `playback/start` requests](#test-failure-during-recordstart-or-playbackstart-requests)
-  - [Playback failures from body matching errors](#playback-failures-from-body-matching-errors)
-  - [Playback failures from inconsistent line breaks](#playback-failures-from-inconsistent-line-breaks)
-  - [Playback failures from URL mismatches](#playback-failures-from-url-mismatches)
-  - [Recordings not being produced](#recordings-not-being-produced)
-  - [ConnectionError during tests](#connectionerror-during-tests)
-  - [Different error than expected when using proxy](#different-error-than-expected-when-using-proxy)
-  - [Test setup failure in test pipeline](#test-setup-failure-in-test-pipeline)
-  - [Fixture not found error](#fixture-not-found-error)
-  - [PermissionError during startup](#permissionerror-during-startup)
+- [Debugging tip](#debugging-tip)
+- [Test collection failure](#test-collection-failure)
+- [Errors in tests using resource preparers](#errors-in-tests-using-resource-preparers)
+- [Test failure during `record/start` or `playback/start` requests](#test-failure-during-recordstart-or-playbackstart-requests)
+- [Playback failures from body matching errors](#playback-failures-from-body-matching-errors)
+- [Playback failures from inconsistent line breaks](#playback-failures-from-inconsistent-line-breaks)
+- [Playback failures from URL mismatches](#playback-failures-from-url-mismatches)
+- [Recordings not being produced](#recordings-not-being-produced)
+- [ConnectionError during tests](#connectionerror-during-tests)
+- [Different error than expected when using proxy](#different-error-than-expected-when-using-proxy)
+- [Test setup failure in test pipeline](#test-setup-failure-in-test-pipeline)
+- [Fixture not found error](#fixture-not-found-error)
+- [PermissionError during startup](#permissionerror-during-startup)
 
 ## Debugging tip
 
@@ -111,9 +109,9 @@ Resource preparers need a management client to function, so test classes that us
 
 ## Test failure during `record/start` or `playback/start` requests
 
-If your library uses out-of-repo recordings and tests fail during startup, logs might indicate that POST requests to
-`record/start` or `playback/start` endpoints are returning 500 responses. In a stack trace, these errors might be raised
-[here][record_request_failure] or [here][playback_request_failure], respectively.
+If tests fail during startup, logs might indicate that POST requests to `record/start` or `playback/start` endpoints
+are returning 500 responses. In a stack trace, these errors might be raised [here][record_request_failure] or
+[here][playback_request_failure], respectively.
 
 This suggests that the test proxy failed to fetch recordings from the assets repository. This likely comes from a
 corrupted `git` configuration in `azure-sdk-for-python/.assets`. To resolve this:
@@ -139,11 +137,9 @@ These folders will be freshly recreated the next time you run tests.
 
 ## Playback failures from body matching errors
 
-In the old, `vcrpy`-based testing system, request and response bodies weren't compared in playback mode by default in
-most packages. The test proxy system enables body matching by default, which can introduce failures for tests that
-passed in the old system. For example, if a test sends a request that includes the current Unix time in its body, the
-body will contain a new value when run in playback mode at a later time. This request might still match the recording if
-body matching is disabled, but not if it's enabled.
+The test proxy system enables body matching by default. For example, if a test sends a request that includes the
+current Unix time in its body, the body will contain a new value when run in playback mode at a later time -- this
+request won't match the recording if body matching is enabled.
 
 Body matching can be turned off with the test proxy by calling the `set_bodiless_matcher` method from
 [devtools_testutils/sanitizers.py][py_sanitizers] at the very start of a test method. This matcher applies only to the
@@ -152,13 +148,12 @@ matching enabled by default.
 
 ## Playback failures from inconsistent line breaks
 
-Some tests require recording content to completely match, including line breaks (for example, when sending the content of
-a test file in a request body). Line breaks can vary between OSes and cause tests to fail on certain platforms, in which
-case it can help to specify a particular format for test files by using [`.gitattributes`][gitattributes].
+Line breaks can vary between OSes and cause tests to fail on certain platforms, in which case it can help to specify a
+particular format for test files by using [`.gitattributes`][gitattributes].
 
-A `.gitattributes` file can be placed at the root of a directory to apply git settings to each file under that directory.
-If a test directory contains files that need to have consistent line breaks, for example LF breaks instead of CRLF ones,
-you can create a `.gitattributes` file in the directory with the following content:
+A `.gitattributes` file can be placed at the root of a directory to apply git settings to each file under that
+directory. If a test directory contains files that need to have consistent line breaks, for example LF breaks instead
+of CRLF ones, you can create a `.gitattributes` file in the directory with the following content:
 
 ```text
 # Force git to checkout text files with LF (line feed) as the ending (vs CRLF)
@@ -209,11 +204,16 @@ that test, which is recommended.
 
 ### Sanitization impacting request URL/body/headers
 
-In some cases, a value in a response body is used in the following request as part of the URL, body, or headers. If this value is sanitized, the recorded request might differ than what is expected during playback. Common culprits include sanitization of "name", "id", and "Location" fields. To resolve this, you can either opt out of specific sanitization or add another sanitizer to align with the sanitized value.
+In some cases, a value in a response body is used in the following request as part of the URL, body, or headers. If
+this value is sanitized, the recorded request might differ than what is expected during playback. Common culprits
+include sanitization of "name", "id", and "Location" fields. To resolve this, you can either opt out of specific
+sanitization or add another sanitizer to align with the sanitized value.
 
 #### Opt out
 
-You can opt out of sanitization for the fields that are used for your requests by calling the `remove_batch_sanitizer` method from `devtools_testutils` with the [sanitizer IDs][test_proxy_sanitizers] to exclude. Generally, this is done in the `conftest.py` file, in the one of the session-scoped fixtures. Example:
+You can opt out of sanitization for the fields that are used for your requests by calling the `remove_batch_sanitizer`
+method from `devtools_testutils` with the [sanitizer IDs][test_proxy_sanitizers] to exclude. Generally, this is done in
+the `conftest.py` file, in the one of the session-scoped fixtures. Example:
 
 ```python
 from devtools_testutils import remove_batch_sanitizers, test_proxy
@@ -321,8 +321,8 @@ skipped, so the `TestProxy` parameter doesn't need to be set in `tests.yml`.
 
 Tests that aren't recorded should omit the `recorded_by_proxy` decorator. However, if these unrecorded tests accept
 parameters that are provided by a preparer like the `devtools_testutils` [EnvironmentVariableLoader][env_var_loader],
-you may see a new test setup error after migrating to the test proxy. For example, imagine a test is decorated with a
-preparer that provides a Key Vault URL as a `azure_keyvault_url` parameter:
+you may see a test setup error. For example, imagine a test is decorated with a preparer that provides a Key Vault URL
+as a `azure_keyvault_url` parameter:
 
 ```python
 class TestExample(AzureRecordedTestCase):

--- a/doc/dev/test_proxy_troubleshooting.md
+++ b/doc/dev/test_proxy_troubleshooting.md
@@ -8,12 +8,15 @@ GitHub repository, but this isn't necessary to read for Python testing.
 ## Table of contents
 
 - [Debugging tip](#debugging-tip)
+- [ServiceRequestError: Cannot connect to host](#servicerequesterror-cannot-connect-to-host)
+- [ResourceNotFoundError: Playback failure](#resourcenotfounderror-playback-failure)
 - [Test collection failure](#test-collection-failure)
 - [Errors in tests using resource preparers](#errors-in-tests-using-resource-preparers)
 - [Test failure during `record/start` or `playback/start` requests](#test-failure-during-recordstart-or-playbackstart-requests)
 - [Playback failures from body matching errors](#playback-failures-from-body-matching-errors)
 - [Playback failures from inconsistent line breaks](#playback-failures-from-inconsistent-line-breaks)
 - [Playback failures from URL mismatches](#playback-failures-from-url-mismatches)
+- [Playback failures from inconsistent test values](#playback-failures-from-inconsistent-test-values)
 - [Recordings not being produced](#recordings-not-being-produced)
 - [ConnectionError during tests](#connectionerror-during-tests)
 - [Different error than expected when using proxy](#different-error-than-expected-when-using-proxy)
@@ -36,6 +39,48 @@ Additionally, the `-k` flag can be used to collect and run tests that have a spe
 containing the strings `test_delete` or `test_upload`.
 
 For more information about `pytest` invocations, refer to [Usage and Invocations][pytest_commands].
+
+## ServiceRequestError: Cannot connect to host
+
+Async tests may occasionally fail during startup with the following exception:
+
+```text
+azure.core.exceptions.ServiceRequestError: Cannot connect to host localhost:5001
+ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate
+verify failed: self signed certificate (_ssl.c:1123)')]
+```
+
+This is caused by the test proxy's certificate being incorrectly configured. The certificate is
+[automatically configured][cert_setup] during proxy startup, but async environments can still nondeterministically fail.
+
+To work around this issue, set the following environment variable in your `.env` file:
+
+```text
+PROXY_URL='http://localhost:5000'
+```
+
+This will target an HTTP endpoint for the test proxy that doesn't require certificates. Service requests will still be
+sent securely from your client; this change only affects test proxy interactions.
+
+## ResourceNotFoundError: Playback failure
+
+Test playback errors typically raise with a message similar to the following:
+
+```text
+FAILED test_client.py::TestClient::test_client_method - azure.core.exceptions.ResourceNotFoundError:
+Playback failure -- for help resolving, see https://aka.ms/azsdk/python/test-proxy/troubleshoot. Error details:
+Unable to find a record for the request POST https://fake_resource.service.azure.net?api-version=2025-09-01
+```
+
+This means that the test recording didn't contain a match for the incoming playback request. This usually just means
+that the test needs to be re-recorded to pick up library updates (e.g. a new service API version).
+
+If playback errors persist after re-recording, you may need to modify session sanitizers or matchers. The following
+sections of this guide describe common scenarios:
+
+- [Playback failures from body matching errors](#playback-failures-from-body-matching-errors)
+- [Playback failures from inconsistent line breaks](#playback-failures-from-inconsistent-line-breaks)
+- [Playback failures from URL mismatches](#playback-failures-from-url-mismatches)
 
 ## Test collection failure
 
@@ -245,6 +290,48 @@ from devtools_testutils import add_uri_regex_sanitizer
 add_uri_regex_sanitizer(regex="(?<=https://.+/foo/bar/)(?<id>[^/?\\.]+)", group_for_replace="id", value="Sanitized")
 ```
 
+## Playback failures from inconsistent test values
+
+To run recorded tests successfully when recorded values are inconsistent or random and can't be sanitized, the test
+proxy provides a `variables` API. This makes it possible for a test to record the values of variables that were used
+during recording and use the same values in playback mode without a sanitizer.
+
+For example, imagine that a test uses a randomized `table_uuid` variable when creating resources. The same random value
+for `table_uuid` can be used in playback mode by using this `variables` API.
+
+There are two requirements for a test to use recorded variables. First, the test method should accept `**kwargs`.
+Second, the test method should `return` a dictionary with any test variables that it wants to record. This dictionary
+will be stored in the recording when the test is run live, and will be passed to the test as a `variables` keyword
+argument when the test is run in playback.
+
+Below is a code example of how a test method could use recorded variables:
+
+```python
+from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy
+
+class TestExample(AzureRecordedTestCase):
+
+    @recorded_by_proxy
+    def test_example(self, **kwargs):
+        # In live mode, variables is an empty dictionary
+        # In playback mode, the value of variables is {"table_uuid": "random-value"}
+        variables = kwargs.pop("variables", {})
+
+        # To fetch variable values, use the `setdefault` method to look for a key ("table_uuid")
+        # and set a real value for that key if it's not present ("random-value")
+        table_uuid = variables.setdefault("table_uuid", "random-value")
+
+        # use variables["table_uuid"] when using the table UUID throughout the test
+        ...
+
+        # return the variables at the end of the test to record them
+        return variables
+```
+
+> **Note:** `variables` will be passed as a named argument to any test that accepts `kwargs` by the test proxy. In
+> environments that don't use the test proxy, though -- like live test pipelines -- `variables` won't be provided.
+> To avoid a KeyError, providing an empty dictionary as the default value to `kwargs.pop` is recommended.
+
 ## Recordings not being produced
 
 Ensure the environment variable `AZURE_SKIP_LIVE_RECORDING` **isn't** set to "true", and that `AZURE_TEST_RUN_LIVE`
@@ -369,6 +456,7 @@ Alternatively, you can delete the installed tool and re-run your tests to automa
 
 <!-- Links -->
 
+[cert_setup]: https://github.com/Azure/azure-sdk-for-python/blob/689bac08962828622a4262fbfecbbf5b429cb481/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py#L210
 [custom_default_matcher]: https://github.com/Azure/azure-sdk-for-python/blob/497f5f3435162c4f2086d1429fc1bba4f31a4354/tools/azure-sdk-tools/devtools_testutils/sanitizers.py#L85
 [detailed_docs]: https://github.com/Azure/azure-sdk-tools/tree/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
 [env_var_loader]: https://github.com/Azure/azure-sdk-for-python/blob/main/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -239,8 +239,14 @@ def recorded_by_proxy(test_func: "Callable") -> None:
 
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
+            troubleshoot = (
+                "Playback failure -- for help resolving, see https://aka.ms/azsdk/python/test-proxy/troubleshoot."
+            )
             message = error_body.get("message") or error_body.get("Message")
-            error_with_message = ResourceNotFoundError(message=message, response=error.response)
+            error_with_message = ResourceNotFoundError(
+                message=f"{troubleshoot} Error details:\n{message}",
+                response=error.response,
+            )
             six.raise_from(error_with_message, error)
 
         finally:


### PR DESCRIPTION
# Description

This adds some undocumented scenarios to the troubleshooting guide and cleans it up a bit generally. Also, the error raising logic from the recording decorator has been updated to include a link to the troubleshooting guide, making it more visible.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
