### PR TITLE
Fix PowerShell command for file listing

### DIFF
--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -38,7 +38,7 @@ extends:
               Inline: |
                 echo "azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true"
                 azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
-                $copiedFiles = (dir '$(Artifacts)' -r | % { $_.FullName })
+                $copiedFiles = (dir -LiteralPath '$(Artifacts)' -r | % { $_.FullName })
                 echo "Copied files: $copiedFiles"
                 if (!$copiedFiles) {
                   echo "Failed to copy any files from 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' please double check they exist"


### PR DESCRIPTION
Seeing issues where nothing is copied and we don't correctly fail. That is because if nothing copies the default `Path` parameter has this weird behavior and tries to match things with the name of the last component.  See https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.5#notes

Which in the case of python finds `D:\a\_work\1\s\sdk\synapse\azure-synapse-artifacts\azure\synapse\artifacts` so we always have a file even though it wasn't copied.