### PR TITLE
[azure-ai-agents] Fix typos in docstrings (missing periods)

### DIFF
--- a/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_operations.py
+++ b/sdk/ai/azure-ai-agents/azure/ai/agents/aio/operations/_operations.py
@@ -1337,7 +1337,7 @@ class RunsOperations:
         :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls whether or not and which tool is called by the model. Is one of
          the following types: str, Union[str, "_models.AgentsToolChoiceOptionMode"],
-         AgentsNamedToolChoice Default value is None.
+         AgentsNamedToolChoice. Default value is None.
         :paramtype tool_choice: str or str or ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
          ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format that the model must output. Is one of the
@@ -1511,7 +1511,7 @@ class RunsOperations:
         :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls whether or not and which tool is called by the model. Is one of
          the following types: str, Union[str, "_models.AgentsToolChoiceOptionMode"],
-         AgentsNamedToolChoice Default value is None.
+         AgentsNamedToolChoice. Default value is None.
         :paramtype tool_choice: str or str or ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
          ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format that the model must output. Is one of the
@@ -4834,7 +4834,7 @@ class _AgentsClientOperationsMixin(
         :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls whether or not and which tool is called by the model. Is one of
          the following types: str, Union[str, "_models.AgentsToolChoiceOptionMode"],
-         AgentsNamedToolChoice Default value is None.
+         AgentsNamedToolChoice. Default value is None.
         :paramtype tool_choice: str or str or ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
          ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format that the model must output. Is one of the
@@ -4968,7 +4968,7 @@ class _AgentsClientOperationsMixin(
         :paramtype truncation_strategy: ~azure.ai.agents.models.TruncationObject
         :keyword tool_choice: Controls whether or not and which tool is called by the model. Is one of
          the following types: str, Union[str, "_models.AgentsToolChoiceOptionMode"],
-         AgentsNamedToolChoice Default value is None.
+         AgentsNamedToolChoice. Default value is None.
         :paramtype tool_choice: str or str or ~azure.ai.agents.models.AgentsToolChoiceOptionMode or
          ~azure.ai.agents.models.AgentsNamedToolChoice
         :keyword response_format: Specifies the format that the model must output. Is one of the


### PR DESCRIPTION
# Description

Added missing periods in docstrings for `tool_choice` and `response_format` parameters in `_operations.py`.
Found these typos while looking into issue #43748.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
