### PR TITLE
Verify_whl applies to `mgmt` packages

### DIFF
--- a/eng/tox/verify_whl.py
+++ b/eng/tox/verify_whl.py
@@ -90,7 +90,6 @@ def should_verify_package(package_name):
     return (
         package_name not in EXCLUDED_PACKAGES
         and "nspkg" not in package_name
-        and "-mgmt" not in package_name
     )
 
 


### PR DESCRIPTION
See title. Image below shows execution error for `azure-mgmt-compute`. Enabling for `mgmt` packages in general.

@msyyc  just FYI you might see new failures from this. Was asked to execute by @lmazuel 

<img width="1258" height="328" alt="image" src="https://github.com/user-attachments/assets/80bd9f1c-2c05-4f5f-ab8e-7c334bccac2c" />
