### PR TITLE
Retrieve package name from "emitter-output-dir"

### DIFF
--- a/scripts/release_helper/python.py
+++ b/scripts/release_helper/python.py
@@ -147,7 +147,10 @@ class IssueProcessPython(IssueProcess):
         emitters = yaml_contents.get("options", {})
         for emitter_name in emitters:
             if "/typespec-python" in emitter_name:
-                self.package_name = emitters[emitter_name].get("emitter-output-dir", "").split("/")[-1]
+                for dir in ["package-dir", "emitter-output-dir"]:
+                    self.package_name = emitters[emitter_name].get(dir, "").split("/")[-1]
+                    if self.package_name:
+                        break
                 break
 
     @property


### PR DESCRIPTION
Sync the package name retrieval for release helper since the `package-dir` option in tspconfig.yaml has been replaced by `emitter-output-dir`.
