### PR TITLE
Update @azure-tools/openai-typespec to latest version (1.7.1)

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -9,7 +9,7 @@
         "@azure-tools/typespec-python": "0.58.0"
       },
       "devDependencies": {
-        "@azure-tools/openai-typespec": "1.6.2",
+        "@azure-tools/openai-typespec": "1.7.1",
         "@azure-tools/typespec-autorest": "~0.64.0",
         "@azure-tools/typespec-azure-core": "~0.64.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.64.0",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@azure-tools/openai-typespec": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.6.2.tgz",
-      "integrity": "sha512-u2Y8ZS6OMO9lUbSyYgBiDuGQkF/ccv9qk6ipvDwu+vZmxRx2c9Zp2VOcC6dxWNOT62DWjlfmbJQy7E/fNaQVrw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.7.1.tgz",
+      "integrity": "sha512-DoZLbQPgHyWKbIiUkCz2/9kKxWnZ/fZwvKGnjo3AJkZ8Si3QOHXR3JBp9LWiErsWPujg6k7NkTocqBXxih8pqQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -43,6 +43,7 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.64.0.tgz",
       "integrity": "sha512-zC2e3px+BqGJvE9DeW00S0PZmkydorB3Hm6Fb2vlJUdmHuTTSochPiZFJF7LHNsAL8sDu7azSHzypESFdN0FmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -68,6 +69,7 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.64.0.tgz",
       "integrity": "sha512-BXiHc5oayhMsG1dHFU1aFK/ZQX2Gl0dKB0FAFceapaFV9093J2obbsdhIDR3Tl0qei9g3Ha+iWKZ4KgnLdhv4w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -82,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.64.0.tgz",
       "integrity": "sha512-1HwGo3Nt8ksafoPp1rFOopSzgh68SFsyVNCauzjO8ftf0fEqhRXo70OaGwP6wmTZJsLnW7u1DbrBNu6b0z2sOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -103,6 +106,7 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.64.0.tgz",
       "integrity": "sha512-CvK5iolfsm8oAUZ5wegGVYp4Vvw2rwQa+rcUVoJkwi9c6QwEr+qT6/S4hIntuzEPLxybJSb/ZIWU9Qx3cDrzXg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -114,10 +118,11 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.64.2.tgz",
-      "integrity": "sha512-1y5YNnMWQXQjjinmAINP9BpV8U5KBdgw/sqFZbtaoJ/gOQynG8TR1xQGgVbkg/sfiMlTYSiL8ru1efO7vHVuMA==",
+      "version": "0.64.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.64.3.tgz",
+      "integrity": "sha512-CnwoynIZD2+0c1/ZgupXCJHst9OLczzFcaiVIYOSK3V/fVkGRvip/hg4i0/9spBCwZVbv10YpNpIqbB2zGilMg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
@@ -1009,6 +1014,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.8.0.tgz",
       "integrity": "sha512-FeLb7Q0z6Bh5dDpqtnU2RlWiIWWWF7rujx2xGMta5dcTuIOZ4jbdyz1hVdxk4iM4qadvaSV4ey/qrSuffNoh3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
         "@inquirer/prompts": "^8.0.1",
@@ -1053,6 +1059,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.78.0.tgz",
       "integrity": "sha512-gSI4rAexxfYyZX0ZqYNRWQyuMb1UeakjAjOeh/2ntmxWCdYc+wSbJjxrxIArsZC+LwzTxq5WpdtD7+7OWzG4yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1065,6 +1072,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.8.0.tgz",
       "integrity": "sha512-ZKa4RISabwL8cUAmE3BkoNmtCYRjerO0+1Ba6XdDJKG+vJC5EGM2hkDf+ZmYsYZgrX0cvbhPXUKKh28zBV60hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1116,6 +1124,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.8.0.tgz",
       "integrity": "sha512-v+RIJpx7vALBSGQmnUWemvXjnrk50HAVqJeg0RbaF3VUnh66Z4itsoNJJmIIc+HmBJng8Ie0V7xv3l02ek6HWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1129,6 +1138,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.78.0.tgz",
       "integrity": "sha512-1clnDw1JbBvjLcfFvEvHdIrnsQuQI5/Cl6mRIrzWWX0pKJ+R89rCdZD1KpidEXw4B4qscD48LsssyrEIFLtuPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1142,6 +1152,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.78.0.tgz",
       "integrity": "sha512-jPARl+e1e/nsDW/1uVsGTzvKmjqezVMyUa13igXxk5nV2ScMdFpH1HhBwTmAhUeaZgY3J81dFHNUnIY67HCrmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1157,6 +1168,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.78.0.tgz",
       "integrity": "sha512-wzh5bVdzh+K+pFQFs/EZkVsTH5TQGi12XwhjxJS0UKRwaW2UwSZeY1HqX07oMMPdYESTbjgMrXcxtn89AlzjvQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1169,6 +1181,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.78.0.tgz",
       "integrity": "sha512-I14X6+IMd0wFMNI8oMFSeFBi2nD4idub+geSO34vuCs4rwuEj3FNzy+rkNkDDvf0+gIUGxeyg7s+YDUcNyiqOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1181,6 +1194,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.78.0.tgz",
       "integrity": "sha512-KSDhJX6A/Onsu9FKVZtR/xSy5va3k0y9/U4eiZUn91V/LQyMZNwmResPDHEVYk6JqaIH8bbd6ANWPu3nMd7mmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -13,7 +13,7 @@
     "@typespec/sse": "~0.78.0",
     "@typespec/streams": "~0.78.0",
     "@typespec/xml": "~0.78.0",
-    "@azure-tools/openai-typespec": "1.6.2",
+    "@azure-tools/openai-typespec": "1.7.1",
     "@azure-tools/typespec-autorest": "~0.64.0",
     "@azure-tools/typespec-azure-core": "~0.64.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.64.0",


### PR DESCRIPTION
Version update is needed for `@azure-tools/openai-typespec`, in order to pick up TypeSpec changes required for the next beta release. This is to unblock merge of latest emitted azure-ai-projects client library into Main branch.

Not sure what the `"peer": true` additions are in the resulting lock file, but I'm assuming it's related to running `npm install` with latest tools.