### PR TITLE
[Python] Updated copilot instruction for local SDK generation workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ This library is failing two release blocking checks - Mypy and Tests - CI. The l
 ## Local SDK Generation and Package Lifecycle (TypeSpec)
 
 ### AUTHORITATIVE REFERENCE
-For all TypeSpec-based SDK workflows (generation, building, validation, testing, versioning, and release preparation), follow #file:../eng/common/instructions/azsdk-tools/local-sdk-workflow.instructions.md
+For all TypeSpec-based SDK workflows (generation, building, validation, testing, versioning, and release), follow #file:../eng/common/instructions/azsdk-tools/local-sdk-workflow.instructions.md
 
 ### DEFAULT BEHAVIORS
 - **Repository:** Use the current workspace as the local SDK repository unless the user specifies a different path.


### PR DESCRIPTION
References the workflow instruction file from the `eng/common` folder.


Test screenshot:
<img width="965" height="1253" alt="image" src="https://github.com/user-attachments/assets/bda35e43-560c-4f78-af41-64f0e5f4f08d" />
