### PR TITLE
[Core] Add jitter to retry policies

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Features Added
 
 - Added `TypeHandlerRegistry` to `azure.core.serialization` to allow developers to register custom serializers and deserializers for specific types or conditions.  #43051
+- Added `retry_jitter_factor` parameter to `RetryPolicy` and `AsyncRetryPolicy` to introduce randomized jitter in retry backoff delays. This helps avoid the situation where many clients or processes simultaneously retry a failed request and overwhelm a service. The jitter factor defaults to 0.2 (20% jitter) and can be set to 0 to disable jitter entirely.
 
 ### Bugs Fixed
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -506,6 +506,7 @@ from azure.core.pipeline.policies import (
 |  |  | retry_status | x | x | How many times to retry on bad status codes. Default value is `3`. |
 |  |  | retry_backoff_factor | x | x | A backoff factor to apply between attempts after the second try (most errors are resolved immediately by a second try without a delay). Retry policy will sleep for: `{backoff factor} * (2 ** ({number of total retries} - 1))` seconds. If the backoff_factor is 0.1, then the retry will sleep for [0.0s, 0.2s, 0.4s, ...] between retries. The default value is `0.8`. |
 |  |  | retry_backoff_max | x | x | The maximum back off time. Default value is `120` seconds (2 minutes). |
+|  |  | retry_jitter_factor | x | x | The factor to use to calculate the jitter. For example, if the backoff is 1 second with a jitter factor of 0.2, the actual backoff delay used will be a random float between 0.8 and 1.2. If set to 0, no jitter will be applied. Default value is 0.2. |
 |  |  | retry_mode | x | x | Fixed or exponential delay between attempts, default is `exponential`. |
 |  |  | timeout | x | x | Timeout setting for the operation in seconds, default is `604800s` (7 days). |
 | AsyncRetryPolicy | AsyncHTTPPolicy |  |  |  |  |
@@ -515,6 +516,7 @@ from azure.core.pipeline.policies import (
 |  |  | retry_status | x | x | How many times to retry on bad status codes. Default value is `3`. |
 |  |  | retry_backoff_factor | x | x | A backoff factor to apply between attempts after the second try (most errors are resolved immediately by a second try without a delay). Retry policy will sleep for: `{backoff factor} * (2 ** ({number of total retries} - 1))` seconds. If the backoff_factor is 0.1, then the retry will sleep for [0.0s, 0.2s, 0.4s, ...] between retries. The default value is `0.8`. |
 |  |  | retry_backoff_max | x | x | The maximum back off time. Default value is `120` seconds (2 minutes). |
+|  |  | retry_jitter_factor | x | x | The factor to use to calculate the jitter. For example, if the backoff is 1 second with a jitter factor of 0.2, the actual backoff delay used will be a random float between 0.8 and 1.2. If set to 0, no jitter will be applied. Default value is 0.2. |
 |  |  | retry_mode | x | x | Fixed or exponential delay between attempts, default is exponential. |
 |  |  | timeout | x | x | Timeout setting for the operation in seconds, default is `604800s` (7 days). |
 | SensitiveHeaderCleanupPolicy | SansIOHTTPPolicy | | | | |

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
@@ -69,7 +69,12 @@ class AsyncRetryPolicy(RetryPolicyBase, AsyncHTTPPolicy[HTTPRequestType, AsyncHT
      Retry policy will sleep for: `{backoff factor} * (2 ** ({number of total retries} - 1))`
      seconds. If the backoff_factor is 0.1, then the retry will sleep
      for [0.0s, 0.2s, 0.4s, ...] between retries. The default value is 0.8.
+    :keyword float retry_jitter_factor: The factor to use to calculate the jitter. For example, if the backoff is
+     1 second with a jitter factor of 0.2, the actual backoff delay used will be a random float between 0.8 and 1.2.
+     If set to 0, no jitter will be applied. Default value is 0.2.
     :keyword int retry_backoff_max: The maximum back off time. Default value is 120 seconds (2 minutes).
+    :keyword RetryMode retry_mode: Fixed or exponential delay between attempts, default is exponential.
+    :keyword int timeout: Timeout setting for the operation in seconds, default is 604800s (7 days).
 
     .. admonition:: Example:
 

--- a/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License.
 # ------------------------------------
 """Tests for the retry policy."""
+import random
+
 try:
     from io import BytesIO
 except ImportError:
     from cStringIO import StringIO as BytesIO
-import sys
 from unittest.mock import Mock
 import pytest
 from azure.core.configuration import ConnectionConfiguration
@@ -45,7 +46,7 @@ def test_retry_code_class_variables():
 
 def test_retry_types():
     history = ["1", "2", "3"]
-    settings = {"history": history, "backoff": 1, "max_backoff": 10}
+    settings = {"history": history, "backoff": 1, "max_backoff": 10, "jitter": 0}
     retry_policy = AsyncRetryPolicy()
     backoff_time = retry_policy.get_backoff_time(settings)
     assert backoff_time == 4
@@ -298,10 +299,9 @@ combinations = [(ServiceRequestError, ServiceRequestTimeoutError), (ServiceRespo
     product(combinations, HTTP_REQUESTS),
 )
 async def test_does_not_sleep_after_timeout(combinations, http_request):
-    # With default settings policy will sleep twice before exhausting its retries: 1.6s, 3.2s.
-    # It should not sleep the second time when given timeout=1
+    # It should not sleep the second time if timeout was exceeded during the first retry.
     transport_error, expected_timeout_error = combinations
-    timeout = 1
+    timeout = 0.5
 
     transport = Mock(
         spec=AsyncHttpTransport,
@@ -326,6 +326,7 @@ def test_configure_retries_uses_constructor_values():
         retry_status=1,
         retry_backoff_factor=0.5,
         retry_backoff_max=60,
+        retry_jitter_factor=0.3,
         timeout=300,
     )
 
@@ -339,6 +340,7 @@ def test_configure_retries_uses_constructor_values():
     assert retry_settings["status"] == 1
     assert retry_settings["backoff"] == 0.5
     assert retry_settings["max_backoff"] == 60
+    assert retry_settings["jitter"] == 0.3
     assert retry_settings["timeout"] == 300
     assert retry_settings["methods"] == frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
     assert retry_settings["history"] == []
@@ -353,6 +355,7 @@ def test_configure_retries_options_override_constructor():
         retry_read=4,
         retry_status=1,
         retry_backoff_factor=0.5,
+        retry_jitter_factor=0.3,
         retry_backoff_max=60,
         timeout=300,
     )
@@ -365,6 +368,7 @@ def test_configure_retries_options_override_constructor():
         "retry_status": 3,
         "retry_backoff_factor": 1.0,
         "retry_backoff_max": 180,
+        "retry_jitter_factor": 0.4,
         "timeout": 600,
         "retry_on_methods": frozenset(["GET", "POST"]),
     }
@@ -377,6 +381,7 @@ def test_configure_retries_options_override_constructor():
     assert retry_settings["status"] == 3
     assert retry_settings["backoff"] == 1.0
     assert retry_settings["max_backoff"] == 180
+    assert retry_settings["jitter"] == 0.4
     assert retry_settings["timeout"] == 600
     assert retry_settings["methods"] == frozenset(["GET", "POST"])
     assert retry_settings["history"] == []
@@ -388,6 +393,7 @@ def test_configure_retries_options_override_constructor():
     assert "retry_status" not in options
     assert "retry_backoff_factor" not in options
     assert "retry_backoff_max" not in options
+    assert "retry_jitter_factor" not in options
     assert "timeout" not in options
     assert "retry_on_methods" not in options
 
@@ -407,6 +413,169 @@ def test_configure_retries_default_values():
     assert retry_settings["status"] == 3  # default retry_status
     assert retry_settings["backoff"] == 0.8  # default retry_backoff_factor
     assert retry_settings["max_backoff"] == 120  # default retry_backoff_max (BACKOFF_MAX)
+    assert retry_settings["jitter"] == 0.2
     assert retry_settings["timeout"] == 604800  # default timeout
     assert retry_settings["methods"] == frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
     assert retry_settings["history"] == []
+
+
+def test_async_get_backoff_time_with_jitter():
+    """Test that jitter is applied when configured for async retry policy."""
+    random.seed(42)
+
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.2)
+
+    # Test with first attempt (should still apply jitter if history has entries)
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.2}
+
+    # Collect multiple results to verify jitter is working
+    results = []
+    for _ in range(10):
+        backoff_time = retry_policy.get_backoff_time(settings)
+        results.append(backoff_time)
+        # Base backoff is 1.0, jitter is ±0.2, so result should be between 0.8 and 1.2
+        assert 0.8 <= backoff_time <= 1.2
+
+    # Verify we get different values (jitter is working)
+    unique_results = set(results)
+    assert len(unique_results) > 1  # Should have some variation due to jitter
+
+
+def test_async_get_backoff_time_without_jitter():
+    """Test that no jitter is applied when jitter factor is 0 for async retry policy."""
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.0)
+
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.0}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+    assert backoff_time == 1.0  # Should be exactly the base value
+
+
+def test_async_get_backoff_time_jitter_with_exponential_backoff():
+    """Test that jitter works correctly with exponential backoff for async retry policy."""
+    random.seed(123)
+
+    retry_policy = AsyncRetryPolicy(retry_mode=RetryMode.Exponential, retry_jitter_factor=0.1)
+
+    # Test with multiple attempts
+    history = ["attempt1", "attempt2", "attempt3"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.1}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base exponential backoff would be 1.0 * (2 ** (3-1)) = 4.0
+    # With 10% jitter, result should be between 3.6 and 4.4
+    expected_base = 4.0
+    jitter_amount = expected_base * 0.1
+    assert (expected_base - jitter_amount) <= backoff_time <= (expected_base + jitter_amount)
+
+
+def test_async_get_backoff_time_jitter_with_fixed_backoff():
+    """Test that jitter works correctly with fixed backoff for async retry policy."""
+    random.seed(456)
+
+    retry_policy = AsyncRetryPolicy(retry_mode=RetryMode.Fixed, retry_jitter_factor=0.3)
+
+    history = ["attempt1", "attempt2", "attempt3"]
+    settings = {"history": history, "backoff": 2.0, "max_backoff": 10, "jitter": 0.3}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base fixed backoff is 2.0
+    # With 30% jitter, result should be between 1.4 and 2.6
+    assert 1.4 <= backoff_time <= 2.6
+
+
+def test_async_get_backoff_time_jitter_respects_max_backoff():
+    """Test that jitter respects the max_backoff limit for async retry policy."""
+    random.seed(789)
+
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.5)
+
+    # Create a scenario where base backoff would exceed max_backoff
+    history = ["attempt1", "attempt2", "attempt3", "attempt4", "attempt5"]
+    settings = {"history": history, "backoff": 2.0, "max_backoff": 5.0, "jitter": 0.5}  # This will cap the backoff
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base exponential would be 2.0 * (2 ** (5-1)) = 32.0, but capped at 5.0
+    # With 50% jitter on the capped value, result should be between 2.5 and 7.5
+    assert 2.5 <= backoff_time <= 7.5
+
+
+def test_async_get_backoff_time_jitter_prevents_negative_values():
+    """Test that jitter cannot result in negative backoff times for async retry policy."""
+    random.seed(101)
+
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=1.5)  # Very high jitter factor
+
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 0.1, "max_backoff": 10, "jitter": 1.5}  # Very small base backoff
+
+    # Run multiple times to ensure we never get negative values
+    for _ in range(100):
+        backoff_time = retry_policy.get_backoff_time(settings)
+        assert backoff_time >= 0
+
+
+def test_async_get_backoff_time_empty_history():
+    """Test that backoff time is 0 when history is empty for async retry policy."""
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.2)
+
+    settings = {"history": [], "backoff": 1.0, "max_backoff": 10, "jitter": 0.2}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+    assert backoff_time == 0
+
+
+@pytest.mark.asyncio
+async def test_async_sleep_backoff_with_jitter():
+    """Test that async sleep_backoff uses jitter when configured."""
+    random.seed(999)
+
+    class MockAsyncTransport:
+        def __init__(self):
+            self.sleep_times = []
+
+        async def sleep(self, duration):
+            self.sleep_times.append(duration)
+
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.2)
+    transport = MockAsyncTransport()
+
+    # Test with jitter
+    settings = {"history": ["attempt1"], "backoff": 1.0, "max_backoff": 10, "jitter": 0.2}
+
+    await retry_policy._sleep_backoff(settings, transport)
+
+    # Should have slept once with jitter applied
+    assert len(transport.sleep_times) == 1
+    sleep_time = transport.sleep_times[0]
+    assert 0.8 <= sleep_time <= 1.2  # Base backoff of 1.0 with ±20% jitter
+
+
+@pytest.mark.asyncio
+async def test_async_sleep_backoff_without_jitter():
+    """Test that async sleep_backoff works without jitter."""
+
+    class MockAsyncTransport:
+        def __init__(self):
+            self.sleep_times = []
+
+        async def sleep(self, duration):
+            self.sleep_times.append(duration)
+
+    retry_policy = AsyncRetryPolicy(retry_jitter_factor=0.0)
+    transport = MockAsyncTransport()
+
+    # Test without jitter
+    settings = {"history": ["attempt1"], "backoff": 1.0, "max_backoff": 10, "jitter": 0.0}
+
+    await retry_policy._sleep_backoff(settings, transport)
+
+    # Should have slept once with exact backoff time
+    assert len(transport.sleep_times) == 1
+    sleep_time = transport.sleep_times[0]
+    assert sleep_time == 1.0  # Exact base backoff with no jitter

