### PR TITLE
[Identity] Bypass cache when claims provided in Managed Identity

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -12,10 +12,12 @@
 
 ### Bugs Fixed
 
-- Fixed an issue with certain credentials not bypassing the token cache when claims are provided in `get_token` or `get_token_info` calls. ([#44552](https://github.com/Azure/azure-sdk-for-python/pull/44552))
+- Fixed an issue with certain credentials not bypassing the token cache when claims are provided in `get_token` or `get_token_info` calls. ([#44552](https://github.com/Azure/azure-sdk-for-python/pull/44552)) ([#44815](https://github.com/Azure/azure-sdk-for-python/pull/44815))
 - Fixed an issue where an unhelpful TypeError was raised during Entra ID token requests that returned empty responses. Now, a ClientAuthenticationError is raised with the full response for better troubleshooting. ([#44258](https://github.com/Azure/azure-sdk-for-python/pull/44258))
 
 ### Other Changes
+
+- Bumped minimum dependency on `msal` to `>=1.31.0`.
 
 ## 1.26.0b1 (2025-11-07)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -124,7 +124,7 @@ class ImdsCredential(MsalManagedIdentityClient):
                 raise CredentialUnavailableError(error_message) from ex
 
         try:
-            token_info = super()._request_token(*scopes)
+            token_info = super()._request_token(*scopes, **kwargs)
         except CredentialUnavailableError:
             # Response is not json, skip the IMDS credential
             raise

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -174,8 +174,8 @@ class ManagedIdentityCredential:
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
-
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
@@ -55,7 +55,7 @@ class ManagedIdentityBase(GetTokenMixin):
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessTokenInfo]:
         # casting because mypy can't determine that these methods are called
         # only by get_token, which raises when self._client is None
-        return cast(ManagedIdentityClient, self._client).get_cached_token(*scopes)
+        return cast(ManagedIdentityClient, self._client).get_cached_token(*scopes, **kwargs)
 
     def _request_token(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:
         return cast(ManagedIdentityClient, self._client).request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
@@ -90,7 +90,11 @@ class ManagedIdentityClientBase(abc.ABC):
 
         return token
 
-    def get_cached_token(self, *scopes: str) -> Optional[AccessTokenInfo]:
+    def get_cached_token(self, *scopes: str, **kwargs: Any) -> Optional[AccessTokenInfo]:
+        # Do not return a cached token if claims are provided.
+        if kwargs.get("claims") is not None:
+            return None
+
         resource = _scopes_to_resource(*scopes)
         now = time.time()
         for token in self._cache.search(TokenCache.CredentialType.ACCESS_TOKEN, target=[resource]):

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_managed_identity_client.py
@@ -45,11 +45,11 @@ class MsalManagedIdentityClient(abc.ABC):  # pylint:disable=client-accepts-api-v
     def close(self) -> None:
         self.__exit__()
 
-    def _request_token(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:  # pylint:disable=unused-argument
+    def _request_token(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')
         resource = _scopes_to_resource(*scopes)
-        result = self._msal_client.acquire_token_for_client(resource=resource)
+        result = self._msal_client.acquire_token_for_client(resource=resource, claims_challenge=kwargs.get("claims"))
         now = int(time.time())
         if result and "access_token" in result and "expires_in" in result:
             refresh_on = int(result["refresh_on"]) if "refresh_on" in result else None

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
@@ -65,7 +65,7 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
         await self._client.close()
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessTokenInfo]:
-        return self._client.get_cached_token(*scopes)
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs: Any) -> AccessTokenInfo:
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -143,7 +143,8 @@ class ManagedIdentityCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
@@ -62,7 +62,7 @@ class AsyncManagedIdentityBase(AsyncContextManager, GetTokenMixin):
     async def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessTokenInfo]:
         # casting because mypy can't determine that these methods are called
         # only by get_token, which raises when self._client is None
-        return cast(AsyncManagedIdentityClient, self._client).get_cached_token(*scopes)
+        return cast(AsyncManagedIdentityClient, self._client).get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs) -> AccessTokenInfo:
         return await cast(AsyncManagedIdentityClient, self._client).request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/pyproject.toml
+++ b/sdk/identity/azure-identity/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "azure-core>=1.31.0",
     "cryptography>=2.5",
-    "msal>=1.30.0",
+    "msal>=1.31.0",
     "msal-extensions>=1.2.0",
     "typing-extensions>=4.0.0",
 ]


### PR DESCRIPTION
Ensure the claims are propagated to the MSAL ManagedIdentityClient or, for those credentials not using MSAL, the cache is bypassed when claims are provided so that a new token request is made.

MSAL MI started [accepting claims challenges](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/730) in 1.31.0, so the minimum msal version was bumped. In MSAL, if a claims challenge is passed in, it ensures that a token from the cache isn't returned. Similar logic is adopted for non-MSAL credentials.

