### PR TITLE
Set AMQP Client Link Max Message Size to 0 for ServiceBus

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -46,6 +46,7 @@ from .constants import (
     OUTGOING_WINDOW,
     DEFAULT_AUTH_TIMEOUT,
     MESSAGE_DELIVERY_DONE_STATES,
+    LINK_MAX_MESSAGE_SIZE
 )
 
 from .management_operation import ManagementOperation

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
@@ -59,6 +59,7 @@ EMPTY_FRAME = b"\x00\x00\x00\x08\x02\x00\x00\x00"
 #: size until they have agreed a definitive maximum frame size for that Connection.
 MIN_MAX_FRAME_SIZE = 512
 MAX_FRAME_SIZE_BYTES = 1024 * 1024
+LINK_MAX_MESSAGE_SIZE = 0
 MAX_CHANNELS = 65535
 INCOMING_WINDOW = 64 * 1024
 OUTGOING_WINDOW = 64 * 1024


### PR DESCRIPTION
This pull request ensures that the EventHub and ServiceBus client link max size is set to 0.
This change prevents any default maximum link size from being applied, which is required for proper client behavior in our environment.

- The client initiates communication by sending an Attach command to the server, including specific configuration settings. Upon receiving this command, the server processes the information, performs a minimum value calculation based on the provided parameters, and then generates a response that is sent back to the client. 
- Our change modifies the client-side request to explicitly send a value of 0 for the maximum message size. By doing this, the server interprets the value as “no limit” on the message size. When the server receives this request, it performs its minimum value calculation based on the requested settings. After completing this calculation, the server enforces its internal 20 MB limit on the message size and returns the resulting configuration back to the client.
