### PR TITLE
[SDK generation pipeline] update log level for unnecessary steps

### DIFF
--- a/eng/tools/azure-sdk-tools/ci_tools/build.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/build.py
@@ -10,6 +10,7 @@ from ci_tools.versioning.version_shared import set_version_py, set_dev_classifie
 from ci_tools.versioning.version_set_dev import get_dev_version, format_build_id
 from ci_tools.logging import logger, configure_logging, run_logged
 
+
 def build_package() -> None:
     parser = argparse.ArgumentParser(
         description="""This is a secondary entrypoint for the "build" action. This command is used to install dependencies and build a specific package within the azure-sdk-for-python repository.""",
@@ -53,14 +54,8 @@ def build_package() -> None:
     if args.package_type == "whl":
         enable_sdist = False
 
-    build_packages(
-        [target_package.folder],
-        artifact_directory,
-        False,
-        DEFAULT_BUILD_ID,
-        enable_wheel,
-        enable_sdist
-    )
+    build_packages([target_package.folder], artifact_directory, False, DEFAULT_BUILD_ID, enable_wheel, enable_sdist)
+
 
 def build() -> None:
     parser = argparse.ArgumentParser(
@@ -174,14 +169,7 @@ def build() -> None:
 
     build_id = format_build_id(args.build_id or DEFAULT_BUILD_ID)
 
-    build_packages(
-        targeted_packages,
-        artifact_directory,
-        str_to_bool(args.is_dev_build),
-        build_id,
-        True,
-        True
-    )
+    build_packages(targeted_packages, artifact_directory, str_to_bool(args.is_dev_build), build_id, True, True)
 
 
 def cleanup_build_artifacts(build_folder):
@@ -203,7 +191,7 @@ def build_packages(
     is_dev_build: bool = False,
     build_id: str = "",
     enable_wheel: bool = True,
-    enable_sdist: bool = True
+    enable_sdist: bool = True,
 ):
     logger.info(f"Generating {targeted_packages} using python{sys.version}")
 
@@ -230,7 +218,11 @@ def build_packages(
 
 
 def create_package(
-    setup_directory_or_file: str, dest_folder: str, enable_wheel: bool = True, enable_sdist: bool = True
+    setup_directory_or_file: str,
+    dest_folder: str,
+    enable_wheel: bool = True,
+    enable_sdist: bool = True,
+    enable_error_logging: bool = True,
 ):
     """
     Uses the invoking python executable to build a wheel and sdist file given a setup.py or setup.py directory. Outputs
@@ -251,15 +243,54 @@ def create_package(
         # given the additional requirements of the package, we should install them in the current environment before attempting to build the package
         # we assume the presence of `wheel`, `build`, `setuptools>=61.0.0`
         pip_output = get_pip_list_output(sys.executable)
-        necessary_install_requirements = [req for req in setup_parsed.requires if parse_require(req).name not in pip_output.keys()]
-        run_logged([sys.executable, "-m", "pip", "install", *necessary_install_requirements], cwd=setup_parsed.folder, check=False, should_stream_to_console=should_log_build_output)
-        run_logged([sys.executable, "-m", "build", f"-n{'s' if enable_sdist else ''}{'w' if enable_wheel else ''}", "-o", dist], cwd=setup_parsed.folder, check=True, should_stream_to_console=should_log_build_output)
+        necessary_install_requirements = [
+            req for req in setup_parsed.requires if parse_require(req).name not in pip_output.keys()
+        ]
+        run_logged(
+            [sys.executable, "-m", "pip", "install", *necessary_install_requirements],
+            cwd=setup_parsed.folder,
+            check=False,
+            should_stream_to_console=should_log_build_output,
+            enable_error_logging=enable_error_logging,
+        )
+        run_logged(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                f"-n{'s' if enable_sdist else ''}{'w' if enable_wheel else ''}",
+                "-o",
+                dist,
+            ],
+            cwd=setup_parsed.folder,
+            check=True,
+            should_stream_to_console=should_log_build_output,
+            enable_error_logging=enable_error_logging,
+        )
     else:
         if enable_wheel:
             if setup_parsed.ext_modules:
-                run_logged([sys.executable, "-m", "cibuildwheel", "--output-dir", dist], cwd=setup_parsed.folder, check=True, should_stream_to_console=should_log_build_output)
+                run_logged(
+                    [sys.executable, "-m", "cibuildwheel", "--output-dir", dist],
+                    cwd=setup_parsed.folder,
+                    check=True,
+                    should_stream_to_console=should_log_build_output,
+                    enable_error_logging=enable_error_logging,
+                )
             else:
-                run_logged([sys.executable, "setup.py", "bdist_wheel", "-d", dist], cwd=setup_parsed.folder, check=True, should_stream_to_console=should_log_build_output)
+                run_logged(
+                    [sys.executable, "setup.py", "bdist_wheel", "-d", dist],
+                    cwd=setup_parsed.folder,
+                    check=True,
+                    should_stream_to_console=should_log_build_output,
+                    enable_error_logging=enable_error_logging,
+                )
 
         if enable_sdist:
-            run_logged([sys.executable, "setup.py", "sdist", "-d", dist], cwd=setup_parsed.folder, check=True, should_stream_to_console=should_log_build_output)
+            run_logged(
+                [sys.executable, "setup.py", "sdist", "-d", dist],
+                cwd=setup_parsed.folder,
+                check=True,
+                should_stream_to_console=should_log_build_output,
+                enable_error_logging=enable_error_logging,
+            )

--- a/eng/tools/azure-sdk-tools/ci_tools/logging/__init__.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/logging/__init__.py
@@ -108,9 +108,9 @@ def run_logged(cmd: list[str], cwd: str, check: bool, should_stream_to_console: 
                 stderr=subprocess.STDOUT
             )
     except subprocess.CalledProcessError as e:
-        logger.error(f"Command failed: {' '.join(cmd)}")
+        logger.warning(f"Command failed: {' '.join(cmd)}")
         if e.stdout:
-            logger.error(f"\n{e.stdout.strip()}")
+            logger.warning(f"\n{e.stdout.strip()}")
         raise
 
 __all__ = ["initialize_logger", "run_logged_to_file", "run_logged"]

--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "--cache-dir",
         dest="cache_dir",
         help="Location that, if present, will be used as the pip cache directory.",
-        default=None
+        default=None,
     )
 
     parser.add_argument(
@@ -54,14 +54,11 @@ if __name__ == "__main__":
         "--work-dir",
         dest="work_dir",
         help="Location that, if present, will be used as working directory to run pip install.",
-        default=None
+        default=None,
     )
 
     parser.add_argument(
-        "--force-create",
-        dest="force_create",
-        help="Force recreate whl even if it is prebuilt",
-        default=False
+        "--force-create", dest="force_create", help="Force recreate whl even if it is prebuilt", default=False
     )
 
     parser.add_argument(
@@ -75,6 +72,13 @@ if __name__ == "__main__":
         "--pre-download-disabled",
         dest="pre_download_disabled",
         help="During a dev build, we will restore package dependencies from a dev feed before installing them. The presence of this flag disables that behavior.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--enable-error-logging",
+        dest="enable_error_logging",
+        help="Enable error logging",
         action="store_true",
     )
 
@@ -93,7 +97,5 @@ if __name__ == "__main__":
         force_create=args.force_create,
         package_type=args.package_type,
         pre_download_disabled=args.pre_download_disabled,
+        enable_error_logging=args.enable_error_logging,
     )
-
-
-

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -570,6 +570,7 @@ commands =
       -p {tox_root} \
       -w {envtmpdir} \
       --package-type sdist
+      --enable-error-logging false
     python {repository_root}/scripts/breaking_changes_checker/detect_breaking_changes.py -t {tox_root} {posargs}
 
 


### PR DESCRIPTION
fix python sdk generation failure for https://github.com/Azure/azure-rest-api-specs/pull/37259

Context:
SDK generation pipeline will fail if there is any error log. It is design across language.

Reason:
Some steps of pipeline is not necessary so we don't hope to fail the pipeline when unnecessary steps (e.g. changelog generation/ apiview generation) fails. So we should remove unnecessary error logging.

NOTE:
The error log was added in https://github.com/Azure/azure-sdk-for-python/pull/42862/files#diff-7f32e2551bf7f52b45f4fa44be31889eea94710eed61a9a49a6cea2f9819d560 last week so add @scbedd to review.