### PR TITLE
Remove explicit setup.py pass to verify dependencies present

### DIFF
--- a/scripts/devops_tasks/verify_dependencies_present.py
+++ b/scripts/devops_tasks/verify_dependencies_present.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     package_name = args.package_name.replace("_", "-")
-    path_to_setup = os.path.join(root_dir, "sdk", args.service, package_name, "setup.py")
+    path_to_setup = os.path.join(root_dir, "sdk", args.service, package_name)
 
     missing_packages = find_packages_missing_on_pypi(path_to_setup)
 


### PR DESCRIPTION
Fixing the failing verify_dependencies_present step to remove explicit "setup.py" in path. Instead, we'll let ParsedSetup detect whether setup.py or pyproject.toml is present.