### PR TITLE
Change Region of Live Tests

### DIFF
--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -39,7 +39,7 @@ var multiRegionConfiguration = [
     isZoneRedundant: false
   }
   {
-    locationName: 'West US'
+    locationName: 'East US 2'
     provisioningState: 'Succeeded'
     failoverPriority: 1
     isZoneRedundant: false


### PR DESCRIPTION
# Description

Several of our live tests run are failing due to capacity issues in West US. This pr moves our live tests to run on an account on east us 2 vs west us. 