### PR TITLE
Fixing `template` release pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -100,6 +100,7 @@ jobs:
         ToxEnvParallel: ${{ parameters.ToxEnvParallel }}
         InjectedPackages: $(InjectedPackages)
         TestProxy: ${{ parameters.TestProxy }}
+        TestPipeline: ${{ parameters.TestPipeline }}
         BeforeTestSteps:
           - ${{ each step in parameters.BeforeTestSteps }}:
             -  ${{ step }}


### PR DESCRIPTION
This is a followup from #42486

I moved the call to SetTestPipeline within `build-tests.yml` template, but I never actually passed the value in to it. So it was defaulting to always off. That's wrong for template!

Apologies for the inconvenience to anyone affected by this.