### PR TITLE
Remove `six` use in azure-sdk-tools

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -6,12 +6,8 @@
 import functools
 import logging
 import os
-import os.path
-import re
-import six
 import sys
 import time
-from typing import Dict
 
 from dotenv import load_dotenv, find_dotenv
 
@@ -24,7 +20,6 @@ from .azure_testcase import (
 from .fake_credentials import SANITIZED
 from .fake_credentials_async import AsyncFakeCredential
 from .helpers import is_live, trim_kwargs_from_test_function
-from .sanitizers import add_general_string_sanitizer
 
 
 _LOGGER = logging.getLogger()
@@ -77,7 +72,7 @@ class AzureRecordedTestCase(object):
             try:
                 key_value = getattr(self.settings, key)
             except Exception as ex:
-                six.raise_from(ValueError("Could not get {}".format(key)), ex)
+                raise ValueError(f"Could not get {key}") from ex
         return key_value
 
     def get_credential(self, client_class, **kwargs):


### PR DESCRIPTION
# Description

The only remaining uses of `six` that I could find are in a handful of test proxy infra files. This removes them, as well as some unused imports.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
