### PR TITLE
bump typespec-python 0.57.1

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,31 +6,31 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.57.0"
+        "@azure-tools/typespec-python": "0.57.1"
       },
       "devDependencies": {
-        "@azure-tools/openai-typespec": "0.1.12",
-        "@azure-tools/typespec-autorest": "~0.63.1",
-        "@azure-tools/typespec-azure-core": "~0.63.1",
-        "@azure-tools/typespec-azure-resource-manager": "~0.63.0",
-        "@azure-tools/typespec-azure-rulesets": "~0.63.0",
-        "@azure-tools/typespec-client-generator-core": "~0.63.4",
+        "@azure-tools/openai-typespec": "1.6.1",
+        "@azure-tools/typespec-autorest": "~0.64.0",
+        "@azure-tools/typespec-azure-core": "~0.64.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.64.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.64.0",
+        "@azure-tools/typespec-client-generator-core": "~0.64.1",
         "@azure-tools/typespec-liftr-base": "0.11.0",
-        "@typespec/compiler": "^1.7.1",
-        "@typespec/events": "~0.77.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": "~0.77.0",
-        "@typespec/sse": "~0.77.0",
-        "@typespec/streams": "~0.77.0",
-        "@typespec/versioning": "~0.77.0",
-        "@typespec/xml": "~0.77.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/events": "~0.78.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": "~0.78.0",
+        "@typespec/sse": "~0.78.0",
+        "@typespec/streams": "~0.78.0",
+        "@typespec/versioning": "~0.78.0",
+        "@typespec/xml": "~0.78.0"
       }
     },
     "node_modules/@azure-tools/openai-typespec": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-0.1.12.tgz",
-      "integrity": "sha512-rvb9VRts3lCY5++IbIAhmqXSdsUgOki6ppnYTKdyDCsFHDRHbeurRTfuegBJDkNhip+hkVk94FVGTwOHWkPYww==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.6.1.tgz",
+      "integrity": "sha512-K9AhZYV3yQymgTBkGAguprHTgXwfojbZu4QnyHy1u0aDpMZmfWbYzex41a8blBTcLDc4wslfHpocIU2bAl7OTQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -39,23 +39,24 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.63.1.tgz",
-      "integrity": "sha512-Nem51jk2eURxa5PPEEUjdguxAEwNIyxTi3ac/GOo/B3SgwIa3WAOpwWqQPyGLPD2hHRKa2pm9FsPu6aLPmgeCQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.64.0.tgz",
+      "integrity": "sha512-zC2e3px+BqGJvE9DeW00S0PZmkydorB3Hm6Fb2vlJUdmHuTTSochPiZFJF7LHNsAL8sDu7azSHzypESFdN0FmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.63.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.63.0",
-        "@azure-tools/typespec-client-generator-core": "^0.63.1",
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": "^0.77.0",
-        "@typespec/versioning": "^0.77.0",
-        "@typespec/xml": "^0.77.0"
+        "@azure-tools/typespec-azure-core": "^0.64.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.64.0",
+        "@azure-tools/typespec-client-generator-core": "^0.64.0",
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": "^0.78.0",
+        "@typespec/versioning": "^0.78.0",
+        "@typespec/xml": "^0.78.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -64,24 +65,26 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.63.1.tgz",
-      "integrity": "sha512-r5bJLDNUYAoP3i6topz3P7Y7vFMig92pO/zUuTgo4Q5hTbFoUgKPBBBmamVSwBh5MO4lMSLekZC3QoEYnsVUDg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.64.0.tgz",
+      "integrity": "sha512-BXiHc5oayhMsG1dHFU1aFK/ZQX2Gl0dKB0FAFceapaFV9093J2obbsdhIDR3Tl0qei9g3Ha+iWKZ4KgnLdhv4w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/rest": "^0.77.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/rest": "^0.78.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.63.0.tgz",
-      "integrity": "sha512-QXHryXgV9Rh7lBW9hrehjdGVM/W8eBN6wnfRRZtAAyfTc1AkRGDKOMFBtRtfbEkQpur16mgQTd7EyH2tpqfuSw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.64.0.tgz",
+      "integrity": "sha512-1HwGo3Nt8ksafoPp1rFOopSzgh68SFsyVNCauzjO8ftf0fEqhRXo70OaGwP6wmTZJsLnW7u1DbrBNu6b0z2sOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -90,53 +93,55 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.63.0",
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": "^0.77.0",
-        "@typespec/versioning": "^0.77.0"
+        "@azure-tools/typespec-azure-core": "^0.64.0",
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": "^0.78.0",
+        "@typespec/versioning": "^0.78.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.63.0.tgz",
-      "integrity": "sha512-oZSderD/MVnPH+W8hh3rsta1uF9xVLp9b2jjyhiHL9lqYGnHUYk8sDti5PUk/LXIz8QAsBMSbXJMDgxTeND8Kg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.64.0.tgz",
+      "integrity": "sha512-CvK5iolfsm8oAUZ5wegGVYp4Vvw2rwQa+rcUVoJkwi9c6QwEr+qT6/S4hIntuzEPLxybJSb/ZIWU9Qx3cDrzXg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.63.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.63.0",
-        "@azure-tools/typespec-client-generator-core": "^0.63.0",
-        "@typespec/compiler": "^1.7.0"
+        "@azure-tools/typespec-azure-core": "^0.64.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.64.0",
+        "@azure-tools/typespec-client-generator-core": "^0.64.0",
+        "@typespec/compiler": "^1.8.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.63.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.63.4.tgz",
-      "integrity": "sha512-gAzvzL1ryCPWCrwyDyaZRvkE2Er4/MGeP0fslH7i8/1AcXAlDUpPMZ40oYnls1rDwM5sOO7/6XNDDCT4/elhYA==",
+      "version": "0.64.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.64.1.tgz",
+      "integrity": "sha512-u1iWLergQmNG/0Wk3wVjCj/Q9cxUlxLGnLhd0hr3H1Wy1xvg7mLRaH+a62J//wvUZYBQsz1XGnm2QnksAzAdzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
-        "yaml": "~2.8.0"
+        "yaml": "~2.8.2"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.63.1",
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/events": "^0.77.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": "^0.77.0",
-        "@typespec/sse": "^0.77.0",
-        "@typespec/streams": "^0.77.0",
-        "@typespec/versioning": "^0.77.0",
-        "@typespec/xml": "^0.77.0"
+        "@azure-tools/typespec-azure-core": "^0.64.0",
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/events": "^0.78.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": "^0.78.0",
+        "@typespec/sse": "^0.78.0",
+        "@typespec/streams": "^0.78.0",
+        "@typespec/versioning": "^0.78.0",
+        "@typespec/xml": "^0.78.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -146,13 +151,13 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.57.0.tgz",
-      "integrity": "sha512-K4pZ3Fe4QljLskH8qVM1wFUGE3nzm7TZynafbRyWCxRR8tHKJrXneZ8FJM3LdeRr8B1gtsMn6PcJAEFUV5nWXg==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.57.1.tgz",
+      "integrity": "sha512-b8oXEhqW8JclPkWafVOBOa5e9mAKGE68ojMAW17eRtfMEYtb+tUQT5urEj+70Sffyt6eSkHw0m1JzDW/ry3wfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": "~0.24.0",
+        "@typespec/http-client-python": "~0.24.1",
         "fs-extra": "~11.2.0",
         "js-yaml": "~4.1.0",
         "semver": "~7.6.2",
