### PR TITLE
Simplify and enhance `discover_targeted_packages`

### DIFF
--- a/eng/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/functions.py
@@ -163,12 +163,16 @@ def glob_packages(glob_string: str, target_root_dir: str) -> List[str]:
     collected_top_level_directories = []
 
     for glob_string in individual_globs:
-        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "setup.py"), recursive=True)
+        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "setup.py"), recursive=True) + glob.glob(
+            os.path.join(target_root_dir, "sdk/*/", glob_string, "setup.py")
+        )
         collected_top_level_directories.extend([os.path.dirname(p) for p in globbed])
 
     # handle pyproject.toml separately, as we need to filter them by the presence of a `[project]` section
     for glob_string in individual_globs:
-        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "pyproject.toml"), recursive=True)
+        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "pyproject.toml"), recursive=True) + glob.glob(
+            os.path.join(target_root_dir, "sdk/*/", glob_string, "pyproject.toml")
+        )
         for p in globbed:
             if get_pyproject(os.path.dirname(p)):
                 collected_top_level_directories.append(os.path.dirname(p))

--- a/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
+++ b/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
@@ -5,8 +5,9 @@ from ci_tools.functions import discover_targeted_packages
 
 
 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
-core_service_root = os.path.join(repo_root, "sdk", "core")
-storage_service_root = os.path.join(repo_root, "sdk", "storage")
+sdk_root = os.path.join(repo_root, "sdk")
+core_service_root = os.path.join(sdk_root, "core")
+storage_service_root = os.path.join(sdk_root, "storage")
 
 
 def test_discovery():
@@ -18,6 +19,20 @@ def test_discovery():
     assert len(results) > 1
     assert len(non_empty_results) == 1
 
+
+def test_discovery_against_sdk():
+    package_directories = discover_targeted_packages("**", sdk_root)
+
+    # ensure we didn't accidentally pick up a couple known packages from within a tests directory
+
+    known_mgmt_test_setup = os.path.join(sdk_root, "netapp", "azure-mgmt-netapp", "tests", "setup.py")
+    known_test_core_setup = os.path.join(repo_root, "sdk", "core", "azure-core", "tests", "testserver_tests", "coretestserver", "setup.py")
+
+    assert known_test_core_setup not in package_directories
+    assert known_mgmt_test_setup not in package_directories
+
+    # this is effectively checking to ensure we don't crash on any of the packages
+    assert len(package_directories) > 0
 
 def test_discovery_omit_mgmt():
     results = discover_targeted_packages("azure*", storage_service_root, filter_type="Omit_management")


### PR DESCRIPTION
Effectively, the first glob match needs to be provided `**` to act recursively. The `sdk/` check explicitly will handle any `*` passed in. Maintaining that for backwards compatibility for now.