### PR TITLE
Exporter release 1.0.0b46

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 1.0.0b46 (Unreleased)
-
-### Features Added
+## 1.0.0b46 (2025-12-04)
 
 ### Breaking Changes
 - Fix to accommodate breaking log changes from Otel


### PR DESCRIPTION
## 1.0.0b46 (2025-12-04)

### Breaking Changes
- Fix to accommodate breaking log changes from Otel
  ([#43626](https://github.com/Azure/azure-sdk-for-python/pull/43626))
- Pin OpenTelemetry versions to guard against upstream logging breaking changes
  ([#44220](https://github.com/Azure/azure-sdk-for-python/pull/44220))

### Bugs Fixed
- Fixes LogDeprecated warnings - `LogDeprecatedInitWarning: LogRecord init with trace_id, span_id, and/or trace_flags is deprecated since 1.35.0. Use context instead`
  ([#44090](https://github.com/Azure/azure-sdk-for-python/pull/44090))
- Fixes issue #43442: SyntaxWarning: 'return' in a 'finally' block in azure-monitor-opentelemetry-exporter with Python 3.14
  ([#44053](https://github.com/Azure/azure-sdk-for-python/pull/44053))

### Other Changes
- Commented OneSettings configuration manager temporarily to avoid user impact during feature testing.
  ([#44179](https://github.com/Azure/azure-sdk-for-python/pull/44179))
