### PR TITLE
Temporarily Disable `whl_no_aio` for `azure-ai-voicelive`

### DIFF
--- a/sdk/ai/azure-ai-voicelive/pyproject.toml
+++ b/sdk/ai/azure-ai-voicelive/pyproject.toml
@@ -76,3 +76,6 @@ pytyped = ["py.typed"]
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
+
+[tool.azure-sdk-build]
+whl_no_aio = false


### PR DESCRIPTION
To unblock other `ai` release.