### PR TITLE
Patching CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -863,4 +863,4 @@
 /eng/emitter-package-lock.json                                       @mccoyp @catalinaperalta @iscai-msft
 
 /pylintrc                                                            @l0lawrence @scbedd @mccoyp
-/sdk/**/ci.yml                                                       @msyyc @lmazuel
+/sdk/**/ci.yml                                                       @msyyc @lmazuel @scbedd


### PR DESCRIPTION
To include `scbedd` as an approver for `sdk/**/ci.yml`.
