### PR TITLE
Update TableClient.from_table_url credential type to include TokenCredential

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
@@ -146,7 +146,7 @@ class TableClient(TablesBaseClient):
         cls,
         table_url: str,
         *,
-        credential: Optional[Union[AzureNamedKeyCredential, AzureSasCredential]] = None,
+        credential: Optional[Union[AzureNamedKeyCredential, AzureSasCredential, TokenCredential]] = None,
         **kwargs: Any,
     ) -> "TableClient":
         """A client to interact with a specific Table.

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_client_async.py
@@ -147,7 +147,7 @@ class TableClient(AsyncTablesBaseClient):
         cls,
         table_url: str,
         *,
-        credential: Optional[Union[AzureNamedKeyCredential, AzureSasCredential]] = None,
+        credential: Optional[Union[AzureNamedKeyCredential, AzureSasCredential, AsyncTokenCredential]] = None,
         **kwargs: Any,
     ) -> "TableClient":
         """A client to interact with a specific Table.
@@ -156,7 +156,7 @@ class TableClient(AsyncTablesBaseClient):
         :keyword credential:
             The credentials with which to authenticate. This is optional if the
             table URL already has a SAS token. The value can be one of AzureNamedKeyCredential (azure-core),
-            AzureSasCredential (azure-core), or a TokenCredential implementation from azure-identity.
+            AzureSasCredential (azure-core), or a AsyncTokenCredential implementation from azure-identity.
         :paramtype credential:
             ~azure.core.credentials.AzureNamedKeyCredential or
             ~azure.core.credentials.AzureSasCredential or None


### PR DESCRIPTION
# Description

Add `TokenCredential` as a credential option in the `from_table_url` constructor of the `TableClient` class to align with the corresponding doc string.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
