### PR TITLE
Added scope override sample for fabric testing.

### DIFF
--- a/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
+++ b/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
@@ -75,9 +75,10 @@ def main():
         run_sample()
     except exceptions.CosmosHttpResponseError as e:
         print(f"CosmosHttpResponseError: {getattr(e, 'status_code', None)} - {e}")
-        if getattr(e, "response", None) is not None and hasattr(e.response, "headers"):
+        resp = getattr(e, "response", None)
+        if resp is not None and getattr(resp, "headers", None) is not None:
             try:
-                print("Response headers:\n" + json.dumps(dict(e.response.headers), indent=2))
+                print("Response headers:\n" + json.dumps(dict(resp.headers), indent=2))
             except Exception:
                 pass
         traceback.print_exc()

--- a/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
+++ b/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
@@ -19,7 +19,7 @@ import config
 # Prerequisites -
 #
 # 1. An Azure Cosmos account in fabric environment and database and container created.
-#
+#    https://learn.microsoft.com/en-us/fabric/database/cosmos-db/overview
 # 2. Python packages (preview + identity) and login:
 #    pip install "azure-cosmos==4.14.0b3" azure-identity
 #    az login

--- a/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
+++ b/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
@@ -75,7 +75,7 @@ def main():
         run_sample()
     except exceptions.CosmosHttpResponseError as e:
         print(f"CosmosHttpResponseError: {getattr(e, 'status_code', None)} - {e}")
-        if getattr(e, "response", None):
+        if getattr(e, "response", None) is not None and hasattr(e.response, "headers"):
             try:
                 print("Response headers:\n" + json.dumps(dict(e.response.headers), indent=2))
             except Exception:

--- a/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
+++ b/sdk/cosmos/azure-cosmos/samples/access_fabric_with_overridenscope_aad.py
@@ -1,0 +1,92 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import json
+import os
+import sys
+import traceback
+import uuid
+
+from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential
+from azure.cosmos import CosmosClient
+import azure.cosmos.exceptions as exceptions
+from azure.cosmos.partition_key import PartitionKey
+import config
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites -
+#
+# 1. An Azure Cosmos account in fabric environment and database and container created.
+#
+# 2. Python packages (preview + identity) and login:
+#    pip install "azure-cosmos==4.14.0b3" azure-identity
+#    az login
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates how to authenticate and use your database account using AAD credentials with Fabric.
+# Read more about operations allowed for this authorization method: https://aka.ms/cosmos-native-rbac
+# ----------------------------------------------------------------------------------------------------------
+# Note:
+# This sample assumes the database and container already exist.
+# It writes one item (PK path assumed to be "/pk") and reads it back.
+# ----------------------------------------------------------------------------------------------------------
+HOST = config.settings["host"]
+DATABASE_ID = config.settings["database_id"]
+CONTAINER_ID = config.settings["container_id"]
+PARTITION_KEY = PartitionKey(path="/pk")
+
+def get_test_item(num: int) -> dict:
+    return {
+        "id": f"Item_{num}",
+        "pk": "partition1",
+        "name": "Item 1",
+        "description": "This is item 1",
+        "runId": str(uuid.uuid4())
+    }
+
+
+def run_sample():
+    # if you want to override scope for AAD authentication.
+    #os.environ["AZURE_COSMOS_AAD_SCOPE_OVERRIDE"] = "https://cosmos.azure.com/.default"
+
+    # AAD auth works with az login
+    aad_credentials = InteractiveBrowserCredential()
+
+    # Use your credentials to authenticate your client.
+    aad_client = CosmosClient(HOST, aad_credentials)
+
+    # Do R/W data operations with your authorized AAD client.
+    db = aad_client.get_database_client(DATABASE_ID)
+    container = db.get_container_client(CONTAINER_ID)
+
+    # Create item
+    item = get_test_item(0)
+    container.create_item(item)
+    print("Created item:", item["id"])
+
+    # Read item
+    read_doc = container.read_item(item=item["id"], partition_key=item["pk"])
+    print("Point read:\n" + json.dumps(read_doc, indent=2))
+
+
+def main():
+    try:
+        run_sample()
+    except exceptions.CosmosHttpResponseError as e:
+        print(f"CosmosHttpResponseError: {getattr(e, 'status_code', None)} - {e}")
+        if getattr(e, "response", None):
+            try:
+                print("Response headers:\n" + json.dumps(dict(e.response.headers), indent=2))
+            except Exception:
+                pass
+        traceback.print_exc()
+        raise
+    except Exception as ex:
+        print(f"Exception: {ex}")
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Adds a console sample for AAD auth (Default/InteractiveBrowserCredential) with fabric account and using the option to override the audience scope explicitly AZURE_COSMOS_AAD_SCOPE_OVERRIDE and also tests the AAD scope fallback mechanism if no scope is overriden. Targets azure-cosmos==4.14.0b3.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
