### PR TITLE
fix aggregate reports

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -23,6 +23,13 @@ stages:
       - job: ValidateDependencies
         timeoutInMinutes: 120
         steps:
+          - task: UsePythonVersion@0
+            displayName: 'Use Python $(PythonVersion)'
+            condition: succeededOrFailed()
+            inputs:
+              versionSpec: '$(PythonVersion)'
+
+          - template: /eng/pipelines/templates/steps/use-venv.yml
 
           - template: /eng/pipelines/templates/steps/analyze_dependency.yml
             parameters:


### PR DESCRIPTION
This pipeline has been failing with an error on the `Install Python Tools` step:

<img width="522" height="497" alt="image" src="https://github.com/user-attachments/assets/8aef626f-ac22-4ecf-8896-0ec4588003b1" />

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5299102&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=cb1fe180-b0cd-5281-bd1c-79ad866fa420

It looks like the [chunk that sets PIP_EXE moved to another template](https://github.com/Azure/azure-sdk-for-python/pull/42486/files#r2271921585), but it doesn't appear that aggregate reports uses that template so adding it back in this PR.

Successfully running now, but the pipeline is failing due to bad links: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5301436&view=logs&s=bb87fef4-c233-5bc4-e2df-3e530d70fc4a&j=09cf8b18-32ff-5ace-942c-480825d4e4bd

 