### PR TITLE
Undoing the `checkout` change until root cause identification

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -82,10 +82,10 @@ jobs:
       value: ${{ parameters.InjectedPackages }}
 
     steps:
-    - checkout: self
-      fetchTags: false
-      sparseCheckoutPatterns: |
-        **
+    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+      parameters:
+        Paths:
+          - '**'
 
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -107,10 +107,10 @@ jobs:
       container: $[ variables['Container'] ]
 
     steps:
-      - checkout: self
-        fetchTags: false
-        sparseCheckoutPatterns: |
-          **
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          Paths:
+            - '**'
 
       - ${{ parameters.PreSteps }}
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -25,10 +25,10 @@ parameters:
     default: []
 
 steps:
-  - checkout: self
-    fetchTags: false
-    sparseCheckoutPatterns: |
-      **
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      Paths:
+        - '**'
 
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'


### PR DESCRIPTION
Unfortunately my change #42827 still has issues on `CI builds`: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5293082&view=logs&j=a8c563f8-3448-5f28-faff-44d890153fee&t=b1574f09-2545-53a9-5b4e-73d417ea803c

<img width="1150" height="374" alt="image" src="https://github.com/user-attachments/assets/e6dd0f0a-8756-4a49-819d-449b3d908c1c" />

We need this to be unblocked ASAP. I will continue my investigations in the meantime. I don't know why public CI passed but internal did not.

FYI @weshaggard  @benbp I'm merging this without waiting for ya'll but not trying to duck the eyes of sauron 👍 