### PR TITLE
Add RunHandler to support MCP toolcall approval and manual function tool call for runs.create_and_process

### DIFF
--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -5,11 +5,16 @@
 ## 1.2.0b5 (Unreleased)
 
 ### Features Added
+- Added `run_handler` parameter to `runs.create_and_process` allowing to make function tool calls manually or approve mcp tool calls.
 
 ### Bugs Fixed
-- Added `RunStepDeltaChunk` to `StreamEventData` model (GitHub issues [43022](https://github.com/Azure/azure-sdk-for-python/issues/43022))
 - Fixed regression, reverted ToolOutput type signature and usage in tool_output submission.  
 - Added `RunStepDeltaComputerUseDetails` and `RunStepDeltaComputerUseToolCall` classes for streaming computer use scenarios.
+- Added `RunStepDeltaChunk` to `StreamEventData` model (GitHub issues [43022](https://github.com/Azure/azure-sdk-for-python/issues/43022))
+
+### Sample updates
+- Added `sample_agents_mcp_in_create_and_process.py` abd `sample_agents_mcp_in_create_and_process_async.py` demonstrating MCP tool call approvals in `runs.create_and_process`.
+- Added `sample_agents_functions_in_create_and_process.py` and `sample_agents_functions_in_create_and_process_async.py` demonstrating manual function tool calls in `runs.create_and_process`.
 
 ## 1.2.0b4 (2025-09-12)
 

--- a/sdk/ai/azure-ai-agents/README.md
+++ b/sdk/ai/azure-ai-agents/README.md
@@ -514,6 +514,36 @@ while run.status in ["queued", "in_progress", "requires_action"]:
 
 <!-- END SNIPPET -->
 
+For scenarios requiring custom approval logic or additional control over MCP tool calls, you can use a `RunHandler` with the `create_and_process` method. This approach allows you to implement custom logic for approving or denying MCP tool calls.
+
+Here's an example that demonstrates manual MCP tool call approval using a `RunHandler`:
+
+<!-- SNIPPET:sample_agents_mcp_in_create_and_process.run_handler -->
+
+```python
+class MyRunHandler(RunHandler):
+    def submit_mcp_tool_approval(self, *, run: ThreadRun, tool_call: RequiredMcpToolCall, **kwargs: Any) -> ToolApproval:
+        return ToolApproval(
+            tool_call_id=tool_call.id,
+            approve=True,
+            headers=mcp_tool.headers,
+        )
+```
+
+<!-- END SNIPPET -->
+
+To use the RunHandler with `create_and_process` for MCP tools:
+
+<!-- SNIPPET:sample_agents_mcp_in_create_and_process.create_and_process -->
+
+```python
+run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+```
+
+<!-- END SNIPPET -->
+
+For a complete example, see [`sample_agents_mcp_in_create_and_process.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_in_create_and_process.py).
+
 ### Create Agent with Azure AI Search
 
 Azure AI Search is an enterprise search system for high-performance applications. It integrates with Azure OpenAI Service and Azure Machine Learning, offering advanced search technologies like vector search and full-text search. Ideal for knowledge base insights, information discovery, and automation. Creating an Agent with Azure AI Search requires an existing Azure AI Search Index. For more information and setup guides, see [Azure AI Search Tool Guide](https://learn.microsoft.com/azure/ai-services/agents/how-to/tools/azure-ai-search?tabs=azurecli%2Cpython&pivots=overview-azure-ai-search).
@@ -633,7 +663,6 @@ When `enable_auto_function_calls` is called, the SDK will automatically invoke f
 - For examples of automatic function calls in action, refer to [`sample_agents_auto_function_call.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_auto_function_call.py) or [`sample_agents_auto_function_call_async.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_async/sample_agents_auto_function_call_async.py).
 - If you prefer to manage function execution manually, refer to [`sample_agents_stream_eventhandler_with_functions.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_streaming/sample_agents_stream_eventhandler_with_functions.py) or
 [`sample_agents_functions.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions.py).
-
 
 ### Create Agent With Azure Function Call
 
@@ -1365,6 +1394,43 @@ run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.
 ```
 
 <!-- END SNIPPET -->
+
+For scenarios requiring manual approval or custom control over function execution (such as security-sensitive operations), you can use a `RunHandler` with the `create_and_process` method. This approach allows you to implement custom logic to decide whether, when, and how functions should be executed.
+
+Here's an example that demonstrates manual function calls using a `RunHandler`:
+
+<!-- SNIPPET:sample_agents_functions_in_create_and_process.run_handler -->
+
+```python
+class MyRunHandler(RunHandler):
+    def submit_function_call_output(
+        self,
+        run: ThreadRun,
+        tool_call: RequiredFunctionToolCall,
+        tool_call_details: RequiredFunctionToolCallDetails,
+        **kwargs: Any,
+    ) -> Any:
+        function_name = tool_call_details.name
+        if function_name == send_email.__name__:
+            # Parse arguments from tool call
+            args_dict = json.loads(tool_call_details.arguments) if tool_call_details.arguments else {}
+            # Call the function directly with the arguments
+            return send_email(**args_dict)
+```
+
+<!-- END SNIPPET -->
+
+To use the RunHandler with `create_and_process`:
+
+<!-- SNIPPET:sample_agents_functions_in_create_and_process.create_and_process -->
+
+```python
+run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+```
+
+<!-- END SNIPPET -->
+
+For a complete example, see [`sample_agents_functions_in_create_and_process.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions_in_create_and_process.py).
 
 With streaming, polling need not be considered. If `function tools` were added to the agents, you should decide to have the function tools called manually or automatically.  Please visit [`manual function call sample`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_streaming/sample_agents_stream_eventhandler_with_functions.py) or [`automatic function call sample`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-agents/samples/agents_streaming/sample_agents_stream_iteration_with_toolset.py).    
 

--- a/sdk/ai/azure-ai-agents/README.md
+++ b/sdk/ai/azure-ai-agents/README.md
@@ -522,7 +522,9 @@ Here's an example that demonstrates manual MCP tool call approval using a `RunHa
 
 ```python
 class MyRunHandler(RunHandler):
-    def submit_mcp_tool_approval(self, *, run: ThreadRun, tool_call: RequiredMcpToolCall, **kwargs: Any) -> ToolApproval:
+    def submit_mcp_tool_approval(
+        self, *, run: ThreadRun, tool_call: RequiredMcpToolCall, **kwargs: Any
+    ) -> ToolApproval:
         return ToolApproval(
             tool_call_id=tool_call.id,
             approve=True,
@@ -537,7 +539,7 @@ To use the RunHandler with `create_and_process` for MCP tools:
 <!-- SNIPPET:sample_agents_mcp_in_create_and_process.create_and_process -->
 
 ```python
-run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler())
 ```
 
 <!-- END SNIPPET -->
@@ -1405,6 +1407,7 @@ Here's an example that demonstrates manual function calls using a `RunHandler`:
 class MyRunHandler(RunHandler):
     def submit_function_call_output(
         self,
+        *,
         run: ThreadRun,
         tool_call: RequiredFunctionToolCall,
         tool_call_details: RequiredFunctionToolCallDetails,
@@ -1425,7 +1428,7 @@ To use the RunHandler with `create_and_process`:
 <!-- SNIPPET:sample_agents_functions_in_create_and_process.create_and_process -->
 
 ```python
-run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler())
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
@@ -24,7 +24,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Type,
     Union,
     cast,
     overload,
@@ -443,7 +442,7 @@ class RunsOperations(RunsOperationsGenerated):
         response_format: Optional["_types.AgentsResponseFormatOption"] = None,
         parallel_tool_calls: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
-        run_handler: Union[_models.AsyncRunHandler, Type[_models.AsyncRunHandler]] = _models.AsyncRunHandler,
+        run_handler: Optional[_models.AsyncRunHandler] = None,
         polling_interval: int = 1,
         **kwargs: Any,
     ) -> _models.ThreadRun:
@@ -526,7 +525,7 @@ class RunsOperations(RunsOperationsGenerated):
         :paramtype metadata: dict[str, str]
         :keyword run_handler: Optional handler to customize run processing and tool execution.
             Default value is None.
-        :paramtype run_handler: Union[~azure.ai.agents.models.AsyncRunHandler, Type[~azure.ai.agents.models.AsyncRunHandler]]
+        :paramtype run_handler: ~azure.ai.agents.models.AsyncRunHandler
         :keyword polling_interval: The time in seconds to wait between polling the service for run status.
             Default value is 1.
         :paramtype polling_interval: int
@@ -558,7 +557,7 @@ class RunsOperations(RunsOperationsGenerated):
         )
 
         # Monitor and process the run status
-        run_handler_obj = run_handler() if isinstance(run_handler, type) else run_handler
+        run_handler_obj = run_handler or _models.AsyncRunHandler()
 
         return await run_handler_obj._start(self, run, polling_interval)  # pylint: disable=protected-access
 

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_patch.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Type,
     Union,
     cast,
     overload,
@@ -32,7 +33,7 @@ from typing import (
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from ... import models as _models
-from ...models._enums import FilePurpose, RunStatus
+from ...models._enums import FilePurpose
 from ._operations import FilesOperations as FilesOperationsGenerated
 from ._operations import MessagesOperations as MessagesOperationsGenerated
 from ._operations import RunsOperations as RunsOperationsGenerated
@@ -442,6 +443,7 @@ class RunsOperations(RunsOperationsGenerated):
         response_format: Optional["_types.AgentsResponseFormatOption"] = None,
         parallel_tool_calls: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
+        run_handler: Union[_models.AsyncRunHandler, Type[_models.AsyncRunHandler]] = _models.AsyncRunHandler,
         polling_interval: int = 1,
         **kwargs: Any,
     ) -> _models.ThreadRun:
@@ -522,6 +524,9 @@ class RunsOperations(RunsOperationsGenerated):
          64 characters in length and values may be up to 512 characters in length. Default value is
          None.
         :paramtype metadata: dict[str, str]
+        :keyword run_handler: Optional handler to customize run processing and tool execution.
+            Default value is None.
+        :paramtype run_handler: Union[~azure.ai.agents.models.AsyncRunHandler, Type[~azure.ai.agents.models.AsyncRunHandler]]
         :keyword polling_interval: The time in seconds to wait between polling the service for run status.
             Default value is 1.
         :paramtype polling_interval: int
@@ -553,51 +558,9 @@ class RunsOperations(RunsOperationsGenerated):
         )
 
         # Monitor and process the run status
-        current_retry = 0
-        while run.status in [
-            RunStatus.QUEUED,
-            RunStatus.IN_PROGRESS,
-            RunStatus.REQUIRES_ACTION,
-        ]:
-            await asyncio.sleep(polling_interval)
-            run = await self.get(thread_id=thread_id, run_id=run.id)
+        run_handler_obj = run_handler() if isinstance(run_handler, type) else run_handler
 
-            if run.status == "requires_action" and isinstance(run.required_action, _models.SubmitToolOutputsAction):
-                tool_calls = run.required_action.submit_tool_outputs.tool_calls
-                if not tool_calls:
-                    logger.warning("No tool calls provided - cancelling run")
-                    await self.cancel(thread_id=thread_id, run_id=run.id)
-                    break
-                # We need tool set only if we are executing local function. In case if
-                # the tool is azure_function we just need to wait when it will be finished.
-                if any(tool_call.type == "function" for tool_call in tool_calls):
-                    toolset = _models.AsyncToolSet()
-                    toolset.add(self._function_tool)
-                    tool_outputs = await toolset.execute_tool_calls(tool_calls)
-
-                    if _has_errors_in_toolcalls_output(tool_outputs):
-                        if current_retry >= self._function_tool_max_retry:  # pylint:disable=no-else-return
-                            logger.warning(
-                                "Tool outputs contain errors - reaching max retry %s", self._function_tool_max_retry
-                            )
-                            return await self.cancel(thread_id=thread_id, run_id=run.id)
-                        else:
-                            logger.warning("Tool outputs contain errors - retrying")
-                            current_retry += 1
-
-                    logger.debug("Tool outputs: %s", tool_outputs)
-                    if tool_outputs:
-                        run2 = await self.submit_tool_outputs(
-                            thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs
-                        )
-                        logger.debug("Tool outputs submitted to run: %s", run2.id)
-            elif isinstance(run.required_action, _models.SubmitToolApprovalAction):
-                logger.warning("Automatic MCP tool approval is not supported.")
-                await self.cancel(thread_id=thread_id, run_id=run.id)
-
-            logger.debug("Current run ID: %s with status: %s", run.id, run.status)
-
-        return run
+        return await run_handler_obj._start(self, run, polling_interval)  # pylint: disable=protected-access
 
     @overload
     async def stream(

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
@@ -23,7 +23,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Type,
     Union,
     cast,
     overload,
@@ -442,7 +441,7 @@ class RunsOperations(RunsOperationsGenerated):
         response_format: Optional["_types.AgentsResponseFormatOption"] = None,
         parallel_tool_calls: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
-        run_handler: Union[_models.RunHandler, Type[_models.RunHandler]] = _models.RunHandler,
+        run_handler: Optional[_models.RunHandler] = None,
         polling_interval: int = 1,
         **kwargs: Any,
     ) -> _models.ThreadRun:
@@ -525,7 +524,7 @@ class RunsOperations(RunsOperationsGenerated):
         :paramtype metadata: dict[str, str]
         :keyword run_handler: Optional handler to customize run processing and tool execution.
             Default value is None.
-        :paramtype run_handler: Union[~azure.ai.agents.models.RunHandler, Type[~azure.ai.agents.models.RunHandler]]
+        :paramtype run_handler: ~azure.ai.agents.models.RunHandler
         :keyword polling_interval: The time in seconds to wait between polling the service for run status.
             Default value is 1.
         :paramtype polling_interval: int
@@ -557,7 +556,7 @@ class RunsOperations(RunsOperationsGenerated):
         )
 
         # Monitor and process the run status
