### PR TITLE
Revert "azure-monitor-opentelemetry-exporter release 1.0.0b42"

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b42 (2025-09-15)
+## 1.0.0b42 (Unreleased)
 
 ### Features Added
 - Customer Facing Statsbeat: Added remaining drop codes to base
@@ -21,6 +21,10 @@
   ([#42846](https://github.com/Azure/azure-sdk-for-python/pull/42846))
 - Customer Facing SDKStats: Refactor to use `Manager` and `Singleton` pattern
   ([#42969](https://github.com/Azure/azure-sdk-for-python/pull/42969))
+
+### Breaking Changes
+
+### Bugs Fixed
 
 ### Other Changes
 


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#43003