### PR TITLE
bump typespec-python 0.53.2

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,44 +6,44 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.53.1"
+        "@azure-tools/typespec-python": "0.53.2"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "~0.61.0",
-        "@azure-tools/typespec-azure-core": "~0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.61.0",
-        "@azure-tools/typespec-azure-rulesets": "~0.61.0",
-        "@azure-tools/typespec-client-generator-core": "~0.61.0",
-        "@azure-tools/typespec-liftr-base": "0.10.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": "~0.75.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "~0.75.0",
-        "@typespec/sse": "~0.75.0",
-        "@typespec/streams": "~0.75.0",
-        "@typespec/versioning": "~0.75.0",
-        "@typespec/xml": "~0.75.0"
+        "@azure-tools/typespec-autorest": "~0.62.0",
+        "@azure-tools/typespec-azure-core": "~0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.62.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.62.0",
+        "@azure-tools/typespec-client-generator-core": "~0.62.0",
+        "@azure-tools/typespec-liftr-base": "0.11.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": "~0.76.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "~0.76.0",
+        "@typespec/sse": "~0.76.0",
+        "@typespec/streams": "~0.76.0",
+        "@typespec/versioning": "~0.76.0",
+        "@typespec/xml": "~0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.61.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.61.1.tgz",
-      "integrity": "sha512-wv7Pk6c0HfWPTpR3jv5OsgzI0UmxhuriqiHu8X/0SRQBGlL4+Lwbf1UATEkLaqXpqlHZ80p7HKfUZOtDR4/yVg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.62.0.tgz",
+      "integrity": "sha512-XftwipfGGMk9e3qGzbRMBvVpfIqLMJKc8H+XlPHFymnCfexBniZn4Qu2t8nzOVM9fgOoFDjNDzk8W5lf59U5Dg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.61.1",
-        "@azure-tools/typespec-client-generator-core": "^0.61.3",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/versioning": "^0.75.0",
-        "@typespec/xml": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.62.0",
+        "@azure-tools/typespec-client-generator-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/versioning": "^0.76.0",
+        "@typespec/xml": "^0.76.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -52,23 +52,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.61.0.tgz",
-      "integrity": "sha512-sqOYBUghAtVMBiAWwT3fMRVSDNwR7IU3AQ96n/ErhAthwWjTe7PFVfK/MPjpI1mO3cdyLeS2DGyI3gt/waWP4g==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.62.0.tgz",
+      "integrity": "sha512-4LIFqNHhKO1/jiCH0U2rfI+yH7vkWcFuwpjNyRTWXw/YghAI2d+aIEwtT4oM8jWeYR3KUQfA6AqGPRCm90AXYA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/rest": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/rest": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.61.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.61.1.tgz",
-      "integrity": "sha512-+BVZf1OfSZfEaXsOp1ZUCyjjZjC465ieIAr1zEz4yD7KaWGW+yE/w+HXbsRNNw0B52FhgVcWX6iVuvBtMZpNMQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.62.0.tgz",
+      "integrity": "sha512-e8lO9DhIkZJ3+1o2VItq1P4gEcy9EyA5G7AhTz8qICCfU23e5xUAUfscDHYH8JAfuO9vYLvCee/MKY01MQJ0vA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -78,33 +78,33 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/versioning": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/versioning": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.61.0.tgz",
-      "integrity": "sha512-EWArbj6dgTz7Xi0mAkp0ru6PoWqfXLHlk8Kt7BzVcHCPojBYK14JW9RYSxBta+h2fAEQTSQu+X1r7Y7PhJE8rA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.62.0.tgz",
+      "integrity": "sha512-jEsR9ogSYkYxcOc5biEKbwbYS77ffD8avjT8Sbf5r+8VMPZj46uK3V0FaySbtPh+EEgoBrVj2jcbGGKDFrse1A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.61.0",
-        "@azure-tools/typespec-client-generator-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.62.0",
+        "@azure-tools/typespec-client-generator-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.61.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.61.3.tgz",
-      "integrity": "sha512-CUhw8vkMzDTYlRfddQERT0ZEJAtwjKteRNuhs1S3IrDceJlHEiXTK+FpPwen/F5DBbj1w2SgnSFfaJ3fL171/w==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.62.0.tgz",
+      "integrity": "sha512-fZilNfvqIW6Jzb97SuM5f+i9p5b0261InQRbQcTbeuYGtb5z5M0v8tuGglE4adU8NqQ1OmEv/oRjQjSeSjlxwA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -115,32 +115,32 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": "^0.75.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/sse": "^0.75.0",
-        "@typespec/streams": "^0.75.0",
-        "@typespec/versioning": "^0.75.0",
-        "@typespec/xml": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": "^0.76.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/sse": "^0.76.0",
+        "@typespec/streams": "^0.76.0",
+        "@typespec/versioning": "^0.76.0",
+        "@typespec/xml": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.10.0.tgz",
-      "integrity": "sha512-FcF8IusZcS2vvm1J+CzaeZkv15FgcFOSR+YoFdIusnnm+mlcLudM92NupdxZnuobPYcfZzq+rRvylxzzgWky7A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.11.0.tgz",
+      "integrity": "sha512-XwHRt6GnmTT51iHHUxyFPts6LnhOE+IkANCkh3lhnDdZjHgr5asA3+NXI8UXHbKmAOLReb+eov8tBoN93aS0Ww==",
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.53.1.tgz",
-      "integrity": "sha512-D7C+i9SO2sybatIVQCIQITAmskNfvaCyE8hfFe8pg8WCW8epTfFjp7XCYaQa99VnYyHhrQgwjRmkVh/7rz1/Ew==",
+      "version": "0.53.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.53.2.tgz",
+      "integrity": "sha512-LCkWr3l9B6InpQ02fNjzs7CA85vZ+KjC+t2+4TtbK8IlxLaXqs/IGsTU82Xoza0sE90bWmzh0VJQQpy0u1ckIw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.20.2",
+        "@typespec/http-client-python": "~0.20.3",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -150,20 +150,20 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.61.0 <1.0.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": ">=0.75.0 <1.0.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": ">=0.75.0 <1.0.0",
-        "@typespec/sse": ">=0.75.0 <1.0.0",
-        "@typespec/streams": ">=0.75.0 <1.0.0",
-        "@typespec/versioning": ">=0.75.0 <1.0.0",
-        "@typespec/xml": ">=0.75.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.62.0 <1.0.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": ">=0.76.0 <1.0.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": ">=0.76.0 <1.0.0",
+        "@typespec/sse": ">=0.76.0 <1.0.0",
+        "@typespec/streams": ">=0.76.0 <1.0.0",
+        "@typespec/versioning": ">=0.76.0 <1.0.0",
+        "@typespec/xml": ">=0.76.0 <1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -606,25 +606,25 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
-      "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.0.tgz",
-      "integrity": "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -639,13 +639,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.19",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.19.tgz",
-      "integrity": "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -660,19 +660,19 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
-      "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
         "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -687,14 +687,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