-        run_handler_obj = run_handler() if isinstance(run_handler, type) else run_handler
+        run_handler_obj = run_handler or _models.RunHandler()
 
         return run_handler_obj._start(self, run, polling_interval)  # pylint: disable=protected-access
 

--- a/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/operations/_patch.py
@@ -23,6 +23,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Type,
     Union,
     cast,
     overload,
@@ -31,7 +32,7 @@ from typing import (
 from azure.core.tracing.decorator import distributed_trace
 
 from .. import models as _models
-from ..models._enums import FilePurpose, RunStatus
+from ..models._enums import FilePurpose
 from ._operations import FilesOperations as FilesOperationsGenerated
 from ._operations import RunsOperations as RunsOperationsGenerated
 from ._operations import ThreadsOperations as ThreadsOperationsGenerated
@@ -441,6 +442,7 @@ class RunsOperations(RunsOperationsGenerated):
         response_format: Optional["_types.AgentsResponseFormatOption"] = None,
         parallel_tool_calls: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
+        run_handler: Union[_models.RunHandler, Type[_models.RunHandler]] = _models.RunHandler,
         polling_interval: int = 1,
         **kwargs: Any,
     ) -> _models.ThreadRun:
@@ -521,6 +523,9 @@ class RunsOperations(RunsOperationsGenerated):
          64 characters in length and values may be up to 512 characters in length. Default value is
          None.
         :paramtype metadata: dict[str, str]
