### PR TITLE
Remove ArtifactName parameter from analyze.yml

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -156,7 +156,6 @@ steps:
   - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
-      ArtifactName: "packages_extended"
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 


### PR DESCRIPTION
Removed `ArtifactName` parameter when referencing `validate-all-packages` template since it's not a valid input parameter of [the template](https://github.com/Azure/azure-sdk-for-python/blob/f09c064ca93ff15b832f9ef5713deb31f7eed2da/eng/common/pipelines/templates/steps/validate-all-packages.yml#L1).

I found this issue while updating the `validate-all-packages.yml` to enforce the parameter validation.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5449843&view=logs&j=96791242-dbf3-587e-3a06-ae5af5c1a705&t=b11d0d4c-04ac-577c-b618-37f9a9c1ba79
```
[debug]There is no previous build still inprogress or about to start.
##[error]Start-DevOpsBuild failed with exception:

{
  "$id": "1",
  "customProperties": {
    "ValidationResults": [
      {
        "result": "error",
        "message": "The \u0027stages\u0027 parameter is not a valid StageList."
      },
      {
        "result": "error",
        "message": "/eng/pipelines/templates/steps/analyze.yml (Line: 159, Col: 21): Unexpected parameter \u0027ArtifactName\u0027"
      }
    ]
  },
  "innerException": null,
  "message": "Could not queue the build because there were validation errors or warnings.",
  "typeName": "Microsoft.TeamFoundation.Build.WebApi.BuildRequestValidationFailedException, Microsoft.TeamFoundation.Build2.WebApi",
  "typeKey": "BuildRequestValidationFailedException",
  "errorCode": 0,
  "eventId": 3000
}


```

