### PR TITLE
Unblock `agentserver` CI for regular PRs

### DIFF
--- a/sdk/agentserver/ci.yml
+++ b/sdk/agentserver/ci.yml
@@ -32,15 +32,13 @@ extends:
     TestProxy: true
     BuildDocs: true
     TestTimeoutInMinutes: 60
-    # The job "Test ubuntu2404_pypy39" in the "python - agentserver" pipeline hangs and eventually times out.
+    # The job "Test ubuntu2404_pypy311" in the "python - agentserver" pipeline hangs and eventually times out.
     # Disable it until the issue is understood.
     MatrixConfigs:
-      - Name: communication_ci_matrix
+      - Name: agentserver
         Path: sdk/agentserver/platform-matrix.json
         Selection: sparse
         GenerateVMJobs: true
-    MatrixFilters:
-      - PythonVersion=^(?!pypy3).*
     Artifacts:
     - name: azure-ai-agentserver-core
       safeName: azureaiagentservercore

--- a/sdk/agentserver/platform-matrix.json
+++ b/sdk/agentserver/platform-matrix.json
@@ -1,6 +1,62 @@
 {
+  "displayNames": {
+    "--disablecov": "",
+    "false": "",
+    "true": ""
+  },
   "matrix": {
-    "$IMPORT": "eng/pipelines/templates/stages/platform-matrix.json",
-    "InstallPortAudio": [ "1" ]
-  }
+    "Agent": {
+      "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" },
+      "windows-2022": { "OSVmImage": "env:WINDOWSVMIMAGE", "Pool": "env:WINDOWSPOOL" }
+    },
+    "PythonVersion": [ "3.10", "3.12" ],
+    "CoverageArg": "--disablecov",
+    "TestSamples": "false"
+  },
+  "include": [
+    {
+      "MacTestConfig": {
+        "macos311": {
+          "OSVmImage": "env:MACVMIMAGE",
+          "Pool": "env:MACPOOL",
+          "PythonVersion": "3.11",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false"
+        }
+      }
+    },
+    {
+      "CoverageConfig": {
+        "ubuntu2404_39_coverage": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "PythonVersion": "3.9",
+          "CoverageArg": "",
+          "TestSamples": "false"
+        }
+      }
+    },
+    {
+      "Config": {
+        "Ubuntu2404_313": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "PythonVersion": "3.13",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false"
+        }
+      }
+    },
+    {
+      "Config": {
+        "Ubuntu2404_314": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "PythonVersion": "3.14",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Investigating blocking issue in #44006

It's just spinning attempting to find a package it can build. Since they're already skipping pypy311 in their release builds I'm just mirroring that here.