### PR TITLE
Fix prompty
   files for reasoning model compatibility

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Unreleased
+
+### Bugs Fixed
+- Updated prompty files to use `max_completion_tokens` instead of `max_tokens` parameter for compatibility with reasoning models (o1, o3 series). Removed unsupported parameters (`temperature`, `top_p`, `presence_penalty`, `frequency_penalty`) from prompty configurations to ensure proper functioning with OpenAI reasoning models.
 
 ## 1.12.0 (2025-10-02)
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_coherence/coherence.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_coherence/coherence.prompty
@@ -4,11 +4,7 @@ description: Evaluates coherence score for QA scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_fluency/fluency.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_fluency/fluency.prompty
@@ -4,11 +4,7 @@ description: Evaluates fluency score for QA scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_groundedness/groundedness_with_query.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_groundedness/groundedness_with_query.prompty
@@ -4,11 +4,7 @@ description: Evaluates groundedness score for RAG scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_groundedness/groundedness_without_query.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_groundedness/groundedness_without_query.prompty
@@ -4,11 +4,7 @@ description: Evaluates groundedness score for RAG scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_intent_resolution/intent_resolution.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_intent_resolution/intent_resolution.prompty
@@ -4,11 +4,7 @@ description: Evaluates whether user intent was identified and correctly resolved
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: json_object
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_relevance/relevance.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_relevance/relevance.prompty
@@ -4,11 +4,7 @@ description: Evaluates relevance score for QA scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: json_object
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_response_completeness/response_completeness.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_response_completeness/response_completeness.prompty
@@ -4,12 +4,8 @@ description: Evaluates Completeness score for QA scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
+    max_completion_tokens: 800
     seed: 123
-    presence_penalty: 0
-    frequency_penalty: 0
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/retrieval.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_retrieval/retrieval.prompty
@@ -4,11 +4,7 @@ description: Evaluates retrieval quality score for RAG scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 1600
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 1600
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_similarity/similarity.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_similarity/similarity.prompty
@@ -4,11 +4,7 @@ description: Evaluates similarity score for QA scenario
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 1
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 1
     response_format:
       type: text
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_adherence/task_adherence.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_adherence/task_adherence.prompty
@@ -4,11 +4,7 @@ description: Evaluates Task Adherence score
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 800
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 800
     response_format:
       type: json_object
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_completion/task_completion.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_completion/task_completion.prompty
@@ -4,11 +4,7 @@ description: Evaluates whether a task was successfully completed
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 1500
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 1500
     response_format:
       type: json_object
 inputs:

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_tool_call_accuracy/tool_call_accuracy.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_tool_call_accuracy/tool_call_accuracy.prompty
@@ -4,11 +4,7 @@ description: Evaluates Tool Call Accuracy for tool used by agent
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    max_tokens: 3000
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
+    max_completion_tokens: 3000
     response_format:
       type: json_object
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_prompty/task_query_response.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_prompty/task_query_response.prompty
@@ -4,10 +4,6 @@ description: Gets queries and responses from a blob of text
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
     response_format:
       type: json_object
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_prompty/task_simulate.prompty
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_prompty/task_simulate.prompty
@@ -4,10 +4,6 @@ description: Simulates a user to complete a conversation
 model:
   api: chat
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    presence_penalty: 0
-    frequency_penalty: 0
     response_format:
       type: json_object
 


### PR DESCRIPTION
## Description
  This PR fixes compatibility issues with OpenAI reasoning models (o1, o3 series) in prompty configuration files.

  ## Changes
  - Updated `max_tokens` to `max_completion_tokens` parameter in all prompty files
  - Removed unsupported parameters: `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`
  - Updated CHANGELOG.md to document the fix

  ## Problem
  When using reasoning models with `is_reasoning_model=True` parameter in evaluators, users encounter `BadRequestError: Unsupported 
  parameter: 'max_tokens'` because the prompty files still use old parameter names incompatible with reasoning models.

  ## Solution
  Updated 14 prompty configuration files to use the correct parameters for reasoning models.

  ## Affected Files
  - All evaluator prompty files in `_evaluators/`
  - Simulator prompty files in `simulator/_prompty/`

  ## Testing
  Tested with GroundednessEvaluator using Azure OpenAI o1-preview model. Error resolved after applying these changes.

  ## Checklist
  - [x] No breaking changes
  - [x] Updated CHANGELOG.md
  - [x] Changes tested locally
  - [x] Informative commit messages