+        :keyword run_handler: Optional handler to customize run processing and tool execution.
+            Default value is None.
+        :paramtype run_handler: Union[~azure.ai.agents.models.RunHandler, Type[~azure.ai.agents.models.RunHandler]]
         :keyword polling_interval: The time in seconds to wait between polling the service for run status.
             Default value is 1.
         :paramtype polling_interval: int
@@ -552,51 +557,9 @@ class RunsOperations(RunsOperationsGenerated):
         )
 
         # Monitor and process the run status
-        current_retry = 0
-        while run.status in [
-            RunStatus.QUEUED,
-            RunStatus.IN_PROGRESS,
-            RunStatus.REQUIRES_ACTION,
-        ]:
-            time.sleep(polling_interval)
-            run = self.get(thread_id=thread_id, run_id=run.id)
+        run_handler_obj = run_handler() if isinstance(run_handler, type) else run_handler
 
-            if run.status == RunStatus.REQUIRES_ACTION and isinstance(
-                run.required_action, _models.SubmitToolOutputsAction
-            ):
-                tool_calls = run.required_action.submit_tool_outputs.tool_calls
-                if not tool_calls:
-                    logger.warning("No tool calls provided - cancelling run")
-                    self.cancel(thread_id=thread_id, run_id=run.id)
-                    break
-                # We need tool set only if we are executing local function. In case if
-                # the tool is azure_function we just need to wait when it will be finished.
-                if any(tool_call.type == "function" for tool_call in tool_calls):
-                    toolset = _models.ToolSet()
-                    toolset.add(self._function_tool)
-                    tool_outputs = toolset.execute_tool_calls(tool_calls)
-
-                    if _has_errors_in_toolcalls_output(tool_outputs):
-                        if current_retry >= self._function_tool_max_retry:  # pylint:disable=no-else-return
-                            logger.warning(
-                                "Tool outputs contain errors - reaching max retry %s", self._function_tool_max_retry
-                            )
-                            return self.cancel(thread_id=thread_id, run_id=run.id)
-                        else:
-                            logger.warning("Tool outputs contain errors - retrying")
-                            current_retry += 1
-
-                    logger.debug("Tool outputs: %s", tool_outputs)
-                    if tool_outputs:
-                        run2 = self.submit_tool_outputs(thread_id=thread_id, run_id=run.id, tool_outputs=tool_outputs)
-                        logger.debug("Tool outputs submitted to run: %s", run2.id)
-            elif isinstance(run.required_action, _models.SubmitToolApprovalAction):
-                logger.warning("Automatic MCP tool approval is not supported.")
-                self.cancel(thread_id=thread_id, run_id=run.id)
-
-            logger.debug("Current run ID: %s with status: %s", run.id, run.status)
-
-        return run
+        return run_handler_obj._start(self, run, polling_interval)  # pylint: disable=protected-access
 
     @overload
     def stream(

--- a/sdk/ai/azure-ai-agents/samples/agents_async/sample_agents_functions_in_create_and_process_async.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_async/sample_agents_functions_in_create_and_process_async.py
@@ -1,0 +1,125 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    This sample demonstrates how to use Agent operations with a mix of automatic and manual
+    function calls from the Azure Agents service using an asynchronous client.
+
+    Some functions (like fetch_current_datetime and fetch_weather) will be executed automatically,
+    while others (like send_email) will require manual approval through the RunHandler.
+
+USAGE:
+    python sample_agents_functions_in_create_and_process_async.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-agents azure-identity
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
+                          page of your Azure AI Foundry portal.
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
+       the "Models + endpoints" tab in your Azure AI Foundry project.
+"""
+import os, sys, json, asyncio
+from typing import Any
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.ai.agents.models import (
+    AsyncFunctionTool,
+    ListSortOrder,
+    RequiredFunctionToolCall,
+    AsyncRunHandler,
+    ThreadRun,
+    AsyncToolSet,
+    RequiredFunctionToolCallDetails,
+)
+
+from utils.user_async_functions import (
+    fetch_current_datetime_async,
+    fetch_weather,
+    send_email_async,
+)
+from utils.user_async_functions import user_async_functions
+
+
+async def main():
+    project_client = AIProjectClient(
+        endpoint=os.environ["PROJECT_ENDPOINT"],
+        credential=DefaultAzureCredential(),
+    )
+
+    # Create a toolset with all functions
+    all_functions_tool = AsyncFunctionTool(user_async_functions)
+    toolset = AsyncToolSet()
+    toolset.add(all_functions_tool)
+
+    # Declare a run handler to execute function tool call manually
+    class MyRunHandler(AsyncRunHandler):
+        async def submit_function_call_output(
+            self,
+            *,
+            run: ThreadRun,
+            tool_call: RequiredFunctionToolCall,
+            tool_call_details: RequiredFunctionToolCallDetails,
+            **kwargs: Any,
+        ) -> Any:
+            function_name = tool_call_details.name
+            if function_name == send_email_async.__name__:
+                # Parse arguments from tool call
+                args_dict = json.loads(tool_call_details.arguments) if tool_call_details.arguments else {}
+                # Call the function directly with the arguments
+                return await send_email_async(**args_dict)
+
+    async with project_client:
+        agents_client = project_client.agents
+
+        # Enable auto function calling for the subset of safe functions
+        auto_functions = {
+            fetch_current_datetime_async,
+            fetch_weather,
+        }
+        agents_client.enable_auto_function_calls(auto_functions)
+
+        # Create an Agent with all function tools available
+        agent = await agents_client.create_agent(
+            model=os.environ["MODEL_DEPLOYMENT_NAME"],
+            name="my-agent",
+            instructions="You are a helpful Agent",
+            toolset=toolset,
+        )
+        print(f"Created Agent, ID: {agent.id}")
+
+        thread = await agents_client.threads.create()
+        print(f"Created thread, ID: {thread.id}")
+
+        message = await agents_client.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content="Hello, send an email with the datetime and weather information in New York?",
+        )
+        print(f"Created message, ID: {message.id}")
+
+        run = await agents_client.runs.create_and_process(
+            thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler()
+        )
+
+        print(f"Run completed with status: {run.status}")
+
+        # Delete the Agent when done
+        await agents_client.delete_agent(agent.id)
+        print("Deleted Agent")
+
+        # Fetch and log all messages
+        messages = agents_client.messages.list(thread_id=thread.id, order=ListSortOrder.ASCENDING)
+        async for msg in messages:
+            if msg.text_messages:
+                last_text = msg.text_messages[-1]
+                print(f"{msg.role}: {last_text.text.value}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/ai/azure-ai-agents/samples/agents_async/sample_agents_mcp_in_create_and_process_async.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_async/sample_agents_mcp_in_create_and_process_async.py
@@ -1,0 +1,188 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    This sample demonstrates how to use Agent operations with the
+    Model Context Protocol (MCP) tool from the Azure Agents service using an asynchronous client.
+    To learn more about Model Context Protocol, visit https://modelcontextprotocol.io/
+
+USAGE:
+    python sample_agents_mcp_in_create_and_process_async.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-agents>=1.2.0b3 azure-identity --pre
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
+                          page of your Azure AI Foundry portal.
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
+       the "Models + endpoints" tab in your Azure AI Foundry project.
+    3) MCP_SERVER_URL - The URL of your MCP server endpoint.
+    4) MCP_SERVER_LABEL - A label for your MCP server.
+"""
+
+import os
+import asyncio
+from typing import Optional, Any
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.ai.agents.models import (
+    ListSortOrder,
+    McpTool,
+    RequiredMcpToolCall,
+    RunStepActivityDetails,
+    ToolApproval,
+    AsyncRunHandler,
+    ThreadRun,
+    AsyncToolSet,
+)
+
+# Get MCP server configuration from environment variables
+mcp_server_url = os.environ.get("MCP_SERVER_URL", "https://gitmcp.io/Azure/azure-rest-api-specs")
+mcp_server_label = os.environ.get("MCP_SERVER_LABEL", "github")
+
+
+async def main():
+    # Create credential in async context manager to ensure proper cleanup
+    async with DefaultAzureCredential() as credential:
+        project_client = AIProjectClient(
+            endpoint=os.environ["PROJECT_ENDPOINT"],
+            credential=credential,
+        )
+
+        # [START create_agent_with_mcp_tool]
+        # Initialize Agent MCP tool
+        mcp_tool = McpTool(
+            server_label=mcp_server_label,
+            server_url=mcp_server_url,
+            allowed_tools=[],  # Optional: specify allowed tools
+        )
+        toolset = AsyncToolSet()
+        toolset.add(mcp_tool)
+
+        # You can also add or remove allowed tools dynamically
+        search_api_code = "search_azure_rest_api_code"
+        mcp_tool.allow_tool(search_api_code)
+        print(f"Allowed tools: {mcp_tool.allowed_tools}")
+
+        class MyRunHandler(AsyncRunHandler):
+            def submit_mcp_tool_approval(
+                self, *, run: ThreadRun, tool_call: RequiredMcpToolCall, **kwargs: Any
+            ) -> ToolApproval:
+                return ToolApproval(
+                    tool_call_id=tool_call.id,
+                    approve=True,
+                    headers=mcp_tool.headers,
+                )
+
+        # Create Agent with MCP tool and process Agent run
+        async with project_client:
+            agents_client = project_client.agents
+
+            # Create a new Agent.
+            # NOTE: To reuse existing Agent, fetch it with get_agent(agent_id)
+            agent = await agents_client.create_agent(
+                model=os.environ["MODEL_DEPLOYMENT_NAME"],
+                name="my-mcp-agent",
+                instructions="You are a helpful Agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
+                toolset=toolset,
+            )
+            # [END create_agent_with_mcp_tool]
+
+            print(f"Created Agent, ID: {agent.id}")
+            print(f"MCP Server: {mcp_tool.server_label} at {mcp_tool.server_url}")
+
+            # Create thread for communication
+            thread = await agents_client.threads.create()
+            print(f"Created thread, ID: {thread.id}")
+
+            # Create message to thread
+            message = await agents_client.messages.create(
+                thread_id=thread.id,
+                role="user",
+                content="Please summarize the Azure REST API specifications Readme",
+            )
+            print(f"Created message, ID: {message.id}")
+
+            # [START handle_tool_approvals]
+            # Create and process Agent run in thread with MCP tools
+            mcp_tool.update_headers("SuperSecret", "123456")
+
+            # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
+            run = await agents_client.runs.create_and_process(
+                thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler()
+            )
+            print(f"Created run, ID: {run.id}")
+
+            print(f"Run completed with status: {run.status}")
+            if run.status == "failed":
+                print(f"Run failed: {run.last_error}")
+
+            # Display run steps and tool calls
+            run_steps = agents_client.run_steps.list(thread_id=thread.id, run_id=run.id)
+
+            # Loop through each step
+            async for step in run_steps:
+                print(f"Step {step['id']} status: {step['status']}")
+
+                # Check if there are tool calls in the step details
+                step_details = step.get("step_details", {})
+                tool_calls = step_details.get("tool_calls", [])
+
+                if tool_calls:
+                    print("  MCP Tool calls:")
+                    for call in tool_calls:
+                        print(f"    Tool Call ID: {call.get('id')}")
+                        print(f"    Type: {call.get('type')}")
+
+                if isinstance(step_details, RunStepActivityDetails):
+                    for activity in step_details.activities:
+                        for function_name, function_definition in activity.tools.items():
+                            print(
+                                f'  The function {function_name} with description "{function_definition.description}" will be called.:'
+                            )
+                            if len(function_definition.parameters) > 0:
+                                print("  Function parameters:")
+                                for argument, func_argument in function_definition.parameters.properties.items():
+                                    print(f"      {argument}")
+                                    print(f"      Type: {func_argument.type}")
+                                    print(f"      Description: {func_argument.description}")
+                            else:
+                                print("This function has no parameters")
+
+                print()  # add an extra newline between steps
+
+            # Fetch and log all messages
+            messages = agents_client.messages.list(thread_id=thread.id, order=ListSortOrder.ASCENDING)
+            print("\nConversation:")
+            print("-" * 50)
+            async for msg in messages:
+                if msg.text_messages:
+                    last_text = msg.text_messages[-1]
+                    print(f"{msg.role.upper()}: {last_text.text.value}")
+                    print("-" * 50)
+
+            # Example of dynamic tool management
+            print(f"\nDemonstrating dynamic tool management:")
+            print(f"Current allowed tools: {mcp_tool.allowed_tools}")
+
+            # Remove a tool
+            try:
+                mcp_tool.disallow_tool(search_api_code)
+                print(f"After removing {search_api_code}: {mcp_tool.allowed_tools}")
+            except ValueError as e:
+                print(f"Error removing tool: {e}")
+
+            # Clean-up and delete the Agent once the run is finished.
+            # NOTE: Comment out this line if you plan to reuse the Agent later.
+            await agents_client.delete_agent(agent.id)
+            print("Deleted Agent")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/ai/azure-ai-agents/samples/agents_async/utils/user_async_functions.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_async/utils/user_async_functions.py
@@ -51,7 +51,12 @@ async def fetch_current_datetime_async(format: Optional[str] = None) -> str:
 
     # Use the provided format if available, else use a default format
     if format:
-        time_format = format
+        # Convert common format patterns to Python datetime format
+        time_format = format.replace("YYYY", "%Y").replace("MM", "%m").replace("DD", "%d")
+        time_format = time_format.replace("HH", "%H").replace("mm", "%M").replace("ss", "%S")
+        # Handle some other common variations
+        time_format = time_format.replace("yyyy", "%Y").replace("dd", "%d")
+        time_format = time_format.replace("hh", "%H")
     else:
         time_format = "%Y-%m-%d %H:%M:%S"
 

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions_in_create_and_process.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions_in_create_and_process.py
@@ -115,7 +115,7 @@ with project_client:
     print(f"Created message, ID: {message.id}")
 
     # [START create_and_process]
-    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler())
     # [END create_and_process]
 
     print(f"Run completed with status: {run.status}")

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions_in_create_and_process.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_functions_in_create_and_process.py
@@ -1,0 +1,132 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    This sample demonstrates how to use Agent operations with a mix of automatic and manual
+    function calls from the Azure Agents service using a synchronous client.
+
+    Some functions (like fetch_current_datetime and fetch_weather) will be executed automatically,
+    while others (like send_email) will require manual approval through the RunHandler.
+
+USAGE:
+    python sample_agents_functions_in_create_and_process.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-agents azure-identity
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
+                          page of your Azure AI Foundry portal.
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
+       the "Models + endpoints" tab in your Azure AI Foundry project.
+"""
+import os, sys, json
+from typing import Any, Optional
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import (
+    FunctionTool,
+    ListSortOrder,
+    RequiredFunctionToolCall,
+    RunHandler,
+    ThreadRun,
+    ToolSet,
+    RequiredFunctionToolCallDetails,
+)
+
+
+# Add package directory to sys.path to import user_functions
+current_dir = os.path.dirname(os.path.abspath(__file__))
+package_dir = os.path.abspath(os.path.join(current_dir, os.pardir, os.pardir))
+if package_dir not in sys.path:
+    sys.path.insert(0, package_dir)
+from samples.utils.user_functions import (
+    fetch_current_datetime,
+    fetch_weather,
+    send_email,
+    calculate_sum,
+)
+from samples.utils.user_functions import user_functions
+
+project_client = AIProjectClient(
+    endpoint=os.environ["PROJECT_ENDPOINT"],
+    credential=DefaultAzureCredential(),
+)
+
+# Create a toolset with all functions
+all_functions_tool = FunctionTool(user_functions)
+toolset = ToolSet()
+toolset.add(all_functions_tool)
+
+
+# Declare a run handler to execute function tool call manually
+# [START run_handler]
+class MyRunHandler(RunHandler):
+    def submit_function_call_output(
+        self,
+        *,
+        run: ThreadRun,
+        tool_call: RequiredFunctionToolCall,
+        tool_call_details: RequiredFunctionToolCallDetails,
+        **kwargs: Any,
+    ) -> Any:
+        function_name = tool_call_details.name
+        if function_name == send_email.__name__:
+            # Parse arguments from tool call
+            args_dict = json.loads(tool_call_details.arguments) if tool_call_details.arguments else {}
+            # Call the function directly with the arguments
+            return send_email(**args_dict)
+
+
+# [END run_handler]
+
+with project_client:
+    agents_client = project_client.agents
+
+    # Enable auto function calling for the subset of safe functions
+    auto_functions = {
+        fetch_current_datetime,
+        fetch_weather,
+        calculate_sum,
+    }
+    agents_client.enable_auto_function_calls(auto_functions)
+
+    # Create an Agent with all function tools available
+    agent = agents_client.create_agent(
+        model=os.environ["MODEL_DEPLOYMENT_NAME"],
+        name="my-agent",
+        instructions="You are a helpful Agent",
+        toolset=toolset,
+    )
+    print(f"Created Agent, ID: {agent.id}")
+
+    thread = agents_client.threads.create()
+    print(f"Created thread, ID: {thread.id}")
+
+    message = agents_client.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content="Hello, send an email with the datetime and weather information in New York?",
+    )
+    print(f"Created message, ID: {message.id}")
+
+    # [START create_and_process]
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+    # [END create_and_process]
+
+    print(f"Run completed with status: {run.status}")
+
+    # Delete the Agent when done
+    agents_client.delete_agent(agent.id)
+    print("Deleted Agent")
+
+    # Fetch and log all messages
+    messages = agents_client.messages.list(thread_id=thread.id, order=ListSortOrder.ASCENDING)
+    for msg in messages:
+        if msg.text_messages:
+            last_text = msg.text_messages[-1]
+            print(f"{msg.role}: {last_text.text.value}")

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_in_create_and_process.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_in_create_and_process.py
@@ -1,0 +1,182 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    This sample demonstrates how to use agent operations with the
+    Model Context Protocol (MCP) tool from the Azure Agents service using a synchronous client.
+    To learn more about Model Context Protocol, visit https://modelcontextprotocol.io/
+
+USAGE:
+    python sample_agents_mcp.py
+
+    Before running the sample:
+
+    pip install azure-ai-projects azure-ai-agents>=1.2.0b3 azure-identity --pre
+
+    Set these environment variables with your own values:
+    1) PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
+                          page of your Azure AI Foundry portal.
+    2) MODEL_DEPLOYMENT_NAME - The deployment name of the AI model, as found under the "Name" column in
+       the "Models + endpoints" tab in your Azure AI Foundry project.
+    3) MCP_SERVER_URL - The URL of your MCP server endpoint.
+    4) MCP_SERVER_LABEL - A label for your MCP server.
+"""
+
+import os
+from typing import Optional, Any
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import (
+    ListSortOrder,
+    McpTool,
+    RequiredMcpToolCall,
+    RunStepActivityDetails,
+    ToolApproval,
+    RunHandler,
+    ThreadRun,
+    ToolSet,
+)
+
+# Get MCP server configuration from environment variables
+mcp_server_url = os.environ.get("MCP_SERVER_URL", "https://gitmcp.io/Azure/azure-rest-api-specs")
+mcp_server_label = os.environ.get("MCP_SERVER_LABEL", "github")
+
+project_client = AIProjectClient(
+    endpoint=os.environ["PROJECT_ENDPOINT"],
+    credential=DefaultAzureCredential(),
+)
+
+# Initialize agent MCP tool
+mcp_tool = McpTool(
+    server_label=mcp_server_label,
+    server_url=mcp_server_url,
+    allowed_tools=[],  # Optional: specify allowed tools
+)
+toolset = ToolSet()
+toolset.add(mcp_tool)
+
+# You can also add or remove allowed tools dynamically
+search_api_code = "search_azure_rest_api_code"
+mcp_tool.allow_tool(search_api_code)
+print(f"Allowed tools: {mcp_tool.allowed_tools}")
+
+
+# [START run_handler]
+class MyRunHandler(RunHandler):
+    def submit_mcp_tool_approval(
+        self, *, run: ThreadRun, tool_call: RequiredMcpToolCall, **kwargs: Any
+    ) -> ToolApproval:
+        return ToolApproval(
+            tool_call_id=tool_call.id,
+            approve=True,
+            headers=mcp_tool.headers,
+        )
+
+
+# [END run_handler]
+
+
+# Create agent with MCP tool and process agent run
+with project_client:
+    agents_client = project_client.agents
+
+    # Create a new agent.
+    # NOTE: To reuse existing agent, fetch it with get_agent(agent_id)
+    agent = agents_client.create_agent(
+        model=os.environ["MODEL_DEPLOYMENT_NAME"],
+        name="my-mcp-agent",
+        instructions="You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
+        toolset=toolset,
+    )
+
+    print(f"Created agent, ID: {agent.id}")
+    print(f"MCP Server: {mcp_tool.server_label} at {mcp_tool.server_url}")
+
+    # Create thread for communication
+    thread = agents_client.threads.create()
+    print(f"Created thread, ID: {thread.id}")
+
+    # Create message to thread
+    message = agents_client.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content="Please summarize the Azure REST API specifications Readme",
+    )
+    print(f"Created message, ID: {message.id}")
+
+    # Create and process agent run in thread with MCP tools
+    mcp_tool.update_headers("SuperSecret", "123456")
+
+    # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
+    # [START create_and_process]
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+    # [END create_and_process]
+    print(f"Created run, ID: {run.id}")
+
+    print(f"Run completed with status: {run.status}")
+    if run.status == "failed":
+        print(f"Run failed: {run.last_error}")
+
+    # Display run steps and tool calls
+    run_steps = agents_client.run_steps.list(thread_id=thread.id, run_id=run.id)
+
+    # Loop through each step
+    for step in run_steps:
+        print(f"Step {step['id']} status: {step['status']}")
+
+        # Check if there are tool calls in the step details
+        step_details = step.get("step_details", {})
+        tool_calls = step_details.get("tool_calls", [])
+
+        if tool_calls:
+            print("  MCP Tool calls:")
+            for call in tool_calls:
+                print(f"    Tool Call ID: {call.get('id')}")
+                print(f"    Type: {call.get('type')}")
+
+        if isinstance(step_details, RunStepActivityDetails):
+            for activity in step_details.activities:
+                for function_name, function_definition in activity.tools.items():
+                    print(
+                        f'  The function {function_name} with description "{function_definition.description}" will be called.:'
+                    )
+                    if len(function_definition.parameters) > 0:
+                        print("  Function parameters:")
+                        for argument, func_argument in function_definition.parameters.properties.items():
+                            print(f"      {argument}")
+                            print(f"      Type: {func_argument.type}")
+                            print(f"      Description: {func_argument.description}")
+                    else:
+                        print("This function has no parameters")
+
+        print()  # add an extra newline between steps
+
+    # Fetch and log all messages
+    messages = agents_client.messages.list(thread_id=thread.id, order=ListSortOrder.ASCENDING)
+    print("\nConversation:")
+    print("-" * 50)
+    for msg in messages:
+        if msg.text_messages:
+            last_text = msg.text_messages[-1]
+            print(f"{msg.role.upper()}: {last_text.text.value}")
+            print("-" * 50)
+
+    # Example of dynamic tool management
+    print(f"\nDemonstrating dynamic tool management:")
+    print(f"Current allowed tools: {mcp_tool.allowed_tools}")
+
+    # Remove a tool
+    try:
+        mcp_tool.disallow_tool(search_api_code)
+        print(f"After removing {search_api_code}: {mcp_tool.allowed_tools}")
+    except ValueError as e:
+        print(f"Error removing tool: {e}")
+
+    # Clean-up and delete the agent once the run is finished.
+    # NOTE: Comment out this line if you plan to reuse the agent later.
+    agents_client.delete_agent(agent.id)
+    print("Deleted agent")

