### PR TITLE
bump typespec-python 0.52.1

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,63 +6,69 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.52.0"
+        "@azure-tools/typespec-python": "0.52.1"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "~0.60.0",
-        "@azure-tools/typespec-azure-core": "~0.60.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.60.0",
-        "@azure-tools/typespec-azure-rulesets": "~0.60.0",
-        "@azure-tools/typespec-client-generator-core": "~0.60.2",
+        "@azure-tools/typespec-autorest": "~0.61.0",
+        "@azure-tools/typespec-azure-core": "~0.61.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.61.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.61.0",
+        "@azure-tools/typespec-client-generator-core": "~0.61.0",
         "@azure-tools/typespec-liftr-base": "0.10.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/events": "~0.74.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": "~0.74.0",
-        "@typespec/sse": "~0.74.0",
-        "@typespec/streams": "~0.74.0",
-        "@typespec/versioning": "~0.74.0",
-        "@typespec/xml": "~0.74.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/events": "~0.75.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": "~0.75.0",
+        "@typespec/sse": "~0.75.0",
+        "@typespec/streams": "~0.75.0",
+        "@typespec/versioning": "~0.75.0",
+        "@typespec/xml": "~0.75.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.60.0.tgz",
-      "integrity": "sha512-aIRr1e4g3irkjLTpxqzJ8BFnNFYwj4nlcG6cKGPuhNtiHhJgHjUhLVUNIW1A9O4jx+3RSErL9AkAl1ep+ZbiuA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.61.0.tgz",
+      "integrity": "sha512-1/netRFLjltoZaNDJ8QuFzZFtFTyL+u9R+hyU7VsNAgpQy5nn3ax28nO04CdkguQZQ0WGDewZSZW0OhEGCWPOA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.60.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.60.0",
-        "@azure-tools/typespec-client-generator-core": "^0.60.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": "^0.74.0",
-        "@typespec/versioning": "^0.74.0"
+        "@azure-tools/typespec-azure-core": "^0.61.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.61.0",
+        "@azure-tools/typespec-client-generator-core": "^0.61.0",
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": "^0.75.0",
+        "@typespec/versioning": "^0.75.0",
+        "@typespec/xml": "^0.75.0"
+      },
+      "peerDependenciesMeta": {
+        "@typespec/xml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.60.0.tgz",
-      "integrity": "sha512-Pmm7blxnEZZ7lhMJWWsiIqMrFthaCK6uu7f+ONN7dq0Mjc/O9w8+43tAIXwnGz1OKAWmiToh3EDbaxeWyt/FhQ==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.61.0.tgz",
+      "integrity": "sha512-sqOYBUghAtVMBiAWwT3fMRVSDNwR7IU3AQ96n/ErhAthwWjTe7PFVfK/MPjpI1mO3cdyLeS2DGyI3gt/waWP4g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/rest": "^0.74.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/rest": "^0.75.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.60.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.60.1.tgz",
-      "integrity": "sha512-MEmI7NXNRddHYFzzXNH0Y1Izr2tCbJdAgh3LfufM2k8oRiIsXxxQ+n2UDReCAxDQeExFT8pqDq32A9AhL9pNJw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.61.0.tgz",
+      "integrity": "sha512-m/M6AareRXacDwyR82g9DqMppfX0eEsv0/q4PW2Lii7wGVzFiiU6fLqsiWBdIHl7GaKszTRtZXNRk/IL9HV8Lw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -72,33 +78,33 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.60.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": "^0.74.0",
-        "@typespec/versioning": "^0.74.0"
+        "@azure-tools/typespec-azure-core": "^0.61.0",
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": "^0.75.0",
+        "@typespec/versioning": "^0.75.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.60.0.tgz",
-      "integrity": "sha512-4sx9StBWkmnBfLJ9b23RSwCs0TkTElaU9+6a/cS6JS0F7UggP/KLQd6LG59D0u9ByXM2x9pvYPO8l/K7UOXoPg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.61.0.tgz",
+      "integrity": "sha512-EWArbj6dgTz7Xi0mAkp0ru6PoWqfXLHlk8Kt7BzVcHCPojBYK14JW9RYSxBta+h2fAEQTSQu+X1r7Y7PhJE8rA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.60.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.60.0",
-        "@azure-tools/typespec-client-generator-core": "^0.60.0",
-        "@typespec/compiler": "^1.4.0"
+        "@azure-tools/typespec-azure-core": "^0.61.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.61.0",
+        "@azure-tools/typespec-client-generator-core": "^0.61.0",
+        "@typespec/compiler": "^1.5.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.60.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.60.3.tgz",
-      "integrity": "sha512-gcaLRoAJnvqg2tNyEYk+vOMhyP0PJpoZZERuDPB9VLiAAdxl3eTz22vAa3wKvnGFpLDxuvo4+ootEYguRCiwdg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.61.0.tgz",
+      "integrity": "sha512-xm6HXmO2vFJ0BBKrkWGXknNyzhEYQ7eUFhngFMy1Mz7vCTTAprjA/jvtC6GpgjrKwVbmt1aQ0JyGmVKEiwWsMg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -109,16 +115,16 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.60.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/events": "^0.74.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": "^0.74.0",
-        "@typespec/sse": "^0.74.0",
-        "@typespec/streams": "^0.74.0",
-        "@typespec/versioning": "^0.74.0",
-        "@typespec/xml": "^0.74.0"
+        "@azure-tools/typespec-azure-core": "^0.61.0",
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/events": "^0.75.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": "^0.75.0",
+        "@typespec/sse": "^0.75.0",
+        "@typespec/streams": "^0.75.0",
+        "@typespec/versioning": "^0.75.0",
+        "@typespec/xml": "^0.75.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -128,13 +134,13 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.52.0.tgz",
-      "integrity": "sha512-UthujdLMFEnqG8bHNTW7HTd3q4O4uRRTkvHzILwuhScwM+b8zIICY926shdik9j8OGc5sjVLdMkYwu5qPB9Wbg==",
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.52.1.tgz",
+      "integrity": "sha512-CsksbsCVliAVsMrrMK4dgLZa/L+CixveLFz36FbJxa01V5Q0jqDYu4Xj+yfIm9bwO3LZ7rY/HjJ/zBicld3GHg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.19.0",
+        "@typespec/http-client-python": "~0.19.1",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -144,20 +150,20 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.60.2 <1.0.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/events": ">=0.74.0 <1.0.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": ">=0.74.0 <1.0.0",
-        "@typespec/sse": ">=0.74.0 <1.0.0",
-        "@typespec/streams": ">=0.74.0 <1.0.0",
-        "@typespec/versioning": ">=0.74.0 <1.0.0",
-        "@typespec/xml": ">=0.74.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.61.0 <1.0.0",
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/events": ">=0.75.0 <1.0.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": ">=0.75.0 <1.0.0",
+        "@typespec/sse": ">=0.75.0 <1.0.0",
+        "@typespec/streams": ">=0.75.0 <1.0.0",
+        "@typespec/versioning": ">=0.75.0 <1.0.0",
+        "@typespec/xml": ">=0.75.0 <1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -993,9 +999,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.4.0.tgz",
-      "integrity": "sha512-/AFiU3ImuhH/vHKzSGv7I2peewdJ7YLhgMCfFDNk6Ae0a5Ylrc8R1GOATVilisEPBFG9lnjHn3uUcyaZs5VWRw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.5.0.tgz",
+      "integrity": "sha512-REJgZOEZ9g9CC72GGT0+nLbjW+5WVlCfm1d6w18N5RsUo7vLXs8IPXwq7xZJzoqU99Q9B4keqzPuTU4OrDUTrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
@@ -1025,9 +1031,9 @@
       }
     },
     "node_modules/@typespec/compiler/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1037,28 +1043,28 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.74.0.tgz",
