### PR TITLE
Sparse-Checkout Entire Repo

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -83,6 +83,9 @@ jobs:
 
     steps:
     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+      parameters:
+        Paths:
+          - '**'
 
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -82,6 +82,8 @@ jobs:
       value: ${{ parameters.InjectedPackages }}
 
     steps:
+    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 
     - template: /eng/pipelines/templates/steps/resolve-package-targeting.yml

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -25,6 +25,8 @@ parameters:
     default: []
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'
     condition: and(succeeded(), or(eq(variables['ENABLE_EXTENSION_BUILD'], 'true'), eq('${{ parameters.ArtifactSuffix }}', 'linux')))

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -26,6 +26,9 @@ parameters:
 
 steps:
   - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      Paths:
+        - '**'
 
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'


### PR DESCRIPTION
We don't need the full history + tags for the basic confirmations though. This should address [these issues](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5279171&view=results) that I'm seeing in main CI builds.