### PR TITLE
Allow certificate bundling to skip if the proxy url isn't https

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -341,8 +341,9 @@ def start_test_proxy(request) -> None:
     """
 
     repo_root = ascend_to_root(request.node.items[0].module.__file__)
+    requires_https = PROXY_URL.startswith("https://")
 
-    if PROXY_URL.startswith("https://"):
+    if requires_https:
         check_certificate_location(repo_root)
 
     if not PROXY_MANUALLY_STARTED:
@@ -369,7 +370,7 @@ def start_test_proxy(request) -> None:
                 _LOGGER.info("Downloading and starting standalone proxy executable...")
                 tool_name = prepare_local_tool(root)
 
-            if PROXY_URL.startswith("https://"):
+            if requires_https:
                 # Always start the proxy with these two defaults set to allow SSL connection
                 passenv = {
                     "ASPNETCORE_Kestrel__Certificates__Default__Path": os.path.join(


### PR DESCRIPTION
See title. This should get rid of the issue we're seeing [in this failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5448644&view=logs&j=f38e89dc-de31-5f99-2d81-05574a7920d1&t=bc8d2f90-f8ca-50b9-a3b3-1ec5eb488e4f&l=439)