--- a/sdk/core/azure-core/tests/test_retry_policy.py
+++ b/sdk/core/azure-core/tests/test_retry_policy.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 """Tests for the retry policy."""
+import random
+
 try:
     from io import BytesIO
 except ImportError:
@@ -45,8 +47,9 @@ def test_retry_code_class_variables():
 
 
 def test_retry_types():
+    # With this history, the backoff without jitter would be 4
     history = ["1", "2", "3"]
-    settings = {"history": history, "backoff": 1, "max_backoff": 10}
+    settings = {"history": history, "backoff": 1, "max_backoff": 10, "jitter": 0.0}
     retry_policy = RetryPolicy()
     backoff_time = retry_policy.get_backoff_time(settings)
     assert backoff_time == 4
@@ -298,10 +301,9 @@ combinations = [(ServiceRequestError, ServiceRequestTimeoutError), (ServiceRespo
     product(combinations, HTTP_REQUESTS),
 )
 def test_does_not_sleep_after_timeout(combinations, http_request):
-    # With default settings policy will sleep twice before exhausting its retries: 1.6s, 3.2s.
-    # It should not sleep the second time when given timeout=1
+    # It should not sleep the second time if timeout was exceeded during the first retry.
     transport_error, expected_timeout_error = combinations
-    timeout = 1
+    timeout = 0.5
 
     transport = Mock(
         spec=HttpTransport,
@@ -326,6 +328,7 @@ def test_configure_retries_uses_constructor_values():
         retry_status=1,
         retry_backoff_factor=0.5,
         retry_backoff_max=60,
+        retry_jitter_factor=0.4,
         timeout=300,
     )
 
@@ -339,6 +342,7 @@ def test_configure_retries_uses_constructor_values():
     assert retry_settings["status"] == 1
     assert retry_settings["backoff"] == 0.5
     assert retry_settings["max_backoff"] == 60
+    assert retry_settings["jitter"] == 0.4
     assert retry_settings["timeout"] == 300
     assert retry_settings["methods"] == frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
     assert retry_settings["history"] == []
@@ -353,6 +357,7 @@ def test_configure_retries_options_override_constructor():
         retry_read=4,
         retry_status=1,
         retry_backoff_factor=0.5,
+        retry_jitter_factor=0.3,
         retry_backoff_max=60,
         timeout=300,
     )
