### PR TITLE
Add McCoy back to tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -843,6 +843,7 @@
 ###########
 /eng/                                                                @scbedd @weshaggard @benbp
 /eng/common/                                                         @Azure/azure-sdk-eng
+/eng/tools/                                                          @scbedd @mccoyp
 /.github/workflows/                                                  @Azure/azure-sdk-eng
 /.github/CODEOWNERS                                                  @lmazuel @xiangyan99 @kashifkhan @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                     @l0lawrence @praveenkuttappan @maririos
@@ -852,7 +853,6 @@
 /.devcontainer/                                                      @scbedd @mccoyp @benbp @weshaggard
 /.vscode/                                                            @scbedd @mccoyp @benbp @weshaggard
 
-/tools/                                                              @scbedd @mccoyp
 /scripts/                                                            @scbedd @mccoyp
 /scripts/breaking_changes_checker/                                   @catalinaperalta
 /doc/                                                                @scbedd @mccoyp


### PR DESCRIPTION
Jacob pointed out we didn't update codeowners when we moved azure-sdk-tools.