### PR TITLE
Support redirect_uri with a path

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -89,7 +89,7 @@ class InteractiveBrowserCredential(InteractiveCredential):
         redirect_uri: str = ""
         if self._parsed_url:
             try:
-                redirect_uri = "http://{}:{}".format(self._parsed_url.hostname, self._parsed_url.port)
+                redirect_uri = "http://{}:{}{}".format(self._parsed_url.hostname, self._parsed_url.port, self._parsed_url.path)
                 server = self._server_class(self._parsed_url.hostname, self._parsed_url.port, timeout=self._timeout)
             except socket.error as ex:
                 raise CredentialUnavailableError(message="Couldn't start an HTTP server on " + redirect_uri) from ex


### PR DESCRIPTION
Support paths in azure.identity's InteractiveBrowserCredential's redirect_uri.  Resolves https://github.com/Azure/azure-sdk-for-python/issues/43940
