### PR TITLE
Fix broken link for feature request guidance

### DIFF
--- a/doc/dev/issues/resolve_issues_effectively.md
+++ b/doc/dev/issues/resolve_issues_effectively.md
@@ -13,17 +13,15 @@ If you are not familiar with the SDK usage of a service, you can find relevant e
 
 For some common errors, you can check [here](#summary-of-common-errors).
 
-## Feature Request(For users)
+## Feature Request (For users)
 
-See [here][request_a_feature] for more details.
+Python SDKs are automatically generated based on REST API, so we generally do not recommend modifying SDK code manually. If you need a new function, but the SDK does not provide it, you need to open an issue in the [REST API repository](https://github.com/Azure/azure-rest-api-specs/issues) to describe clearly the feature you want.
 
 ## Bug Report (For users)
 
 Please describe the bug in as much detail as possible, such as listing the SDK package name, version and operating system info you use.
 
 If you can provide detailed reproduction steps, it will help us locate and solve the issue.
-
-<hr/>
 
 ## Summary Of Common Errors
 
@@ -73,7 +71,6 @@ When this error occurs, you can check the version of `msrest` and upgrade it to 
 
 
 [sample repo]: https://github.com/Azure-Samples/azure-samples-python-management
-[request_a_feature]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/how_to_request_a_feature_in_sdk.md
 [rest API]: https://github.com/Azure/azure-rest-api-specs
 [rest issue]: https://github.com/Azure/azure-rest-api-specs/issues
 [SDK dependency]: https://github.com/Azure/azure-sdk-for-python/blob/main/shared_requirements.txt


### PR DESCRIPTION
# Description

This fixes a [failing nightly pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5478882&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=daad9aaa-beba-5665-190c-580804cd27d6) by removing a link to a now-removed doc. The gist of the guidance is instead referenced directly.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
