### PR TITLE
[Cosmos] fix: add ability to replace indexing policies with vector indexes

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Features Added
 * Added read_items API to provide an efficient method for retrieving multiple items in a single request. See [PR 42167](https://github.com/Azure/azure-sdk-for-python/pull/42167).
+* Added ability to replace a container's indexing policy if a vector embedding policy was present. See [PR 42810](https://github.com/Azure/azure-sdk-for-python/pull/42810).
 
 #### Breaking Changes
 
@@ -13,7 +14,6 @@
 * Fixed bug where containers named with spaces or special characters using session consistency would fall back to eventual consistency. See [PR 42608](https://github.com/Azure/azure-sdk-for-python/pull/42608)
 * Fixed bug where `excluded_locations` was not being honored for some metadata calls. See [PR 42266](https://github.com/Azure/azure-sdk-for-python/pull/42266).
 * Fixed partition scoping for per partition circuit breaker. See [PR 42751](https://github.com/Azure/azure-sdk-for-python/pull/42751)
-* Fixed bug where users were unable to replace a container's indexing policy if a vector embedding policy was present. See [PR 42810](https://github.com/Azure/azure-sdk-for-python/pull/42810).
 
 #### Other Changes
 * Added session token false progress merge logic. See [42393](https://github.com/Azure/azure-sdk-for-python/pull/42393)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed bug where containers named with spaces or special characters using session consistency would fall back to eventual consistency. See [PR 42608](https://github.com/Azure/azure-sdk-for-python/pull/42608)
 * Fixed bug where `excluded_locations` was not being honored for some metadata calls. See [PR 42266](https://github.com/Azure/azure-sdk-for-python/pull/42266).
 * Fixed partition scoping for per partition circuit breaker. See [PR 42751](https://github.com/Azure/azure-sdk-for-python/pull/42751)
+* Fixed bug where users were unable to replace a container's indexing policy if a vector embedding policy was present. See [PR 42810](https://github.com/Azure/azure-sdk-for-python/pull/42810).
 
 #### Other Changes
 * Added session token false progress merge logic. See [42393](https://github.com/Azure/azure-sdk-for-python/pull/42393)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -519,6 +519,7 @@ class DatabaseProxy(object):
         analytical_storage_ttl: Optional[int] = None,
         computed_properties: Optional[List[Dict[str, str]]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
+        vector_embedding_policy: Optional[Dict[str, Any]] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Reset the properties of the container.
@@ -596,7 +597,8 @@ class DatabaseProxy(object):
                 "conflictResolutionPolicy": conflict_resolution_policy,
                 "analyticalStorageTtl": analytical_storage_ttl,
                 "computedProperties": computed_properties,
-                "fullTextPolicy": full_text_policy
+                "fullTextPolicy": full_text_policy,
+                "vectorEmbeddingPolicy": vector_embedding_policy
             }.items()
             if value is not None
         }

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -584,6 +584,7 @@ class DatabaseProxy(object):
         analytical_storage_ttl: Optional[int] = None,
         computed_properties: Optional[List[Dict[str, str]]] = None,
         full_text_policy: Optional[Dict[str, Any]] = None,
+        vector_embedding_policy: Optional[Dict[str, Any]] = None,
         **kwargs: Any
     ) -> ContainerProxy:
         """Reset the properties of the container.
@@ -665,6 +666,7 @@ class DatabaseProxy(object):
                 "analyticalStorageTtl": analytical_storage_ttl,
                 "computedProperties": computed_properties,
                 "fullTextPolicy": full_text_policy,
+                "vectorEmbeddingPolicy": vector_embedding_policy
             }.items()
             if value is not None
         }

--- a/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
@@ -152,7 +152,8 @@ class TestVectorPolicy(unittest.TestCase):
                 {"path": "/*"},
                 {"path": "/vector1/*"},
                 {"path": "/\"_etag\"/?"}
-            ], "fullTextIndexes": [],
+            ],
+            "fullTextIndexes": [],
             "vectorIndexes": [
                 {
                     "path": "/vector1",

--- a/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
@@ -374,6 +374,29 @@ class TestVectorPolicy(unittest.TestCase):
             indexing_policy=indexing_policy,
             vector_embedding_policy=vector_embedding_policy
         )
+        # don't provide vector embedding policy
+        try:
+            self.test_db.replace_container(
+                created_container,
+                PartitionKey(path="/id"),
+                indexing_policy=indexing_policy)
+            pytest.fail("Container replace should have failed for missing embedding policy.")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == 400
+            assert ("The Vector Indexing Policy's path::/vector1 not matching in Embedding's path."
+                    in e.http_error_message)
+        # don't provide vector indexing policy
+        try:
+            self.test_db.replace_container(
+                created_container,
+                PartitionKey(path="/id"),
+                vector_embedding_policy=vector_embedding_policy)
+            pytest.fail("Container replace should have failed for missing indexing policy.")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == 400
+            assert ("The Vector Indexing Policy cannot be changed in Collection Replace."
+                    in e.http_error_message)
+        # using a new indexing policy
         new_indexing_policy = {
             "vectorIndexes": [
                 {"path": "/vector1", "type": "quantizedFlat"}]
@@ -382,11 +405,31 @@ class TestVectorPolicy(unittest.TestCase):
             self.test_db.replace_container(
                 created_container,
                 PartitionKey(path="/id"),
+                vector_embedding_policy=vector_embedding_policy,
                 indexing_policy=new_indexing_policy)
-            pytest.fail("Container replace should have failed for indexing policy.")
+            pytest.fail("Container replace should have failed for new indexing policy.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert ("The Vector Indexing Policy's path::/vector1 not matching in Embedding's path."
+            assert ("Paths in existing vector indexing policy cannot be modified in Collection Replace"
+                    in e.http_error_message)
+        # using a new vector embedding policy
+        new_embedding_policy = {
+            "vectorEmbeddings": [
+                {
+                    "path": "/vector1",
+                    "dataType": "float32",
+                    "dimensions": 384,
+                    "distanceFunction": "euclidean"}]}
+        try:
+            self.test_db.replace_container(
+                created_container,
+                PartitionKey(path="/id"),
+                vector_embedding_policy=new_embedding_policy,
+                indexing_policy=indexing_policy)
+            pytest.fail("Container replace should have failed for new embedding policy.")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == 400
+            assert ("The Vector Embedding Policy cannot be changed in Collection Replace"
                     in e.http_error_message)
         self.test_db.delete_container(container_id)
 

--- a/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
@@ -94,6 +94,83 @@ class TestVectorPolicy(unittest.TestCase):
         assert properties["indexingPolicy"]["vectorIndexes"] == indexing_policy["vectorIndexes"]
         self.test_db.delete_container(container_id)
 
+    def test_replace_vector_indexing_policy(self):
+        # Replace should work so long as the new indexing policy doesn't change the vector indexes, and as long as
+        # the previously defined vector embedding policy is also provided.
+        vector_embedding_policy = {
+            "vectorEmbeddings": [
+                {
+                    "path": "/vector1",
+                    "dataType": "float32",
+                    "dimensions": 256,
+                    "distanceFunction": "euclidean"
+                }
+            ]
+        }
+        indexing_policy = {
+            "indexingMode": "consistent",
+            "automatic": True,
+            "includedPaths": [
+                {
+                    "path": "/*"
+                }
+            ],
+            "excludedPaths": [
+                {
+                    "path": "/vector1/*"
+                },
+                {
+                    "path": "/\"_etag\"/?"
+                }
+            ],
+            "fullTextIndexes": [],
+            "vectorIndexes": [
+                {
+                    "path": "/vector1",
+                    "type": "diskANN",
+                    "quantizationByteSize": 128,
+                    "indexingSearchListSize": 100
+                }
+            ]
+        }
+        container_id = "vector_container" + str(uuid.uuid4())
+        created_container = self.test_db.create_container(
+            id=container_id,
+            partition_key=PartitionKey(path="/id"),
+            indexing_policy=indexing_policy,
+            vector_embedding_policy=vector_embedding_policy
+        )
+        new_indexing_policy = {
+            "indexingMode": "consistent",
+            "automatic": True,
+            "includedPaths": [
+                {"path": "/color/?"},
+                {"path": "/description/?"},
+                {"path": "/cost/?"}
+            ],
+            "excludedPaths": [
+                {"path": "/*"},
+                {"path": "/vector1/*"},
+                {"path": "/\"_etag\"/?"}
+            ], "fullTextIndexes": [],
+            "vectorIndexes": [
+                {
+                    "path": "/vector1",
+                    "type": "diskANN",
+                    "quantizationByteSize": 128,
+                    "indexingSearchListSize": 100
+                }]
+        }
+        self.test_db.replace_container(
+            created_container,
+            PartitionKey(path="/id"),
+            vector_embedding_policy=vector_embedding_policy,
+            indexing_policy=new_indexing_policy)
+        properties = created_container.read()
+        assert properties["vectorEmbeddingPolicy"] == vector_embedding_policy
+        assert properties["indexingPolicy"]["vectorIndexes"] == indexing_policy["vectorIndexes"]
+        self.test_db.delete_container(container_id)
+
     def test_fail_create_vector_indexing_policy(self):
         vector_embedding_policy = {
             "vectorEmbeddings": [

--- a/sdk/cosmos/azure-cosmos/tests/test_vector_policy_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_vector_policy_async.py
@@ -148,7 +148,8 @@ class TestVectorPolicyAsync(unittest.IsolatedAsyncioTestCase):
                 {"path": "/*"},
                 {"path": "/vector1/*"},
                 {"path": "/\"_etag\"/?"}
-            ], "fullTextIndexes": [],
+            ],
+            "fullTextIndexes": [],
             "vectorIndexes": [
                 {
                     "path": "/vector1",


### PR DESCRIPTION
Since in Python we require each part of the container definition to be provided individually (indexing policy, vector embedding policy, ttl, computed properties, etc) we had not included `vector_embedding_policy` as part of the method definition since this feature is not yet fully supported.

However, if a user wants to replace different parts of their indexing policy while already having a vector embedding policy in the container, we should allow for this to happen. In our other SDKs, when replacing a container using the equivalent `replace_container` operations, the entire context of the initial container is leveraged in the operation, making it a straight-forward process for users to update any relevant fields they want - and as such this behavior was already enabled.

These changes make it so we allow that behavior in the Python SDK as well.