@@ -364,6 +369,7 @@ def test_configure_retries_options_override_constructor():
         "retry_read": 7,
         "retry_status": 3,
         "retry_backoff_factor": 1.0,
+        "retry_jitter_factor": 0.4,
         "retry_backoff_max": 180,
         "timeout": 600,
         "retry_on_methods": frozenset(["GET", "POST"]),
@@ -377,6 +383,7 @@ def test_configure_retries_options_override_constructor():
     assert retry_settings["status"] == 3
     assert retry_settings["backoff"] == 1.0
     assert retry_settings["max_backoff"] == 180
+    assert retry_settings["jitter"] == 0.4
     assert retry_settings["timeout"] == 600
     assert retry_settings["methods"] == frozenset(["GET", "POST"])
     assert retry_settings["history"] == []
@@ -388,6 +395,7 @@ def test_configure_retries_options_override_constructor():
     assert "retry_status" not in options
     assert "retry_backoff_factor" not in options
     assert "retry_backoff_max" not in options
+    assert "retry_jitter_factor" not in options
     assert "timeout" not in options
     assert "retry_on_methods" not in options
 
@@ -407,6 +415,118 @@ def test_configure_retries_default_values():
     assert retry_settings["status"] == 3  # default retry_status
     assert retry_settings["backoff"] == 0.8  # default retry_backoff_factor
     assert retry_settings["max_backoff"] == 120  # default retry_backoff_max (BACKOFF_MAX)
