### PR TITLE
Fix failing checkouts on mac livetests

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -107,6 +107,11 @@ jobs:
       container: $[ variables['Container'] ]
 
     steps:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          Paths:
+            - '**'
+
       - ${{ parameters.PreSteps }}
 
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml


### PR DESCRIPTION
This mirrors a PR I submitted this past Friday #42793 

[Addressing livetest failures]() that I addressed in `main` for the playback pipeline.