### PR TITLE
[Storage] Fix NFS tests

### DIFF
--- a/sdk/storage/azure-storage-file-share/tests/test_nfs.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs.py
@@ -51,7 +51,7 @@ class TestStorageFileNFS(StorageRecordedTestCase):
                 pass
 
     def teardown_method(self):
-        if self.fsc:
+        if self.is_live and self.fsc:
             try:
                 self.fsc.delete_share(self.share_name)
             except:

--- a/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_nfs_async.py
@@ -58,7 +58,7 @@ class TestStorageFileNFSAsync(AsyncStorageRecordedTestCase):
                     pass
 
     def teardown_method(self):
-        if self.fsc:
+        if self.is_live and self.fsc:
             try:
                 fsc = ShareServiceClient(
                     account_url=self.account_url,


### PR DESCRIPTION
NFS Tests in Playback mode are extremely slow and often hang CI. This is due to the `teardown_method` hanging while attempting to delete the share. We don't need to change anything about the recordings as there really isn't any shares to delete in playback mode, but adding the `self.is_live` check first will drastically improve the performance.