### PR TITLE
Bug fix for message field on Microsoft.ApplicationInsights.Message

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fix logic for message field on Microsoft.ApplicationInsights.Message to sync with Breeze
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -82,6 +82,8 @@ class AzureMonitorLogExporter(BaseExporter, LogExporter):
 
     def _log_to_envelope(self, log_data: LogData) -> TelemetryItem:
         envelope = _convert_log_to_envelope(log_data)
+        if envelope is None:
+            return None
         envelope.instrumentation_key = self._instrumentation_key
         return envelope
 
@@ -189,6 +191,9 @@ def _convert_log_to_envelope(log_data: LogData) -> TelemetryItem:
             severity_level=severity_level,  # type: ignore
             properties=properties,
         )
+        if len(data.message) == 0:
+            _logger.warning("Log record body cannot be empty. Skipping export for this log record.")
+            return None
         envelope.data = MonitorBase(base_data=data, base_type="MessageData")
 
     return envelope

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -408,16 +408,12 @@ class TestAzureLogExporter(unittest.TestCase):
     def test_log_to_envelope_log_none(self):
         exporter = self._exporter
         envelope = exporter._log_to_envelope(self._log_data_none)
-        self.assertEqual(envelope.name, "Microsoft.ApplicationInsights.Message")
-        self.assertEqual(envelope.data.base_type, "MessageData")
-        self.assertEqual(envelope.data.base_data.message, "")
+        self.assertEqual(envelope, None)
 
     def test_log_to_envelope_log_empty(self):
         exporter = self._exporter
         envelope = exporter._log_to_envelope(self._log_data_empty)
-        self.assertEqual(envelope.name, "Microsoft.ApplicationInsights.Message")
-        self.assertEqual(envelope.data.base_type, "MessageData")
-        self.assertEqual(envelope.data.base_data.message, "")
+        self.assertEqual(envelope, None)
 
     def test_log_to_envelope_log_complex_body(self):
         exporter = self._exporter


### PR DESCRIPTION
# Description

Bug fix for message field on Microsoft.ApplicationInsights.Message to not export logs with empty message body

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
