### PR TITLE
[azure-iot-deviceprovisioning] fix CHANGELOG

### DIFF
--- a/sdk/iothub/azure-iot-deviceprovisioning/CHANGELOG.md
+++ b/sdk/iothub/azure-iot-deviceprovisioning/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## 1.0.0b1 (2023-06-14)
 
+### Other Changes
+
   - Initial Release


### PR DESCRIPTION
Fix CI failure https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5436679&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=8dd92614-7454-569d-3061-0c20dc3c788d to unblock release of `azure-mgmt-iothubprovisioningservices`

Context: 
https://teams.microsoft.com/l/message/19:4175567f1e154a80ab5b88cbd22ea92f@thread.skype/1760060147585?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1759845174233&teamName=Azure%20SDK&channelName=Language%20-%20Python%20-%20Reviews&createdTime=1760060147585