### PR TITLE
[Test Proxy] Support AARCH64 platform

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -69,7 +69,7 @@ AVAILABLE_TEST_PROXY_BINARIES = {
             "file_name": "test-proxy-standalone-linux-arm64.tar.gz",
             "executable": "Azure.Sdk.Tools.TestProxy",
         },
-        "AARCH64": {
+        "AARCH64": {  # AARCH64 and ARM64 are synonyms; use the ARM binary
             "system": "Linux",
             "machine": "AARCH64",
             "file_name": "test-proxy-standalone-linux-arm64.tar.gz",


### PR DESCRIPTION
# Description

@kashifkhan ran into a case where ARM on Linux was failing to find a proxy binary for his platform:

```
root:proxy_startup.py:283 There are no available standalone proxy binaries for platform "AARCH64"
```

Since AARCH64 and ARM64 are apparently two names for the same platform, I had him try using the ARM binary and just adding AARCH64 to our list of known platforms. It worked for him, so I think we can push this out to other folks in case anyone else hits this.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
