### PR TITLE
[Storage] Fix download perf tests with parallelism

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -46,19 +46,21 @@ class _ServiceTest(PerfStressTest):
             use_managed_identity = os.environ.get("AZURE_STORAGE_USE_MANAGED_IDENTITY", "false").lower() == "true"
             if self.args.use_entra_id or use_managed_identity:
                 account_name = self.get_from_env("AZURE_STORAGE_ACCOUNT_NAME")
-                self.sync_token_credential = SyncManagedIdentityCredential() if use_managed_identity else self.get_credential(is_async=False)
-                self.async_token_credential = AsyncManagedIdentityCredential() if use_managed_identity else self.get_credential(is_async=True)
+                _ServiceTest.sync_token_credential = SyncManagedIdentityCredential() if use_managed_identity else self.get_credential(is_async=False)
+                _ServiceTest.async_token_credential = AsyncManagedIdentityCredential() if use_managed_identity else self.get_credential(is_async=True)
 
                 # We assume these tests will only be run on the Azure public cloud for now.
                 url = f"https://{account_name}.blob.core.windows.net"
-                _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=self.sync_token_credential, **self._client_kwargs)
-                _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=self.async_token_credential, **self._client_kwargs)
+                _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=_ServiceTest.sync_token_credential, **self._client_kwargs)
+                _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=_ServiceTest.async_token_credential, **self._client_kwargs)
             else:
                 connection_string = self.get_from_env("AZURE_STORAGE_CONNECTION_STRING")
                 _ServiceTest.service_client = SyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
                 _ServiceTest.async_service_client = AsyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
         self.service_client = _ServiceTest.service_client
         self.async_service_client = _ServiceTest.async_service_client
+        self.sync_token_credential = _ServiceTest.sync_token_credential
+        self.async_token_credential = _ServiceTest.async_token_credential
 
     async def close(self):
         await self.async_service_client.close()

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/download.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/download.py
@@ -13,8 +13,8 @@ class DownloadTest(_BlobTest):
         super().__init__(arguments)
         self.download_stream = WriteStream()
 
-    async def global_setup(self):
-        await super().global_setup()
+    async def setup(self):
+        await super().setup()
         data = RandomStream(self.args.size)
         await self.async_blob_client.upload_blob(data)
 

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/download_basic.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/download_basic.py
@@ -18,13 +18,13 @@ TOKEN_SCOPE = "https://storage.azure.com/.default"
 class DownloadBasicTest(_BlobTest):
     def __init__(self, arguments):
         super().__init__(arguments)
+        self.chunk_size = self.args.max_block_size or 4 * 1024 * 1024
 
-    async def global_setup(self):
-        await super().global_setup()
+    async def setup(self):
+        await super().setup()
         data = RandomStream(self.args.size)
         await self.async_blob_client.upload_blob(data, max_concurrency=10)
 
-        self.chunk_size = self.args.max_block_size or 4 * 1024 * 1024
         if self.async_token_credential:
             token = await self.async_token_credential.get_token(TOKEN_SCOPE)
             self.auth_header = "Bearer " + token.token

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/download_to_file.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/download_to_file.py
@@ -12,15 +12,12 @@ from devtools_testutils.perfstress_tests import RandomStream
 from ._test_base import _BlobTest
 
 class DownloadToFileTest(_BlobTest):
-    _temp_file: Optional[str] = None
-
-    async def global_setup(self):
-        await super().global_setup()
-        data = RandomStream(self.args.size)
-        await self.async_blob_client.upload_blob(data)
+    _temp_file: str = ""
 
     async def setup(self):
         await super().setup()
+        data = RandomStream(self.args.size)
+        await self.async_blob_client.upload_blob(data)
         with tempfile.NamedTemporaryFile(delete=False) as tf:
             self._temp_file = tf.name
 


### PR DESCRIPTION
This fixes a couple of issues with download perf tests when running with parallelism and process count set such that there are multiple threads per process. There were some issues in test setup that meant not all threads would get setup properly.