### PR TITLE
[Identity] Add envvar to toggle SP live test skip

### DIFF
--- a/sdk/identity/azure-identity/tests/conftest.py
+++ b/sdk/identity/azure-identity/tests/conftest.py
@@ -63,6 +63,8 @@ def record_imds_test(request):
 @pytest.fixture()
 def live_service_principal():
     """Fixture for live Identity tests. Skips them when environment configuration is incomplete."""
+    if os.environ.get("AZURE_SKIP_SP_LIVE_TESTS", "False").lower() == "true":
+        pytest.skip("Skipping live service principal tests as per AZURE_SKIP_SP_LIVE_TESTS environment variable.")
     missing_variables = [
         v
         for v in (

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -15,6 +15,7 @@ extends:
         PEM_CONTENT: $(python-identity-certificate)
         AZURE_TEST_RUN_LIVE: true
         AZURE_SKIP_LIVE_RECORDING: 'True'
+        AZURE_SKIP_SP_LIVE_TESTS: 'True'
       CloudConfig:
         Public:
           SubscriptionConfigurations:


### PR DESCRIPTION
For security reasons, a service principal for testing is unavailable during CI live test runs. A toggle was added to more easily toggle these tests, and it is set to True by default (SP tests are skipped).

