### PR TITLE
[eng] fix `scripts/dev_setup.py` for windows os

### DIFF
--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -75,7 +75,7 @@ args = parser.parse_args()
 
 packages = {
     tuple(os.path.dirname(f).rsplit(os.sep, 1))
-    for f in glob.glob(os.path.join(root_dir, "sdk/*/azure-*/setup.py")) + glob.glob(os.path.join(root_dir, "eng/tools/azure-sdk-tools/"))
+    for f in glob.glob(os.path.join(root_dir, "sdk/*/azure-*/setup.py")) + glob.glob(os.path.join(root_dir, "eng/tools/azure-*/pyproject.toml"))
 }
 # [(base_folder, package_name), ...] to {package_name: base_folder, ...}
 packages = {package_name: base_folder for (base_folder, package_name) in packages}


### PR DESCRIPTION
fix https://github.com/Azure/azure-sdk-for-python/issues/42943

The root cause is that https://github.com/Azure/azure-sdk-for-python/pull/42637/files#diff-1cffc538fdb842b1ac3d5694c84074e4c3d7e1f457f16ebbb817c719352a533e doesn't work for Windows OS.

I have tested this PR locally in Linux and Windows.