### PR TITLE
Build/Analyze ignore package compatibility

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -89,14 +89,14 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.VerifySdist'],'true'))
     inputs:
      scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-     arguments: '"$(TargetingString)" --service=${{parameters.ServiceDirectory}} --toxenv=verifysdist ${{ parameters.AdditionalTestArgs }}'
+     arguments: '"$(TargetingString)" --disable-compatibility-filter --service=${{parameters.ServiceDirectory}} --toxenv=verifysdist ${{ parameters.AdditionalTestArgs }}'
 
   - task: PythonScript@0
     displayName: 'Verify whl'
     condition: and(succeededOrFailed(), ne(variables['Skip.VerifyWhl'],'true'))
     inputs:
      scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-     arguments: '"$(TargetingString)" --service=${{parameters.ServiceDirectory}} --toxenv=verifywhl ${{ parameters.AdditionalTestArgs }}'
+     arguments: '"$(TargetingString)" --disable-compatibility-filter --service=${{parameters.ServiceDirectory}} --toxenv=verifywhl ${{ parameters.AdditionalTestArgs }}'
 
   - template: run_mypy.yml
     parameters:
@@ -123,7 +123,7 @@ steps:
     displayName: 'Run Keyword Validation Check'
     inputs:
       scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-      arguments: '"$(TargetingString)" --service=${{parameters.ServiceDirectory}} --toxenv=verify_keywords ${{ parameters.AdditionalTestArgs }}'
+      arguments: '"$(TargetingString)" --disable-compatibility-filter --service=${{parameters.ServiceDirectory}} --toxenv=verify_keywords ${{ parameters.AdditionalTestArgs }}'
     condition: and(succeededOrFailed(), ne(variables['Skip.KeywordCheck'],'true'))
 
   - template: ../steps/run_bandit.yml

--- a/eng/pipelines/templates/steps/run_bandit.yml
+++ b/eng/pipelines/templates/steps/run_bandit.yml
@@ -17,6 +17,7 @@ steps:
         --mark_arg="${{ parameters.TestMarkArgument }}"
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="bandit"
+        --disable-compatibility-filter
         --disablecov
         ${{ parameters.AdditionalTestArgs }}
     env: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/steps/run_black.yml
+++ b/eng/pipelines/templates/steps/run_black.yml
@@ -14,6 +14,7 @@ steps:
         "$(TargetingString)"
         --service="${{ parameters.ServiceDirectory }}"
         --checks="black"
+        --disable-compatibility-filter
         --filter-type="Omit_management"
         ${{ parameters.AdditionalTestArgs }}
     env:

--- a/eng/pipelines/templates/steps/run_breaking_changes.yml
+++ b/eng/pipelines/templates/steps/run_breaking_changes.yml
@@ -14,6 +14,7 @@ steps:
         --mark_arg="${{ parameters.TestMarkArgument }}"
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="breaking"
+        --disable-compatibility-filter
         --disablecov
     env: ${{ parameters.EnvVars }}
     condition: and(succeededOrFailed(), ne(variables['Skip.BreakingChanges'],'true'))

--- a/eng/pipelines/templates/steps/run_mypy.yml
+++ b/eng/pipelines/templates/steps/run_mypy.yml
@@ -17,6 +17,7 @@ steps:
         --service="${{ parameters.ServiceDirectory }}"
         --checks="mypy"
         --disablecov
+        --disable-compatibility-filter
         ${{ parameters.AdditionalTestArgs }}
     env:
       TOX_PIP_IMPL: "uv"

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -15,6 +15,7 @@ steps:
         "$(TargetingString)"
         --service="${{ parameters.ServiceDirectory }}"
         --checks="pylint"
+        --disable-compatibility-filter
         --filter-type="Omit_management"
         ${{ parameters.AdditionalTestArgs }}
     env:

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -17,6 +17,7 @@ steps:
         --mark_arg="${{ parameters.TestMarkArgument }}"
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="pyright"
+        --disable-compatibility-filter
         --disablecov
         ${{ parameters.AdditionalTestArgs }}
     condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'))
