### PR TITLE
[Identity] Encode claims for certain credentials

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -17,7 +17,7 @@ from azure.core.credentials import AccessToken, AccessTokenInfo, TokenRequestOpt
 from azure.core.exceptions import ClientAuthenticationError
 
 from .. import CredentialUnavailableError
-from .._internal import resolve_tenant, within_dac, validate_tenant_id, validate_scope
+from .._internal import encode_base64, resolve_tenant, within_dac, validate_tenant_id, validate_scope
 from .._internal.decorators import log_get_token
 
 
@@ -184,7 +184,7 @@ class AzureDeveloperCliCredential:
         if tenant:
             command_args += ["--tenant-id", tenant]
         if claims:
-            command_args += ["--claims", claims]
+            command_args += ["--claims", encode_base64(claims)]
         output = _run_command(command_args, self._process_timeout)
 
         token = parse_token(output)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -18,6 +18,7 @@ from azure.core.exceptions import ClientAuthenticationError
 from .. import CredentialUnavailableError
 from .._internal import (
     _scopes_to_resource,
+    encode_base64,
     resolve_tenant,
     within_dac,
     validate_tenant_id,
@@ -155,8 +156,8 @@ class AzureCliCredential:
         self, *scopes: str, options: Optional[TokenRequestOptions] = None, **kwargs: Any
     ) -> AccessTokenInfo:
         # Check for claims challenge first
-        if options and options.get("claims"):
-            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=options.get("claims"))
+        if options and "claims" in options and options["claims"]:
+            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=encode_base64(options["claims"]))
 
             # Add tenant if provided in options
             if options.get("tenant_id"):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -15,6 +15,7 @@ from .azure_cli import get_safe_working_dir
 from .. import CredentialUnavailableError
 from .._internal import (
     _scopes_to_resource,
+    encode_base64,
     resolve_tenant,
     within_dac,
     validate_tenant_id,
@@ -183,8 +184,8 @@ class AzurePowerShellCredential:
     ) -> AccessTokenInfo:
 
         # Check if claims challenge is provided
-        if options and options.get("claims"):
-            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=options.get("claims"))
+        if options and "claims" in options and options["claims"]:
+            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=encode_base64(options["claims"]))
             if options.get("tenant_id"):
                 error_message += f" -Tenant {options.get('tenant_id')}"
             raise CredentialUnavailableError(message=error_message)

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -9,6 +9,7 @@ from .aadclient_certificate import AadClientCertificate
 from .decorators import wrap_exceptions
 from .interactive import InteractiveCredential
 from .utils import (
+    encode_base64,
     get_default_authority,
     normalize_authority,
     process_credential_exclusions,
@@ -46,6 +47,7 @@ __all__ = [
     "AadClientBase",
     "AuthCodeRedirectServer",
     "AadClientCertificate",
+    "encode_base64",
     "get_default_authority",
     "InteractiveCredential",
     "normalize_authority",

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import base64
 import os
 import platform
 import logging
@@ -223,3 +224,8 @@ def is_wsl() -> bool:
     platform_name = getattr(uname, "system", uname[0]).lower()
     release = getattr(uname, "release", uname[2]).lower()
     return platform_name == "linux" and "microsoft" in release
+
+
+def encode_base64(s: str) -> str:
+    encoded = base64.b64encode(s.encode("utf-8"))
+    return encoded.decode("utf-8")

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -26,7 +26,7 @@ from ..._credentials.azd_cli import (
     sanitize_output,
     extract_cli_error_message,
 )
-from ..._internal import resolve_tenant, within_dac, validate_tenant_id, validate_scope
+from ..._internal import encode_base64, resolve_tenant, within_dac, validate_tenant_id, validate_scope
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         if tenant:
             command_args += ["--tenant-id", tenant]
         if claims:
-            command_args += ["--claims", claims]
+            command_args += ["--claims", encode_base64(claims)]
         output = await _run_command(command_args, self._process_timeout)
 
         token = parse_token(output)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -27,6 +27,7 @@ from ..._credentials.azure_cli import (
 )
 from ..._internal import (
     _scopes_to_resource,
+    encode_base64,
     resolve_tenant,
     within_dac,
     validate_tenant_id,
@@ -149,8 +150,8 @@ class AzureCliCredential(AsyncContextManager):
         self, *scopes: str, options: Optional[TokenRequestOptions] = None, **kwargs: Any
     ) -> AccessTokenInfo:
         # Check for claims challenge first
-        if options and options.get("claims"):
-            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=options.get("claims"))
+        if options and "claims" in options and options["claims"]:
+            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=encode_base64(options["claims"]))
 
             # Add tenant if provided in options
             if options.get("tenant_id"):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -18,7 +18,7 @@ from ..._credentials.azure_powershell import (
     parse_token,
     CLAIMS_UNSUPPORTED_ERROR,
 )
