### PR TITLE
Prep for release of Python Projects SDK version 1.1.0b3

### DIFF
--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -10,12 +10,6 @@ via `pip install --pre azure-ai-projects` will install latest beta version of `a
 (which has features in preview) instead of latest stable version (which does
 not include preview features).
 
-### Breaking changes
-
-### Bugs Fixed
-
-### Sample updates
-
 ## 1.1.0b2 (2025-08-05)
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-projects/CHANGELOG.md
+++ b/sdk/ai/azure-ai-projects/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Release History
 
-## 1.1.0b3 (Unreleased)
+## 1.1.0b3 (2025-08-26)
 
 ### Features added
 
-* File `setup.py` was updated to indicate the dependency `azure-ai-agents>=1.2.0b1`
-instead of `azure-ai-agents>=1.0.0`. This means that in a clean environment installing
-this version of `azure-ai-projects` will install latest beta version of `azure-ai-agents`
-(which has lots of features in preview) instead of latest stable version (which does
+* File `setup.py` was updated to indicate the dependency `azure-ai-agents>=1.2.0b3`
+instead of `azure-ai-agents>=1.0.0`. This means that in a clean environment, installing
+via `pip install --pre azure-ai-projects` will install latest beta version of `azure-ai-agents`
+(which has features in preview) instead of latest stable version (which does
 not include preview features).
 
 ### Breaking changes

--- a/sdk/ai/azure-ai-projects/setup.py
+++ b/sdk/ai/azure-ai-projects/setup.py
@@ -71,7 +71,7 @@ setup(
         "azure-core>=1.30.0",
         "typing-extensions>=4.12.2",
         "azure-storage-blob>=12.15.0",
-        "azure-ai-agents>=1.2.0b1",
+        "azure-ai-agents>=1.2.0b3",
     ],
     python_requires=">=3.9",
 )


### PR DESCRIPTION
After discussion with Johan, I would like to do a release of Python projects SDK, for the sole purpose of updating dependencies. File `setup.py` was updated to indicate the dependency `azure-ai-agents>=1.2.0b3` instead of `azure-ai-agents>=1.0.0`. This means that in a clean environment, installing via `pip install --pre azure-ai-projects` will install latest beta version of `azure-ai-agents`. We got reports from 1P customers that were surprised that Agents beta features have vanished, after they installed latest azure-ai-projects.