### PR TITLE
[sdk generation pipeline] add `--no` for npx

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -516,7 +516,7 @@ def gen_typespec(
     typespec_python = "@azure-tools/typespec-python"
     # call scirpt to generate sdk
     try:
-        tsp_client = "npx --prefix eng/common/tsp-client tsp-client"
+        tsp_client = "npx --no --prefix eng/common/tsp-client tsp-client"
         if spec_folder:
             tsp_dir = (Path(spec_folder) / typespec_relative_path).resolve()
             repo_url = rest_repo_url.replace("https://github.com/", "")


### PR DESCRIPTION
use `npx --no` option to ask npx do not download and install any extra lib. (this may provide security benefit too – avoid install unintended lib in pipeline)