### PR TITLE
Remove custom matrix defs from agentserver

### DIFF
--- a/sdk/agentserver/ci.yml
+++ b/sdk/agentserver/ci.yml
@@ -32,15 +32,6 @@ extends:
     TestProxy: true
     BuildDocs: true
     TestTimeoutInMinutes: 60
-    # The job "Test ubuntu2404_pypy39" in the "python - agentserver" pipeline hangs and eventually times out.
-    # Disable it until the issue is understood.
-    MatrixConfigs:
-      - Name: communication_ci_matrix
-        Path: sdk/agentserver/platform-matrix.json
-        Selection: sparse
-        GenerateVMJobs: true
-    MatrixFilters:
-      - PythonVersion=^(?!pypy3).*
     Artifacts:
     - name: azure-ai-agentserver-core
       safeName: azureaiagentservercore


### PR DESCRIPTION
They are facing a failure on pypy311 due to missing dependency. Let's repro here and see what's available to resolve on pypi.

The conflict is that the dependency tree for `openai` doesn't universally support `pypy311` (or previous `pypy39`).

On my local pypy install, I face:

```
semick@CPC-scbed-QJJWS:~/repo/azure-sdk-for-python/sdk/agentserver/azure-ai-agentserver-langgraph$ unblock-agentserver-packages|>uv pip install dev_requirements.txt
? `dev_requirements.txt` looks like a local requirements file but was passed as a package name. Did you mean `-r dev_require✔ `dev_requirements.txt` looks like a local requirements file but was passed as a package name. Did you mean `-r dev_requirements.txt`? · yes
Using Python 3.11.13 environment at: /home/semick/repo/azure-sdk-for-python/venv
Resolved 83 packages in 1.73s
      Built azure-ai-agentserver-core @ file:///home/semick/repo/azure-sdk-for-python/sdk/agentserver/azure-ai-agentserver-core
  × Failed to build `jiter==0.12.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)

      [stdout]
      Running `maturin pep517 build-wheel -i /home/semick/.cache/uv/builds-v0/.tmpdhJkTd/bin/python --compatibility off`

      [stderr]
      info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
      info: latest update on 2025-11-10, rust version 1.91.1 (ed61e7d7e 2025-11-07)
      error: process didn't exit successfully: `/home/semick/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc
      -vV` (exit status: 127)
      --- stderr
      /home/semick/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc: error while loading shared libraries:
      librustc_driver-453cf35e1dd187fa.so: cannot open shared object file: No such file or directory

      💥 maturin failed
        Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
        Caused by: `cargo metadata` exited with an error:
      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/home/semick/.cache/uv/builds-v0/.tmpdhJkTd/bin/python',
      '--compatibility', 'off'] returned non-zero exit status 1

      hint: This usually indicates a problem with the package or the build environment.
  help: `jiter` (v0.12.0) was included because `azure-ai-agentserver-core` (v1.0.0b1) depends on `openai` (v2.8.0) which
        depends on `jiter`
```
        
And the same package (azure-ai-agentserver-langgraph) in CI faces a [similar error](https://dev.azure.com/azure-sdk/public/public%20Team/_build/results?buildId=5569688&view=logs&j=d049a9a1-4a4a-5c37-2173-6c4a695afdc9&t=7ee882b8-a8b9-5189-4d4c-cc3267cbaadd&l=3072) for the `openai` dependency `orjson`.

I believe these dependencies have limited compatibility while assembling for pypy311.
