### PR TITLE
Fix test resource deployment for ledger library

### DIFF
--- a/sdk/confidentialledger/test-resources.bicep
+++ b/sdk/confidentialledger/test-resources.bicep
@@ -11,7 +11,7 @@ param ledgerName string = 'pysdkci-${uniqueString(resourceGroup().id)}'
 param testApplicationOid string
 
 @description('The location of the resource. Currently, not all regions are supported.')
-param location string = 'westeurope' // Australia East is our frontier region for production testing
+param location string = 'westeurope'
 // Explicitly set a region due to regional restrictions e.g. ACL is not currently available in westus
 
 var azureConfidentialLedgerUrl = 'https://${ledgerName}.confidential-ledger.azure.com'

--- a/sdk/confidentialledger/test-resources.bicep
+++ b/sdk/confidentialledger/test-resources.bicep
@@ -11,7 +11,7 @@ param ledgerName string = 'pysdkci-${uniqueString(resourceGroup().id)}'
 param testApplicationOid string
 
 @description('The location of the resource. Currently, not all regions are supported.')
-param location string = 'AustraliaEast' // Australia East is our frontier region for production testing
+param location string = 'westeurope' // Australia East is our frontier region for production testing
 // Explicitly set a region due to regional restrictions e.g. ACL is not currently available in westus
 
 var azureConfidentialLedgerUrl = 'https://${ledgerName}.confidential-ledger.azure.com'


### PR DESCRIPTION
Fix test resource deployment. The pipeline was failing to deploy resources for this service due to lack of regional availability in the tme subscription. This PR fixes the deployment issue. Tests and sample problems will be resolved separately.