### PR TITLE
Adding test for checking float16 datatype for vector embedding policy

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_vector_policy.py
@@ -461,7 +461,7 @@ class TestVectorPolicy(unittest.TestCase):
             "vectorEmbeddings": [
                 {
                     "path": "/vector1",
-                    "dataType": "float32",
+                    "dataType": "float33",
                     "dimensions": 256,
                     "distanceFunction": "euclidean"
                 }]}


### PR DESCRIPTION
# Description

Added test for checking float16 datatype for vector embedding policy.

Since the test can only be ran with Stage account for now, we are skipping the test with `@unittest.skip`.

Once the backend change is pushed to prod, we will remove the `@unittest.skip`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