+    assert retry_settings["jitter"] == 0.2  # default retry_jitter_factor
     assert retry_settings["timeout"] == 604800  # default timeout
     assert retry_settings["methods"] == frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
     assert retry_settings["history"] == []
+
+
+def test_get_backoff_time_with_jitter():
+    """Test that jitter is applied when configured."""
+    random.seed(42)
+
+    retry_policy = RetryPolicy(retry_jitter_factor=0.2)
+
+    # Test with first attempt (should still apply jitter if history has entries)
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.2}
+
+    # Collect multiple results to verify jitter is working
+    results = []
+    for _ in range(10):
+        backoff_time = retry_policy.get_backoff_time(settings)
+        results.append(backoff_time)
+        # Base backoff is 1.0, jitter is ±0.2, so result should be between 0.8 and 1.2
+        assert 0.8 <= backoff_time <= 1.2
+
+    # Verify we get different values (jitter is working)
+    unique_results = set(results)
+    assert len(unique_results) > 1  # Should have some variation due to jitter
+
+
+def test_get_backoff_time_without_jitter():
+    """Test that no jitter is applied when jitter factor is 0."""
+    retry_policy = RetryPolicy(retry_jitter_factor=0.0)
+
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.0}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+    assert backoff_time == 1.0  # Should be exactly the base value
+
+
+def test_get_backoff_time_jitter_with_exponential_backoff():
+    """Test that jitter works correctly with exponential backoff."""
+    random.seed(123)
+
+    retry_policy = RetryPolicy(retry_mode=RetryMode.Exponential, retry_jitter_factor=0.1)
+
+    # Test with multiple attempts
+    history = ["attempt1", "attempt2", "attempt3"]
+    settings = {"history": history, "backoff": 1.0, "max_backoff": 10, "jitter": 0.1}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base exponential backoff would be 1.0 * (2 ** (3-1)) = 4.0
+    # With 10% jitter, result should be between 3.6 and 4.4
+    expected_base = 4.0
+    jitter_amount = expected_base * 0.1
+    assert (expected_base - jitter_amount) <= backoff_time <= (expected_base + jitter_amount)
+
+
+def test_get_backoff_time_jitter_with_fixed_backoff():
+    """Test that jitter works correctly with fixed backoff."""
+    random.seed(456)
+
+    retry_policy = RetryPolicy(retry_mode=RetryMode.Fixed, retry_jitter_factor=0.3)
+
+    history = ["attempt1", "attempt2", "attempt3"]
+    settings = {"history": history, "backoff": 2.0, "max_backoff": 10, "jitter": 0.3}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base fixed backoff is 2.0
+    # With 30% jitter, result should be between 1.4 and 2.6
+    assert 1.4 <= backoff_time <= 2.6
+
+
+def test_get_backoff_time_jitter_respects_max_backoff():
+    """Test that jitter respects the max_backoff limit."""
+    random.seed(789)
+
+    retry_policy = RetryPolicy(retry_jitter_factor=0.5)
+
+    # Create a scenario where base backoff would exceed max_backoff
+    history = ["attempt1", "attempt2", "attempt3", "attempt4", "attempt5"]
+    settings = {"history": history, "backoff": 2.0, "max_backoff": 5.0, "jitter": 0.5}  # This will cap the backoff
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+
+    # Base exponential would be 2.0 * (2 ** (5-1)) = 32.0, but capped at 5.0
+    # With 50% jitter on the capped value, result should be between 2.5 and 7.5
+    assert 2.5 <= backoff_time <= 7.5
+
+
+def test_get_backoff_time_jitter_prevents_negative_values():
+    """Test that jitter cannot result in negative backoff times."""
+    random.seed(101)
+
+    retry_policy = RetryPolicy(retry_jitter_factor=1.5)  # Very high jitter factor
+
+    history = ["attempt1"]
+    settings = {"history": history, "backoff": 0.1, "max_backoff": 10, "jitter": 1.5}  # Very small base backoff
+
+    # Run multiple times to ensure we never get negative values
+    for _ in range(100):
+        backoff_time = retry_policy.get_backoff_time(settings)
+        assert backoff_time >= 0
+
+
+def test_get_backoff_time_empty_history():
+    """Test that backoff time is 0 when history is empty."""
+    retry_policy = RetryPolicy(retry_jitter_factor=0.2)
+
+    settings = {"history": [], "backoff": 1.0, "max_backoff": 10, "jitter": 0.2}
+
+    backoff_time = retry_policy.get_backoff_time(settings)
+    assert backoff_time == 0