--- a/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_in_create_and_process.py
+++ b/sdk/ai/azure-ai-agents/samples/agents_tools/sample_agents_mcp_in_create_and_process.py
@@ -113,7 +113,7 @@ with project_client:
 
     # mcp_tool.set_approval_mode("never")  # Uncomment to disable approval requirement
     # [START create_and_process]
-    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler)
+    run = agents_client.runs.create_and_process(thread_id=thread.id, agent_id=agent.id, run_handler=MyRunHandler())
     # [END create_and_process]
     print(f"Created run, ID: {run.id}")
 

--- a/sdk/ai/azure-ai-agents/samples/utils/user_functions.py
+++ b/sdk/ai/azure-ai-agents/samples/utils/user_functions.py
@@ -23,7 +23,12 @@ def fetch_current_datetime(format: Optional[str] = None) -> str:
 
     # Use the provided format if available, else use a default format
     if format:
-        time_format = format
+        # Convert common format patterns to Python datetime format
+        time_format = format.replace("YYYY", "%Y").replace("MM", "%m").replace("DD", "%d")
+        time_format = time_format.replace("HH", "%H").replace("mm", "%M").replace("ss", "%S")
+        # Handle some other common variations
+        time_format = time_format.replace("yyyy", "%Y").replace("dd", "%d")
+        time_format = time_format.replace("hh", "%H")
     else:
         time_format = "%Y-%m-%d %H:%M:%S"
 