-from ..._internal import resolve_tenant, validate_tenant_id, validate_scope
+from ..._internal import encode_base64, resolve_tenant, validate_tenant_id, validate_scope
 
 
 class AzurePowerShellCredential(AsyncContextManager):
@@ -124,8 +124,8 @@ class AzurePowerShellCredential(AsyncContextManager):
     ) -> AccessTokenInfo:
 
         # Check if claims challenge is provided
-        if options and options.get("claims"):
-            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=options.get("claims"))
+        if options and "claims" in options and options["claims"]:
+            error_message = CLAIMS_UNSUPPORTED_ERROR.format(claims_value=encode_base64(options["claims"]))
             if options.get("tenant_id"):
                 error_message += f" -Tenant {options.get('tenant_id')}"
             raise CredentialUnavailableError(message=error_message)

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
@@ -343,7 +343,7 @@ def test_multitenant_authentication_not_allowed(get_token_method):
 def test_claims_challenge_raises_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
     credential = AzureDeveloperCliCredential()
 
     expected_message = "Suggestion: re-authentication required, run `azd auth login` to acquire a new token."
@@ -405,7 +405,8 @@ def test_empty_claims_does_not_raise_error(get_token_method):
 def test_claims_command_line_argument(get_token_method):
     """The credential should pass claims as --claims argument to azd command"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     access_token = "access token"
     expected_expires_on = 1602015811
 
@@ -413,7 +414,7 @@ def test_claims_command_line_argument(get_token_method):
         # Verify that claims are passed as --claims argument
         assert "--claims" in command_line
         claims_index = command_line.index("--claims")
-        assert command_line[claims_index + 1] == claims
+        assert command_line[claims_index + 1] == expected_encoded_claims
 
         return json.dumps(
             {

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
@@ -339,12 +339,12 @@ async def test_multitenant_authentication_not_allowed(get_token_method):
 async def test_claims_challenge_raises_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
     credential = AzureDeveloperCliCredential()
 
     expected_message = "Suggestion: re-authentication required, run `azd auth login` to acquire a new token."
     error_output = """\
-{"data":{"message":"\\nERROR: fetching token: AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access '797f4846-ba00-4fd7-ba43-dac1f8f63013'. Trace ID: 2039f8fa-554b-4f18-9ee5-b59ba6a69801 Correlation ID: c13395dd-4409-4abf-835c-5be43cd98cbc Timestamp: 2025-08-18 22:08:14Z\\n"}}
+{"data":{"message":"\\nERROR: fetching token: AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access 'tenant-id'. Trace ID: trace-id Correlation ID: correlation-id Timestamp: 2025-08-18 22:08:14Z\\n"}}
 {"data":{"message":"Suggestion: re-authentication required, run `azd auth login` to acquire a new token.\\n"}}"""
 
     def fake_exec(*args, **kwargs):
@@ -410,7 +410,8 @@ async def test_empty_claims_does_not_raise_error(get_token_method):
 async def test_claims_command_line_argument(get_token_method):
     """The credential should pass claims as --claims argument to azd command"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     access_token = "access token"
     expected_expires_on = 1602015811
 
@@ -420,7 +421,7 @@ async def test_claims_command_line_argument(get_token_method):
         # Verify that claims are passed as --claims argument
         assert "--claims" in command_line
         claims_index = command_line.index("--claims")
