### PR TITLE
bump typespec-python 0.56.0

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.55.0"
+        "@azure-tools/typespec-python": "0.56.0"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "~0.63.0",
@@ -134,13 +134,13 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.55.0.tgz",
-      "integrity": "sha512-uMB94SDCaWy4EW/EApVwmW6+d6QPK9ii3VmfGdaOCwXyC20If62cIfYiHZCwQT3Nr7VJQBpHHiBYi9G4FjUWgw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.56.0.tgz",
+      "integrity": "sha512-PBAMl+BJf8+s+CQPWXpsYOx8CUWa9zx+RQ7r479vWKdU0YsbkuMGtiRWjjfhAdI0N7yZvGcFyqVogYt4O1CqBw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.22.0",
+        "@typespec/http-client-python": "~0.23.0",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -615,13 +615,13 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.2.tgz",
-      "integrity": "sha512-iTPV4tMMct7iOpwer5qmTP7gjnk1VQJjsNfAaC2b8Q3qiuHM3K2yjjDr5u1MKfkrvp2JD4Flf8sIPpF21pmZmw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.3.tgz",
+      "integrity": "sha512-xtQP2eXMFlOcAhZ4ReKP2KZvDIBb1AnCfZ81wWXG3DXLVH0f0g4obE0XDPH+ukAEMRcZT0kdX2AS1jrWGXbpxw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.2",
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/figures": "^2.0.2",
         "@inquirer/type": "^4.0.2"
       },
@@ -638,12 +638,12 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.2.tgz",
-      "integrity": "sha512-A0/13Wyi+8iFeNDX6D4zZYKPoBLIEbE4K/219qHcnpXMer2weWvaTo63+2c7mQPPA206DEMSYVOPnEw3meOlCw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.3.tgz",
+      "integrity": "sha512-lyEvibDFL+NA5R4xl8FUmNhmu81B+LDL9L/MpKkZlQDJZXzG8InxiqYxiAlQYa9cqLLhYqKLQwZqXmSTqCLjyw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.0.2.tgz",
-      "integrity": "sha512-lgMRx/n02ciiNELBvFLHtmcjbV5tf5D/I0UYfCg2YbTZWmBZ10/niLd3IjWBxz8LtM27xP+4oLEa06Slmb7p7A==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.0.tgz",
+      "integrity": "sha512-+jD/34T1pK8M5QmZD/ENhOfXdl9Zr+BrQAUc5h2anWgi7gggRq15ZbiBeLoObj0TLbdgW7TAIQRU2boMc9uOKQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.2",
@@ -685,12 +685,12 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.2.tgz",
-      "integrity": "sha512-pXQ4Nf0qmFcJuYB6NlcIIxH6l6zKOwNg1Jh/ZRdKd2dTqBB4OXKUFbFwR2K4LVXVtq15ZFFatBVT+rerYR8hWQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.3.tgz",
+      "integrity": "sha512-wYyQo96TsAqIciP/r5D3cFeV8h4WqKQ/YOvTg5yOfP2sqEbVVpbxPpfV3LM5D0EP4zUI3EZVHyIUIllnoIa8OQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/external-editor": "^2.0.2",
         "@inquirer/type": "^4.0.2"
       },