--- a/sdk/ai/azure-ai-agents/tests/test_agents_mock.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_mock.py
@@ -774,7 +774,13 @@ class TestAgentsMock:
 class TestIntegrationAgentsMock:
 
     def submit_tool_outputs(
-        self, thread_id: str, run_id: str, *, tool_outputs: List[StructuredToolOutput], stream_parameter: bool, stream: bool
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        tool_outputs: List[StructuredToolOutput],
+        stream_parameter: bool,
+        stream: bool,
     ) -> Iterator[bytes]:
         assert thread_id == "thread_01"
         assert run_id == "run_01"

--- a/sdk/ai/azure-ai-agents/tests/test_agents_mock.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_mock.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Iterator, List, MutableMapping, Optional, Dict
+from typing import Any, Callable, Iterator, List, MutableMapping, Optional, Dict
 
 import json
 import os
@@ -24,6 +24,12 @@ from azure.ai.agents.models import (
     ToolSet,
     AgentEventHandler,
     ThreadRun,
+    RunHandler,
+    McpTool,
+    ToolApproval,
+    RequiredMcpToolCall,
+    SubmitToolApprovalAction,
+    SubmitToolApprovalDetails,
 )
 
 from user_functions import user_functions
@@ -88,7 +94,7 @@ class TestAgentsMock:
         client.runs.submit_tool_outputs = MagicMock()
         return client
 
