### PR TITLE
Use azpysdk generate in CI

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -506,7 +506,7 @@ function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {
       Write-Host "Generating project under directory 'sdk/$directory'" -ForegroundColor Yellow
       Write-Host "======================================================================`n"
 
-      Invoke-LoggedCommand "azpysdk generate ."
+      Invoke-LoggedCommand "azpysdk generate --isolate ."
     }
     catch {
       Write-Host "##[error]Error generating project under directory $directory"


### PR DESCRIPTION
for https://github.com/Azure/azure-sdk-for-python/issues/42601?issue=Azure%7Cazure-sdk-for-python%7C42883

although. this is only used in the `archetype-typespec-emitter` template, which I couldn't find a usage of by Python, i only saw it used by `http-client-csharp - ci`