### PR TITLE
Fix issue with broken `_version` parsing in `ParsedSetup`

### DIFF
--- a/eng/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -47,7 +47,6 @@ EXCLUDE = {
     "scripts",
     "images",
     ".tox"
-    ".venv*"
 }
 
 


### PR DESCRIPTION
[After installing requirements, we became unable to parse a valid version from the package on disk](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5386868&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=5da75d26-b661-5189-46a3-f9dd247b5d85&l=179)

The reason was because we recursively search for a _version.py file, but we were accidentally searching within the venv isolation folder that is created in the package folder: `.venv_pylint`. We were finding a `_version.py`, then returning `0.0.0` because the version didn't match our regex.

This code change prevents us from searching in those temp dirs.