### PR TITLE
[Identity] Update requirements and cryptography CI minimum

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -41,7 +41,7 @@ MINIMUM_VERSION_GENERIC_OVERRIDES = {
     "azure-core": "1.11.0",
     "requests": "2.19.0",
     "six": "1.12.0",
-    "cryptography": "38.0.3",
+    "cryptography": "41.0.0",
     "msal": "1.23.0",
     "azure-storage-file-datalake": "12.2.0",
 }

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,5 +1,5 @@
 ../../core/azure-core
-azure-identity-broker>=1.1.0 ; platform.python_implementation != "PyPy"
+azure-identity-broker>=1.1.0 ; platform.python_implementation != "PyPy" and python_version < '3.14.0'
 aiohttp>=3.0
 typing_extensions>=3.7.2
 -e ../../../eng/tools/azure-sdk-tools

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -76,15 +76,12 @@ class TestVisualStudioCodeCredential:
             os.unlink(tmp_file.name)
 
     def test_broker_credential_requirements_not_installed(self):
-        """Test that the credential w"""
+        """Test that the credential works without the broker installed."""
 
         with patch.dict("sys.modules", {"azure.identity.broker": None}):
-            with patch("azure.identity.broker.InteractiveBrowserBrokerCredential") as mock_credential:
-                with pytest.raises(CredentialUnavailableError):
-                    # This should raise an error because the broker requirements are not installed.
-                    VisualStudioCodeCredential().get_token_info("https://management.azure.com/.default")
-
-        assert mock_credential.call_count == 0, "InteractiveBrowserBrokerCredential should not be instantiated"
+            with pytest.raises(CredentialUnavailableError):
+                # This should raise an error because the broker requirements are not installed.
+                VisualStudioCodeCredential().get_token_info("https://management.azure.com/.default")
 
 
 class TestLoadVSCodeAuthRecord:


### PR DESCRIPTION
PyPy 3.11 needs a later version of cryptography as 2.5 is too old and relies on CPython ABI symbols (PySlice_AdjustIndices) that is no longer supported.

Also disabling the broker package dependency for 3.14 until pymsalruntime can produce 3.14-compat whl files.

