### PR TITLE
Fix broken link. Grab the document from the release/azure-ai-projects/1.0.0 branch instead.

### DIFF
--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -217,7 +217,7 @@ and `sample_agents_browser_automation_async.py`.
 
 ### Breaking Changes
 - enable_auto_function_calls supports positional arguments instead of keyword arguments.
-- Please see the [agents migration guide](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-projects/AGENTS_MIGRATION_GUIDE.md) on how to use `azure-ai-projects` with `azure-ai-agents` package.
+- Please see the [agents migration guide](https://github.com/Azure/azure-sdk-for-python/blob/release/azure-ai-projects/1.0.0/sdk/ai/azure-ai-projects/AGENTS_MIGRATION_GUIDE.md) on how to use `azure-ai-projects` with `azure-ai-agents` package.
   
 ### Features Added
 - Initial version - splits off Azure AI Agents functionality from the Azure AI Projects SDK.


### PR DESCRIPTION
This error was called out by the release pipeline.