### PR TITLE
docs(playwrighttesting): Readme update with deprecation message

### DIFF
--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- This package has been deprecated and will no longer be maintained after **February 9, 2026**. This package will only receive security fixes until **February 9, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
+- This package has been deprecated and will no longer be maintained after **March 8, 2026**. This package will only receive security fixes until **March 8, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
 
 ## 1.0.0 (2024-12-18)
 

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (2025-09-07)
+## 1.0.1 (2025-09-08)
 
 ### Other Changes
 

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.1 (2025-09-07)
+
+### Other Changes
+
+- This package has been deprecated and will no longer be maintained after **February 9, 2026**. This package will only receive security fixes until **February 9, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
+
 ## 1.0.0 (2024-12-18)
 
 ### Features Added

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (2025-09-08)
+## 1.0.1 (2025-09-09)
 
 ### Other Changes
 

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
 
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. This package will only receive security fixes until **February 9, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. This package will only receive security fixes until **March 8, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
 
 This is the Microsoft Azure Playwrighttesting Management Client Library.
 This package has been tested with Python 3.8+.

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
 
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **@azure-mgmt-playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. This package will only receive security fixes until **February 9, 2026**. To receive updates on new features and non-security bug fixes, upgrade to the replacement package, [@azure-mgmt-playwright](https://pypi.org/project/azure-mgmt-playwright/). Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading.
 
 This is the Microsoft Azure Playwrighttesting Management Client Library.
 This package has been tested with Python 3.8+.

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/README.md
@@ -1,5 +1,9 @@
 # Microsoft Azure SDK for Python
 
+**Deprecation message**
+
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **@azure-mgmt-playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 This is the Microsoft Azure Playwrighttesting Management Client Library.
 This package has been tested with Python 3.8+.
 For a more complete view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/azure/mgmt/playwrighttesting/_version.py
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/azure/mgmt/playwrighttesting/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/sdk_packaging.toml
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/sdk_packaging.toml
@@ -10,3 +10,4 @@ need_azuremgmtcore = true
 sample_link = ""
 exclude_folders = ""
 title = "PlaywrightTestingMgmtClient"
+auto_update = false

--- a/sdk/playwrighttesting/azure-mgmt-playwrighttesting/setup.py
+++ b/sdk/playwrighttesting/azure-mgmt-playwrighttesting/setup.py
@@ -49,7 +49,7 @@ setup(
     url="https://github.com/Azure/azure-sdk-for-python",
     keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
**Deprecation of Microsoft Playwright Testing SDKs (Control Plane) _Note: This PR should not be merged before September 8th._**

As part of the retirement of Microsoft Playwright Testing (MPT) and its merger into Azure App Testing, we plan to deprecate the SDK packages associated with this service. This aligns with Azure’s service retirement policy and the ARM API Deprecation guidelines.

MPT’s core web testing capabilities are being integrated into Azure App Testing to provide a unified experience for both Load Testing and Playwright-based web testing. The standalone MPT service will be retired, and customers will need to migrate to Azure App Testing.
