### PR TITLE
Create_and_process for mcp

### DIFF
--- a/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
@@ -1200,7 +1200,7 @@ class RunsOperations(RunsOperationsGenerated):
         :rtype: ~azure.ai.agents.models.ThreadRun
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self.submit_tool_outputs_and_process(thread_id=thread_id, run_id=run_id, body=body, tool_outputs=tool_outputs, tool_approvals=tool_approvals, polling_interval=polling_interval, **kwargs)
+        self.submit_tool_outputs(thread_id=thread_id, run_id=run_id, body=body, tool_outputs=tool_outputs, tool_approvals=tool_approvals, polling_interval=polling_interval, **kwargs)
         return self._process(thread_id=thread_id, run_id=run_id, polling_interval=polling_interval)
 
     # pylint: disable=arguments-differ

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp in_create_and_run.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp in_create_and_run.py
@@ -7,11 +7,11 @@
 """
 DESCRIPTION:
     This sample demonstrates how to use agent operations with the
-    Model Context Protocol (MCP) tool from the Azure Agents service using a synchronous client.
+    Model Context Protocol (MCP) tool in runs.create_and_run using a synchronous client.
     To learn more about Model Context Protocol, visit https://modelcontextprotocol.io/
 
 USAGE:
-    python sample_agents_mcp.py
+    python sample_agents_mcp in_create_and_run.py
 
     Before running the sample:
 
@@ -36,6 +36,7 @@ from azure.ai.agents.models import (
     RunStepActivityDetails,
     SubmitToolApprovalAction,
     ToolApproval,
+    ToolSet,
 )
 
 # Get MCP server configuration from environment variables
@@ -54,6 +55,8 @@ mcp_tool = McpTool(
     server_url=mcp_server_url,
     allowed_tools=[],  # Optional: specify allowed tools
 )
+toolSet = ToolSet()
+toolSet.add(mcp_tool)
 
 # You can also add or remove allowed tools dynamically
 search_api_code = "search_azure_rest_api_code"
@@ -93,16 +96,12 @@ with project_client:
     # Create and process agent run in thread with MCP tools
     mcp_tool.update_headers("SuperSecret", "123456")
     # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
-    run = agents_client.runs.create(
-        thread_id=thread.id, agent_id=agent.id, tool_resources=mcp_tool.resources
-    )
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, toolset=toolSet)
     print(f"Created run, ID: {run.id}")
 
-    while run.status in ["queued", "in_progress", "requires_action"]:
-        time.sleep(1)
-        run = agents_client.runs.get(thread_id=thread.id, run_id=run.id)
+    while run.status in ["requires_action"]:
 
-        if run.status == "requires_action" and isinstance(run.required_action, SubmitToolApprovalAction):
+        if isinstance(run.required_action, SubmitToolApprovalAction):
             tool_calls = run.required_action.submit_tool_approval.tool_calls
             if not tool_calls:
                 print("No tool calls provided - cancelling run")
@@ -126,7 +125,7 @@ with project_client:
 
             print(f"tool_approvals: {tool_approvals}")
             if tool_approvals:
-                agents_client.runs.submit_tool_outputs(
+                run = agents_client.runs.submit_tool_outputs_and_process(
                     thread_id=thread.id, run_id=run.id, tool_approvals=tool_approvals
                 )
 

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp.py
@@ -36,6 +36,7 @@ from azure.ai.agents.models import (
     RunStepActivityDetails,
     SubmitToolApprovalAction,
     ToolApproval,
+    ToolSet,
 )
 
 # Get MCP server configuration from environment variables
@@ -54,6 +55,8 @@ mcp_tool = McpTool(
     server_url=mcp_server_url,
     allowed_tools=[],  # Optional: specify allowed tools
 )
+toolSet = ToolSet()
+toolSet.add(mcp_tool)
 
 # You can also add or remove allowed tools dynamically
 search_api_code = "search_azure_rest_api_code"
@@ -93,7 +96,7 @@ with project_client:
     # Create and process agent run in thread with MCP tools
     mcp_tool.update_headers("SuperSecret", "123456")
     # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
-    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, tool_resources=mcp_tool.resources)
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, toolset=toolSet)
     print(f"Created run, ID: {run.id}")
 
     while run.status in ["requires_action"]:

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_stream_iteration.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_stream_iteration.py
@@ -7,11 +7,11 @@
 """
 DESCRIPTION:
     This sample demonstrates how to use agent operations with the