### PR DESCRIPTION
## Motivation

In environments where multiple clients across multiple processes are sending requests, we want to avoid the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem) where all these clients are retrying simultaneously. A service could potentially be overwhelmed by synchronized waves of retry attempts.

Jitter can be used to add some randomness to the calculated backoff times to break the synchronization.

## Modifications

1. Added a configurable option `retry_jitter_factor` to `RetryPolicy` and `AsyncRetryPolicy` with a default value of 0.2 (20% jitter).
    - For example, with a calculated backoff time of 6.4s, the retry delay will be 6.4 ± (6.4 × 0.2) = 6.4 ± 1.28 seconds (random value from 5.12s to 7.68s)
2. The first retry is no longer immediate when using exponential backoff. Instead, the first retry will now respect the configured backoff time and jitter factor

**Example retry delays:**

With default values of 0.8 backoff factor and 0.2 jitter factor.

**Before:** 0s 1.6s, 3.2s, 6.4s, 12.8s, ...
**After:** 0.8±0.16s, 1.6±0.32s, 3.2±0.64s, 6.4±1.28s, 12.8±2.56s, ...

## Additional notes

- Python is the only language to use the immediate first retry heuristic. Is this still needed?
- .NET uses a similar jitter algorithm and also has a default jitter factor of 0.2 ([reference](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/DelayStrategy.cs#L25))
- Java uses a similar jitter algorithm but uses a default jitter factor of 0.05 ([reference](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/ExponentialBackoff.java#L49))

## To-do

Determine what the default jitter factor should be?


