### PR TITLE
Modified order of opentelemetry dependencies to avoid build failures

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
   ([#43012](https://github.com/Azure/azure-sdk-for-python/pull/43012))
 - Modified ordering of dependencies in setup.py to avoid dependency conflicts in future.
+  ([#43023](https://github.com/Azure/azure-sdk-for-python/pull/43023))
 
 ## 1.8.0 (2025-09-08)
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 - Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
   ([#43012](https://github.com/Azure/azure-sdk-for-python/pull/43012))
+- Modified ordering of dependencies in setup.py to avoid dependency conflicts in future.
 
 ## 1.8.0 (2025-09-08)
 

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -83,6 +83,7 @@ setup(
         "azure-core<2.0.0,>=1.28.0",
         "azure-core-tracing-opentelemetry~=1.0.0b11",
         "azure-monitor-opentelemetry-exporter~=1.0.0b41",
+        "opentelemetry-sdk~=1.36",
         "opentelemetry-instrumentation-django~=0.57b0",
         "opentelemetry-instrumentation-fastapi~=0.57b0",
         "opentelemetry-instrumentation-flask~=0.57b0",
@@ -91,7 +92,6 @@ setup(
         "opentelemetry-instrumentation-urllib~=0.57b0",
         "opentelemetry-instrumentation-urllib3~=0.57b0",
         "opentelemetry-resource-detector-azure~=0.1.5",
-        "opentelemetry-sdk~=1.36",
     ],
     entry_points={
         "opentelemetry_distro": [


### PR DESCRIPTION
# Description

Modified ordering of dependencies in setup.py to avoid dependency conflicts in future.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
