### PR TITLE
[evaluation] refactor: Make AzureOpenAIGrader.get_token_provider private

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/aoai_grader.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_aoai/aoai_grader.py
@@ -118,7 +118,7 @@ class AzureOpenAIGrader:
                 api_key=api_key,  # Default-style access to appease linters.
                 api_version=DEFAULT_AOAI_API_VERSION,  # Force a known working version
                 azure_deployment=model_config.get("azure_deployment", ""),
-                azure_ad_token_provider=self.get_token_provider(self._credential) if not api_key else None,
+                azure_ad_token_provider=self._get_token_provider(self._credential) if not api_key else None,
                 default_headers=default_headers,
             )
         from openai import OpenAI
@@ -132,7 +132,7 @@ class AzureOpenAIGrader:
         )
 
     @staticmethod
-    def get_token_provider(cred: TokenCredential) -> "AzureADTokenProvider":
+    def _get_token_provider(cred: TokenCredential) -> "AzureADTokenProvider":
         """Get the token provider the AzureOpenAI client.
 
         :param TokenCredential cred: The Azure authentication credential.


### PR DESCRIPTION
# Description

This pull request updates the name of AzureOpenAIGrader.get_token_provider to reflect
that the method isn't meant to be called by users.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
