### PR TITLE
Fix two warnings in devtools_testutils folder

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
@@ -68,7 +68,7 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
                 user_auth = use_pwsh == "true" or use_cli == "true" or use_azd == "true"
                 if not user_auth:
                     # All variables are required for service principal authentication
-                    _logger.warn(
+                    _logger.warning(
                         "Environment variables for service principal credentials are not all set. "
                         "Please either set the variables or request user-based authentication by setting "
                         "an 'AZURE_TEST_USE_X_AUTH' environment variable to 'true'. See "

--- a/eng/tools/azure-sdk-tools/devtools_testutils/preparers.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/preparers.py
@@ -6,6 +6,7 @@
 import contextlib
 import functools
 import logging
+import inspect
 from collections import namedtuple
 from threading import Lock
 
@@ -145,7 +146,7 @@ You must specify use_cache=True in the preparer decorator""".format(
                 except ImportError:
                     fn(test_class_instance, **trimmed_kwargs)
                 else:
-                    if asyncio.iscoroutinefunction(fn):
+                    if inspect.iscoroutinefunction(fn):
                         asyncio.run(fn(test_class_instance, **trimmed_kwargs))
                     else:
                         fn(test_class_instance, **trimmed_kwargs)


### PR DESCRIPTION
When I run my tests (Python version 3.14) I keep getting the two warnings below. Fixing them in this PR

```
============================================================================================ test session starts ============================================================================================
platform win32 -- Python 3.14.0, pytest-9.0.1, pluggy-1.6.0
rootdir: e:\src\sdk-repos\azure-sdk-for-python
configfile: setup.cfg
plugins: anyio-4.11.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 2 items

tests\agents\tools\test_agent_image_generation.py .                                                                                                                                                    [ 50%]
tests\agents\tools\test_agent_image_generation_async.py .                                                                                                                                              [100%]

============================================================================================= warnings summary ==============================================================================================
sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation.py::TestAgentImageGeneration::test_agent_image_generation
sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation_async.py::TestAgentImageGenerationAsync::test_agent_image_generation_async
  E:\src\sdk-repos\azure-sdk-for-python-2\eng\tools\azure-sdk-tools\devtools_testutils\envvariable_loader.py:71: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    _logger.warn(

sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation.py::TestAgentImageGeneration::test_agent_image_generation
sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation_async.py::TestAgentImageGenerationAsync::test_agent_image_generation_async
  E:\src\sdk-repos\azure-sdk-for-python-2\eng\tools\azure-sdk-tools\devtools_testutils\preparers.py:148: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(fn):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 2 passed, 4 warnings in 71.62s (0:01:11) ==================================================================================
```