### PR TITLE
[Storage] Update perf test arg parsing to allow for SDK defaults and add max_ge…

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/README.md
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/README.md
@@ -61,9 +61,10 @@ These options are available for all perf tests:
 The options are available for all Blob perf tests:
 - `--size=10240` Size in bytes of data to be transferred in upload or download tests. Default is 10240.
 - `--max-concurrency=1` Number of threads to concurrently upload/download a single operation using the SDK API parameter. Default is 1.
-- `--max-put-size` Maximum size of data uploading in single HTTP PUT. Default is 64\*1024\*1024.
-- `--max-block-size` Maximum size of data in a block within a blob. Defaults to 4\*1024\*1024.
-- `--buffer-threshold` Minimum block size to prevent full block buffering. Defaults to 4\*1024\*1024+1.
+- `--max-put-size` Maximum size of data uploading in single HTTP PUT.
+- `--max-block-size` Maximum size of data in a block within a blob.
+- `--max-get-size` Initial chunk size of a Blob download.
+- `--buffer-threshold` Minimum block size to prevent full block buffering.
 - `--client-encryption` The version of client-side encryption to use. Leave out for no encryption.
 
 #### List Blobs command line options

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -23,9 +23,14 @@ class _ServiceTest(PerfStressTest):
         super().__init__(arguments)
         if self.args.test_proxies:
             self._client_kwargs['_additional_pipeline_policies'] = self._client_kwargs['per_retry_policies']
-        self._client_kwargs['max_single_put_size'] = self.args.max_put_size
-        self._client_kwargs['max_block_size'] = self.args.max_block_size
-        self._client_kwargs['min_large_block_upload_threshold'] = self.args.buffer_threshold
+        if self.args.max_put_size is not None:
+            self._client_kwargs['max_single_put_size'] = self.args.max_put_size
+        if self.args.max_block_size is not None:
+            self._client_kwargs['max_block_size'] = self.args.max_block_size
+        if self.args.max_get_size is not None:
+            self._client_kwargs['max_single_get_size'] = self.args.max_get_size
+        if self.args.buffer_threshold is not None:
+            self._client_kwargs['min_large_block_upload_threshold'] = self.args.buffer_threshold
         if self.args.client_encryption:
             self.key_encryption_key = KeyWrapper()
             self._client_kwargs['require_encryption'] = True
@@ -58,9 +63,10 @@ class _ServiceTest(PerfStressTest):
     @staticmethod
     def add_arguments(parser):
         super(_ServiceTest, _ServiceTest).add_arguments(parser)
-        parser.add_argument('--max-put-size', nargs='?', type=int, help='Maximum size of data uploading in single HTTP PUT. Defaults to 64*1024*1024', default=64*1024*1024)
-        parser.add_argument('--max-block-size', nargs='?', type=int, help='Maximum size of data in a block within a blob. Defaults to 4*1024*1024', default=4*1024*1024)
-        parser.add_argument('--buffer-threshold', nargs='?', type=int, help='Minimum block size to prevent full block buffering. Defaults to 4*1024*1024+1', default=4*1024*1024+1)
+        parser.add_argument('--max-put-size', nargs='?', type=int, help='Maximum size of data uploading in single HTTP PUT. Defaults to SDK default.', default=None)
+        parser.add_argument('--max-block-size', nargs='?', type=int, help='Maximum size of data in a block within a blob. Defaults to SDK default.', default=None)
+        parser.add_argument('--max-get-size', nargs='?', type=int, help='Initial chunk size of a Blob download. Defaults to SDK default.', default=None)
+        parser.add_argument('--buffer-threshold', nargs='?', type=int, help='Minimum block size to prevent full block buffering. Defaults to SDK default.', default=None)
         parser.add_argument('--client-encryption', nargs='?', type=str, help='The version of client-side encryption to use. Leave out for no encryption.', default=None)
         parser.add_argument('--max-concurrency', nargs='?', type=int, help='Maximum number of concurrent threads used for data transfer. Defaults to 1', default=1)
         parser.add_argument('-s', '--size', nargs='?', type=int, help='Size of data to transfer.  Default is 10240.', default=10240)

--- a/sdk/storage/azure-storage-file-share/tests/perfstress_tests/README.md
+++ b/sdk/storage/azure-storage-file-share/tests/perfstress_tests/README.md
@@ -49,7 +49,7 @@ These options are available for all perf tests:
 The options are available for all SB perf tests:
 - `--size=100` Size in bytes of data to be transferred in upload or download tests. Default is 10240.
 - `--max-concurrency=1` Number of threads to concurrently upload/download a single operation using the SDK API parameter. Default is 1.
-- `--max-range-size`Maximum size of data uploading in single HTTP PUT. Default is 4*1024*1024.
+- `--max-range-size`Maximum size of data uploading in single HTTP PUT.
 
 ### T2 Tests
 The tests currently written for the T2 SDK:

--- a/sdk/storage/azure-storage-file-share/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-file-share/tests/perfstress_tests/_test_base.py
@@ -20,7 +20,7 @@ class _ServiceTest(PerfStressTest):
         super().__init__(arguments)
         connection_string = self.get_from_env("AZURE_STORAGE_CONNECTION_STRING")
         kwargs = {}
-        if self.args.max_range_size:
+        if self.args.max_range_size is not None:
             kwargs['max_range_size'] = self.args.max_range_size
         if not _ServiceTest.service_client or self.args.no_client_share:
             _ServiceTest.service_client = SyncShareServiceClient.from_connection_string(conn_str=connection_string, **kwargs)
@@ -35,7 +35,7 @@ class _ServiceTest(PerfStressTest):
     @staticmethod
     def add_arguments(parser):
         super(_ServiceTest, _ServiceTest).add_arguments(parser)
-        parser.add_argument('-r', '--max-range-size', nargs='?', type=int, help='Maximum size of data uploading in single HTTP PUT. Defaults to 4*1024*1024', default=4*1024*1024)
+        parser.add_argument('-r', '--max-range-size', nargs='?', type=int, help='Maximum size of data uploading in single HTTP PUT. Defaults to SDK default.', default=None)
         parser.add_argument('-c', '--max-concurrency', nargs='?', type=int, help='Maximum number of concurrent threads used for data transfer. Defaults to 1', default=1)
         parser.add_argument('-s', '--size', nargs='?', type=int, help='Size of data to transfer.  Default is 10240.', default=10240)
         parser.add_argument('--no-client-share', action='store_true', help='Create one ServiceClient per test instance.  Default is to share a single ServiceClient.', default=False)


### PR DESCRIPTION
Adjust the transfer size arguments of perf tests to default to `None` instead of a fixed value and only add them to client keywords if they are specified. This means that the values will use SDK defaults when not specified which allows us to test SDK defaults, even if they change in the future. Update Blob and File tests.

Also add support for `max_single_get_size` via new perf test argument `--max_get_size`.