### PR TITLE
Ensure we clean up after every `check` run by `dispatch_checks.py`

### DIFF
--- a/eng/scripts/dispatch_checks.py
+++ b/eng/scripts/dispatch_checks.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import signal
+import shutil
 from dataclasses import dataclass
 from typing import List
 
@@ -76,6 +77,16 @@ async def run_check(semaphore: asyncio.Semaphore, package: str, check: str, base
             print(header.replace('OUTPUT', 'STDERR'))
             print(stderr.rstrip())
             print(trailer)
+
+        # if we have any output collections to complete, do so now here
+
+        # finally, we need to clean up any temp dirs created by --isolate
+        if in_ci():
+            isolate_dir = os.path.join(package, f".venv_{check}")
+            try:
+                shutil.rmtree(isolate_dir)
+            except:
+                logger.warning(f"Failed to remove isolate dir {isolate_dir} for {package} / {check}")
         return CheckResult(package, check, exit_code, duration, stdout, stderr)
 
 


### PR DESCRIPTION
@xitzhang FYI

The issue was that we recursively look for `_version.py` beneath the package directory. We had a left behind `.venv_mypy` directory present there. Because that's technically in the package directory, it matched `_version.py` files found there, and used the version from it.

There was a dependency `dotenv` in the venv site-packages directory which hada file named `_version.py` and because it did, and we have a default fallback we grabbed that version.py file and then failed to parse -> which defaulted to `0.0.0`.

This is a short term fix, the real fix will be to ensure we never look in any hidden directory under the package folder. I'll submit that in a follow-up PR with additional tests as well. For now I want to unblock #42910 for merge to `main` and I can do so in a non-hacky way. Just not the entire solution future proofed.

Proved out the fix in #42930 