### PR TITLE
azure-monitor-opentelemetry release 1.8.1

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
   ([#43012](https://github.com/Azure/azure-sdk-for-python/pull/43012))
 - Modified ordering of dependencies in setup.py to avoid dependency conflicts in future.
-  ([#43023](https://github.com/Azure/azure-sdk-for-python/pull/43023))
+  ([#43023](https://github.com/Azure/azure-sdk-for-python/pull/43023)) 
 
 ## 1.8.0 (2025-09-08)
 


### PR DESCRIPTION
# Description

## 1.8.1 (2025-09-16)

### Bugs Fixed
- Fixed version pinned for opentelemetry-sdk to resolve dependency conflicts.
  ([#43012](https://github.com/Azure/azure-sdk-for-python/pull/43012))
- Modified ordering of dependencies in setup.py to avoid dependency conflicts in future.
  ([#43023](https://github.com/Azure/azure-sdk-for-python/pull/43023)) 