-    Model Context Protocol (MCP) tool from the Azure Agents service using a synchronous client.
+    Model Context Protocol (MCP) tool in stream with iteration from the Azure Agents service using a synchronous client.
     To learn more about Model Context Protocol, visit https://modelcontextprotocol.io/
 
 USAGE:
-    python sample_agents_mcp.py
+    python sample_agents_mcp_stream_iteration.py
 
     Before running the sample:
 
@@ -27,15 +27,19 @@ USAGE:
 """
 
 import os, time
+from azure.ai.agents.models._models import RunStep, ThreadRun
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential
 from azure.ai.agents.models import (
     ListSortOrder,
     McpTool,
+    MessageDeltaChunk,
     RequiredMcpToolCall,
     RunStepActivityDetails,
     SubmitToolApprovalAction,
+    ThreadMessage,
     ToolApproval,
+    ToolSet,
 )
 
 # Get MCP server configuration from environment variables
@@ -54,6 +58,8 @@ mcp_tool = McpTool(
     server_url=mcp_server_url,
     allowed_tools=[],  # Optional: specify allowed tools
 )
+toolset = ToolSet()
+toolset.add(mcp_tool)
 
 # You can also add or remove allowed tools dynamically
 search_api_code = "search_azure_rest_api_code"
@@ -70,9 +76,8 @@ with project_client:
         model=os.environ["MODEL_DEPLOYMENT_NAME"],
         name="my-mcp-agent",
         instructions="You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
-        tools=mcp_tool.definitions,
+        toolset=toolset,
     )
-    # [END create_agent_with_mcp_tool]
 
     print(f"Created agent, ID: {agent.id}")
     print(f"MCP Server: {mcp_tool.server_label} at {mcp_tool.server_url}")
@@ -89,87 +94,71 @@ with project_client:
     )
     print(f"Created message, ID: {message.id}")
 
-    # [START handle_tool_approvals]
     # Create and process agent run in thread with MCP tools
     mcp_tool.update_headers("SuperSecret", "123456")
     # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
-    run = agents_client.runs.create(
-        thread_id=thread.id, agent_id=agent.id, tool_resources=mcp_tool.resources
-    )
-    print(f"Created run, ID: {run.id}")
+    with agents_client.runs.stream(thread_id=thread.id, agent_id=agent.id) as stream:
+        for event_type, event_data, _ in stream:
 
-    while run.status in ["queued", "in_progress", "requires_action"]:
-        time.sleep(1)
-        run = agents_client.runs.get(thread_id=thread.id, run_id=run.id)
+            if isinstance(event_data, MessageDeltaChunk):
+                print(f"Text delta received: {event_data.text}")
+            elif isinstance(event_data, ThreadRun):
+                if isinstance(event_data.required_action, SubmitToolApprovalAction):
+                    tool_calls = event_data.required_action.submit_tool_approval.tool_calls
+                    if not tool_calls:
+                        print("No tool calls provided - cancelling run")
+                        agents_client.runs.cancel(thread_id=thread.id, run_id=event_data.id)
+                        break
 
-        if run.status == "requires_action" and isinstance(run.required_action, SubmitToolApprovalAction):
-            tool_calls = run.required_action.submit_tool_approval.tool_calls
-            if not tool_calls:
-                print("No tool calls provided - cancelling run")
-                agents_client.runs.cancel(thread_id=thread.id, run_id=run.id)
-                break
+                    tool_approvals = []
+                    for tool_call in tool_calls:
+                        if isinstance(tool_call, RequiredMcpToolCall):
+                            try:
+                                print(f"Approving tool call: {tool_call}")
+                                tool_approvals.append(
+                                    ToolApproval(
+                                        tool_call_id=tool_call.id,
+                                        approve=True,
+                                        headers=mcp_tool.headers,
+                                    )
+                                )
+                            except Exception as e:
+                                print(f"Error approving tool_call {tool_call.id}: {e}")
 
-            tool_approvals = []
-            for tool_call in tool_calls:
-                if isinstance(tool_call, RequiredMcpToolCall):
-                    try:
-                        print(f"Approving tool call: {tool_call}")
-                        tool_approvals.append(
-                            ToolApproval(
-                                tool_call_id=tool_call.id,
-                                approve=True,
-                                headers=mcp_tool.headers,
-                            )
+                        print(f"tool_approvals: {tool_approvals}")
+                    if tool_approvals:
+                        run = agents_client.runs.submit_tool_outputs_stream(
+                            thread_id=thread.id, run_id=event_data.id, tool_approvals=tool_approvals, event_handler=stream
                         )
-                    except Exception as e:
-                        print(f"Error approving tool_call {tool_call.id}: {e}")
+            elif isinstance(event_data, RunStep):
+                print(f"Step {event_data.id} status: {event_data.status}")
 
-            print(f"tool_approvals: {tool_approvals}")
-            if tool_approvals:
-                agents_client.runs.submit_tool_outputs(
-                    thread_id=thread.id, run_id=run.id, tool_approvals=tool_approvals
-                )
+                # Check if there are tool calls in the step details
+                step_details = event_data.get("step_details", {})
+                tool_calls = step_details.get("tool_calls", [])
 
-        print(f"Current run status: {run.status}")
-        # [END handle_tool_approvals]
+                if tool_calls:
+                    print("  MCP Tool calls:")
+                    for call in tool_calls:
+                        print(f"    Tool Call ID: {call.get('id')}")
+                        print(f"    Type: {call.get('type')}")
 
-    print(f"Run completed with status: {run.status}")
-    if run.status == "failed":
-        print(f"Run failed: {run.last_error}")
+                if isinstance(step_details, RunStepActivityDetails):
+                    for activity in step_details.activities:
+                        for function_name, function_definition in activity.tools.items():
+                            print(
+                                f'  The function {function_name} with description "{function_definition.description}" will be called.:'
+                            )
+                            if len(function_definition.parameters) > 0:
+                                print("  Function parameters:")
+                                for argument, func_argument in function_definition.parameters.properties.items():
+                                    print(f"      {argument}")
+                                    print(f"      Type: {func_argument.type}")
+                                    print(f"      Description: {func_argument.description}")
+                            else:
+                                print("This function has no parameters")
 
-    # Display run steps and tool calls
-    run_steps = agents_client.run_steps.list(thread_id=thread.id, run_id=run.id)
-
-    # Loop through each step
-    for step in run_steps:
-        print(f"Step {step['id']} status: {step['status']}")
-
-        # Check if there are tool calls in the step details
-        step_details = step.get("step_details", {})
-        tool_calls = step_details.get("tool_calls", [])
-
-        if tool_calls:
-            print("  MCP Tool calls:")
-            for call in tool_calls:
-                print(f"    Tool Call ID: {call.get('id')}")
-                print(f"    Type: {call.get('type')}")
-
-        if isinstance(step_details, RunStepActivityDetails):
-            for activity in step_details.activities:
-                for function_name, function_definition in activity.tools.items():
-                    print(
-                        f'  The function {function_name} with description "{function_definition.description}" will be called.:'
-                    )
-                    if len(function_definition.parameters) > 0:
-                        print("  Function parameters:")
-                        for argument, func_argument in function_definition.parameters.properties.items():
-                            print(f"      {argument}")
-                            print(f"      Type: {func_argument.type}")
-                            print(f"      Description: {func_argument.description}")
-                    else:
-                        print("This function has no parameters")
-
-        print()  # add an extra newline between steps
+                print()  # add an extra newline between steps
 
     # Fetch and log all messages
     messages = agents_client.messages.list(thread_id=thread.id, order=ListSortOrder.ASCENDING)


### PR DESCRIPTION
Extract the process logic in create_and_process into a new API
When process encounter approval necessary, it will break at the while loop and return run with status = required_action.
Update the mcp sample to take advantage of this design.  
Subject to keep the original sample and make a new sample with create_and_process.