### PR TITLE
Ensure we can't break `dev_setup.py`

### DIFF
--- a/.github/workflows/azure-sdk-tools.yml
+++ b/.github/workflows/azure-sdk-tools.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
     paths:
       - "eng/tools/azure-sdk-tools/**"
+      - ".github/workflows/azure-sdk-tools.yml"
 
 jobs:
   build-and-test:

--- a/.github/workflows/azure-sdk-tools.yml
+++ b/.github/workflows/azure-sdk-tools.yml
@@ -29,3 +29,27 @@ jobs:
           pytest ./tests
         shell: bash
         working-directory: eng/tools/azure-sdk-tools
+
+  dev-setup-and-import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.13
+
+      - name: Run dev_setup to install specified packages
+        run: |
+          python scripts/dev_setup.py --packageList azure-storage-blob,azure-appconfiguration
+        shell: bash
+
+      - name: Validate imports
+        run: |
+          python - <<'PY'
+          from azure.storage.blob import *
+          from azure.appconfiguration import *
+          print("Successful Imports")
+          PY
+        shell: bash


### PR DESCRIPTION
I did not realize how important that script is. It is used as part of `automation_init.sh`, which is used as part of azure-rest-api-specs validation.

We need to ensure that package works properly, so adding an integration test on any change to azure-sdk-tools to avoid this break in the future.