@@ -162,20 +167,20 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.63.4 <1.0.0",
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/events": ">=0.77.0 <1.0.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": ">=0.77.0 <1.0.0",
-        "@typespec/sse": ">=0.77.0 <1.0.0",
-        "@typespec/streams": ">=0.77.0 <1.0.0",
-        "@typespec/versioning": ">=0.77.0 <1.0.0",
-        "@typespec/xml": ">=0.77.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.64.1 <1.0.0",
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/events": ">=0.78.0 <1.0.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": ">=0.78.0 <1.0.0",
+        "@typespec/sse": ">=0.78.0 <1.0.0",
+        "@typespec/streams": ">=0.78.0 <1.0.0",
+        "@typespec/versioning": ">=0.78.0 <1.0.0",
+        "@typespec/xml": ">=0.78.0 <1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1005,10 +1010,11 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.7.1.tgz",
-      "integrity": "sha512-sb3MEsKjFlAx8ZG484exs5Ec+JwmYf2anJqLjMusrV3rRMUhv3fbEulk9MD+l4eOkBS46VMNGqRu0wTn8suVVA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.8.0.tgz",
+      "integrity": "sha512-FeLb7Q0z6Bh5dDpqtnU2RlWiIWWWF7rujx2xGMta5dcTuIOZ4jbdyz1hVdxk4iM4qadvaSV4ey/qrSuffNoh3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
         "@inquirer/prompts": "^8.0.1",
@@ -1019,13 +1025,13 @@
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
-        "prettier": "~3.6.2",
+        "prettier": "~3.7.4",
         "semver": "^7.7.1",
         "tar": "^7.5.2",
         "temporal-polyfill": "^0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
