### PR TITLE
[Identity] Update tenant resolution logic

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - Fixed an issue where `AzureDeveloperCliCredential` would time out during token requests when `azd` prompts for user interaction. This issue commonly occurred in environments where the `AZD_DEBUG` environment variable was set, causing the Azure Developer CLI to display additional prompts that interfered with automated token acquisition. ([#42535](https://github.com/Azure/azure-sdk-for-python/pull/42535))
+- Fixed an issue where credentials configured with a default tenant ID of "organizations" (such as `InteractiveBrowserCredential` and `DeviceCodeCredential`) would fail authentication when a specific tenant ID was provided in `get_token` or `get_token_info` method calls. ([#42721](https://github.com/Azure/azure-sdk-for-python/pull/42721))
 
 ### Other Changes
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -128,6 +128,11 @@ def resolve_tenant(
             tenant_id,
         )
         return tenant_id
+    # Some dev credentials commonly default to the "organizations" special tenant which can authenticate users against
+    # multiple tenants that the user belongs to. If an allowed tenant list was not provided and the credential's
+    # tenant is set to 'organizations', allow the request with the specified tenant ID.
+    if not additionally_allowed_tenants and default_tenant == "organizations":
+        return tenant_id
     raise ClientAuthenticationError(
         message="The current credential is not configured to acquire tokens for tenant {}. "
         "To enable acquiring tokens for this tenant add it to the additionally_allowed_tenants "


### PR DESCRIPTION
Our tenant resolution logic shouldn't error out requests for certain dev credentials (e.g. `DeviceCodeCredential` and `InteractiveBrowserCredential`) if a tenant is passed into `get_token` or `get_token_info`. This happens if the no tenant was configured on the credential and the default "organizations" tenant is used.

Something similar was done in Go: https://github.com/Azure/azure-sdk-for-go/pull/23951

