### PR TITLE
Support multiple open api and mcp for toolset.

### DIFF
--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - Added Computer Use Preview tool for use with the computer-use-preview model
 - ToolSet now supports adding multiple McpTool instances and OpenApiTool instances.
-- Added static merge_resources method to `McpTool` with accompanying sample.
+- Added static functions `Tool.get_tool_resources` and `Tool.get_tool_definitions` to simplify extracting tool resources and definitions from collections of tools, making it easier to configure agents with multiple tool instances.
+
 ### Bugs Fixed
 
 - Fix issue with tracing an Agent message, when the message has "in progress" status (related to [GitHub Issue 42645](https://github.com/Azure/azure-sdk-for-python/issues/42645)).

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Added Computer Use Preview tool for use with the computer-use-preview model
 - ToolSet now supports adding multiple McpTool instances and OpenApiTool instances.
-- Added static functions `Tool.get_tool_resources` and `Tool.get_tool_definitions` to simplify extracting tool resources and definitions from collections of tools, making it easier to configure agents with multiple tool instances.
+- Added static functions `get_tool_resources` and `get_tool_definitions` in `azure.ai.agents.models` to simplify extracting tool resources and definitions from collections of tools, making it easier to configure agents with multiple tool instances.
 
 ### Bugs Fixed
 

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Features Added
 
 - Added Computer Use Preview tool for use with the computer-use-preview model
-- Added static `merge_resources` method to `McpTool` with accompanying sample.
-
+- ToolSet now supports adding multiple McpTool instances and OpenApiTool instances.
+- Added static merge_resources method to `McpTool` with accompanying sample.
 ### Bugs Fixed
 
 - Fix issue with tracing an Agent message, when the message has "in progress" status (related to [GitHub Issue 42645](https://github.com/Azure/azure-sdk-for-python/issues/42645)).

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -20,8 +20,11 @@
 
 ### Sample updates
 
-- Added Computer Use Preview tool sample demonstrating use with the computer-use-preview model
 - Added sample demonstrating multiple McpTool instance usage.
+- Added `sample_agents_mcp_stream_eventhandler.py` demonstrating how to use MCP tools with streaming and event handlers for real-time processing.
+- Added `sample_agents_mcp_stream_iteration.py` showing MCP tool usage with streaming iteration for step-by-step response handling.
+- Added `sample_agents_multiple_mcp.py` illustrating how to configure and use multiple MCP tool.
+
 
 ## 1.2.0b3 (2025-08-22)
 

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 # Release History
 
-## 1.2.0b4 (Unreleased)
-
-### Breaking Changes
+## 1.2.0b4 (2025-09-12)
 
 ### Features Added
 

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -463,9 +463,9 @@ class Tool(ABC, Generic[ToolDefinitionT]):
             raise ValueError("Invalid resources for ToolResources.") from e
         
     @staticmethod
-    def merge_resources(tools: List['Tool']) -> ToolResources:
+    def get_tool_resources(tools: List['Tool']) -> ToolResources:
         """
-        Get the resources for all tools.
+        Get the tool resources from tools.
 
         :param tools: The list of tool objects whose resources should be merged.
         :type tools: List[Tool]
@@ -489,7 +489,21 @@ class Tool(ABC, Generic[ToolDefinitionT]):
                     tool_resources[key] = value
         return Tool._create_tool_resources_from_dict(tool_resources)
     
-    
+    @staticmethod
+    def get_tool_definitions(tools: List['Tool']) -> List[ToolDefinition]:
+        """
+        Get the tool definitions from tools.
+
+        :param tools: Tools from which to collect definitions.
+        :type tools: List[Tool]
+        :return: List of collected tool definitions.
+        :rtype: List[ToolDefinition]
+        """
+        tool_definitions: List[ToolDefinition] = []
+        for tool in tools:
+            tool_definitions.extend(tool.definitions)
+        return tool_definitions
+
 class BaseFunctionTool(Tool[FunctionToolDefinition]):
     """
     A tool that executes user-defined functions.
@@ -1796,7 +1810,7 @@ class BaseToolSet(ABC):
 
         :rtype: ToolResources
         """
-        return Tool.merge_resources(self._tools)
+        return Tool.get_tool_resources(self._tools)
 
     def get_definitions_and_resources(self) -> Dict[str, Any]:
         """

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1691,15 +1691,7 @@ class BaseToolSet:
         ...
     @overload
     def remove(self, tool_type: Type[Tool]) -> None: 
-        """
-        Remove a tool of the specified type from the toolset.
-
-        This removes the first matching tool instance of the given type.
-
-        :param tool_type: The tool class to remove.
-        :type tool_type: Type[Tool]
-        :raises ValueError: If a tool of the specified type is not found.
-        """
+        """Remove any tool from the toolset."""
         ...
     def remove(self, tool_type: Type[Tool], **kwargs) -> None:
         """

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -444,7 +444,7 @@ class Tool(ABC, Generic[ToolDefinitionT]):
         :param Any tool_call: The tool call to execute.
         :return: The output of the tool operations.
         """
-        
+
     @staticmethod
     def _create_tool_resources_from_dict(resources: Dict[str, Any]) -> ToolResources:
         """
@@ -461,9 +461,9 @@ class Tool(ABC, Generic[ToolDefinitionT]):
         except TypeError as e:
             logger.error("Error creating ToolResources: %s", e)  # pylint: disable=do-not-log-exceptions-if-not-debug
             raise ValueError("Invalid resources for ToolResources.") from e
-        
+
     @staticmethod
-    def get_tool_resources(tools: List['Tool']) -> ToolResources:
+    def get_tool_resources(tools: List["Tool"]) -> ToolResources:
         """
         Get the tool resources from tools.
 
@@ -488,9 +488,9 @@ class Tool(ABC, Generic[ToolDefinitionT]):
                 else:
                     tool_resources[key] = value
         return Tool._create_tool_resources_from_dict(tool_resources)
-    
+
     @staticmethod
-    def get_tool_definitions(tools: List['Tool']) -> List[ToolDefinition]:
+    def get_tool_definitions(tools: List["Tool"]) -> List[ToolDefinition]:
         """
         Get the tool definitions from tools.
 
@@ -503,6 +503,7 @@ class Tool(ABC, Generic[ToolDefinitionT]):
         for tool in tools:
             tool_definitions.extend(tool.definitions)
         return tool_definitions
+
 
 class BaseFunctionTool(Tool[FunctionToolDefinition]):
     """
@@ -1030,6 +1031,7 @@ class McpTool(Tool[MCPToolDefinition]):
         :param Any tool_call: The tool call to execute.
         :type tool_call: Any
         """
+
 
 class AzureFunctionTool(Tool[AzureFunctionToolDefinition]):
     """
@@ -1647,7 +1649,7 @@ class BaseToolSet(ABC):
         :raises ValueError: If a tool of the same type already exists, or if an MCP tool with the same server label already exists.
         """
         self.validate_tool_type(tool)
-        
+
         # Special handling for OpenApiTool - add definitions to existing tool instead of raising error
         if isinstance(tool, OpenApiTool):
             # Find existing OpenApiTool if any
@@ -1660,10 +1662,10 @@ class BaseToolSet(ABC):
                         description=definition.openapi.description,
                         spec=definition.openapi.spec,
                         auth=definition.openapi.auth,
-                        default_parameters=definition.openapi.default_params
+                        default_parameters=definition.openapi.default_params,
                     )
                 return  # Early return since we added to existing tool
-        
+
         # Special handling for McpTool - check for same server label
         if isinstance(tool, McpTool):
             # Check if there's already an MCP tool with the same server label
@@ -1673,13 +1675,13 @@ class BaseToolSet(ABC):
             # Allow multiple MCP tools (with different server labels)
             self._tools.append(tool)
             return
-            
+
         if any(isinstance(existing_tool, type(tool)) for existing_tool in self._tools):
             raise ValueError(f"Tool of type {type(tool).__name__} already exists in the ToolSet.")
         self._tools.append(tool)
 
     @overload
-    def remove(self, tool_type: Type[OpenApiTool], *, name: str) -> None: 
+    def remove(self, tool_type: Type[OpenApiTool], *, name: str) -> None:
         """
         Remove a specific API definition from an OpenApiTool by name.
 
@@ -1690,7 +1692,8 @@ class BaseToolSet(ABC):
         :raises ValueError: If the OpenApiTool isn't found or the named definition doesn't exist.
         """
         ...
-    @overload  
+
+    @overload
     def remove(self, tool_type: Type[OpenApiTool]) -> None:
         """
         Remove the OpenApiTool from the toolset.
@@ -1702,8 +1705,9 @@ class BaseToolSet(ABC):
         :raises ValueError: If no OpenApiTool is found in the toolset.
         """
         ...
+
     @overload
-    def remove(self, tool_type: Type[McpTool], *, server_label: str) -> None: 
+    def remove(self, tool_type: Type[McpTool], *, server_label: str) -> None:
         """
         Remove a specific McpTool from the toolset by its server label.
 
@@ -1714,7 +1718,8 @@ class BaseToolSet(ABC):
         :raises ValueError: If no McpTool with the given server label is found.
         """
         ...
-    @overload  
+
+    @overload
     def remove(self, tool_type: Type[McpTool]) -> None:
         """
         Remove all McpTool instances from the toolset.
@@ -1724,10 +1729,12 @@ class BaseToolSet(ABC):
         :raises ValueError: If there are no McpTool instances in the toolset.
         """
         ...
+
     @overload
-    def remove(self, tool_type: Type[Tool]) -> None: 
+    def remove(self, tool_type: Type[Tool]) -> None:
         """Remove any tool from the toolset."""
         ...
+
     def remove(self, tool_type: Type[Tool], **kwargs) -> None:
         """
         Remove a tool of the specified type from the tool set.
@@ -1754,7 +1761,7 @@ class BaseToolSet(ABC):
                         logger.info("OpenApiTool removed from ToolSet as it has no remaining definitions.")
                     return
             raise ValueError(f"Tool of type {tool_type.__name__} not found in the ToolSet.")
-        
+
         # Special handling for McpTool with server_label parameter
         if tool_type == McpTool and "server_label" in kwargs:
             server_label = kwargs["server_label"]
@@ -1764,7 +1771,7 @@ class BaseToolSet(ABC):
                     logger.info("McpTool with server label '%s' removed from the ToolSet.", server_label)
                     return
             raise ValueError(f"McpTool with server label '{server_label}' not found in the ToolSet.")
-        
+
         # Special handling for McpTool without server_label - remove ALL MCP tools
         if tool_type == McpTool:
             removed_count = 0
@@ -1776,13 +1783,13 @@ class BaseToolSet(ABC):
                     del self._tools[i]
                     logger.info("McpTool with server label '%s' removed from the ToolSet.", server_label)
                     removed_count += 1
-            
+
             if removed_count == 0:
                 raise ValueError(f"No tools of type {tool_type.__name__} found in the ToolSet.")
             else:
                 logger.info("Removed %d MCP tools from the ToolSet.", removed_count)
                 return
-        
+
         # Standard tool removal
         for i, tool in enumerate(self._tools):
             if isinstance(tool, tool_type):
@@ -1850,7 +1857,7 @@ class BaseToolSet(ABC):
                 if isinstance(tool, McpTool) and tool.server_label == server_label:
                     return cast(ToolT, tool)
             raise ValueError(f"McpTool with server label '{server_label}' not found in the ToolSet.")
-        
+
         # Special handling for McpTool without server_label - check if there are multiple
         if tool_type == McpTool:
             mcp_tools = [tool for tool in self._tools if isinstance(tool, McpTool)]
@@ -1865,7 +1872,7 @@ class BaseToolSet(ABC):
             else:
                 # Only one MCP tool found, return it
                 return cast(ToolT, mcp_tools[0])
-        
+
         # Standard tool retrieval - return first tool of specified type
         for tool in self._tools:
             if isinstance(tool, tool_type):

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -746,7 +746,7 @@ class OpenApiTool(Tool[OpenApiToolDefinition]):
     def __init__(
         self,
         name: str,
-        description: str,
+        description: Optional[str],
         spec: Any,
         auth: OpenApiAuthDetails,
         default_parameters: Optional[List[str]] = None,

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1735,7 +1735,7 @@ class BaseToolSet(ABC):
 
     @overload
     def remove(self, tool_type: Type[Tool]) -> None:
-        """Remove a tool by from the toolset.
+        """Remove a tool by name from the toolset.
 
         :param tool_type: The tool class to target.
         :type tool_type: Type[Tool]

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1863,15 +1863,14 @@ class BaseToolSet(ABC):
             mcp_tools = [tool for tool in self._tools if isinstance(tool, McpTool)]
             if len(mcp_tools) == 0:
                 raise ValueError(f"Tool of type {tool_type.__name__} not found in the ToolSet.")
-            elif len(mcp_tools) > 1:
+            if len(mcp_tools) > 1:
                 server_labels = [tool.server_label for tool in mcp_tools]
                 raise ValueError(
                     f"Multiple McpTool instances found with server labels: {server_labels}. "
                     f"Please specify 'server_label' parameter to identify which MCP tool to retrieve."
                 )
-            else:
-                # Only one MCP tool found, return it
-                return cast(ToolT, mcp_tools[0])
+            # Only one MCP tool found, return it
+            return cast(ToolT, mcp_tools[0])
 
         # Standard tool retrieval - return first tool of specified type
         for tool in self._tools:

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1684,6 +1684,16 @@ class BaseToolSet(ABC):
         self._tools.append(tool)
 
     @overload
+    def remove(self, tool_type: Type[Tool]) -> None:
+        """Remove a tool by name from the toolset.
+
+        :param tool_type: The tool class to target.
+        :type tool_type: Type[Tool]
+
+        """
+        ...
+
+    @overload
     def remove(self, tool_type: Type[OpenApiTool], *, name: str) -> None:
         """
         Remove a specific API definition from an OpenApiTool by name.
@@ -1697,19 +1707,6 @@ class BaseToolSet(ABC):
         ...
 
     @overload
-    def remove(self, tool_type: Type[OpenApiTool]) -> None:
-        """
-        Remove the OpenApiTool from the toolset.
-
-        If multiple definitions exist within the OpenApiTool, the entire tool is removed.
-
-        :param tool_type: The tool class to target. Must be OpenApiTool.
-        :type tool_type: Type[OpenApiTool]
-        :raises ValueError: If no OpenApiTool is found in the toolset.
-        """
-        ...
-
-    @overload
     def remove(self, tool_type: Type[McpTool], *, server_label: str) -> None:
         """
         Remove a specific McpTool from the toolset by its server label.
@@ -1719,27 +1716,6 @@ class BaseToolSet(ABC):
         :keyword server_label: The unique server label identifying the MCP tool to remove.
         :paramtype server_label: str
         :raises ValueError: If no McpTool with the given server label is found.
-        """
-        ...
-
-    @overload
-    def remove(self, tool_type: Type[McpTool]) -> None:
-        """
-        Remove all McpTool instances from the toolset.
-
-        :param tool_type: The tool class to target. Must be McpTool.
-        :type tool_type: Type[McpTool]
-        :raises ValueError: If there are no McpTool instances in the toolset.
-        """
-        ...
-
-    @overload
-    def remove(self, tool_type: Type[Tool]) -> None:
-        """Remove a tool by name from the toolset.
-
-        :param tool_type: The tool class to target.
-        :type tool_type: Type[Tool]
-
         """
         ...
 

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -746,7 +746,7 @@ class OpenApiTool(Tool[OpenApiToolDefinition]):
     def __init__(
         self,
         name: str,
-        description: Optional[str] = None,
+        description: Optional[str],
         spec: Any,
         auth: OpenApiAuthDetails,
         default_parameters: Optional[List[str]] = None,
@@ -788,7 +788,7 @@ class OpenApiTool(Tool[OpenApiToolDefinition]):
     def add_definition(
         self,
         name: str,
-        description: Optional[str] = None,
+        description: Optional[str],
         spec: Any,
         auth: Optional[OpenApiAuthDetails] = None,
         default_parameters: Optional[List[str]] = None,

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1738,7 +1738,12 @@ class BaseToolSet(ABC):
 
     @overload
     def remove(self, tool_type: Type[Tool]) -> None:
-        """Remove any tool from the toolset."""
+        """Remove any tool from the toolset.
+
+        :param tool_type: The tool class to target.
+        :type tool_type: Type[Tool]
+
+        """
         ...
 
     def remove(self, tool_type: Type[Tool], **kwargs) -> None:
@@ -1751,9 +1756,6 @@ class BaseToolSet(ABC):
 
         :param tool_type: The type of tool to remove.
         :type tool_type: Type[Tool]
-        :param kwargs: Additional keyword arguments. May include 'name' for OpenApiTool
-            or 'server_label' for McpTool.
-        :type kwargs: Any
         :return: None
         :rtype: None
         :raises ValueError: If a tool of the specified type is not found.
@@ -1887,8 +1889,6 @@ class BaseToolSet(ABC):
 
         :param tool_type: The type of tool to get.
         :type tool_type: Type[Tool]
-        :param kwargs: Additional keyword arguments. May include 'server_label' for McpTool.
-        :type kwargs: Any
         :return: The tool of the specified type.
         :rtype: Tool
         :raises ValueError: If a tool of the specified type is not found, if no McpTool with the specified server_label is found, or if there are multiple MCP tools but no server_label is provided.

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1638,6 +1638,12 @@ class BaseToolSet(ABC):
 
         Implementations should raise ``ValueError`` (or a more specific exception) if
         the tool type is not permitted.
+
+        :param tool: The tool to validate.
+        :type tool: Tool
+        :return: None
+        :rtype: None
+        :raises ValueError: If the tool type is not permitted for this tool set.
         """
         raise NotImplementedError
 
@@ -1743,9 +1749,14 @@ class BaseToolSet(ABC):
         For McpTool without server_label, removes ALL MCP tools from the toolset.
         Otherwise, removes the entire tool from the toolset.
 
-        :param Type[Tool] tool_type: The type of tool to remove.
-        :param str name: (Optional) For OpenApiTool - the name of the specific API definition to remove.
-        :param str server_label: (Optional) For McpTool - the server label of the specific MCP tool to remove.
+        :param tool_type: The type of tool to remove.
+        :type tool_type: Type[Tool]
+        :keyword name: (Optional) For OpenApiTool - the name of the specific API definition to remove.
+        :paramtype name: str
+        :keyword server_label: (Optional) For McpTool - the server label of the specific MCP tool to remove.
+        :paramtype server_label: str
+        :return: None
+        :rtype: None
         :raises ValueError: If a tool of the specified type is not found.
         """
         # Special handling for OpenApiTool with name parameter
@@ -1786,9 +1797,8 @@ class BaseToolSet(ABC):
 
             if removed_count == 0:
                 raise ValueError(f"No tools of type {tool_type.__name__} found in the ToolSet.")
-            else:
-                logger.info("Removed %d MCP tools from the ToolSet.", removed_count)
-                return
+            logger.info("Removed %d MCP tools from the ToolSet.", removed_count)
+            return
 
         # Standard tool removal
         for i, tool in enumerate(self._tools):
@@ -1844,8 +1854,10 @@ class BaseToolSet(ABC):
         If there are multiple MCP tools and no server_label is provided, raises an error.
         Otherwise, returns the first (or only) tool of the specified type.
 
-        :param Type[Tool] tool_type: The type of tool to get.
-        :param str server_label: (Optional) For McpTool - the server label of the specific MCP tool to get.
+        :param tool_type: The type of tool to get.
+        :type tool_type: Type[Tool]
+        :keyword server_label: (Optional) For McpTool - the server label of the specific MCP tool to get.
+        :paramtype server_label: str
         :return: The tool of the specified type.
         :rtype: Tool
         :raises ValueError: If a tool of the specified type is not found, if no McpTool with the specified server_label is found, or if there are multiple MCP tools but no server_label is provided.

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -1693,8 +1693,8 @@ class BaseToolSet(ABC):
 
         :param tool_type: The tool class to target. Must be OpenApiTool.
         :type tool_type: Type[OpenApiTool]
-        :param name: The name of the OpenAPI definition to remove from the tool.
-        :type name: str
+        :keyword name: The name of the OpenAPI definition to remove from the tool.
+        :paramtype name: str
         :raises ValueError: If the OpenApiTool isn't found or the named definition doesn't exist.
         """
         ...
@@ -1719,8 +1719,8 @@ class BaseToolSet(ABC):
 
         :param tool_type: The tool class to target. Must be McpTool.
         :type tool_type: Type[McpTool]
-        :param server_label: The unique server label identifying the MCP tool to remove.
-        :type server_label: str
+        :keyword server_label: The unique server label identifying the MCP tool to remove.
+        :paramtype server_label: str
         :raises ValueError: If no McpTool with the given server label is found.
         """
         ...
@@ -1751,10 +1751,9 @@ class BaseToolSet(ABC):
 
         :param tool_type: The type of tool to remove.
         :type tool_type: Type[Tool]
-        :keyword name: (Optional) For OpenApiTool - the name of the specific API definition to remove.
-        :paramtype name: str
-        :keyword server_label: (Optional) For McpTool - the server label of the specific MCP tool to remove.
-        :paramtype server_label: str
+        :param kwargs: Additional keyword arguments. May include 'name' for OpenApiTool
+            or 'server_label' for McpTool.
+        :type kwargs: Any
         :return: None
         :rtype: None
         :raises ValueError: If a tool of the specified type is not found.
@@ -1842,11 +1841,43 @@ class BaseToolSet(ABC):
         }
 
     @overload
-    def get_tool(self, tool_type: Type[McpTool]) -> McpTool: ...
+    def get_tool(self, tool_type: Type[McpTool]) -> McpTool:
+        """
+        Get an MCP tool from the tool set.
+
+        :param tool_type: The MCP tool type to get.
+        :type tool_type: Type[McpTool]
+        :return: The MCP tool.
+        :rtype: McpTool
+        """
+        ...
+
     @overload
-    def get_tool(self, tool_type: Type[McpTool], *, server_label: str) -> McpTool: ...
+    def get_tool(self, tool_type: Type[McpTool], *, server_label: str) -> McpTool:
+        """
+        Get an MCP tool with a specific server label from the tool set.
+
+        :param tool_type: The MCP tool type to get.
+        :type tool_type: Type[McpTool]
+        :keyword server_label: The server label of the specific MCP tool to get.
+        :paramtype server_label: str
+        :return: The MCP tool with the specified server label.
+        :rtype: McpTool
+        """
+        ...
+
     @overload
-    def get_tool(self, tool_type: Type[ToolT]) -> ToolT: ...
+    def get_tool(self, tool_type: Type[ToolT]) -> ToolT:
+        """
+        Get a tool of the specified type from the tool set.
+
+        :param tool_type: The type of tool to get.
+        :type tool_type: Type[Tool]
+        :return: The tool of the specified type.
+        :rtype: Tool
+        """
+        ...
+
     def get_tool(self, tool_type: Type[ToolT], **kwargs) -> ToolT:
         """
         Get a tool of the specified type from the tool set.
@@ -1856,8 +1887,8 @@ class BaseToolSet(ABC):
 
         :param tool_type: The type of tool to get.
         :type tool_type: Type[Tool]
-        :keyword server_label: (Optional) For McpTool - the server label of the specific MCP tool to get.
-        :paramtype server_label: str
+        :param kwargs: Additional keyword arguments. May include 'server_label' for McpTool.
+        :type kwargs: Any
         :return: The tool of the specified type.
         :rtype: Tool
         :raises ValueError: If a tool of the specified type is not found, if no McpTool with the specified server_label is found, or if there are multiple MCP tools but no server_label is provided.

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/models/_patch.py
@@ -746,7 +746,7 @@ class OpenApiTool(Tool[OpenApiToolDefinition]):
     def __init__(
         self,
         name: str,
-        description: Optional[str],
+        description: Optional[str] = None,
         spec: Any,
         auth: OpenApiAuthDetails,
         default_parameters: Optional[List[str]] = None,
@@ -788,7 +788,7 @@ class OpenApiTool(Tool[OpenApiToolDefinition]):
     def add_definition(
         self,
         name: str,
-        description: Optional[str],
+        description: Optional[str] = None,
         spec: Any,
         auth: Optional[OpenApiAuthDetails] = None,
         default_parameters: Optional[List[str]] = None,

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_computer_use.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_computer_use.py
@@ -52,6 +52,7 @@ from azure.ai.agents.models import (
 )
 from azure.identity import DefaultAzureCredential
 
+
 def image_to_base64(image_path: str) -> str:
     """
     Convert an image file to a Base64-encoded string.
@@ -70,6 +71,7 @@ def image_to_base64(image_path: str) -> str:
         return base64.b64encode(file_data).decode("utf-8")
     except Exception as exc:
         raise OSError(f"Error reading file '{image_path}'") from exc
+
 
 asset_file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../assets/cua_screenshot.jpg"))
 action_result_file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../assets/cua_screenshot_next.jpg"))
@@ -144,7 +146,7 @@ with project_client:
                         print(f"Executing computer use action: {action.type}")
                         if isinstance(action, TypeAction):
                             print(f"  Text to type: {action.text}")
-                            #(add hook to input text in managed environment API here)
+                            # (add hook to input text in managed environment API here)
 
                             tool_outputs.append(
                                 ComputerToolOutput(tool_call_id=tool_call.id, output=computer_screenshot)

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
@@ -72,10 +72,7 @@ mcp_tool2 = McpTool(
     allowed_tools=["microsoft_docs_search"],  # Optional: specify allowed tools
 )
 
-tools: list[Tool] = []
-tools.append(mcp_tool1)
-tools.append(mcp_tool2)
-
+tools: list[Tool] = [mcp_tool1, mcp_tool2]
 
 # Create agent with MCP tool and process agent run
 with project_client:

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
@@ -40,6 +40,8 @@ from azure.ai.agents.models import (
     SubmitToolApprovalAction,
     Tool,
     ToolApproval,
+    get_tool_resources,
+    get_tool_definitions,
 )
 
 # Get MCP server configuration from environment variables
@@ -84,7 +86,7 @@ with project_client:
         model=os.environ["MODEL_DEPLOYMENT_NAME"],
         name="my-mcp-agent",
         instructions="You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
-        tools=Tool.get_tool_definitions(tools),
+        tools=get_tool_definitions(tools),
     )
 
     print(f"Created agent, ID: {agent.id}")
@@ -106,7 +108,7 @@ with project_client:
     # Create and process agent run in thread with MCP tools
     mcp_tool1.update_headers("SuperSecret", "123456")
     mcp_tool2.set_approval_mode("never")  # Disable approval for MS Learn MCP tool
-    tool_resources = Tool.get_tool_resources(tools)
+    tool_resources = get_tool_resources(tools)
     print(tool_resources)
     run = agents_client.runs.create(thread_id=thread.id, agent_id=agent.id, tool_resources=tool_resources)
     print(f"Created run, ID: {run.id}")

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
@@ -28,7 +28,6 @@ USAGE:
     6) MCP_SERVER_LABEL_2 - A label for your second MCP server.
 """
 
-from ast import List
 import os, time
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
@@ -28,6 +28,7 @@ USAGE:
     6) MCP_SERVER_LABEL_2 - A label for your second MCP server.
 """
 
+from ast import List
 import os, time
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential
@@ -37,6 +38,7 @@ from azure.ai.agents.models import (
     RequiredMcpToolCall,
     RunStepActivityDetails,
     SubmitToolApprovalAction,
+    Tool,
     ToolApproval,
 )
 
@@ -70,7 +72,10 @@ mcp_tool2 = McpTool(
     allowed_tools=["microsoft_docs_search"],  # Optional: specify allowed tools
 )
 
-mcp_tools = [mcp_tool1, mcp_tool2]
+tools: list[Tool] = []
+tools.append(mcp_tool1)
+tools.append(mcp_tool2)
+
 
 # Create agent with MCP tool and process agent run
 with project_client:
@@ -82,7 +87,7 @@ with project_client:
         model=os.environ["MODEL_DEPLOYMENT_NAME"],
         name="my-mcp-agent",
         instructions="You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
-        tools=[tool.definitions[0] for tool in mcp_tools],
+        tools=[tool.definitions[0] for tool in tools],
     )
 
     print(f"Created agent, ID: {agent.id}")
@@ -104,7 +109,7 @@ with project_client:
     # Create and process agent run in thread with MCP tools
     mcp_tool1.update_headers("SuperSecret", "123456")
     mcp_tool2.set_approval_mode("never")  # Disable approval for MS Learn MCP tool
-    tool_resources = McpTool.merge_resources(mcp_tools)
+    tool_resources = Tool.merge_resources(tools)
     print(tool_resources)
     run = agents_client.runs.create(thread_id=thread.id, agent_id=agent.id, tool_resources=tool_resources)
     print(f"Created run, ID: {run.id}")

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_multiple_mcp.py
@@ -87,7 +87,7 @@ with project_client:
         model=os.environ["MODEL_DEPLOYMENT_NAME"],
         name="my-mcp-agent",
         instructions="You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
-        tools=[tool.definitions[0] for tool in tools],
+        tools=Tool.get_tool_definitions(tools),
     )
 
     print(f"Created agent, ID: {agent.id}")
@@ -109,7 +109,7 @@ with project_client:
     # Create and process agent run in thread with MCP tools
     mcp_tool1.update_headers("SuperSecret", "123456")
     mcp_tool2.set_approval_mode("never")  # Disable approval for MS Learn MCP tool
-    tool_resources = Tool.merge_resources(tools)
+    tool_resources = Tool.get_tool_resources(tools)
     print(tool_resources)
     run = agents_client.runs.create(thread_id=thread.id, agent_id=agent.id, tool_resources=tool_resources)
     print(f"Created run, ID: {run.id}")

--- a/sdk/ai/azure-ai-agents/tests/test_agents_client.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_client.py
@@ -4035,7 +4035,9 @@ class TestAgentClient(TestAgentClientBase):
                     MessageInputImageUrlBlock(image_url=url_param),
                 ]
                 # Create message to thread
-                message = agents_client.messages.create(thread_id=thread.id, role=MessageRole.USER, content=content_blocks)
+                message = agents_client.messages.create(
+                    thread_id=thread.id, role=MessageRole.USER, content=content_blocks
+                )
                 run = agents_client.runs.create(thread_id=thread.id, agent_id=agent.id)
                 submitted_tool_outputs = False
                 result_image_base64 = image_to_base64(self._get_screenshot_next_file())

--- a/sdk/ai/azure-ai-agents/tests/test_agents_client_base.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_client_base.py
@@ -76,6 +76,7 @@ def fetch_current_datetime_recordings():
     time_json = json.dumps({"current_time": "2024-10-10 12:30:19"})
     return time_json
 
+
 def image_to_base64(image_path: str) -> str:
     """
     Convert an image file to a Base64-encoded string.
@@ -94,6 +95,7 @@ def image_to_base64(image_path: str) -> str:
         return base64.b64encode(file_data).decode("utf-8")
     except Exception as exc:
         raise OSError(f"Error reading file '{image_path}'") from exc
+
 
 class TestAgentClientBase(AzureRecordedTestCase):
     """Base class for Agents Client tests. Please put all code common to sync and async tests here."""

--- a/sdk/ai/azure-ai-agents/tests/test_toolset_functions.py
+++ b/sdk/ai/azure-ai-agents/tests/test_toolset_functions.py
@@ -1,0 +1,186 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import pytest
+
+import azure.ai.agents.models as _models
+
+
+class TestToolSetFunctions:
+    def test_remove_code_interpreter_tool(self):
+        """Test removing a CodeInterpreterTool from ToolSet."""
+        toolset = _models.ToolSet()
+        code_interpreter = _models.CodeInterpreterTool(file_ids=["file1", "file2"])
+        toolset.add(code_interpreter)
+
+        # Verify tool was added
+        assert len(toolset._tools) == 1
+        assert isinstance(toolset._tools[0], _models.CodeInterpreterTool)
+
+        # Remove the tool
+        toolset.remove(_models.CodeInterpreterTool)
+
+        # Verify tool was removed
+        assert len(toolset._tools) == 0
+
+    def test_remove_file_search_tool(self):
+        """Test removing a FileSearchTool from ToolSet."""
+        toolset = _models.ToolSet()
+        file_search = _models.FileSearchTool(vector_store_ids=["vs1", "vs2"])
+        toolset.add(file_search)
+
+        # Verify tool was added
+        assert len(toolset._tools) == 1
+        assert isinstance(toolset._tools[0], _models.FileSearchTool)
+
+        # Remove the tool
+        toolset.remove(_models.FileSearchTool)
+
+        # Verify tool was removed
+        assert len(toolset._tools) == 0
+
+    def test_add_and_remove_openapi_tool_by_name(self):
+        """Test removing a specific API definition from OpenApiTool by name."""
+        from azure.ai.agents.models import OpenApiAuthDetails
+
+        toolset = _models.ToolSet()
+        auth = OpenApiAuthDetails(type="api_key")
+        openapi_tool = _models.OpenApiTool(name="api1", description="First API", spec={"openapi": "3.0.0"}, auth=auth)
+
+        # Add another definition to the same tool
+        openapi_tool2 = _models.OpenApiTool(name="api2", description="Second API", spec={"openapi": "3.0.0"}, auth=auth)
+
+        toolset.add(openapi_tool)
+        toolset.add(openapi_tool2)
+
+        # Verify tool was added with 2 definitions
+        assert len(toolset._tools) == 1
+        assert len(toolset._tools[0].definitions) == 2
+
+        # Remove one definition by name
+        toolset.remove(_models.OpenApiTool, name="api1")
+
+        # Verify tool still exists but with only 1 definition
+        assert len(toolset._tools) == 1
+        assert len(toolset._tools[0].definitions) == 1
+        assert toolset._tools[0].definitions[0].openapi.name == "api2"
+
+    def test_remove_openapi_tool_entire_tool(self):
+        """Test removing entire OpenApiTool without specifying name."""
+        from azure.ai.agents.models import OpenApiAuthDetails
+
+        toolset = _models.ToolSet()
+        auth = OpenApiAuthDetails(type="api_key")
+        openapi_tool = _models.OpenApiTool(name="api1", description="First API", spec={"openapi": "3.0.0"}, auth=auth)
+
+        # Add another definition
+        openapi_tool.add_definition(name="api2", description="Second API", spec={"openapi": "3.0.0"}, auth=auth)
+
+        toolset.add(openapi_tool)
+
+        # Verify tool was added with 2 definitions
+        assert len(toolset._tools) == 1
+        assert len(toolset._tools[0].definitions) == 2
+
+        # Remove entire OpenApiTool without name parameter
+        toolset.remove(_models.OpenApiTool)
+
+        # Verify entire tool was removed
+        assert len(toolset._tools) == 0
+
+    def test_remove_mcp_tool_by_server_label(self):
+        """Test removing a specific McpTool by server label."""
+        toolset = _models.ToolSet()
+
+        mcp_tool1 = _models.McpTool(server_label="server1", server_url="http://server1.com", allowed_tools=["tool1"])
+
+        mcp_tool2 = _models.McpTool(server_label="server2", server_url="http://server2.com", allowed_tools=["tool2"])
+
+        toolset.add(mcp_tool1)
+        toolset.add(mcp_tool2)
+
+        # Verify both tools were added
+        assert len(toolset._tools) == 2
+
+        # Remove one by server label
+        toolset.remove(_models.McpTool, server_label="server1")
+
+        # Verify only one tool remains
+        assert len(toolset._tools) == 1
+        assert toolset._tools[0].server_label == "server2"
+
+    def test_remove_all_mcp_tools(self):
+        """Test removing all McpTool instances without specifying server_label."""
+        toolset = _models.ToolSet()
+
+        mcp_tool1 = _models.McpTool(server_label="server1", server_url="http://server1.com", allowed_tools=["tool1"])
+
+        mcp_tool2 = _models.McpTool(server_label="server2", server_url="http://server2.com", allowed_tools=["tool2"])
+
+        toolset.add(mcp_tool1)
+        toolset.add(mcp_tool2)
+
+        # Add a non-MCP tool
+        def dummy_function():
+            pass
+
+        function_tool = _models.FunctionTool({dummy_function})
+        toolset.add(function_tool)
+
+        # Verify all tools were added
+        assert len(toolset._tools) == 3
+
+        # Remove all MCP tools
+        toolset.remove(_models.McpTool)
+
+        # Verify only the function tool remains
+        assert len(toolset._tools) == 1
+        assert isinstance(toolset._tools[0], _models.FunctionTool)
+
+    def test_remove_nonexistent_tool_type(self):
+        """Test error when trying to remove a tool type that doesn't exist."""
+        toolset = _models.ToolSet()
+
+        with pytest.raises(ValueError, match="Tool of type FunctionTool not found in the ToolSet"):
+            toolset.remove(_models.FunctionTool)
+
+    def test_remove_openapi_tool_nonexistent_name(self):
+        """Test error when trying to remove nonexistent API definition by name."""
+        from azure.ai.agents.models import OpenApiAuthDetails
+
+        toolset = _models.ToolSet()
+        auth = OpenApiAuthDetails(type="api_key")
+        openapi_tool = _models.OpenApiTool(name="api1", description="First API", spec={"openapi": "3.0.0"}, auth=auth)
+
+        toolset.add(openapi_tool)
+
+        # Try to remove a definition that doesn't exist
+        with pytest.raises(ValueError, match="Definition with the name 'nonexistent' does not exist"):
+            toolset.remove(_models.OpenApiTool, name="nonexistent")
+
+    def test_remove_openapi_tool_by_name_no_openapi_tool(self):
+        """Test error when trying to remove API definition by name but no OpenApiTool exists."""
+        toolset = _models.ToolSet()
+
+        with pytest.raises(ValueError, match="Tool of type OpenApiTool not found in the ToolSet"):
+            toolset.remove(_models.OpenApiTool, name="api1")
+
+    def test_remove_mcp_tool_nonexistent_server_label(self):
+        """Test error when trying to remove McpTool with nonexistent server label."""
+        toolset = _models.ToolSet()
+
+        mcp_tool = _models.McpTool(server_label="server1", server_url="http://server1.com", allowed_tools=["tool1"])
+
+        toolset.add(mcp_tool)
+
+        # Try to remove MCP tool with nonexistent server label
+        with pytest.raises(ValueError, match="McpTool with server label 'nonexistent' not found in the ToolSet"):
+            toolset.remove(_models.McpTool, server_label="nonexistent")
+
+    def test_remove_mcp_tool_no_mcp_tools(self):
+        """Test error when trying to remove McpTool but none exist."""
+        toolset = _models.ToolSet()
+
+        with pytest.raises(ValueError, match="No tools of type McpTool found in the ToolSet"):
+            toolset.remove(_models.McpTool)


### PR DESCRIPTION
The original code already support multiple open api tool by providing add_definition and remove_definition at OpenAPITool.  But now we want to support multiple MCP tool.   But add_definition and remove_definition don't make sense since adding multiple MCP tool also not only requires adding multiple definition but also tool_resources.    So I have discussed with Glenn and Jarno and allowing add and remove multiple tool in toolset are better optional.  