-    def get_toolset(self, file_id: Optional[str], function: Optional[str]) -> Optional[ToolSet]:
+    def get_toolset(self, file_id: Optional[str], function: Optional[Callable[..., Any]]) -> Optional[ToolSet]:
         """Get the tool set with given file id and function"""
         if file_id is None or function is None:
             return None
@@ -215,6 +221,34 @@ class TestAgentsMock:
             sb = SubmitToolOutputsAction(submit_tool_outputs=SubmitToolOutputsDetails(tool_calls=tool_calls))
             run_dict["required_action"] = sb.as_dict()
             run_dict["tools"] = definitions
+        return run_dict
+
+    def _get_run_for_mcp(
+        self, thread_id: str, tool_set: Optional[ToolSet], mcp_tool: McpTool, is_complete: bool = False
+    ) -> Dict[str, Any]:
+        """Return JSON as if we have created the run."""
+        with open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "test_data",
+                "thread_run.json",
+            ),
+            "r",
+        ) as fp:
+            run_dict: Dict[str, Any] = json.load(fp)
+        run_dict["id"] = thread_id
+        run_dict["assistant_id"] = thread_id[3:]
+        assert isinstance(run_dict, dict)
+        if is_complete:
+            run_dict["status"] = RunStatus.COMPLETED
+
+        tool_calls: list[RequiredToolCall] = [
+            RequiredMcpToolCall(id="0", arguments="", name="", server_label=mcp_tool.server_label)
+        ]
+        definitions = []
+        sb = SubmitToolApprovalAction(submit_tool_approval=SubmitToolApprovalDetails(tool_calls=tool_calls))
+        run_dict["required_action"] = sb.as_dict()
+        run_dict["tools"] = definitions
         return run_dict
 
     def _assert_tool_call(self, submit_tool_mock: MagicMock, run_id: str, tool_set: Optional[ToolSet]) -> None:
