### PR TITLE
[Key Vault] Clean up testing utilities

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -5,9 +5,7 @@
 import os
 
 import pytest
-from azure.keyvault.administration import ApiVersion
 from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
-from azure.identity.aio import ManagedIdentityCredential
 from devtools_testutils import AzureRecordedTestCase
 
 
@@ -133,10 +131,3 @@ class KeyVaultSettingsClientPreparer(BaseClientPreparer):
         return self.create_client_from_credential(
             KeyVaultSettingsClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
         )
-
-
-def get_decorator(**kwargs):
-    """returns a test decorator for test parameterization"""
-    versions = kwargs.pop("api_versions", None) or ApiVersion
-    params = [pytest.param(api_version) for api_version in versions]
-    return params

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -8,7 +8,6 @@ import pytest
 
 from azure.keyvault.administration import ApiVersion
 from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
-from azure.identity import ManagedIdentityCredential
 from devtools_testutils import AzureRecordedTestCase
 
 

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
@@ -11,7 +11,8 @@ from azure.keyvault.administration import KeyVaultDataAction, KeyVaultPermission
 from devtools_testutils import add_general_regex_sanitizer, set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import KeyVaultAccessControlClientPreparer, get_decorator
+from _async_test_case import KeyVaultAccessControlClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 from test_access_control import assert_role_definitions_equal
 

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
@@ -10,7 +10,8 @@ from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import KeyVaultBackupClientPreparer, KeyVaultBackupClientSasPreparer, get_decorator
+from _async_test_case import KeyVaultBackupClientPreparer, KeyVaultBackupClientSasPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True)

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
@@ -9,7 +9,8 @@ from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import KeyVaultBackupClientPreparer, get_decorator
+from _async_test_case import KeyVaultBackupClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True)

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -8,7 +8,8 @@ from azure.keyvault.administration.aio import KeyVaultSettingsClient
 from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import KeyVaultSettingsClientPreparer, get_decorator
+from _async_test_case import KeyVaultSettingsClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 only_latest = get_decorator(api_versions=[DEFAULT_VERSION])

--- a/sdk/keyvault/azure-keyvault-certificates/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/_async_test_case.py
@@ -5,17 +5,9 @@
 
 import os
 
-from azure.keyvault.certificates import ApiVersion
 from azure.keyvault.certificates._shared.client_base import DEFAULT_VERSION
 from devtools_testutils import AzureRecordedTestCase, is_live
 import pytest
-
-
-def get_decorator(**kwargs):
-    """returns a test decorator for test parameterization"""
-    versions = kwargs.pop("api_versions", None) or ApiVersion
-    params = [pytest.param(api_version) for api_version in versions]
-    return params
 
 
 class AsyncCertificatesClientPreparer(AzureRecordedTestCase):

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -35,7 +35,8 @@ from azure.keyvault.certificates._shared.client_base import DEFAULT_VERSION
 import pytest
 
 from _shared.test_case_async import KeyVaultTestCase
-from _async_test_case import get_decorator, AsyncCertificatesClientPreparer
+from _async_test_case import AsyncCertificatesClientPreparer
+from _test_case import get_decorator
 from certs import CERT_CONTENT_PASSWORD_ENCODED, CERT_CONTENT_NOT_PASSWORD_ENCODED
 
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
@@ -8,7 +8,8 @@ from azure.keyvault.certificates import ApiVersion, CertificatePolicy, Certifica
 import pytest
 
 from _shared.test_case_async import KeyVaultTestCase
-from _async_test_case import get_decorator, AsyncCertificatesClientPreparer
+from _async_test_case import AsyncCertificatesClientPreparer
+from _test_case import get_decorator
 from devtools_testutils.aio import recorded_by_proxy_async
 
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
@@ -11,7 +11,8 @@ from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 from OpenSSL import crypto
 
