### PR TITLE
Bugfix for Paginated Query Tests

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_query.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query.py
@@ -617,7 +617,7 @@ class TestQuery(unittest.TestCase):
         
         # Test pagination with max_item_count limiting items per page
         max_items_per_page = 7
-        query = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.value"
+        query = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c['value']"
         query_iterable = created_collection.query_items(
             query=query,
             parameters=[{"name": "@pk", "value": partition_key_value}],

--- a/sdk/cosmos/azure-cosmos/tests/test_query_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_async.py
@@ -664,7 +664,7 @@ class TestQueryAsync(unittest.IsolatedAsyncioTestCase):
         
         # Test pagination with max_item_count limiting items per page
         max_items_per_page = 7
-        query = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.value"
+        query = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c['value']"
         query_iterable = created_collection.query_items(
             query=query,
             parameters=[{"name": "@pk", "value": partition_key_value}],

--- a/sdk/cosmos/azure-cosmos/tests/test_query_cross_partition.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_cross_partition.py
@@ -528,7 +528,7 @@ class TestCrossPartitionQuery(unittest.TestCase):
         
         # Test cross-partition query with max_item_count
         max_items_per_page = 8
-        query = "SELECT * FROM c ORDER BY c.value"
+        query = "SELECT * FROM c ORDER BY c['value']"
         query_iterable = created_collection.query_items(
             query=query,
             enable_cross_partition_query=True,

--- a/sdk/cosmos/azure-cosmos/tests/test_query_cross_partition_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_cross_partition_async.py
@@ -585,7 +585,7 @@ class TestQueryCrossPartitionAsync(unittest.IsolatedAsyncioTestCase):
         
         # Test cross-partition query with max_item_count
         max_items_per_page = 8
-        query = "SELECT * FROM c ORDER BY c.value"
+        query = "SELECT * FROM c ORDER BY c['value']"
         query_iterable = created_collection.query_items(
             query=query,
             max_item_count=max_items_per_page


### PR DESCRIPTION
# Description

The original sql query in the tests was not escaping the reserved keyword value correctly. Once replacing that c.value with c['value'] the tests work as intended. 
