### PR TITLE
Fix for `azure-ai-agents` on `3.13`

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -80,7 +80,7 @@ PLATFORM_SPECIFIC_MINIMUM_OVERRIDES = {
         "requests": "2.30.0"
     },
     ">=3.13.0": {
-        "typing-extensions": "4.12.0",
+        "typing-extensions": "4.13.0",
         "aiohttp": "3.10.6"
     }
 }


### PR DESCRIPTION
See title. Could dig deeper as to reasoning but have bigger fish rn.