### PR TITLE
Modify logic for message body on Microsoft.ApplicationInsights.MessageData to include default message for messages with empty body and export logs

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Modify logic for message body on Microsoft.ApplicationInsights.MessageData to include default message for messages with empty body and export logs
+- Modified logic for message body on Microsoft.ApplicationInsights.MessageData to include default message for messages with empty body and export logs
   ([#43091](https://github.com/Azure/azure-sdk-for-python/pull/43091))
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -326,4 +326,7 @@ _INTEGER_MIN: int = Int32.minval
 
 _DEFAULT_AAD_SCOPE = "https://monitor.azure.com//.default"
 
+# Default message for messages(MessageData) with empty body
+_DEFAULT_LOG_MESSAGE = "n/a"
+
 # cSpell:disable

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -18,6 +18,7 @@ from azure.monitor.opentelemetry.exporter import _utils
 from azure.monitor.opentelemetry.exporter._constants import (
     _EXCEPTION_ENVELOPE_NAME,
     _MESSAGE_ENVELOPE_NAME,
+    _DEFAULT_LOG_MESSAGE,
 )
 from azure.monitor.opentelemetry.exporter._generated.models import (
     ContextTagKeys,
@@ -191,7 +192,7 @@ def _convert_log_to_envelope(log_data: LogData) -> TelemetryItem:
         )
         data.message = data.message.strip()
         if len(data.message) == 0:
-            data.message = "n/a"
+            data.message = _DEFAULT_LOG_MESSAGE
         envelope.data = MonitorBase(base_data=data, base_type="MessageData")
 
     return envelope

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -29,6 +29,7 @@ from azure.monitor.opentelemetry.exporter.export.logs._exporter import (
 from azure.monitor.opentelemetry.exporter._constants import (
     _APPLICATION_INSIGHTS_EVENT_MARKER_ATTRIBUTE,
     _MICROSOFT_CUSTOM_EVENT_NAME,
+    _DEFAULT_LOG_MESSAGE,
 )
 from azure.monitor.opentelemetry.exporter._generated.models import ContextTagKeys
 from azure.monitor.opentelemetry.exporter._utils import (
@@ -424,21 +425,21 @@ class TestAzureLogExporter(unittest.TestCase):
         envelope = exporter._log_to_envelope(self._log_data_none)
         self.assertEqual(envelope.name, "Microsoft.ApplicationInsights.Message")
         self.assertEqual(envelope.data.base_type, "MessageData")
-        self.assertEqual(envelope.data.base_data.message, "n/a")
+        self.assertEqual(envelope.data.base_data.message, _DEFAULT_LOG_MESSAGE)
 
     def test_log_to_envelope_log_empty(self):
         exporter = self._exporter
         envelope = exporter._log_to_envelope(self._log_data_empty)
         self.assertEqual(envelope.name, "Microsoft.ApplicationInsights.Message")
         self.assertEqual(envelope.data.base_type, "MessageData")
-        self.assertEqual(envelope.data.base_data.message, "n/a")
+        self.assertEqual(envelope.data.base_data.message, _DEFAULT_LOG_MESSAGE)
     
     def test_log_to_envelope_log_empty_with_whitespaces(self):
         exporter = self._exporter
         envelope = exporter._log_to_envelope(self._log_data_empty_with_whitespaces)
         self.assertEqual(envelope.name, "Microsoft.ApplicationInsights.Message")
         self.assertEqual(envelope.data.base_type, "MessageData")
-        self.assertEqual(envelope.data.base_data.message, "n/a")
+        self.assertEqual(envelope.data.base_data.message, _DEFAULT_LOG_MESSAGE)
 
     def test_log_to_envelope_log_complex_body(self):
         exporter = self._exporter


### PR DESCRIPTION
# Description

Modify logic in PR (#43060) to include default message for messages with empty body and export logs

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