-      "integrity": "sha512-CY6JTtheMKAUlxiPmwx2fLIAWEwezsXmQYUMRhyuW44Q73unQIkexE43LUnNWOJSZckYucqUp+ihXh7jxzWeVQ==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.75.0.tgz",
+      "integrity": "sha512-V7unXnj+sZoa/1wQG8G6x2TiQqotx18S/qFbDzdfJRPCVpH/Z3xIpppce4jTZALXT97tKZK5GDHijn2zWuWWxg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0"
+        "@typespec/compiler": "^1.5.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.4.0.tgz",
-      "integrity": "sha512-Y0PDDtBu+oZnwivfhbL0lN6Mk3QiCxZ66DgB5kFjcgKNpnXf0u440PPyaL42a8lbchzz5lVwz+cinyIMI89FIQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.5.0.tgz",
+      "integrity": "sha512-52XLXwqSY2SY6nSvfkiTsNiJzlMeIAZ6MFIVJ5YkoibA21TNAP4DtjTZgC2GieZLY2NNN/rqDCqBX+DyWqTrfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/streams": "^0.74.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/streams": "^0.75.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1067,9 +1073,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.19.0.tgz",
-      "integrity": "sha512-qpRx0iOKPjGXtzLAt+naH4QrzEbxUeHUGLfoaPpvvuT2D00p3BgH+MP4lwg4VU4C1qU7BSTB5FjUhEfMMY5ZaA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.19.1.tgz",
+      "integrity": "sha512-locwViJwAG/hL3ePrzTjc3iPZE2D1AY4A3TFq7X+SGHGb/ayXDanihKiIkGJMZRL1f7ejuTw2KGQZMHdSOhH4w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1083,97 +1089,97 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.60.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.60.2 <1.0.0",
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/events": ">=0.74.0 <1.0.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/openapi": "^1.4.0",
-        "@typespec/rest": ">=0.74.0 <1.0.0",
-        "@typespec/sse": ">=0.74.0 <1.0.0",
-        "@typespec/streams": ">=0.74.0 <1.0.0",
-        "@typespec/versioning": ">=0.74.0 <1.0.0",
-        "@typespec/xml": ">=0.74.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.61.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.61.0 <1.0.0",
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/events": ">=0.75.0 <1.0.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/openapi": "^1.5.0",
+        "@typespec/rest": ">=0.75.0 <1.0.0",
+        "@typespec/sse": ">=0.75.0 <1.0.0",
+        "@typespec/streams": ">=0.75.0 <1.0.0",
+        "@typespec/versioning": ">=0.75.0 <1.0.0",
+        "@typespec/xml": ">=0.75.0 <1.0.0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.4.0.tgz",
-      "integrity": "sha512-ZfrCsmZG/Zt1laLaWC0pKvnZr4jqrm/YS/YuZe/gVrSYKBxGLopXle7H0wrSSMYkIVCNCLiC68/HqRxV6XTfoA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.5.0.tgz",
+      "integrity": "sha512-27sXkSK2r1sAmVMLv+pwlN/Cm+yg9nEK8iuGyJRuEkBk7hcsJDbTnBlsEvlRTI8DqljtzA7YECDHBLK88zZHeg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/http": "^1.4.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/http": "^1.5.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.74.0.tgz",
-      "integrity": "sha512-dE+Xmv01AQ7m8jUvEbGsUQLSVo3sLzMpnHRbQEOnJX42oDqtIsz/2GEOXKQpNm1AKBISK66E2FFB5boz999Ziw==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.75.0.tgz",
+      "integrity": "sha512-rQ+RP0kcrKWjbpCIkBd8hpxYSNc3CfQxl0MLP1+MYGRHlHL8ss4xbwdANIYZXZZ2i2Hqt19B7cEUGD4MLoCHvw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/http": "^1.4.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/http": "^1.5.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.74.0.tgz",
-      "integrity": "sha512-+m7/elbGp7q/kqCGaBRj8v8wVMWKVEV8AsZOjf1PY2MkMUrux9ivOijBIktgoLBXDn+ocO2qVfFrHWG2slZSaw==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.75.0.tgz",
+      "integrity": "sha512-8iODUY3C/0hR9sTzyHeTgYfZkKeqZM+/P0OmN1ZWlLUokXQ67yydGXIqnjl+yaeuntwN8H2DDwLguU15c+j+UQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0",
-        "@typespec/events": "^0.74.0",
-        "@typespec/http": "^1.4.0",
-        "@typespec/streams": "^0.74.0"
+        "@typespec/compiler": "^1.5.0",
+        "@typespec/events": "^0.75.0",
+        "@typespec/http": "^1.5.0",
+        "@typespec/streams": "^0.75.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.74.0.tgz",
-      "integrity": "sha512-LIWizQgzGt8qN8ravte4DrPLPNOk9ge73bV9Us2TOECagTVQWwgMVy7+o/Beff3sOLQO/sEOwfzvmnNpSlauHg==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.75.0.tgz",
+      "integrity": "sha512-ubvxCN+SZwN9aEarz8CPtMJgnopeu8dXyut47q0FAPp9nykmXy7s+dmsopR+7OX0Fhcnh8ZFYTQcJzJ3QftOiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0"
+        "@typespec/compiler": "^1.5.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.74.0.tgz",
-      "integrity": "sha512-eFIa23tycWJgv3Lxyu6jUlRi02dhtQE4Jjx3Ui5vEbwHW8pMEzuyF7ALt1c+V9HOLkfDkS4dJkiOVIoikZHPvQ==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.75.0.tgz",
+      "integrity": "sha512-wdLcVx5UW4WRks/OXfqLiaDTtWfAWgv/nj69u99gRJU6iY9ExEvK5x9NQszZQKYnu6tM7nkoYMg4zu+7YBUBaw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0"
+        "@typespec/compiler": "^1.5.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.74.0.tgz",
-      "integrity": "sha512-NiXatOfpyPxU94f2tEBAygxJeS7CvIr5lvnfZkC0tUHwkiJeLrI1jt13kDVB5CE6zNK6I3d7c37xsQs9WXGFAQ==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.75.0.tgz",
+      "integrity": "sha512-JVafN1nZE3BcQrKbaAFVWw/IleTRdsJpwT3oZ2m7EfWnG30sKtoR9inF9dRoW+XXIjNzCfeYqjkwzEkEnIrCww==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.4.0"
+        "@typespec/compiler": "^1.5.0"
       }
     },
     "node_modules/ajv": {
@@ -1552,9 +1558,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
+      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,23 +1,23 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.52.0"
+    "@azure-tools/typespec-python": "0.52.1"
   },
   "devDependencies": {
-    "@typespec/compiler": "^1.4.0",
-    "@typespec/http": "^1.4.0",
-    "@typespec/rest": "~0.74.0",
-    "@typespec/versioning": "~0.74.0",
-    "@typespec/openapi": "^1.4.0",
-    "@typespec/events": "~0.74.0",
-    "@typespec/sse": "~0.74.0",
-    "@typespec/streams": "~0.74.0",
-    "@typespec/xml": "~0.74.0",
-    "@azure-tools/typespec-azure-core": "~0.60.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.60.0",
-    "@azure-tools/typespec-autorest": "~0.60.0",
-    "@azure-tools/typespec-azure-rulesets": "~0.60.0",
-    "@azure-tools/typespec-client-generator-core": "~0.60.2",
+    "@typespec/compiler": "^1.5.0",
+    "@typespec/http": "^1.5.0",
+    "@typespec/rest": "~0.75.0",
+    "@typespec/versioning": "~0.75.0",
+    "@typespec/openapi": "^1.5.0",
+    "@typespec/events": "~0.75.0",
+    "@typespec/sse": "~0.75.0",
+    "@typespec/streams": "~0.75.0",
+    "@typespec/xml": "~0.75.0",
+    "@azure-tools/typespec-azure-core": "~0.61.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.61.0",
+    "@azure-tools/typespec-autorest": "~0.61.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.61.0",
+    "@azure-tools/typespec-client-generator-core": "~0.61.0",
     "@azure-tools/typespec-liftr-base": "0.10.0"
   }
 }

