### PR TITLE
Dropping support for Python 3.7 and 3.8 for azure-ai-ml

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Ensuring that azureml-dataprep-rslex is only installed for PyPy below 3.10 and CPython below 3.13.
 - Adding support for Python 3.14.
+- Dropping support for Python 3.7 and 3.8.
 
 ## 1.30.0 (2025-10-29)
 

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -46,8 +46,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
# Description
For Azure SDK, 3.9 and later is supported:
<img width="800" height="443" alt="image" src="https://github.com/user-attachments/assets/40684811-e780-4288-9305-f4e399c1c886" /> 

Complying with the same for azure-ai-ml sdk package.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