-        "yaml": "~2.8.0",
+        "yaml": "~2.8.2",
         "yargs": "~18.0.0"
       },
       "bin": {
@@ -1049,28 +1055,30 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.77.0.tgz",
-      "integrity": "sha512-NbOzi7axEt/xGgXaLjcGGV2HjQKNFjbvsQpCeDA6loUghZDK5+5ik/jwMumeUDunoBsAKF78ZxVF5qhQh56dGA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.78.0.tgz",
+      "integrity": "sha512-gSI4rAexxfYyZX0ZqYNRWQyuMb1UeakjAjOeh/2ntmxWCdYc+wSbJjxrxIArsZC+LwzTxq5WpdtD7+7OWzG4yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0"
+        "@typespec/compiler": "^1.8.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.7.0.tgz",
-      "integrity": "sha512-4cGkcMiob3bedWbFkRcq614TDH7WPEI3YMgrg44mBarj903arpEniAESIhNUbLQzQFFc5rOJagexQDl4agVDyA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.8.0.tgz",
+      "integrity": "sha512-ZKa4RISabwL8cUAmE3BkoNmtCYRjerO0+1Ba6XdDJKG+vJC5EGM2hkDf+ZmYsYZgrX0cvbhPXUKKh28zBV60hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/streams": "^0.77.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/streams": "^0.78.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1079,9 +1087,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.24.0.tgz",
-      "integrity": "sha512-cWxx2tfitW8sLRXtJMEbZOLDx4HxWIGkr+CSz4Dduiw/Sao9W3sxro9DPVJglqiMQayKZN3xh7BDPbew7eXzEg==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.24.1.tgz",
+      "integrity": "sha512-pYjfHq+4QduKLV+DxBQ+ua3cAU4e8a7Evx91QKww87wOWqKYZY2YqjTna6IclRGtLjTDvJG594JBl58DMeWWTg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1095,97 +1103,103 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.63.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.63.4 <1.0.0",
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/events": ">=0.77.0 <1.0.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/openapi": "^1.7.0",
-        "@typespec/rest": ">=0.77.0 <1.0.0",
-        "@typespec/sse": ">=0.77.0 <1.0.0",
-        "@typespec/streams": ">=0.77.0 <1.0.0",
-        "@typespec/versioning": ">=0.77.0 <1.0.0",
-        "@typespec/xml": ">=0.77.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.64.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.64.1 <1.0.0",
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/events": ">=0.78.0 <1.0.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/openapi": "^1.8.0",
+        "@typespec/rest": ">=0.78.0 <1.0.0",
+        "@typespec/sse": ">=0.78.0 <1.0.0",
+        "@typespec/streams": ">=0.78.0 <1.0.0",
+        "@typespec/versioning": ">=0.78.0 <1.0.0",
+        "@typespec/xml": ">=0.78.0 <1.0.0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.7.0.tgz",
-      "integrity": "sha512-tEAIgGnjLvOjbGAoCfkBudvpe/tXaOXkzy5nVFXs4921/jAaMTwzcJIt0bTXZpp5cExdlL7w9ZrnehARHiposQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.8.0.tgz",
+      "integrity": "sha512-v+RIJpx7vALBSGQmnUWemvXjnrk50HAVqJeg0RbaF3VUnh66Z4itsoNJJmIIc+HmBJng8Ie0V7xv3l02ek6HWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/http": "^1.7.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/http": "^1.8.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.77.0.tgz",
-      "integrity": "sha512-DEUMD9zYqUVUhKCGktV7Z+sFkzj+bcSpJRhEXxOrJxupWM4I3N4deMop+ulxezxlLxIRUz7ELc+6WucYXgOnAA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.78.0.tgz",
+      "integrity": "sha512-1clnDw1JbBvjLcfFvEvHdIrnsQuQI5/Cl6mRIrzWWX0pKJ+R89rCdZD1KpidEXw4B4qscD48LsssyrEIFLtuPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/http": "^1.7.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/http": "^1.8.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.77.0.tgz",
-      "integrity": "sha512-rVML/sPNj+MomKXftko/eUNM5OhHlIevoit3Dbtaf1aWS5pcJ5jKX05Prz53VIyeUP7ra5ocmPE/iIEPb8ZbCA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.78.0.tgz",
+      "integrity": "sha512-jPARl+e1e/nsDW/1uVsGTzvKmjqezVMyUa13igXxk5nV2ScMdFpH1HhBwTmAhUeaZgY3J81dFHNUnIY67HCrmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0",
-        "@typespec/events": "^0.77.0",
-        "@typespec/http": "^1.7.0",
-        "@typespec/streams": "^0.77.0"
+        "@typespec/compiler": "^1.8.0",
+        "@typespec/events": "^0.78.0",
+        "@typespec/http": "^1.8.0",
+        "@typespec/streams": "^0.78.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.77.0.tgz",
-      "integrity": "sha512-qqfJW4n19Jgi5FxQhsEgoIc5zD9o47AAoZxLKUX91z6aB/YWrLSTrrrIAvhNCESXuB89zlJPwlZ/j4YmpxZ/jw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.78.0.tgz",
+      "integrity": "sha512-wzh5bVdzh+K+pFQFs/EZkVsTH5TQGi12XwhjxJS0UKRwaW2UwSZeY1HqX07oMMPdYESTbjgMrXcxtn89AlzjvQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0"
+        "@typespec/compiler": "^1.8.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.77.0.tgz",
-      "integrity": "sha512-eAInPZYPkxpBUS8IKQfNZ5eZsLfkWqEX0d6YM/AfooGYbxcKdHQBfYOWBvRC4NkKEMub4ROaD5GcPLYTyWQIWw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.78.0.tgz",
+      "integrity": "sha512-I14X6+IMd0wFMNI8oMFSeFBi2nD4idub+geSO34vuCs4rwuEj3FNzy+rkNkDDvf0+gIUGxeyg7s+YDUcNyiqOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0"
+        "@typespec/compiler": "^1.8.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.77.0.tgz",
-      "integrity": "sha512-DNVAOMaRUPGpLEsqf3sn7UAWuAE1rs8Jf1FIAU7DF/sVmzeXs4OBanxSSsVmbcdfPRHPbjPuRnW6e+QS2Sjk3Q==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.78.0.tgz",
+      "integrity": "sha512-KSDhJX6A/Onsu9FKVZtR/xSy5va3k0y9/U4eiZUn91V/LQyMZNwmResPDHEVYk6JqaIH8bbd6ANWPu3nMd7mmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.7.0"
+        "@typespec/compiler": "^1.8.0"
       }
     },
     "node_modules/ajv": {
@@ -1732,9 +1746,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,24 +1,24 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.57.0"
+    "@azure-tools/typespec-python": "0.57.1"
   },
   "devDependencies": {
-    "@typespec/compiler": "^1.7.1",
-    "@typespec/http": "^1.7.0",
-    "@typespec/rest": "~0.77.0",
-    "@typespec/versioning": "~0.77.0",
-    "@typespec/openapi": "^1.7.0",
-    "@typespec/events": "~0.77.0",
-    "@typespec/sse": "~0.77.0",
-    "@typespec/streams": "~0.77.0",
-    "@typespec/xml": "~0.77.0",
-    "@azure-tools/openai-typespec": "0.1.12",
-    "@azure-tools/typespec-autorest": "~0.63.1",
-    "@azure-tools/typespec-azure-core": "~0.63.1",
-    "@azure-tools/typespec-azure-resource-manager": "~0.63.0",
-    "@azure-tools/typespec-azure-rulesets": "~0.63.0",
-    "@azure-tools/typespec-client-generator-core": "~0.63.4",
+    "@typespec/compiler": "^1.8.0",
+    "@typespec/http": "^1.8.0",
+    "@typespec/rest": "~0.78.0",
+    "@typespec/versioning": "~0.78.0",
+    "@typespec/openapi": "^1.8.0",
+    "@typespec/events": "~0.78.0",
+    "@typespec/sse": "~0.78.0",
+    "@typespec/streams": "~0.78.0",
+    "@typespec/xml": "~0.78.0",
+    "@azure-tools/openai-typespec": "1.6.1",
+    "@azure-tools/typespec-autorest": "~0.64.0",
+    "@azure-tools/typespec-azure-core": "~0.64.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.64.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.64.0",
+    "@azure-tools/typespec-client-generator-core": "~0.64.1",
     "@azure-tools/typespec-liftr-base": "0.11.0"
   }
 }


### PR DESCRIPTION
Bump @azure-tools/typespec-python from 0.57.0 to 0.57.1

Also updates related TypeSpec dependencies to compatible versions:
- @typespec/compiler: ^1.7.1 → ^1.8.0
- @typespec/http: ^1.7.0 → ^1.8.0
- @typespec/openapi: ^1.7.0 → ^1.8.0
- @typespec/rest, versioning, events, sse, streams, xml: ~0.77.0 → ~0.78.0
- @azure-tools/typespec-autorest: ~0.63.1 → ~0.64.0
- @azure-tools/typespec-azure-core: ~0.63.1 → ~0.64.0
- @azure-tools/typespec-azure-resource-manager: ~0.63.0 → ~0.64.0
- @azure-tools/typespec-azure-rulesets: ~0.63.0 → ~0.64.0
- @azure-tools/typespec-client-generator-core: ~0.63.4 → ~0.64.1
- @azure-tools/openai-typespec: 0.1.12 → 1.6.1