-        assert command_line[claims_index + 1] == claims
+        assert command_line[claims_index + 1] == expected_encoded_claims
 
         output = json.dumps(
             {

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -401,8 +401,9 @@ def test_multitenant_authentication_not_allowed(get_token_method):
 def test_claims_challenge_raises_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "test-claims-challenge"
-    expected_command = f"az login --claims-challenge {claims} --scope scope"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
+    expected_command = f"az login --claims-challenge {expected_encoded_claims} --scope scope"
 
     credential = AzureCliCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_command)):
@@ -446,9 +447,10 @@ def test_empty_claims_does_not_raise_error(get_token_method):
 def test_claims_challenge_with_tenant(get_token_method):
     """The credential should include tenant in the error message when claims and tenant are provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     tenant_id = "test-tenant-id"
-    expected_command = f"az login --claims-challenge {claims} --tenant {tenant_id} --scope scope"
+    expected_command = f"az login --claims-challenge {expected_encoded_claims} --tenant {tenant_id} --scope scope"
 
     credential = AzureCliCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_command)):

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -395,8 +395,9 @@ async def test_multitenant_authentication_not_allowed(get_token_method):
 async def test_claims_challenge_raises_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "test-claims-challenge"
-    expected_command = f"az login --claims-challenge {claims} --scope scope"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
+    expected_command = f"az login --claims-challenge {expected_encoded_claims} --scope scope"
 
     credential = AzureCliCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_command)):
@@ -449,9 +450,10 @@ async def test_empty_claims_does_not_raise_error(get_token_method):
 async def test_claims_challenge_with_tenant(get_token_method):
     """The credential should include tenant in the error message when claims and tenant are provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     tenant_id = "test-tenant-id"
-    expected_command = f"az login --claims-challenge {claims} --tenant {tenant_id} --scope scope"
+    expected_command = f"az login --claims-challenge {expected_encoded_claims} --tenant {tenant_id} --scope scope"
 
     credential = AzureCliCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_command)):

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -395,8 +395,9 @@ def test_multitenant_authentication_not_allowed(get_token_method):
 def test_claims_challenge_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "some-claims"
-    expected_message = f"Connect-AzAccount -ClaimsChallenge {claims}"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
+    expected_message = f"Connect-AzAccount -ClaimsChallenge {expected_encoded_claims}"
 
     credential = AzurePowerShellCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_message)):
@@ -442,9 +443,10 @@ def test_empty_claims_no_error(get_token_method):
 def test_claims_challenge_with_tenant(get_token_method):
     """The credential should include tenant in the error message when claims and tenant are provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     tenant_id = "test-tenant-id"
-    expected_message = f"Connect-AzAccount -ClaimsChallenge {claims} -Tenant {tenant_id}"
+    expected_message = f"Connect-AzAccount -ClaimsChallenge {expected_encoded_claims} -Tenant {tenant_id}"
 
     credential = AzurePowerShellCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_message)):

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -404,8 +404,9 @@ async def test_multitenant_authentication_not_allowed(get_token_method):
 async def test_claims_challenge_error(get_token_method):
     """The credential should raise CredentialUnavailableError when claims challenge is provided"""
 
-    claims = "some-claims"
-    expected_message = f"Connect-AzAccount -ClaimsChallenge {claims}"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
+    expected_message = f"Connect-AzAccount -ClaimsChallenge {expected_encoded_claims}"
 
     credential = AzurePowerShellCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_message)):
@@ -451,9 +452,10 @@ async def test_empty_claims_no_error(get_token_method):
 async def test_claims_challenge_with_tenant(get_token_method):
     """The credential should include tenant in the error message when claims and tenant are provided"""
 
-    claims = "test-claims-challenge"
+    claims = '{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}'
+    expected_encoded_claims = "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
     tenant_id = "test-tenant-id"
-    expected_message = f"Connect-AzAccount -ClaimsChallenge {claims} -Tenant {tenant_id}"
+    expected_message = f"Connect-AzAccount -ClaimsChallenge {expected_encoded_claims} -Tenant {tenant_id}"
 
     credential = AzurePowerShellCredential()
     with pytest.raises(CredentialUnavailableError, match=re.escape(expected_message)):


### PR DESCRIPTION
Subprocess-based credentials rely on the claims being base64-encoded, however our authentication policies call get_token/get_token_info with claims as a JSON string. Here, we ensure that the claims are encoded before being used.
