### PR TITLE
Fix Issues with unset `DOTNET_ROOT` on macos machines

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -80,6 +80,9 @@ jobs:
     - template: ../variables/globals.yml
     - name: InjectedPackages
       value: ${{ parameters.InjectedPackages }}
+    - ${{ if eq(lower(parameters.OSName), 'macos') }}:
+      - name: DOTNET_ROOT
+        value: $(HOME)/.dotnet
 
     steps:
     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml


### PR DESCRIPTION
[Issues like this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5758234&view=logs&j=8d612083-8e4c-5501-f3a1-a3c24d0ecf0d&t=3971ec31-1f68-5fd6-153c-5f1801d0e659)

It's caused by macos agent updates. I think it's still rolling out, which is why we have some successes without this code change.