### PR TITLE
`mypy` environment needs a couple `types` pins added

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/mypy.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/mypy.py
@@ -17,7 +17,7 @@ from ci_tools.logging import logger
 PYTHON_VERSION = "3.9"
 MYPY_VERSION = "1.14.1"
 
-ADDITIONAL_LOCKED_DEPENENCIES = [
+ADDITIONAL_LOCKED_DEPENDENCIES = [
   "types-chardet==5.0.4.6",
   "types-requests==2.31.0.6",
   "types-six==1.16.21.9",
@@ -53,7 +53,7 @@ class mypy(Check):
             package_dir = parsed.folder
             package_name = parsed.name
             # dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
-            additional_requirements = ADDITIONAL_LOCKED_DEPENENCIES
+            additional_requirements = ADDITIONAL_LOCKED_DEPENDENCIES
 
             executable, staging_directory = self.get_executable(args.isolate, args.command, sys.executable, package_dir)
             logger.info(f"Processing {package_name} for mypy check")

--- a/eng/tools/azure-sdk-tools/azpysdk/mypy.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/mypy.py
@@ -52,15 +52,15 @@ class mypy(Check):
         for parsed in targeted:
             package_dir = parsed.folder
             package_name = parsed.name
-            # dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
+            dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
             additional_requirements = ADDITIONAL_LOCKED_DEPENDENCIES
 
             executable, staging_directory = self.get_executable(args.isolate, args.command, sys.executable, package_dir)
             logger.info(f"Processing {package_name} for mypy check")
 
             # # need to install dev_requirements to ensure that type-hints properly resolve
-            # if os.path.exists(dev_requirements):
-            #     additional_requirements += ["-r", dev_requirements]
+            if os.path.exists(dev_requirements):
+                additional_requirements += ["-r", dev_requirements]
 
             # install mypy
             try:

--- a/eng/tools/azure-sdk-tools/azpysdk/mypy.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/mypy.py
@@ -52,15 +52,15 @@ class mypy(Check):
         for parsed in targeted:
             package_dir = parsed.folder
             package_name = parsed.name
-            dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
+            # dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
             additional_requirements = ADDITIONAL_LOCKED_DEPENENCIES
 
             executable, staging_directory = self.get_executable(args.isolate, args.command, sys.executable, package_dir)
             logger.info(f"Processing {package_name} for mypy check")
 
-            # need to install dev_requirements to ensure that type-hints properly resolve
-            if os.path.exists(dev_requirements):
-                additional_requirements += ["-r", dev_requirements]
+            # # need to install dev_requirements to ensure that type-hints properly resolve
+            # if os.path.exists(dev_requirements):
+            #     additional_requirements += ["-r", dev_requirements]
 
             # install mypy
             try:

--- a/eng/tools/azure-sdk-tools/azpysdk/mypy.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/mypy.py
@@ -17,6 +17,13 @@ from ci_tools.logging import logger
 PYTHON_VERSION = "3.9"
 MYPY_VERSION = "1.14.1"
 
+ADDITIONAL_LOCKED_DEPENENCIES = [
+  "types-chardet==5.0.4.6",
+  "types-requests==2.31.0.6",
+  "types-six==1.16.21.9",
+  "types-redis==4.6.0.7",
+  "PyGitHub>=1.59.0"
+]
 
 class mypy(Check):
     def __init__(self) -> None:
@@ -45,17 +52,23 @@ class mypy(Check):
         for parsed in targeted:
             package_dir = parsed.folder
             package_name = parsed.name
+            dev_requirements = os.path.join(package_dir, "dev_requirements.txt")
+            additional_requirements = ADDITIONAL_LOCKED_DEPENENCIES
 
             executable, staging_directory = self.get_executable(args.isolate, args.command, sys.executable, package_dir)
             logger.info(f"Processing {package_name} for mypy check")
+
+            # need to install dev_requirements to ensure that type-hints properly resolve
+            if os.path.exists(dev_requirements):
+                additional_requirements += ["-r", dev_requirements]
 
             # install mypy
             try:
                 if args.next:
                     # use latest version of mypy
-                    install_into_venv(executable, ["mypy"])
+                    install_into_venv(executable, ["mypy"] + additional_requirements)
                 else:
-                    install_into_venv(executable, [f"mypy=={MYPY_VERSION}"])
+                    install_into_venv(executable, [f"mypy=={MYPY_VERSION}"] + additional_requirements)
             except CalledProcessError as e:
                 logger.error("Failed to install mypy:", e)
                 return e.returncode


### PR DESCRIPTION
Transferring pins that I missed catching in review of the transition of the `mypy` environment

- [Running core keeping dev_requirements install](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5314539&view=results)
- [Running core without dev_reqs (also current version for this PR)](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5314565&view=results)