### PR TITLE
bump typespec-python 0.49.0

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.48.2"
+        "@azure-tools/typespec-python": "0.49.0"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "~0.59.1",
@@ -128,13 +128,13 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.48.2.tgz",
-      "integrity": "sha512-r/N9firQT+fFkmyLtVgbB6DwbLK04LIJJ8V0omPgeikvZGlhzGRtdwOtaQdGb0iX1/bDPXvGClftu65JPOjhVg==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.49.0.tgz",
+      "integrity": "sha512-WiUWymCX5Zd2vetfUPwYiang1W0+pXMsD+arAPGsWo+nxV1Le1etp4lY/cuw7Yx+fuyMOm+iHyaw/M/C2jRlDQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.15.2",
+        "@typespec/http-client-python": "~0.16.0",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -144,11 +144,11 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-autorest": ">=0.59.1 <1.0.0",
         "@azure-tools/typespec-azure-core": ">=0.59.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.59.2 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.59.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.59.1 <1.0.0",
         "@typespec/compiler": "^1.3.0",
         "@typespec/events": ">=0.73.0 <1.0.0",
         "@typespec/http": "^1.3.0",
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.15.2.tgz",
-      "integrity": "sha512-tgbdsqB212HYeAjHk+w3wdsZ6wLmvIZbFD92qdZBRovuk6p6bMJAcHFoN17x3NV2T4NTeKWqBpsY9wlj5Cn8gw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.16.0.tgz",
+      "integrity": "sha512-4eLOnm4Pd/KSbYPbXO3Ed97Ts7UpAkbWaRRPH554d7JBkVUH652yu0JVf6xQc7YEBMh2K+sDURGNTz0fDuMLgQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1074,11 +1074,11 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-autorest": ">=0.59.1 <1.0.0",
         "@azure-tools/typespec-azure-core": ">=0.59.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.59.2 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.59.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.59.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.59.1 <1.0.0",
         "@typespec/compiler": "^1.3.0",
         "@typespec/events": ">=0.73.0 <1.0.0",
         "@typespec/http": "^1.3.0",
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.48.2"
+    "@azure-tools/typespec-python": "0.49.0"
   },
   "devDependencies": {
     "@typespec/compiler": "^1.3.0",

--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.10.2",
-      "use": ["@autorest/python@6.38.2", "@autorest/modelerfour@4.27.0"],
+      "use": ["@autorest/python@6.39.0", "@autorest/modelerfour@4.27.0"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false,

--- a/swagger_to_sdk_config_dpg.json
+++ b/swagger_to_sdk_config_dpg.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.10.2",
-      "use": ["@autorest/python@6.38.2", "@autorest/modelerfour@4.27.0"]
+      "use": ["@autorest/python@6.39.0", "@autorest/modelerfour@4.27.0"]
     },
     "advanced_options": {
       "create_sdk_pull_requests": true,


### PR DESCRIPTION
This PR updates @azure-tools/typespec-python from 0.48.2 to 0.49.0.

Changes:
- Updated eng/emitter-package.json to use typespec-python 0.49.0
- Regenerated eng/emitter-package-lock.json with the latest dependencies

This ensures we're using the latest version of the TypeSpec Python emitter for SDK generation.