### PR TITLE
Modified pinned version for opentelemetry-sdk

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
+  ([#43012](https://github.com/Azure/azure-sdk-for-python/pull/43012))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -91,7 +91,7 @@ setup(
         "opentelemetry-instrumentation-urllib~=0.57b0",
         "opentelemetry-instrumentation-urllib3~=0.57b0",
         "opentelemetry-resource-detector-azure~=0.1.5",
-        "opentelemetry-sdk~=1.36.0",
+        "opentelemetry-sdk~=1.36",
     ],
     entry_points={
         "opentelemetry_distro": [


### PR DESCRIPTION
x# Description

This PR updates the pinned version of `opentelemetry-sdk` from `1.36.0` to `1.36` to support versions >= 1.36.0 and < 2.0.0, ensuring compatibility with of the dependent packages and instrumentation libraries. The [previous distro](https://github.com/Azure/azure-sdk-for-python/pull/42247/files) release had pinned the SDK to 1.36.0, which supported compatibility to versions >= 1.36.0 and < 1.37.0. 

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
