### PR TITLE
Remove recording condition for playback-only test decorator

### DIFF
--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -23,7 +23,6 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-import os
 import pytest
 
 # In instances where packages do not require azure-sdk-tools we need to make sure that the following imports do not fail.
@@ -51,7 +50,7 @@ def pytest_runtest_setup(item):
     if is_playback_test_marked:
         from devtools_testutils import is_live
 
-        if is_live() and os.environ.get("AZURE_SKIP_LIVE_RECORDING", "").lower() == "true":
+        if is_live():
             pytest.skip("playback test only")
 
 


### PR DESCRIPTION
# Description

We have a `playback_test_only` test decorator that's intended to skip tests in live mode. However, there's an additional requirement that `AZURE_SKIP_LIVE_RECORDING` is True, which shouldn't be relevant and is confusing.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
