### PR TITLE
Added logic for race conditions and global instance for customer SDKStats

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -13,6 +13,7 @@
   ([#42551](https://github.com/Azure/azure-sdk-for-python/pull/42551))
 - Rename Customer Statsbeat to Customer SDKStats as per [Spec] - https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/581
   ([#42573](https://github.com/Azure/azure-sdk-for-python/pull/42573))
+- Customer Facing SDKStats: Added logic for race conditions and updated the implementation to use a global instance for customer SDKStats metrics
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -181,17 +181,17 @@ class CustomerSdkStatsProperties:
         self.version = version
         self.compute_type = compute_type
 
-## Map from Azure Monitor envelope names to TelemetryType
+## Map from Azure Monitor envelope base_types to TelemetryType
 _TYPE_MAP = {
-                _EVENT_ENVELOPE_NAME: _CUSTOM_EVENT,
-                _METRIC_ENVELOPE_NAME: _CUSTOM_METRIC,
-                _REMOTE_DEPENDENCY_ENVELOPE_NAME: _DEPENDENCY,
-                _EXCEPTION_ENVELOPE_NAME: _EXCEPTION,
-                _PAGE_VIEW_ENVELOPE_NAME: _PAGE_VIEW,
-                _MESSAGE_ENVELOPE_NAME: _TRACE,
-                _REQUEST_ENVELOPE_NAME: _REQUEST,
-                _PERFORMANCE_COUNTER_ENVELOPE_NAME: _PERFORMANCE_COUNTER,
-                _AVAILABILITY_ENVELOPE_NAME: _AVAILABILITY,
+                "EventData": _CUSTOM_EVENT,
+                "MetricData": _CUSTOM_METRIC,
+                "RemoteDependencyData": _DEPENDENCY,
+                "ExceptionData": _EXCEPTION,
+                "PageViewData": _PAGE_VIEW,
+                "MessageData": _TRACE,
+                "RequestData": _REQUEST,
+                "PerformanceCounterData": _PERFORMANCE_COUNTER,
+                "AvailabilityData": _AVAILABILITY,
             }
 
 # Map RP names

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_customer_sdkstats.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_customer_sdkstats.py
@@ -40,6 +40,9 @@ from azure.monitor.opentelemetry.exporter import VERSION
 from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _CUSTOMER_SDKSTATS_STATE,
     _CUSTOMER_SDKSTATS_STATE_LOCK,
+    _CUSTOMER_SDKSTATS_REQUESTS_LOCK,
+    get_customer_sdkstats_metrics,
+    set_customer_sdkstats_metrics,
 )
 
 class _CustomerSdkStatsTelemetryCounters:
@@ -65,7 +68,7 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
         self._customer_sdkstats_exporter._is_customer_sdkstats = True
         metric_reader_options = {
             "exporter": self._customer_sdkstats_exporter,
-            "export_interval_millis": _get_customer_sdkstats_export_interval()
+            "export_interval_millis": _get_customer_sdkstats_export_interval() * 1000 # Convert to milliseconds
         }
         self._customer_sdkstats_metric_reader = PeriodicExportingMetricReader(**metric_reader_options)
         self._customer_sdkstats_meter_provider = MeterProvider(
@@ -98,11 +101,11 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
     def count_successful_items(self, count: int, telemetry_type: str) -> None:
         if not self._is_enabled or count <= 0:
             return
-
-        if telemetry_type in self._counters.total_item_success_count:
-            self._counters.total_item_success_count[telemetry_type] += count
-        else:
-            self._counters.total_item_success_count[telemetry_type] = count
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            if telemetry_type in self._counters.total_item_success_count:
+                self._counters.total_item_success_count[telemetry_type] += count
+            else:
+                self._counters.total_item_success_count[telemetry_type] = count
 
     def count_dropped_items(
         self, count: int, telemetry_type: str, drop_code: DropCodeType,
@@ -110,23 +113,19 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
     ) -> None:
         if not self._is_enabled or count <= 0:
             return
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            if telemetry_type not in self._counters.total_item_drop_count:
+                self._counters.total_item_drop_count[telemetry_type] = {}
+            drop_code_map = self._counters.total_item_drop_count[telemetry_type]
 
-        # Get or create the drop_code map for this telemetry_type
-        if telemetry_type not in self._counters.total_item_drop_count:
-            self._counters.total_item_drop_count[telemetry_type] = {}
-        drop_code_map = self._counters.total_item_drop_count[telemetry_type]
+            if drop_code not in drop_code_map:
+                drop_code_map[drop_code] = {}
+            reason_map = drop_code_map[drop_code]
 
-        # Get or create the reason map for this drop_code
-        if drop_code not in drop_code_map:
-            drop_code_map[drop_code] = {}
-        reason_map = drop_code_map[drop_code]
+            reason = self._get_drop_reason(drop_code, exception_message)
 
-        # Generate a low-cardinality, informative reason description
-        reason = self._get_drop_reason(drop_code, exception_message)
-
-        # Update the count for this reason
-        current_count = reason_map.get(reason, 0)
-        reason_map[reason] = current_count + count
+            current_count = reason_map.get(reason, 0)
+            reason_map[reason] = current_count + count
 
     def count_retry_items(
         self, count: int, telemetry_type: str, retry_code: RetryCodeType,
@@ -135,18 +134,19 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
         if not self._is_enabled or count <= 0:
             return
 
-        if telemetry_type not in self._counters.total_item_retry_count:
-            self._counters.total_item_retry_count[telemetry_type] = {}
-        retry_code_map = self._counters.total_item_retry_count[telemetry_type]
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            if telemetry_type not in self._counters.total_item_retry_count:
+                self._counters.total_item_retry_count[telemetry_type] = {}
+            retry_code_map = self._counters.total_item_retry_count[telemetry_type]
 
-        if retry_code not in retry_code_map:
-            retry_code_map[retry_code] = {}
-        reason_map = retry_code_map[retry_code]
+            if retry_code not in retry_code_map:
+                retry_code_map[retry_code] = {}
+            reason_map = retry_code_map[retry_code]
 
-        reason = self._get_retry_reason(retry_code, exception_message)
+            reason = self._get_retry_reason(retry_code, exception_message)
 
-        current_count = reason_map.get(reason, 0)
-        reason_map[reason] = current_count + count
+            current_count = reason_map.get(reason, 0)
+            reason_map[reason] = current_count + count
 
     def _item_success_callback(self, options: CallbackOptions) -> Iterable[Observation]: # pylint: disable=unused-argument
         if not getattr(self, "_is_enabled", False):
@@ -154,11 +154,12 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
 
         observations: List[Observation] = []
 
-        for telemetry_type, count in self._counters.total_item_success_count.items():
-            if count > 0:
-                attributes = {
-                    "language": self._customer_properties.language,
-                    "version": self._customer_properties.version,
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            for telemetry_type, count in self._counters.total_item_success_count.items():
+                if count > 0:
+                    attributes = {
+                        "language": self._customer_properties.language,
+                        "version": self._customer_properties.version,
                     "compute_type": self._customer_properties.compute_type,
                     "telemetry_type": telemetry_type
                 }
@@ -170,11 +171,13 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
         if not getattr(self, "_is_enabled", False):
             return []
         observations: List[Observation] = []
-        for telemetry_type, drop_code_map in self._counters.total_item_drop_count.items():
-            for drop_code, reason_map in drop_code_map.items():
-                for reason, count in reason_map.items():
-                    if count > 0:
-                        attributes = {
+
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            for telemetry_type, drop_code_map in self._counters.total_item_drop_count.items():
+                for drop_code, reason_map in drop_code_map.items():
+                    for reason, count in reason_map.items():
+                        if count > 0:
+                            attributes = {
                             "language": self._customer_properties.language,
                             "version": self._customer_properties.version,
                             "compute_type": self._customer_properties.compute_type,
@@ -190,11 +193,13 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
         if not getattr(self, "_is_enabled", False):
             return []
         observations: List[Observation] = []
-        for telemetry_type, retry_code_map in self._counters.total_item_retry_count.items():
-            for retry_code, reason_map in retry_code_map.items():
-                for reason, count in reason_map.items():
-                    if count > 0:
-                        attributes = {
+
+        with _CUSTOMER_SDKSTATS_REQUESTS_LOCK:
+            for telemetry_type, retry_code_map in self._counters.total_item_retry_count.items():
+                for retry_code, reason_map in retry_code_map.items():
+                    for reason, count in reason_map.items():
+                        if count > 0:
+                            attributes = {
                             "language": self._customer_properties.language,
                             "version": self._customer_properties.version,
                             "compute_type": self._customer_properties.compute_type,
@@ -234,41 +239,33 @@ class CustomerSdkStatsMetrics(metaclass=Singleton): # pylint: disable=too-many-i
         }
         return retry_code_reasons.get(retry_code, "unknown_reason")
 
-# Global customer sdkstats singleton
-_CUSTOMER_SDKSTATS_METRICS = None
-_CUSTOMER_SDKSTATS_LOCK = threading.Lock()
-
+_CUSTOMER_SDKSTATS_METRICS_LOCK = threading.Lock()
 
 # pylint: disable=global-statement
 # pylint: disable=protected-access
 def collect_customer_sdkstats(exporter):
-    global _CUSTOMER_SDKSTATS_METRICS
     # Only start customer sdkstats if did not exist before
-    if _CUSTOMER_SDKSTATS_METRICS is None:
-        with _CUSTOMER_SDKSTATS_LOCK:
+    if get_customer_sdkstats_metrics() is None:
+        with _CUSTOMER_SDKSTATS_METRICS_LOCK:
             # Double-check inside the lock to avoid race conditions
-            if _CUSTOMER_SDKSTATS_METRICS is None:
+            if get_customer_sdkstats_metrics() is None:
 
                 connection_string = (
                     f"InstrumentationKey={exporter._instrumentation_key};"
                     f"IngestionEndpoint={exporter._endpoint}"
                 )
-                _CUSTOMER_SDKSTATS_METRICS = CustomerSdkStatsMetrics(connection_string)
-
-    exporter._customer_sdkstats_metrics = _CUSTOMER_SDKSTATS_METRICS
-    if hasattr(exporter, 'storage') and exporter.storage:
-        exporter.storage._customer_sdkstats_metrics = _CUSTOMER_SDKSTATS_METRICS
-
+                metrics = CustomerSdkStatsMetrics(connection_string)
+                set_customer_sdkstats_metrics(metrics)
 
 def shutdown_customer_sdkstats_metrics() -> None:
-    global _CUSTOMER_SDKSTATS_METRICS
     shutdown_success = False
-    if _CUSTOMER_SDKSTATS_METRICS is not None:
-        with _CUSTOMER_SDKSTATS_LOCK:
+    metrics = get_customer_sdkstats_metrics()
+    if metrics is not None:
+        with _CUSTOMER_SDKSTATS_METRICS_LOCK:
             try:
-                if _CUSTOMER_SDKSTATS_METRICS._customer_sdkstats_meter_provider is not None:
-                    _CUSTOMER_SDKSTATS_METRICS._customer_sdkstats_meter_provider.shutdown()
-                    _CUSTOMER_SDKSTATS_METRICS = None
+                if metrics._customer_sdkstats_meter_provider is not None:
+                    metrics._customer_sdkstats_meter_provider.shutdown()
+                    set_customer_sdkstats_metrics(None)
                     shutdown_success = True
             except:  # pylint: disable=bare-except
                 pass

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
@@ -4,7 +4,10 @@ import os
 import threading
 from typing import Dict, Union
 
-from azure.monitor.opentelemetry.exporter._constants import _APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL
+from azure.monitor.opentelemetry.exporter._constants import (
+    _APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL,
+    _APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW
+)
 
 _REQUESTS_MAP: Dict[str, Union[int, Dict[int, int]]] = {}
 _REQUESTS_MAP_LOCK = threading.Lock()
@@ -18,6 +21,12 @@ _STATSBEAT_STATE = {
 }
 _STATSBEAT_STATE_LOCK = threading.Lock()
 _STATSBEAT_FAILURE_COUNT_THRESHOLD = 3
+
+
+_CUSTOMER_SDKSTATS_REQUESTS_LOCK = threading.Lock()
+
+_CUSTOMER_SDKSTATS_METRICS = None
+_CUSTOMER_SDKSTATS_METRICS_STATE_LOCK = threading.Lock()
 
 _CUSTOMER_SDKSTATS_STATE = {
     "SHUTDOWN": False,
@@ -80,19 +89,38 @@ def set_statsbeat_live_metrics_feature_set():
     with _STATSBEAT_STATE_LOCK:
         _STATSBEAT_STATE["LIVE_METRICS_FEATURE_SET"] = True
 
+
 def get_customer_sdkstats_shutdown():
     return _CUSTOMER_SDKSTATS_STATE["SHUTDOWN"]
 
+
 def get_local_storage_setup_state_readonly():
     return _LOCAL_STORAGE_SETUP_STATE["READONLY"]
+
 
 def set_local_storage_setup_state_readonly():
     with _LOCAL_STORAGE_SETUP_STATE_LOCK:
         _LOCAL_STORAGE_SETUP_STATE["READONLY"] = True
 
+
 def get_local_storage_setup_state_exception():
     return _LOCAL_STORAGE_SETUP_STATE["EXCEPTION_OCCURRED"]
+
 
 def set_local_storage_setup_state_exception(value):
     with _LOCAL_STORAGE_SETUP_STATE_LOCK:
         _LOCAL_STORAGE_SETUP_STATE["EXCEPTION_OCCURRED"] = value
+
+
+def is_customer_sdkstats_enabled():
+    return os.environ.get(_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW, "").lower() == "true"
+
+
+def get_customer_sdkstats_metrics():
+    return _CUSTOMER_SDKSTATS_METRICS
+
+# pylint: disable=global-statement
+def set_customer_sdkstats_metrics(metrics):
+    global _CUSTOMER_SDKSTATS_METRICS
+    with _CUSTOMER_SDKSTATS_METRICS_STATE_LOCK:
+        _CUSTOMER_SDKSTATS_METRICS = metrics

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_utils.py
@@ -13,7 +13,10 @@ from azure.monitor.opentelemetry.exporter._constants import (
 from azure.monitor.opentelemetry.exporter._utils import _get_telemetry_type
 from azure.monitor.opentelemetry.exporter._generated.models import TelemetryItem
 from azure.monitor.opentelemetry.exporter._storage import StorageExportResult
-from azure.monitor.opentelemetry.exporter.statsbeat._state import get_local_storage_setup_state_exception
+from azure.monitor.opentelemetry.exporter.statsbeat._state import (
+    get_local_storage_setup_state_exception,
+    get_customer_sdkstats_metrics,
+)
 
 
 from azure.monitor.opentelemetry.exporter._constants import (
@@ -82,6 +85,7 @@ def _update_requests_map(type_name, value):
                 _REQUESTS_MAP[type_name] = {}
             _REQUESTS_MAP[type_name][value] = prev + 1
 
+
 def categorize_status_code(status_code: int) -> str:
     status_map = {
         400: "bad_request",
@@ -121,88 +125,97 @@ def _determine_client_retry_code(error) -> Tuple[RetryCodeType, Optional[str]]:
         return (RetryCode.CLIENT_TIMEOUT, error_message)
     return (RetryCode.CLIENT_EXCEPTION, error_message)
 
-def _track_successful_items(customer_sdkstats_metrics, envelopes: List[TelemetryItem]):
-    if customer_sdkstats_metrics:
-        for envelope in envelopes:
-            telemetry_type = _get_telemetry_type(envelope)
-            customer_sdkstats_metrics.count_successful_items(
-                1,
-                telemetry_type
-            )
+def _track_successful_items(envelopes: List[TelemetryItem]):
+    customer_sdkstats_metrics = get_customer_sdkstats_metrics()
+    if not customer_sdkstats_metrics:
+        return
+
+    for envelope in envelopes:
+        telemetry_type = _get_telemetry_type(envelope)
+        customer_sdkstats_metrics.count_successful_items(
+            1,
+            telemetry_type
+        )
 
 def _track_dropped_items(
-        customer_sdkstats_metrics,
         envelopes: List[TelemetryItem],
         drop_code: DropCodeType,
         error_message: Optional[str] = None
     ):
-    if customer_sdkstats_metrics:
-        if error_message is None:
-            for envelope in envelopes:
-                telemetry_type = _get_telemetry_type(envelope)
-                customer_sdkstats_metrics.count_dropped_items(
-                    1,
-                    telemetry_type,
-                    drop_code
-                )
-        else:
-            for envelope in envelopes:
-                telemetry_type = _get_telemetry_type(envelope)
-                customer_sdkstats_metrics.count_dropped_items(
-                    1,
-                    telemetry_type,
-                    drop_code,
-                    error_message
-                )
+    customer_sdkstats_metrics = get_customer_sdkstats_metrics()
+    if not customer_sdkstats_metrics:
+        return
 
-def _track_retry_items(customer_sdkstats_metrics, envelopes: List[TelemetryItem], error) -> None:
-    if customer_sdkstats_metrics:
-        retry_code, message = _determine_client_retry_code(error)
+    if error_message is None:
         for envelope in envelopes:
             telemetry_type = _get_telemetry_type(envelope)
-            if isinstance(retry_code, int):
-                # For status codes, include the message if available
-                if message:
-                    customer_sdkstats_metrics.count_retry_items(
-                        1,
-                        telemetry_type,
-                        retry_code,
-                        str(message)
-                    )
-                else:
-                    customer_sdkstats_metrics.count_retry_items(
-                        1,
-                        telemetry_type,
-                        retry_code
-                    )
-            else:
+            customer_sdkstats_metrics.count_dropped_items(
+                1,
+                telemetry_type,
+                drop_code
+            )
+    else:
+        for envelope in envelopes:
+            telemetry_type = _get_telemetry_type(envelope)
+            customer_sdkstats_metrics.count_dropped_items(
+                1,
+                telemetry_type,
+                drop_code,
+                error_message
+            )
+
+def _track_retry_items(envelopes: List[TelemetryItem], error) -> None:
+    customer_sdkstats_metrics = get_customer_sdkstats_metrics()
+    if not customer_sdkstats_metrics:
+        return
+    retry_code, message = _determine_client_retry_code(error)
+    for envelope in envelopes:
+        telemetry_type = _get_telemetry_type(envelope)
+        if isinstance(retry_code, int):
+            # For status codes, include the message if available
+            if message:
                 customer_sdkstats_metrics.count_retry_items(
                     1,
                     telemetry_type,
                     retry_code,
                     str(message)
                 )
-
-def _track_dropped_items_from_storage(customer_sdkstats_metrics, result_from_storage_put, envelopes):
-    if customer_sdkstats_metrics:
-        if result_from_storage_put == StorageExportResult.CLIENT_STORAGE_DISABLED:
-            # Track items that would have been retried but are dropped since client has local storage disabled
-            _track_dropped_items(customer_sdkstats_metrics, envelopes, DropCode.CLIENT_STORAGE_DISABLED)
-        elif result_from_storage_put == StorageExportResult.CLIENT_READONLY:
-            # If filesystem is readonly, track dropped items in customer sdkstats
-            _track_dropped_items(customer_sdkstats_metrics, envelopes, DropCode.CLIENT_READONLY)
-        elif result_from_storage_put == StorageExportResult.CLIENT_PERSISTENCE_CAPACITY_REACHED:
-            # If data has to be dropped due to persistent storage being full, track dropped items
-            _track_dropped_items(customer_sdkstats_metrics, envelopes, DropCode.CLIENT_PERSISTENCE_CAPACITY)
-        elif get_local_storage_setup_state_exception() != "":
-            # For exceptions caught in _check_and_set_folder_permissions during storage setup
-            _track_dropped_items(customer_sdkstats_metrics, envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put) # pylint: disable=line-too-long
-        elif isinstance(result_from_storage_put, str):
-            # For any exceptions occurred in put method of either LocalFileStorage or LocalFileBlob, track dropped item with reason # pylint: disable=line-too-long
-            _track_dropped_items(customer_sdkstats_metrics, envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put) # pylint: disable=line-too-long
+            else:
+                customer_sdkstats_metrics.count_retry_items(
+                    1,
+                    telemetry_type,
+                    retry_code
+                )
         else:
-            # LocalFileBlob.put returns StorageExportResult.LOCAL_FILE_BLOB_SUCCESS here. Don't need to track anything in this case. # pylint: disable=line-too-long
-            pass
+            customer_sdkstats_metrics.count_retry_items(
+                1,
+                telemetry_type,
+                retry_code,
+                str(message)
+            )
+
+def _track_dropped_items_from_storage(result_from_storage_put, envelopes):
+    customer_sdkstats_metrics = get_customer_sdkstats_metrics()
+    if not customer_sdkstats_metrics:
+        return
+    if result_from_storage_put == StorageExportResult.CLIENT_STORAGE_DISABLED:
+        # Track items that would have been retried but are dropped since client has local storage disabled
+        _track_dropped_items(envelopes, DropCode.CLIENT_STORAGE_DISABLED)
+    elif result_from_storage_put == StorageExportResult.CLIENT_READONLY:
+        # If filesystem is readonly, track dropped items in customer statsbeat
+        _track_dropped_items(envelopes, DropCode.CLIENT_READONLY)
+    elif result_from_storage_put == StorageExportResult.CLIENT_PERSISTENCE_CAPACITY_REACHED:
+        # If data has to be dropped due to persistent storage being full, track dropped items
+        _track_dropped_items(envelopes, DropCode.CLIENT_PERSISTENCE_CAPACITY)
+    elif get_local_storage_setup_state_exception() != "":
+        # For exceptions caught in _check_and_set_folder_permissions during storage setup
+        _track_dropped_items(envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put)
+    elif isinstance(result_from_storage_put, str):
+        # For any exceptions occurred in put method of either LocalFileStorage or LocalFileBlob, track dropped item with reason # pylint: disable=line-too-long
+        _track_dropped_items(envelopes, DropCode.CLIENT_EXCEPTION, result_from_storage_put)
+    else:
+        # LocalFileBlob.put returns StorageExportResult.LOCAL_FILE_BLOB_SUCCESS here. Don't need to track anything in this case. # pylint: disable=line-too-long
+        pass
 
 def _get_customer_sdkstats_export_interval() -> int:
     customer_sdkstats_ei_env = os.environ.get(_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL)


### PR DESCRIPTION
# Description

- Changes for taking care of race conditions
- Global state for Customer SDKStats

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
