### PR TITLE
refactor install and test

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/install_and_test.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/install_and_test.py
@@ -107,10 +107,18 @@ class InstallAndTest(Check):
             exit(coverage_result.returncode)
 
     def run_pytest(
-        self, executable: str, staging_directory: str, package_dir: str, package_name: str, pytest_args: List[str]
+        self,
+        executable: str,
+        staging_directory: str,
+        package_dir: str,
+        package_name: str,
+        pytest_args: List[str],
+        cwd: Optional[str] = None,
     ) -> None:
         pytest_command = ["-m", "pytest", *pytest_args]
-        pytest_result = self.run_venv_command(executable, pytest_command, cwd=staging_directory, immediately_dump=True)
+        pytest_result = self.run_venv_command(
+            executable, pytest_command, cwd=(cwd or staging_directory), immediately_dump=True
+        )
         if pytest_result.returncode != 0:
             if pytest_result.returncode == 5 and is_error_code_5_allowed(package_dir, package_name):
                 logger.info(

--- a/eng/tools/azure-sdk-tools/azpysdk/install_and_test.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/install_and_test.py
@@ -60,30 +60,9 @@ class InstallAndTest(Check):
             logger.info(f"Processing {package_name} using interpreter {executable}")
 
             try:
-                self._install_common_requirements(executable, package_dir)
-                if self.should_install_dev_requirements():
-                    self.install_dev_reqs(executable, args, package_dir)
-                self.after_dependencies_installed(executable, package_dir, staging_directory, args)
+                self.install_all_requiremenmts(executable, staging_directory, package_name, package_dir, args)
             except CalledProcessError as exc:
-                logger.error(f"Failed to prepare dependencies for {package_name}: {exc}")
-                results.append(exc.returncode)
-                continue
-
-            try:
-                create_package_and_install(
-                    distribution_directory=staging_directory,
-                    target_setup=package_dir,
-                    skip_install=False,
-                    cache_dir=None,
-                    work_dir=staging_directory,
-                    force_create=False,
-                    package_type=self.package_type,
-                    pre_download_disabled=False,
-                    python_executable=executable,
-                )
-            except CalledProcessError as exc:
-                logger.error(f"Failed to build/install {self.package_type} for {package_name}: {exc}")
-                results.append(1)
+                results.append(exc.returncode or 1)
                 continue
 
             try:
@@ -94,46 +73,83 @@ class InstallAndTest(Check):
                 continue
 
             pytest_args = self._build_pytest_args(package_dir, args)
-            pytest_command = ["-m", "pytest", *pytest_args]
-            pytest_result = self.run_venv_command(
-                executable, pytest_command, cwd=staging_directory, immediately_dump=True
-            )
-
-            if pytest_result.returncode != 0:
-                if pytest_result.returncode == 5 and is_error_code_5_allowed(package_dir, package_name):
-                    logger.info(
-                        "pytest exited with code 5 for %s, which is allowed for management or opt-out packages.",
-                        package_name,
-                    )
-                    # Align with tox: skip coverage when tests are skipped entirely
-                    continue
-                else:
-                    results.append(pytest_result.returncode)
-                    logger.error(f"pytest failed for {package_name} with exit code {pytest_result.returncode}.")
-                    continue
+            try:
+                self.run_pytest(executable, staging_directory, package_dir, package_name, pytest_args)
+            except CalledProcessError as exc:
+                results.append(exc.returncode or 1)
+                continue
 
             if not self.coverage_enabled:
                 continue
 
-            coverage_command = [
-                os.path.join(REPO_ROOT, "eng/tox/run_coverage.py"),
-                "-t",
-                package_dir,
-                "-r",
-                REPO_ROOT,
-            ]
-            coverage_result = self.run_venv_command(executable, coverage_command, cwd=package_dir)
-            if coverage_result.returncode != 0:
-                logger.error(
-                    f"Coverage generation failed for {package_name} with exit code {coverage_result.returncode}."
-                )
-                if coverage_result.stdout:
-                    logger.error(coverage_result.stdout)
-                if coverage_result.stderr:
-                    logger.error(coverage_result.stderr)
-                results.append(coverage_result.returncode)
-
+            try:
+                self.check_coverage(executable, package_dir, package_name)
+            except CalledProcessError as exc:
+                results.append(exc.returncode or 1)
+                continue
         return max(results) if results else 0
+
+    def check_coverage(self, executable: str, package_dir: str, package_name: str) -> None:
+        coverage_command = [
+            os.path.join(REPO_ROOT, "eng/tox/run_coverage.py"),
+            "-t",
+            package_dir,
+            "-r",
+            REPO_ROOT,
+        ]
+        coverage_result = self.run_venv_command(executable, coverage_command, cwd=package_dir)
+        if coverage_result.returncode != 0:
+            logger.error(f"Coverage generation failed for {package_name} with exit code {coverage_result.returncode}.")
+            if coverage_result.stdout:
+                logger.error(coverage_result.stdout)
+            if coverage_result.stderr:
+                logger.error(coverage_result.stderr)
+            exit(coverage_result.returncode)
+
+    def run_pytest(
+        self, executable: str, staging_directory: str, package_dir: str, package_name: str, pytest_args: List[str]
+    ) -> None:
+        pytest_command = ["-m", "pytest", *pytest_args]
+        pytest_result = self.run_venv_command(executable, pytest_command, cwd=staging_directory, immediately_dump=True)
+        if pytest_result.returncode != 0:
+            if pytest_result.returncode == 5 and is_error_code_5_allowed(package_dir, package_name):
+                logger.info(
+                    "pytest exited with code 5 for %s, which is allowed for management or opt-out packages.",
+                    package_name,
+                )
+                # Align with tox: skip coverage when tests are skipped entirely
+                return
+            else:
+                logger.error(f"pytest failed for {package_name} with exit code {pytest_result.returncode}.")
+                exit(pytest_result.returncode)
+
+    def install_all_requiremenmts(
+        self, executable: str, staging_directory: str, package_name: str, package_dir: str, args: argparse.Namespace
+    ) -> None:
+        try:
+            self._install_common_requirements(executable, package_dir)
+            if self.should_install_dev_requirements():
+                self.install_dev_reqs(executable, args, package_dir)
+            self.after_dependencies_installed(executable, package_dir, staging_directory, args)
+        except CalledProcessError as exc:
+            logger.error(f"Failed to prepare dependencies for {package_name}: {exc}")
+            exit(exc.returncode or 1)
+
+        try:
+            create_package_and_install(
+                distribution_directory=staging_directory,
+                target_setup=package_dir,
+                skip_install=False,
+                cache_dir=None,
+                work_dir=staging_directory,
+                force_create=False,
+                package_type=self.package_type,
+                pre_download_disabled=False,
+                python_executable=executable,
+            )
+        except CalledProcessError as exc:
+            logger.error(f"Failed to build/install {self.package_type} for {package_name}: {exc}")
+            exit(1)
 
     def get_env_defaults(self) -> Dict[str, str]:
         defaults: Dict[str, str] = {}

--- a/eng/tools/azure-sdk-tools/azpysdk/optional.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/optional.py
@@ -9,11 +9,9 @@ from .install_and_test import InstallAndTest
 from ci_tools.functions import (
     install_into_venv,
     uninstall_from_venv,
-    is_error_code_5_allowed,
 )
-from ci_tools.scenario.generation import create_package_and_install, prepare_environment
-from ci_tools.variables import discover_repo_root, in_ci, set_envvar_defaults
-from ci_tools.environment_exclusions import is_check_enabled
+from ci_tools.scenario.generation import prepare_environment
+from ci_tools.variables import discover_repo_root, set_envvar_defaults
 from ci_tools.parsing import get_config_setting
 from ci_tools.logging import logger
 
@@ -64,13 +62,6 @@ class optional(InstallAndTest):
             package_name = parsed.name
             executable, staging_directory = self.get_executable(args.isolate, args.command, sys.executable, package_dir)
             logger.info(f"Processing {package_name} using interpreter {executable}")
-
-            # try:
-            #     self.install_dev_reqs(executable, args, package_dir)
-            # except CalledProcessError as exc:
-            #     logger.error(f"Failed to install dependencies for {package_name}: {exc}")
-            #     results.append(exc.returncode)
-            #     continue
 
             try:
                 self.prepare_and_test_optional(package_name, package_dir, staging_directory, args.optional, args)

--- a/eng/tools/azure-sdk-tools/azpysdk/optional.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/optional.py
@@ -64,7 +64,11 @@ class optional(InstallAndTest):
             logger.info(f"Processing {package_name} using interpreter {executable}")
 
             try:
-                self.prepare_and_test_optional(package_name, package_dir, staging_directory, args.optional, args)
+                result = self.prepare_and_test_optional(
+                    package_name, package_dir, staging_directory, args.optional, args
+                )
+                if result != 0:
+                    results.append(result)
             except Exception as e:
                 logger.error(f"Optional check for package {package_name} failed with exception: {e}")
                 results.append(1)
@@ -76,7 +80,7 @@ class optional(InstallAndTest):
     # TODO remove pytest() function from ci_tools.functions as it was only used in the old version of this logic
     def prepare_and_test_optional(
         self, package_name: str, package_dir: str, temp_dir: str, target_env_name: str, args: argparse.Namespace
-    ) -> None:
+    ) -> int:
         """
         Prepare and test the optional environment for the given package.
         """