-from _async_test_case import AsyncCertificatesClientPreparer, get_decorator
+from _async_test_case import AsyncCertificatesClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True)

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -13,7 +13,7 @@ from azure.keyvault.keys._shared.client_base import ApiVersion
 from devtools_testutils import AzureRecordedTestCase
 
 
-HSM_SUPPORTED_VERSIONS = {ApiVersion.V7_2, ApiVersion.V7_3, ApiVersion.V7_4, ApiVersion.V7_5, ApiVersion.V7_6}
+HSM_UNSUPPORTED_VERSIONS = {ApiVersion.V2016_10_01, ApiVersion.V7_0, ApiVersion.V7_1}
 
 
 def get_attestation_token(attestation_uri):
@@ -47,7 +47,7 @@ def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
     versions = api_versions or pytest.api_version  # pytest.api_version -> [DEFAULT_VERSION] if live, ApiVersion if not
 
     for api_version in versions:
-        if not only_vault and api_version in HSM_SUPPORTED_VERSIONS:
+        if not only_vault and api_version not in HSM_UNSUPPORTED_VERSIONS:
             combinations.append([api_version, True])
         if not only_hsm:
             combinations.append([api_version, False])

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -24,7 +24,8 @@ from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION
 from azure.keyvault.keys.aio import KeyClient
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import AsyncKeysClientPreparer, get_decorator
+from _async_test_case import AsyncKeysClientPreparer
+from _test_case import get_decorator
 from _shared.helpers import Request, mock_response
 from _shared.helpers_async import async_validating_transport
 from _shared.test_case_async import KeyVaultTestCase

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -21,12 +21,12 @@ from azure.keyvault.keys.crypto.aio import (
     KeyWrapAlgorithm,
     SignatureAlgorithm,
 )
-from azure.keyvault.keys._generated._serialization import Deserializer, Serializer
+from azure.keyvault.keys._generated._serialization import Deserializer
 from azure.keyvault.keys._generated.models import KeySignParameters
-from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import AsyncKeysClientPreparer, get_decorator
+from _async_test_case import AsyncKeysClientPreparer
+from _test_case import get_decorator
 from _shared.helpers_async import get_completed_future
 from _shared.test_case_async import KeyVaultTestCase
 from _keys_test_case import KeysTestCase

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
@@ -7,7 +7,8 @@ from azure.keyvault.keys.crypto.aio import CryptographyClient
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import AsyncKeysClientPreparer, get_decorator
+from _async_test_case import AsyncKeysClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True, only_vault=True)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -28,9 +28,9 @@ from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION
 import pytest
 
 from _shared.test_case_async import KeyVaultTestCase
-from _async_test_case import get_attestation_token, get_decorator, get_release_policy, is_public_cloud, AsyncKeysClientPreparer
+from _test_case import get_decorator, get_release_policy, is_public_cloud
+from _async_test_case import get_attestation_token, AsyncKeysClientPreparer
 from test_key_client import _assert_lifetime_actions_equal, _assert_rotation_policies_equal
-from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 from _keys_test_case import KeysTestCase
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -9,7 +9,8 @@ import pytest
 from azure.keyvault.keys import KeyType
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import AsyncKeysClientPreparer, get_decorator
+from _async_test_case import AsyncKeysClientPreparer
+from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True, only_vault=True)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -6,7 +6,7 @@ import asyncio
 
 
 import pytest
-from devtools_testutils import AzureRecordedTestCase, is_live
+from devtools_testutils import AzureRecordedTestCase
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from _async_test_case import AsyncSecretsClientPreparer


### PR DESCRIPTION
# Description

There are some testing helpers in KV tests that were implemented once each for sync and async tests. These duplicates are consolidated to one definition where possible.

Also, `azure-keyvault-keys` tests are run across Key Vault as well as Managed HSM. To track API versions that support the latter service, we've been using an `HSM_SUPPORTED_VERSIONS` list -- instead of this setup, where the list needs to be updated with each new API version, this PR switches to using an `HSM_UNSUPPORTED_VERSIONS` list that won't need to be changed.

Miscellaneous unused imports are also removed.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
