### PR TITLE
add azure-keyvault-admin to the smoketest set on a core change

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -105,7 +105,7 @@ function Get-python-AdditionalValidationPackagesFromPackageSet {
       "azure-data-table",
       "azure-appconfig",
       "azure-keyvault-keys",
-      "azure-keyvault-admin",
+      "azure-keyvault-administration",
       "azure-identity",
       "azure-mgmt-core",
       "azure-core-experimental",


### PR DESCRIPTION
@mccoyp this is how the failure in azure-keyvault-admin slipped through with that polling change.