### PR TITLE
[Identity] Update for next-pylint

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -278,14 +278,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 )
             )
         if not exclude_shared_token_cache_credential and SharedTokenCacheCredential.supported():
-            try:
-                # username and/or tenant_id are only required when the cache contains tokens for multiple identities
-                shared_cache = SharedTokenCacheCredential(
-                    username=shared_cache_username, tenant_id=shared_cache_tenant_id, authority=authority, **kwargs
-                )
-                credentials.append(shared_cache)
-            except Exception as ex:  # pylint:disable=broad-except
-                _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
+            # username and/or tenant_id are only required when the cache contains tokens for multiple identities
+            shared_cache = SharedTokenCacheCredential(
+                username=shared_cache_username, tenant_id=shared_cache_tenant_id, authority=authority, **kwargs
+            )
+            credentials.append(shared_cache)
         if not exclude_visual_studio_code_credential:
             credentials.append(VisualStudioCodeCredential(tenant_id=vscode_tenant_id))
         if not exclude_cli_credential:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -198,9 +198,9 @@ class _SharedTokenCacheCredential(SharedTokenCacheBase):
                 return token
             except Exception as e:  # pylint: disable=broad-except
                 if within_dac.get():
-                    raise CredentialUnavailableError(  # pylint: disable=raise-missing-from
+                    raise CredentialUnavailableError(
                         message=getattr(e, "message", str(e)), response=getattr(e, "response", None)
-                    )
+                    ) from e
                 raise
 
         raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -203,7 +203,7 @@ class InteractiveCredential(MsalCredential, ABC):
             return token
         except Exception as ex:  # pylint:disable=broad-except
             if not (isinstance(ex, AuthenticationRequiredError) and allow_prompt):
-                _LOGGER.warning(
+                _LOGGER.warning(  # pylint: disable=do-not-log-raised-errors
                     "%s.%s failed: %s",
                     self.__class__.__name__,
                     base_method_name,
@@ -225,7 +225,7 @@ class InteractiveCredential(MsalCredential, ABC):
             # this may be the first authentication, or the user may have authenticated a different identity
             self._auth_record = _build_auth_record(result)
         except Exception as ex:
-            _LOGGER.warning(
+            _LOGGER.warning(  # pylint: disable=do-not-log-raised-errors
                 "%s.%s failed: %s",
                 self.__class__.__name__,
                 base_method_name,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -239,14 +239,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 )
             )
         if not exclude_shared_token_cache_credential and SharedTokenCacheCredential.supported():
-            try:
-                # username and/or tenant_id are only required when the cache contains tokens for multiple identities
-                shared_cache = SharedTokenCacheCredential(
-                    username=shared_cache_username, tenant_id=shared_cache_tenant_id, authority=authority, **kwargs
-                )
-                credentials.append(shared_cache)
-            except Exception as ex:  # pylint:disable=broad-except
-                _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
+            # username and/or tenant_id are only required when the cache contains tokens for multiple identities
+            shared_cache = SharedTokenCacheCredential(
+                username=shared_cache_username, tenant_id=shared_cache_tenant_id, authority=authority, **kwargs
+            )
+            credentials.append(shared_cache)
         if not exclude_visual_studio_code_credential:
             credentials.append(VisualStudioCodeCredential(tenant_id=vscode_tenant_id))
         if not exclude_cli_credential:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -151,9 +151,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
                 return token
             except Exception as e:  # pylint: disable=broad-except
                 if within_dac.get():
-                    raise CredentialUnavailableError(  # pylint: disable=raise-missing-from
+                    raise CredentialUnavailableError(
                         message=getattr(e, "message", str(e)), response=getattr(e, "response", None)
-                    )
+                    ) from e
                 raise
         raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))
 


### PR DESCRIPTION
This updates azure-identity to pass the next-pylint check.

One notable change:
The exception catching for the instantiation of `SharedTokenCacheCredential` was removed. The exception logging here causes pylint to complain with "Do not log exceptions in levels other than debug".  However, this level of exception catching is no longer needed since it was initially [put in](https://github.com/Azure/azure-sdk-for-python/pull/8294/) because `SharedTokenCacheCredential` used to import `msal_extensions` which could potentially cause ImportErrors.

Now, `SharedTokenCacheCredential` constructors only have basic setup and potentially some validation (just like other credentials in DAC)


Closes: #40686