### PR TITLE
Improvements to console logging 

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 def _patch_user_agent(user_agent: Optional[str]) -> str:
     # All authenticated external clients exposed by this client will have this application id
     # set on their user-agent. For more info on user-agent HTTP header, see:
@@ -82,7 +83,9 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
     def __init__(self, endpoint: str, credential: TokenCredential, **kwargs: Any) -> None:
 
-        self._console_logging_enabled: bool = (os.environ.get("AZURE_AI_PROJECTS_CONSOLE_LOGGING", "false").lower() == "true")
+        self._console_logging_enabled: bool = (
+            os.environ.get("AZURE_AI_PROJECTS_CONSOLE_LOGGING", "false").lower() == "true"
+        )
 
         if self._console_logging_enabled:
             import sys
@@ -208,7 +211,7 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
                         print(f"  {key}: {value}")
 
                     content = response.read()
-                    if content is None or content == b'':
+                    if content is None or content == b"":
                         print("Body: [No content]")
                     else:
                         try:
@@ -244,7 +247,7 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
                         print(f"Body: [Cannot access content: {access_error}]")
                         return
 
-                    if content is None or content == b'':
+                    if content is None or content == b"":
                         print("Body: [No content]")
                         return
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-instance-attributes
     """AIProjectClient.
 
@@ -67,7 +68,9 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
 
     def __init__(self, endpoint: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
 
-        self._console_logging_enabled: bool = (os.environ.get("AZURE_AI_PROJECTS_CONSOLE_LOGGING", "false").lower() == "true")
+        self._console_logging_enabled: bool = (
+            os.environ.get("AZURE_AI_PROJECTS_CONSOLE_LOGGING", "false").lower() == "true"
+        )
 
         if self._console_logging_enabled:
             import sys
@@ -130,7 +133,6 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
                 "azure.identity package not installed. Please install it using 'pip install azure.identity'"
             ) from e
 
-        # TODO: Test the case where input endpoint URL has "/" at the end
         base_url = self._config.endpoint + "/openai"  # pylint: disable=protected-access
 
         if "default_query" not in kwargs:
@@ -194,7 +196,7 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
                         print(f"  {key}: {value}")
 
                     content = await response.aread()
-                    if content is None or content == b'':
+                    if content is None or content == b"":
                         print("Body: [No content]")
                     else:
                         try:
@@ -230,7 +232,7 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
                         print(f"Body: [Cannot access content: {access_error}]")
                         return
 
-                    if content is None or content == b'':
+                    if content is None or content == b"":
                         print("Body: [No content]")
                         return
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_models.py
@@ -5671,7 +5671,9 @@ class FileSearchTool(Tool, discriminator="file_search"):
         visibility=["read", "create", "update", "delete", "query"]
     )
     """Ranking options for search."""
-    filters: Optional[Union["_models.ComparisonFilter", "_models.CompoundFilter"]] = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    filters: Optional[Union["_models.ComparisonFilter", "_models.CompoundFilter"]] = rest_field(
+        visibility=["read", "create", "update", "delete", "query"]
+    )
     """A filter to apply. Is either a ComparisonFilter type or a CompoundFilter type."""
 
     @overload


### PR DESCRIPTION
Internal customers have reported that they don't see console logs even though they set `AZURE_AI_PROJECTS_CONSOLE_LOGGING=true` in the .env file. This is because, at the moment, logging setup as done when the AIProjectClient is imported from the package azure-ai-projects. This is usually done in sample code BEFORE `load_dotenv()` is called, therefore AZURE_AI_PROJECTS_CONSOLE_LOGGING is read too late.
With this change, I'm moving the logic to set logging into the constructor of AIProjectClient, which comes after `load_dotenv()` is called. This fixes the issue.

Also:
- Update OpenAI request/response logs such that HTTP headers are sorted by header name
- Better logging of the case where OpenAI request or response have no payload.