@@ -30,6 +31,7 @@ steps:
         --mark_arg="${{ parameters.TestMarkArgument }}"
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="verifytypes"
+        --disable-compatibility-filter
         --disablecov
         ${{ parameters.AdditionalTestArgs }}
     condition: and(succeededOrFailed(), ne(variables['Skip.Verifytypes'],'true'))

--- a/eng/scripts/dispatch_checks.py
+++ b/eng/scripts/dispatch_checks.py
@@ -318,6 +318,13 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         help="Maximum number of concurrent checks (default: number of CPU cores).",
     )
 
+    parser.add_argument(
+        "--disable-compatibility-filter",
+        dest="disable_compatibility_filter",
+        action="store_true",
+        help="Flag to disable compatibility filter while discovering packages.",
+    )
+
     args = parser.parse_args()
 
     configure_logging(args)
@@ -340,7 +347,7 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         args.filter_type = "Build"
         compatibility_filter = False
     else:
-        compatibility_filter = True
+        compatibility_filter = not args.disable_compatibility_filter
 
     targeted_packages = discover_targeted_packages(
         args.glob_string, target_dir, "", args.filter_type, compatibility_filter

--- a/eng/tools/azure-sdk-tools/ci_tools/build.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/build.py
@@ -161,7 +161,7 @@ def build() -> None:
         target_dir,
         args.package_filter_string,
         filter_type="Build",
-        compatibility_filter=True,
+        compatibility_filter=False,
         include_inactive=args.inactive,
     )
 

--- a/scripts/devops_tasks/dispatch_tox.py
+++ b/scripts/devops_tasks/dispatch_tox.py
@@ -114,6 +114,13 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         help="Location to generate any output files(if any). For e.g. apiview stub file",
     )
 
+    parser.add_argument(
+        "--disable-compatibility-filter",
+        dest="disable_compatibility_filter",
+        action="store_true",
+        help="Flag to disable compatibility filter while discovering packages.",
+    )
+
     args = parser.parse_args()
 
     configure_logging(args)
@@ -132,7 +139,7 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         args.filter_type = "Build"
         compatibility_filter = False
     else:
-        compatibility_filter = True
+        compatibility_filter = not args.disable_compatibility_filter
 
     targeted_packages = discover_targeted_packages(
         args.glob_string, target_dir, "", args.filter_type, compatibility_filter


### PR DESCRIPTION
Context. I'm trying to unblock #43771 . In that PR, there is a package that _does not support_ `3.9`. We _build_ on `python 3.9`. By default, our common package discovery function [will filter packages that](https://github.com/Azure/azure-sdk-for-python/blob/1cf5ad0ce6020a6e1778bea3edeb3c31d932f607/eng/tools/azure-sdk-tools/ci_tools/functions.py#L256) are not compatible with the running interpreter. This means that the package in #43771 isn't compatible with **build**, which is obviously a blocker.

The devs on that PR rightly identified that they could override the [`TEST_COMPATIBILITY_MAP`](https://github.com/Azure/azure-sdk-for-python/blob/1cf5ad0ce6020a6e1778bea3edeb3c31d932f607/eng/tools/azure-sdk-tools/ci_tools/functions.py#L58) to FORCE the common discovery to find their package, but are now blocked on the fact that the package is incompatible with python 3.9 _but still running on 3.9_ because of their override of the `TEST_COMPATIBILITY_MAP` to _build_ the package.

To address their issue, I am making `build` and `analyze` phases totally ignore the running interpreter as far as filtering packages during discovery. I'm doing that by adding a new parameter where one wasn't necessary before.

Once this PR merges, #43771 will merely need to remove their `TEST_COMPATIBILITY_MAP` changes and should be unblocked.

Verification builds:
- [Core](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5539561&view=results)
- [Storage](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5539562&view=results)
- [ai](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5539565&view=results)