@@ -87,7 +91,7 @@ class optional(InstallAndTest):
 
         if len(optional_configs) == 0:
             logger.info(f"No optional environments detected in pyproject.toml within {package_dir}.")
-            exit(0)
+            return 0
 
         config_results = []
 
@@ -172,7 +176,6 @@ class optional(InstallAndTest):
 
         if all(config_results):
             logger.info(f"All optional environment(s) for {package_name} completed successfully.")
-            exit(0)
         else:
             for i, config in enumerate(optional_configs):
                 if i >= len(config_results):
@@ -182,4 +185,5 @@ class optional(InstallAndTest):
                     logger.error(
                         f"Optional environment {config_name} for {package_name} completed with non-zero exit-code. Check test results above."
                     )
-            exit(1)
+            return 1
+        return 0

--- a/eng/tools/azure-sdk-tools/azpysdk/optional.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/optional.py
@@ -87,7 +87,8 @@ class optional(InstallAndTest):
             exit(0)
 
         config_results = []
-
+        print("??")
+        print(optional_configs)
         for config in optional_configs:
             env_name = config.get("name")
 
@@ -160,8 +161,10 @@ class optional(InstallAndTest):
             logger.info(f"Invoking tests for package {package_name} and optional environment {env_name}")
 
             try:
-                self.run_pytest(environment_exe, temp_dir, package_dir, package_name, pytest_args, cwd=package_dir)
-                config_results.append(True)
+                pytest_result = self.run_pytest(
+                    environment_exe, temp_dir, package_dir, package_name, pytest_args, cwd=package_dir
+                )
+                config_results.append(True if pytest_result == 0 else False)
             except Exception as exc:
                 config_results.append(False)
 