--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.10.2",
-      "use": ["@autorest/python@6.40.0", "@autorest/modelerfour@4.27.0"],
+      "use": ["@autorest/python@6.41.3", "@autorest/modelerfour@4.27.0"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false,

--- a/swagger_to_sdk_config_dpg.json
+++ b/swagger_to_sdk_config_dpg.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.10.2",
-      "use": ["@autorest/python@6.40.0", "@autorest/modelerfour@4.27.0"]
+      "use": ["@autorest/python@6.41.3", "@autorest/modelerfour@4.27.0"]
     },
     "advanced_options": {
       "create_sdk_pull_requests": true,


### PR DESCRIPTION
Updates @azure-tools/typespec-python from 0.52.0 to 0.52.1 and related TypeSpec dependencies to maintain compatibility.

Changes:
- Updated @azure-tools/typespec-python: 0.52.0 → 0.52.1
- Updated @azure-tools/typespec-autorest: ~0.60.0 → ~0.61.0  
- Updated @azure-tools/typespec-azure-core: ~0.60.0 → ~0.61.0
- Updated @azure-tools/typespec-azure-resource-manager: ~0.60.0 → ~0.61.0
- Updated @azure-tools/typespec-azure-rulesets: ~0.60.0 → ~0.61.0
- Updated @azure-tools/typespec-client-generator-core: ~0.60.2 → ~0.61.0
- Updated @typespec/compiler: ^1.4.0 → ^1.5.0
- Updated @typespec/http: ^1.4.0 → ^1.5.0
- Updated @typespec/openapi: ^1.4.0 → ^1.5.0
- Updated @typespec/rest: ~0.74.0 → ~0.75.0
- Updated @typespec/versioning: ~0.74.0 → ~0.75.0
- Updated @typespec/events: ~0.74.0 → ~0.75.0
- Updated @typespec/sse: ~0.74.0 → ~0.75.0
- Updated @typespec/streams: ~0.74.0 → ~0.75.0
- Updated @typespec/xml: ~0.74.0 → ~0.75.0

This update ensures compatibility between typespec-python and its dependencies, as typespec-python 0.52.1 requires typespec-autorest >=0.61.0.