### PR TITLE
[engsys] fix: Apply PEP 503 name normalization during package verification in latestdependencies

### DIFF
--- a/eng/tox/verify_installed_packages.py
+++ b/eng/tox/verify_installed_packages.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import sys
 import logging
+import re
 from os import path
 
 # import common_task module
@@ -16,6 +17,19 @@ root_dir = path.abspath(path.join(path.abspath(__file__), "..", "..", ".."))
 common_task_path = path.abspath(path.join(root_dir, "scripts", "devops_tasks"))
 sys.path.append(common_task_path)
 from common_tasks import get_installed_packages
+
+
+def normalize_package_name(package_name: str) -> str:
+    """Apply PEP 503 normalization rules to package names
+
+    .. see-also::
+
+        https://peps.python.org/pep-0503/#normalized-names
+        https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
+    """
+
+    return re.sub(r"[-_.]+", "-", package_name).lower()
+
 
 def verify_packages(package_file_path):
     # this method verifies packages installed on machine is matching the expected package version
@@ -38,11 +52,11 @@ def verify_packages(package_file_path):
     for p in get_installed_packages():
         if "==" in p:
             [package, version] = p.split("==")
-            installed[package.upper().replace("_","-")] = version
+            installed[normalize_package_name(package)] = version
     expected = {}
     for p in packages:
         [package, version] = p.split("==")
-        expected[package.upper().replace("_","-")] = version
+        expected[normalize_package_name(package)] = version
 
     missing_packages = [pkg for pkg in expected.keys() if installed.get(pkg) != expected.get(pkg)]
 


### PR DESCRIPTION
# Description

When running `tox run -e latestdependency`, tox does an e2e check to validate that
the actually installed packages match the computed upper range version.

Some packages, like ruamel.yaml, may appear under different names across the set of expected and
installed package sets (e.g. `ruamel-yaml` and `ruamel.yaml`) despite both names referring to the same package per PEP 503.

<img width="2912" height="1212" alt="image" src="https://github.com/user-attachments/assets/20a2283e-6618-4b02-b179-c5ae386026c9" />


The verify package step partially applies the PEP 503 algorithm (just case normalization and substituting `_` for `-`), which
misses cases like `ruamel.yaml` where the correct substitution would be `.` -> `-`.

This pull request resolves the above issue by applying the name normalization algorithm as described in PEP 503
https://peps.python.org/pep-0503/#normalized-names

Supersedes #44587 

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