@@ -707,12 +707,12 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.2.tgz",
-      "integrity": "sha512-siFG1swxfjFIOxIcehtZkh+KUNB/YCpyfHNEGu+nC/SBXIbgUWibvThLn/WesSxLRGOeSKdNKoTm+GQCKFm6Ww==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.3.tgz",
+      "integrity": "sha512-2oINvuL27ujjxd95f6K2K909uZOU2x1WiAl7Wb1X/xOtL8CgQ1kSxzykIr7u4xTkXkXOAkCuF45T588/YKee7w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -758,12 +758,12 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.2.tgz",
-      "integrity": "sha512-hN2YRo1QiEc9lD3mK+CPnTS4TK2RhCMmMmP4nCWwTkmQL2vx9jPJWYk+rbUZpwR1D583ZJk1FI3i9JZXIpi/qg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.3.tgz",
+      "integrity": "sha512-4R0TdWl53dtp79Vs6Df2OHAtA2FVNqya1hND1f5wjHWxZJxwDMSNB1X5ADZJSsQKYAJ5JHCTO+GpJZ42mK0Otw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -779,12 +779,12 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.2.tgz",
-      "integrity": "sha512-4McnjTSYrlthNW1ojkkmP75WLRYhQs7GXm6pDDoIrHqJuV5uUYwfdbB0geHdaKMarAqJQgoOVjzIT0jdWCsKew==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.3.tgz",
+      "integrity": "sha512-TjQLe93GGo5snRlu83JxE38ZPqj5ZVggL+QqqAF2oBA5JOJoxx25GG3EGH/XN/Os5WOmKfO8iLVdCXQxXRZIMQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -800,13 +800,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.2.tgz",
-      "integrity": "sha512-oSDziMKiw4G2e4zS+0JRfxuPFFGh6N/9yUaluMgEHp2/Yyj2JGwfDO7XbwtOrxVrz+XsP/iaGyWXdQb9d8A0+g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.3.tgz",
+      "integrity": "sha512-rCozGbUMAHedTeYWEN8sgZH4lRCdgG/WinFkit6ZPsp8JaNg2T0g3QslPBS5XbpORyKP/I+xyBO81kFEvhBmjA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.2",
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -822,21 +822,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.0.2.tgz",
-      "integrity": "sha512-2zK5zY48fZcl6+gG4eqOC/UzZsJckHCRvjXoLuW4D8LKOCVGdcJiSKkLnumSZjR/6PXPINDGOrGHqNxb+sxJDg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.1.0.tgz",
+      "integrity": "sha512-LsZMdKcmRNF5LyTRuZE5nWeOjganzmN3zwbtNfcs6GPh3I2TsTtF1UYZlbxVfhxd+EuUqLGs/Lm3Xt4v6Az1wA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.0.2",
-        "@inquirer/confirm": "^6.0.2",
-        "@inquirer/editor": "^5.0.2",
-        "@inquirer/expand": "^5.0.2",
-        "@inquirer/input": "^5.0.2",
-        "@inquirer/number": "^4.0.2",
-        "@inquirer/password": "^5.0.2",
-        "@inquirer/rawlist": "^5.0.2",
-        "@inquirer/search": "^4.0.2",
-        "@inquirer/select": "^5.0.2"
+        "@inquirer/checkbox": "^5.0.3",
+        "@inquirer/confirm": "^6.0.3",
+        "@inquirer/editor": "^5.0.3",
+        "@inquirer/expand": "^5.0.3",
+        "@inquirer/input": "^5.0.3",
+        "@inquirer/number": "^4.0.3",
+        "@inquirer/password": "^5.0.3",
+        "@inquirer/rawlist": "^5.1.0",
+        "@inquirer/search": "^4.0.3",
+        "@inquirer/select": "^5.0.3"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -851,12 +851,12 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.0.2.tgz",
-      "integrity": "sha512-AcNALEdQKUQDeJcpC1a3YC53m1MLv+sMUS+vRZ8Qigs1Yg3Dcdtmi82rscJplogKOY8CXkKW4wvVwHS2ZjCIBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.1.0.tgz",
+      "integrity": "sha512-yUCuVh0jW026Gr2tZlG3kHignxcrLKDR3KBp+eUgNz+BAdSeZk0e18yt2gyBr+giYhj/WSIHCmPDOgp1mT2niQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/type": "^4.0.2"
       },
       "engines": {
@@ -872,12 +872,12 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.0.2.tgz",
-      "integrity": "sha512-hg63w5toohdzE65S3LiGhdfIL0kT+yisbZARf7zw65PvyMUTutTN3eMAvD/B6y/25z88vTrB7kSB45Vz5CbrXg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.0.3.tgz",
+      "integrity": "sha512-lzqVw0YwuKYetk5VwJ81Ba+dyVlhseHPx9YnRKQgwXdFS0kEavCz2gngnNhnMIxg8+j1N/rUl1t5s1npwa7bqg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/figures": "^2.0.2",
         "@inquirer/type": "^4.0.2"
       },
@@ -894,13 +894,13 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.0.2.tgz",
-      "integrity": "sha512-JygTohvQxSNnvt7IKANVlg/eds+yN5sLRilYeGc4ri/9Aqi/2QPoXBMV5Cz/L1VtQv63SnTbPXJZeCK2pSwsOA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.0.3.tgz",
+      "integrity": "sha512-M+ynbwS0ecQFDYMFrQrybA0qL8DV0snpc4kKevCCNaTpfghsRowRY7SlQBeIYNzHqXtiiz4RG9vTOeb/udew7w==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.2",
-        "@inquirer/core": "^11.0.2",
+        "@inquirer/core": "^11.1.0",
         "@inquirer/figures": "^2.0.2",
         "@inquirer/type": "^4.0.2"
       },
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.22.0.tgz",
-      "integrity": "sha512-wA94VWecB5mRsS1RqYjQqZR9hFmQhgtBmp+YFjebBkbmNEcW/+tPH2hl4R5pZ8gCOxbMpz0YF4Ut7QuXFlaaqA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.23.0.tgz",
+      "integrity": "sha512-6iPSAAaPiG7dPkIlKs51RPoVNtW9J61/lvtb7II52MFk9LGUloxvoV+vxBcyFZsF23IyE/nRWgMNR7+VvNqy4Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1505,9 +1505,9 @@
       "license": "ISC"
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.55.0"
+    "@azure-tools/typespec-python": "0.56.0"
   },
   "devDependencies": {
     "@typespec/compiler": "^1.7.0",


### PR DESCRIPTION
This PR bumps @azure-tools/typespec-python from 0.55.0 to 0.56.0.

Updated files:
- eng/emitter-package.json
- eng/emitter-package-lock.json