@@ -506,6 +540,121 @@ class TestAgentsMock:
                 self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset2)
             else:
                 self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset1)
+
+    @patch("azure.ai.agents._client.PipelineClient")
+    def test_create_and_process_with_manual_function_calls(
+        self,
+        mock_pipeline_client_gen: MagicMock,
+    ) -> None:
+        """Test that if user have set tool set in create create_and_process_run method, that tools are used."""
+        toolset1 = self.get_toolset("file_for_agent_1", function1)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        side_effect = [self._get_agent_json("first", "123", toolset1)]
+        side_effect.append(self._get_run("run123", toolset1))  # create_run
+        side_effect.append(self._get_run("run123", toolset1))  # get_run
+        side_effect.append(
+            self._get_run("run123", toolset1, is_complete=True)
+        )  # get_run after resubmitting with tool results
+
+        class MyRunHandler(RunHandler):
+            def submit_function_call_output(
+                self,
+                *,
+                run: ThreadRun,
+                tool_call: RequiredFunctionToolCall,
+                tool_call_details: RequiredFunctionToolCallDetails,
+                **kwargs: Any,
+            ) -> Optional[Any]:
+                if tool_call_details.name == function1.__name__:
+                    return function1()
+
+        mock_response.json.side_effect = side_effect
+        mock_pipeline_response = MagicMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = MagicMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        agents_client = self.get_mock_client()
+        with agents_client:
+            # Check that pipelines are created as expected.
+            run_handler = MyRunHandler()
+            agent1 = agents_client.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful agent",
+                toolset=toolset1,
+            )
+            self._assert_pipeline_and_reset(mock_pipeline._pipeline.run, tool_set=toolset1)
+
+            # Create run with new tool set, which also can be none.
+            agents_client.runs.create_and_process(
+                thread_id="some_thread_id", agent_id=agent1.id, polling_interval=0, run_handler=run_handler
+            )
+            self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset1)
+
+    @patch("azure.ai.agents._client.PipelineClient")
+    def test_create_and_process_with_mcp(
+        self,
+        mock_pipeline_client_gen: MagicMock,
+    ) -> None:
+        """Test that if user have set tool set in create create_and_process_run method, that tools are used."""
+        toolset1 = ToolSet()
+        mcp_tool = McpTool(server_label="server1", server_url="http://server1.com", allowed_tools=["tool1"])
+        toolset1.add(mcp_tool)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        side_effect = [self._get_agent_json("first", "123", toolset1)]
+        side_effect.append(self._get_run_for_mcp("run123", toolset1, mcp_tool))  # create_run
+        side_effect.append(self._get_run_for_mcp("run123", toolset1, mcp_tool))  # get_run
+        side_effect.append(
+            self._get_run_for_mcp("run123", toolset1, mcp_tool, is_complete=True)
+        )  # get_run after resubmitting with tool results
+
+        class MyRunHandler(RunHandler):
+            def submit_mcp_tool_approval(
+                self,
+                *,
+                run: ThreadRun,
+                tool_call: RequiredMcpToolCall,
+                **kwargs: Any,
+            ) -> Optional[ToolApproval]:
+                self.tool_approval = ToolApproval(
+                    tool_call_id=tool_call.id,
+                    approve=True,
+                    headers=mcp_tool.headers,
+                )
+                return self.tool_approval
+
+        mock_response.json.side_effect = side_effect
+        mock_pipeline_response = MagicMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = MagicMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        agents_client = self.get_mock_client()
+        with agents_client:
+            # Check that pipelines are created as expected.
+            run_handler = MyRunHandler()
+            agent1 = agents_client.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful agent",
+                toolset=toolset1,
+            )
+
+            # Create run with new tool set, which also can be none.
+            agents_client.runs.create_and_process(
+                thread_id="some_thread_id", agent_id=agent1.id, polling_interval=0, run_handler=run_handler
+            )
+
+            agents_client.runs.submit_tool_outputs.assert_called_once()
+            agents_client.runs.submit_tool_outputs.assert_called_with(
+                thread_id="some_thread_id",
+                run_id="run123",
+                tool_approvals=[run_handler.tool_approval],
+            )
+            agents_client.runs.submit_tool_outputs.reset_mock()
 
     @patch("azure.ai.agents._client.PipelineClient")
     @pytest.mark.parametrize(

--- a/sdk/ai/azure-ai-agents/tests/test_agents_mock_async.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_mock_async.py
@@ -28,7 +28,7 @@ from azure.ai.agents.models import (
     SubmitToolApprovalDetails,
     SubmitToolOutputsAction,
     SubmitToolOutputsDetails,
-    ToolOutput,
+    ToolApproval,
     AsyncAgentEventHandler,
     ThreadRun,
 )
@@ -470,6 +470,7 @@ class TestAgentsMock:
         class MyRunHandler(AsyncRunHandler):
             async def submit_function_call_output(
                 self,
+                *,
                 run: ThreadRun,
                 tool_call: RequiredFunctionToolCall,
                 tool_call_details: RequiredFunctionToolCallDetails,
@@ -524,6 +525,7 @@ class TestAgentsMock:
         class MyRunHandler(AsyncRunHandler):
             def submit_mcp_tool_approval(
                 self,
+                *,
                 run: ThreadRun,
                 tool_call: RequiredMcpToolCall,
                 **kwargs: Any,
@@ -776,7 +778,13 @@ class TestAgentsMock:
 class TestIntegrationAgentsClient:
 
     def submit_tool_outputs(
-        self, thread_id: str, run_id: str, *, tool_outputs: List[StructuredToolOutput], stream_parameter: bool, stream: bool
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        tool_outputs: List[StructuredToolOutput],
+        stream_parameter: bool,
+        stream: bool,
     ) -> AsyncIterator[bytes]:
         assert thread_id == "thread_01"
         assert run_id == "run_01"

--- a/sdk/ai/azure-ai-agents/tests/test_agents_mock_async.py
+++ b/sdk/ai/azure-ai-agents/tests/test_agents_mock_async.py
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, MutableMapping, Optional, Dict, List, AsyncIterator
+from typing import Any, Callable, MutableMapping, Optional, Dict, List, AsyncIterator
 
 import json
 import os
@@ -14,15 +14,21 @@ from azure.ai.agents.aio import AgentsClient
 from azure.ai.agents.aio.operations import RunsOperations
 from azure.ai.agents.models import (
     AsyncFunctionTool,
+    AsyncRunHandler,
     AsyncToolSet,
     CodeInterpreterTool,
+    McpTool,
     RequiredFunctionToolCall,
     RequiredFunctionToolCallDetails,
+    RequiredMcpToolCall,
     RequiredToolCall,
     RunStatus,
     StructuredToolOutput,
+    SubmitToolApprovalAction,
+    SubmitToolApprovalDetails,
     SubmitToolOutputsAction,
     SubmitToolOutputsDetails,
+    ToolOutput,
     AsyncAgentEventHandler,
     ThreadRun,
 )
@@ -80,7 +86,7 @@ class TestAgentsMock:
         client._client.format_url = MagicMock()
         return client
 
-    def get_toolset(self, file_id: Optional[str], function: Optional[str]) -> Optional[AsyncToolSet]:
+    def get_toolset(self, file_id: Optional[str], function: Optional[Callable[..., Any]]) -> Optional[AsyncToolSet]:
         """Get the tool set with given file id and function"""
         if file_id is None or function is None:
             return None
@@ -207,6 +213,34 @@ class TestAgentsMock:
             sb = SubmitToolOutputsAction(submit_tool_outputs=SubmitToolOutputsDetails(tool_calls=tool_calls))
             run_dict["required_action"] = sb.as_dict()
             run_dict["tools"] = definitions
+        return run_dict
+
+    def _get_run_for_mcp(
+        self, thread_id: str, tool_set: Optional[AsyncToolSet], mcp_tool: McpTool, is_complete: bool = False
+    ) -> Dict[str, Any]:
+        """Return JSON as if we have created the run."""
+        with open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "test_data",
+                "thread_run.json",
+            ),
+            "r",
+        ) as fp:
+            run_dict: Dict[str, Any] = json.load(fp)
+        run_dict["id"] = thread_id
+        run_dict["assistant_id"] = thread_id[3:]
+        assert isinstance(run_dict, dict)
+        if is_complete:
+            run_dict["status"] = RunStatus.COMPLETED
+
+        tool_calls: list[RequiredToolCall] = [
+            RequiredMcpToolCall(id="0", arguments="", name="", server_label=mcp_tool.server_label)
+        ]
+        definitions = []
+        sb = SubmitToolApprovalAction(submit_tool_approval=SubmitToolApprovalDetails(tool_calls=tool_calls))
+        run_dict["required_action"] = sb.as_dict()
+        run_dict["tools"] = definitions
         return run_dict
 
     def _assert_tool_call(self, submit_tool_mock: AsyncMock, run_id: str, tool_set: Optional[AsyncToolSet]) -> None:
@@ -415,6 +449,121 @@ class TestAgentsMock:
                 self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset2)
             else:
                 self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset1)
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.agents.aio._client.AsyncPipelineClient")
+    async def test_create_and_process_with_manual_function_calls(
+        self,
+        mock_pipeline_client_gen: AsyncMock,
+    ) -> None:
+        """Test that if user have set tool set in create create_and_process_run method, that tools are used."""
+        toolset1 = self.get_toolset("file_for_agent_1", function1)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        side_effect = [self._get_agent_json("first", "123", toolset1)]
+        side_effect.append(self._get_run("run123", toolset1))  # create_run
+        side_effect.append(self._get_run("run123", toolset1))  # get_run
+        side_effect.append(
+            self._get_run("run123", toolset1, is_complete=True)
+        )  # get_run after resubmitting with tool results
+
+        class MyRunHandler(AsyncRunHandler):
+            async def submit_function_call_output(
+                self,
+                run: ThreadRun,
+                tool_call: RequiredFunctionToolCall,
+                tool_call_details: RequiredFunctionToolCallDetails,
+                **kwargs: Any,
+            ) -> Optional[Any]:
+                if tool_call_details.name == function1.__name__:
+                    return function1()
+
+        mock_response.json.side_effect = side_effect
+        mock_pipeline_response = AsyncMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = AsyncMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        agents_client = self.get_mock_client()
+        async with agents_client:
+            # Check that pipelines are created as expected.
+            run_handler = MyRunHandler()
+            agent1 = await agents_client.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful agent",
+                toolset=toolset1,
+            )
+            self._assert_pipeline_and_reset(mock_pipeline._pipeline.run, tool_set=toolset1)
+
+            # Create run with new tool set, which also can be none.
+            await agents_client.runs.create_and_process(
+                thread_id="some_thread_id", agent_id=agent1.id, polling_interval=0, run_handler=run_handler
+            )
+            self._assert_tool_call(agents_client.runs.submit_tool_outputs, "run123", toolset1)
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.agents.aio._client.AsyncPipelineClient")
+    async def test_create_and_process_with_mcp(
+        self,
+        mock_pipeline_client_gen: AsyncMock,
+    ) -> None:
+        """Test that if user have set tool set in create create_and_process_run method, that tools are used."""
+        toolset1 = AsyncToolSet()
+        mcp_tool = McpTool(server_label="server1", server_url="http://server1.com", allowed_tools=["tool1"])
+        toolset1.add(mcp_tool)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        side_effect = [self._get_agent_json("first", "123", toolset1)]
+        side_effect.append(self._get_run_for_mcp("run123", toolset1, mcp_tool))  # create_run
+        side_effect.append(self._get_run_for_mcp("run123", toolset1, mcp_tool))  # get_run
+        side_effect.append(
+            self._get_run_for_mcp("run123", toolset1, mcp_tool, is_complete=True)
+        )  # get_run after resubmitting with tool results
+
+        class MyRunHandler(AsyncRunHandler):
+            def submit_mcp_tool_approval(
+                self,
+                run: ThreadRun,
+                tool_call: RequiredMcpToolCall,
+                **kwargs: Any,
+            ) -> Optional[ToolApproval]:
+                self.tool_approval = ToolApproval(
+                    tool_call_id=tool_call.id,
+                    approve=True,
+                    headers=mcp_tool.headers,
+                )
+                return self.tool_approval
+
+        mock_response.json.side_effect = side_effect
+        mock_pipeline_response = AsyncMock()
+        mock_pipeline_response.http_response = mock_response
+        mock_pipeline = AsyncMock()
+        mock_pipeline._pipeline.run.return_value = mock_pipeline_response
+        mock_pipeline_client_gen.return_value = mock_pipeline
+        agents_client = self.get_mock_client()
+        async with agents_client:
+            # Check that pipelines are created as expected.
+            run_handler = MyRunHandler()
+            agent1 = await agents_client.create_agent(
+                model="gpt-4-1106-preview",
+                name="first",
+                instructions="You are a helpful agent",
+                toolset=toolset1,
+            )
+
+            # Create run with new tool set, which also can be none.
+            await agents_client.runs.create_and_process(
+                thread_id="some_thread_id", agent_id=agent1.id, polling_interval=0, run_handler=run_handler
+            )
+
+            agents_client.runs.submit_tool_outputs.assert_called_once()
+            agents_client.runs.submit_tool_outputs.assert_called_with(
+                thread_id="some_thread_id",
+                run_id="run123",
+                tool_approvals=[run_handler.tool_approval],
+            )
+            agents_client.runs.submit_tool_outputs.reset_mock()
 
     @pytest.mark.asyncio
     @patch("azure.ai.agents.aio.operations._operations.RunsOperations.cancel")


### PR DESCRIPTION
Currently if you execute run by calling runs.create_and_process, you can't use MCP tools unless you change to use runs.create.   This is because create_and_process can't resolve required toolcall.   

To resolve this, I introduced run_handler that let you resolve mcp tool approval.   While I am making this feature for mcp, I am inspired to support manual function tool call for runs.create_and_process.