### PR TITLE
Add Env Setup to Copilot Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@
 
 ### RULE 3: VERIFY ENVIRONMENT FIRST
 **REQUIRED CONDITIONS:**
-- **ALWAYS** run the [`azsdk_verify_setup`](../eng/common/instructions/azsdk-tools/verify-setup.instructions.md) tool **BEFORE PROCEEDING WITH OTHER OPERATIONS**, to check the user's development environment setup with the appropriate venv path. Don't fulfill a request until this tool has been run.
+- Always run the [`azsdk_verify_setup`](../eng/common/instructions/azsdk-tools/verify-setup.instructions.md) tool to check the user's development environment setup for using SDK MCP tools. DO NOT PROCEED with running other tools before completing this step. Only skip for queries that don't need tools.
 - To use Azure MCP tool calls, users must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) if not installed, and recommend restarting the IDE to start the MCP server.
 
 ---


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/12592

explicit:
<img width="377" height="603" alt="image" src="https://github.com/user-attachments/assets/0e40b16c-adc7-4f2a-93c6-bb9c1bae42a1" />

before running another tool:
<img width="329" height="485" alt="image" src="https://github.com/user-attachments/assets/74f9914d-35ce-46d9-aef2-a4615c5042b5" />

non-mcp related queries (it doesn't try to run the tool)
<img width="380" height="234" alt="image" src="https://github.com/user-attachments/assets/19204c21-3649-45e6-9eaf-21be8ca363bc" />

<img width="376" height="337" alt="image" src="https://github.com/user-attachments/assets/f8068de0-17cb-4d4e-baf2-9b5c29570fbf" />


ack:
- We want this check to be proactive and happen without explicit invokation. However, currently, Copilot would only remember if the tool is run in the current session, not in newer sessions, so it could be annoying for the user to constantly have to verify setup in new sessions due to a lack of a caching. This will be accepted for Scenario 1 and improved in future iterations
- LLM performs better with the relative link to instructions