### PR TITLE
[Load Testing] Fix broken reference doc links

### DIFF
--- a/sdk/loadtesting/azure-developer-loadtesting/README.md
+++ b/sdk/loadtesting/azure-developer-loadtesting/README.md
@@ -293,7 +293,7 @@ additional questions or comments.
 [default_azure_credential]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity#defaultazurecredential
 [pip]: https://pypi.org/project/pip/
 [azure_sub]: https://azure.microsoft.com/free/
-[api_reference_doc]: https://docs.microsoft.com/rest/api/loadtesting/
+[api_reference_doc]: https://learn.microsoft.com/rest/api/apptesting/loadtest/
 [product_documentation]: https://azure.microsoft.com/services/load-testing/
-[obtaining_data_plane_uri]: https://learn.microsoft.com/rest/api/loadtesting/data-plane-uri
+[obtaining_data_plane_uri]: https://learn.microsoft.com/rest/api/apptesting/loadtest/data-plane-uri
 [python_logging]: https://docs.python.org/3/library/logging.html


### PR DESCRIPTION
# Description

The URL paths for REST API reference docs recently changed, resulting in [broken links](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5546243&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=daad9aaa-beba-5665-190c-580804cd27d6).

This updates the broken links to use the new `/apptesting/loadtest` format.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