-      "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/external-editor": "^1.0.2",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -709,14 +709,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.21.tgz",
-      "integrity": "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -731,12 +731,12 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "license": "MIT",
       "dependencies": {
-        "chardet": "^2.1.0",
+        "chardet": "^2.1.1",
         "iconv-lite": "^0.7.0"
       },
       "engines": {
@@ -752,22 +752,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
-      "integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -782,13 +782,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.21.tgz",
-      "integrity": "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -803,14 +803,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.21.tgz",
-      "integrity": "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -825,21 +825,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.9.0.tgz",
-      "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.0",
-        "@inquirer/confirm": "^5.1.19",
-        "@inquirer/editor": "^4.2.21",
-        "@inquirer/expand": "^4.0.21",
-        "@inquirer/input": "^4.2.5",
-        "@inquirer/number": "^3.0.21",
-        "@inquirer/password": "^4.0.21",
-        "@inquirer/rawlist": "^4.1.9",
-        "@inquirer/search": "^3.2.0",
-        "@inquirer/select": "^4.4.0"
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
       },
       "engines": {
         "node": ">=18"
@@ -854,14 +854,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.9.tgz",
-      "integrity": "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/type": "^3.0.9",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -876,15 +876,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.0.tgz",
-      "integrity": "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -899,16 +899,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
-      "integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -923,9 +923,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
-      "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -987,9 +987,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -999,9 +999,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.5.0.tgz",
-      "integrity": "sha512-REJgZOEZ9g9CC72GGT0+nLbjW+5WVlCfm1d6w18N5RsUo7vLXs8IPXwq7xZJzoqU99Q9B4keqzPuTU4OrDUTrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.6.0.tgz",
+      "integrity": "sha512-yxyV+ch8tnqiuU2gClv/mQEESoFwpkjo6177UkYfV0nVA9PzTg4zVVc7+WIMZk04wiLRRT3H1uc11FB1cwLY3g==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
@@ -1009,13 +1009,13 @@
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "env-paths": "^3.0.0",
-        "globby": "~14.1.0",
+        "globby": "~15.0.0",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
         "prettier": "~3.6.2",
         "semver": "^7.7.1",
-        "tar": "^7.4.3",
+        "tar": "^7.5.2",
         "temporal-polyfill": "^0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
@@ -1043,28 +1043,28 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.75.0.tgz",
-      "integrity": "sha512-V7unXnj+sZoa/1wQG8G6x2TiQqotx18S/qFbDzdfJRPCVpH/Z3xIpppce4jTZALXT97tKZK5GDHijn2zWuWWxg==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.76.0.tgz",
+      "integrity": "sha512-mdjYQ5HA3Y4ZeyAEmiIDdRa9hbc/5qey5hU9UCA0gL+YWVYgoqLPbZQQTwqq3smM35+5cWp9GTGPyNHcOoRwOA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.5.0.tgz",
-      "integrity": "sha512-52XLXwqSY2SY6nSvfkiTsNiJzlMeIAZ6MFIVJ5YkoibA21TNAP4DtjTZgC2GieZLY2NNN/rqDCqBX+DyWqTrfQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.6.0.tgz",
+      "integrity": "sha512-q/JwVw21CF4buE3ZS+xSoy2TKAOwyhZ7g3kdNqCgm69BI5p5GGu+3ZlUA+4Blk8hkt0G8XcIN8fhJP+a4O6KAw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/streams": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/streams": "^0.76.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1073,9 +1073,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.20.2.tgz",
-      "integrity": "sha512-v3rG3hBY4HGTna0kULDio+2tHV8t4yf8IGrEWDgvXtlghliAHQ92DVIlbT8mnSFsOGPni9YtB0IkkMDt2csPOg==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.20.3.tgz",
+      "integrity": "sha512-bIpra3zxh/MfDvyUhWjJYP6EoyQL12MIC3TPDUedas2AmJGys+tX3CUzYLY1zQj1DrtimLz4KyhOs6b0kl+Vbg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1089,97 +1089,97 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.61.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.61.0 <1.0.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": ">=0.75.0 <1.0.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": ">=0.75.0 <1.0.0",
-        "@typespec/sse": ">=0.75.0 <1.0.0",
-        "@typespec/streams": ">=0.75.0 <1.0.0",
-        "@typespec/versioning": ">=0.75.0 <1.0.0",
-        "@typespec/xml": ">=0.75.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.62.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.62.0 <1.0.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": ">=0.76.0 <1.0.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": ">=0.76.0 <1.0.0",
+        "@typespec/sse": ">=0.76.0 <1.0.0",
+        "@typespec/streams": ">=0.76.0 <1.0.0",
+        "@typespec/versioning": ">=0.76.0 <1.0.0",
+        "@typespec/xml": ">=0.76.0 <1.0.0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.5.0.tgz",
-      "integrity": "sha512-27sXkSK2r1sAmVMLv+pwlN/Cm+yg9nEK8iuGyJRuEkBk7hcsJDbTnBlsEvlRTI8DqljtzA7YECDHBLK88zZHeg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.6.0.tgz",
+      "integrity": "sha512-KuxYAzfP5ljM0PUhSGclNZgTG0H+kyTQcwn6cf4TKhO72R2QMQmiMtN2plqvzsfkL+TLwad1iZhMWTCAMFAQ4w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.75.0.tgz",
-      "integrity": "sha512-rQ+RP0kcrKWjbpCIkBd8hpxYSNc3CfQxl0MLP1+MYGRHlHL8ss4xbwdANIYZXZZ2i2Hqt19B7cEUGD4MLoCHvw==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.76.0.tgz",
+      "integrity": "sha512-6jtQWdcmuKyG9cmqWsJjaq64f6N5B/1DS4X3ZoTNgYhHA27Hnsxo1HZWXcpv7Wl+MxLAZM6kgpML0ugDEZcrYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.75.0.tgz",
-      "integrity": "sha512-8iODUY3C/0hR9sTzyHeTgYfZkKeqZM+/P0OmN1ZWlLUokXQ67yydGXIqnjl+yaeuntwN8H2DDwLguU15c+j+UQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.76.0.tgz",
+      "integrity": "sha512-mCd4oAXr0Tt990T2PDjx+6H0jmPHINyCH0XRU2HrWtGW5lG/NQVIs5oOxElc7NGg629HrolfLTw0oW8hdMD7Eg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": "^0.75.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/streams": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": "^0.76.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/streams": "^0.76.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.75.0.tgz",
-      "integrity": "sha512-ubvxCN+SZwN9aEarz8CPtMJgnopeu8dXyut47q0FAPp9nykmXy7s+dmsopR+7OX0Fhcnh8ZFYTQcJzJ3QftOiQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.76.0.tgz",
+      "integrity": "sha512-7gQPtsokyn0Mjr43MAik6ZkQt1PZjseU+KcBE2iGT9P6oWYYTH3K1C4LLGXHZAbgEtBvFn4S+U8HPbDhj4nEhw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.75.0.tgz",
-      "integrity": "sha512-wdLcVx5UW4WRks/OXfqLiaDTtWfAWgv/nj69u99gRJU6iY9ExEvK5x9NQszZQKYnu6tM7nkoYMg4zu+7YBUBaw==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.76.0.tgz",
+      "integrity": "sha512-dguO/B+mwlCyenWGG+M+16cMQuGHSTJbU5Z0pyUou1uyWrB1px//s4pW7PKD14S+fPutJE0wTMQm+CctOq6quA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.75.0.tgz",
-      "integrity": "sha512-JVafN1nZE3BcQrKbaAFVWw/IleTRdsJpwT3oZ2m7EfWnG30sKtoR9inF9dRoW+XXIjNzCfeYqjkwzEkEnIrCww==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.76.0.tgz",
+      "integrity": "sha512-+I7hdWZDO3qBfzRT3St+1Dg/NQAMNLz8w1OydutSnVMx0G3KWg/ESonaByszBUfdq6Z5iTtls3gvj4wgrw80gA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/ajv": {
@@ -1582,20 +1582,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-15.0.0.tgz",
+      "integrity": "sha512-oB4vkQGqlMl682wL1IlWd02tXCbquGWM4voPEI85QmNKCaw8zGTm1f1rubFgkg3Eli2PtKlFgrnmUqasbQWlkw==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
+        "ignore": "^7.0.5",
         "path-type": "^6.0.0",
         "slash": "^5.1.0",
         "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1690,9 +1690,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,23 +1,23 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.53.1"
+    "@azure-tools/typespec-python": "0.53.2"
   },
   "devDependencies": {
-    "@typespec/compiler": "^1.5.0",
-    "@typespec/http": "^1.5.0",
-    "@typespec/rest": "~0.75.0",
-    "@typespec/versioning": "~0.75.0",
-    "@typespec/openapi": "^1.5.0",
-    "@typespec/events": "~0.75.0",
-    "@typespec/sse": "~0.75.0",
-    "@typespec/streams": "~0.75.0",
-    "@typespec/xml": "~0.75.0",
-    "@azure-tools/typespec-azure-core": "~0.61.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.61.0",
-    "@azure-tools/typespec-autorest": "~0.61.0",
-    "@azure-tools/typespec-azure-rulesets": "~0.61.0",
-    "@azure-tools/typespec-client-generator-core": "~0.61.0",
-    "@azure-tools/typespec-liftr-base": "0.10.0"
+    "@typespec/compiler": "^1.6.0",
+    "@typespec/http": "^1.6.0",
+    "@typespec/rest": "~0.76.0",
+    "@typespec/versioning": "~0.76.0",
+    "@typespec/openapi": "^1.6.0",
+    "@typespec/events": "~0.76.0",
+    "@typespec/sse": "~0.76.0",
+    "@typespec/streams": "~0.76.0",
+    "@typespec/xml": "~0.76.0",
+    "@azure-tools/typespec-azure-core": "~0.62.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.62.0",
+    "@azure-tools/typespec-autorest": "~0.62.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.62.0",
+    "@azure-tools/typespec-client-generator-core": "~0.62.0",
+    "@azure-tools/typespec-liftr-base": "0.11.0"
   }
 }


### PR DESCRIPTION
Bump @azure-tools/typespec-python to 0.53.2 in eng/emitter-package.json and regenerate emitter-package-lock.json via npm-check-updates and tsp-client generate-lock-file.