--- a/eng/tools/azure-sdk-tools/azpysdk/optional.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/optional.py
@@ -82,13 +82,15 @@ class optional(InstallAndTest):
         """
         optional_configs = get_config_setting(package_dir, "optional")
 
+        if not isinstance(optional_configs, list):
+            optional_configs = []
+
         if len(optional_configs) == 0:
             logger.info(f"No optional environments detected in pyproject.toml within {package_dir}.")
             exit(0)
 
         config_results = []
-        print("??")
-        print(optional_configs)
+
         for config in optional_configs:
             env_name = config.get("name")
 

--- a/eng/tools/azure-sdk-tools/azpysdk/optional.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/optional.py
@@ -110,8 +110,14 @@ class optional(InstallAndTest):
 
             # install package and testing requirements
             try:
-                self.install_all_requiremenmts(environment_exe, temp_dir, package_name, package_dir, args)
-            except Exception as exc:
+                install_result = self.install_all_requiremenmts(
+                    environment_exe, temp_dir, package_name, package_dir, args
+                )
+                if install_result != 0:
+                    logger.error(f"Failed to install base requirements for {package_name} in optional env {env_name}.")
+                    config_results.append(False)
+                    break
+            except CalledProcessError as exc:
                 logger.error(
                     f"Failed to install base requirements for {package_name} in optional env {env_name}: {exc}"
                 )
@@ -123,7 +129,7 @@ class optional(InstallAndTest):
             if additional_installs:
                 try:
                     install_into_venv(environment_exe, additional_installs, package_dir)
-                except Exception as exc:
+                except CalledProcessError as exc:
                     logger.error(
                         f"Unable to complete installation of additional packages {additional_installs} for {package_name}, check command output above."
                     )
@@ -135,7 +141,7 @@ class optional(InstallAndTest):
             if additional_uninstalls:
                 try:
                     uninstall_from_venv(environment_exe, additional_uninstalls, package_dir)
-                except Exception as exc:
+                except CalledProcessError as exc:
                     logger.error(
                         f"Unable to complete removal of packages targeted for uninstall {additional_uninstalls} for {package_name}, check command output above."
                     )
@@ -171,7 +177,7 @@ class optional(InstallAndTest):
                     environment_exe, temp_dir, package_dir, package_name, pytest_args, cwd=package_dir
                 )
                 config_results.append(True if pytest_result == 0 else False)
-            except Exception as exc:
+            except CalledProcessError as exc:
                 config_results.append(False)
 
         if all(config_results):


### PR DESCRIPTION
made a new branch for these changes coz i dont wanna accidentally push something broken to the other branch
- since `optional` needs to run pytest multiple times and needs its own implementation of run()
- i refactored InstallAndTest to be more modular so i can reuse more of it

i did check that whl, devtest, and optional still seem to run as expected for azure-core