### PR TITLE
Ignore `Accept-Encoding` during matching

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -299,7 +299,7 @@ def set_common_sanitizers() -> None:
 
     # Remove headers from recordings if we don't need them, and ignore them if present
     # Authorization, for example, can contain sensitive info and can cause matching failures during challenge auth
-    headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id"
+    headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id, Accept-Encoding"
     set_custom_default_matcher(excluded_headers=headers_to_ignore)
     batch_sanitizers[Sanitizer.REMOVE_HEADER] = [{"headers": headers_to_ignore}]
 


### PR DESCRIPTION
By default

[storage test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5442250&view=results)