### PR TITLE
Distro release 1.8.5

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bugs Fixed
 
-- Fix the format of the fixed percentage sampler constant and ensure backward compatability
+- Fix the format of the fixed percentage sampler constant and ensure backward compatibility
   ([#44656](https://github.com/Azure/azure-sdk-for-python/pull/44656))
 - Only add PerformanceCounter Processors after PerformanceCounter setup to avoid circular dependency.
   ([#44661](https://github.com/Azure/azure-sdk-for-python/pull/44661))


### PR DESCRIPTION
# Release History

## 1.8.5 (2026-01-28)

### Features Added

- In double-instrumentation scenarios, surface in the log stream instead of just in diagnostic logs.
  ([#44682](https://github.com/Azure/azure-sdk-for-python/pull/44682))

### Bugs Fixed

- Fix the format of the fixed percentage sampler constant and ensure backward compatability
  ([#44656](https://github.com/Azure/azure-sdk-for-python/pull/44656))
- Only add PerformanceCounter Processors after PerformanceCounter setup to avoid circular dependency.
  ([#44661](https://github.com/Azure/azure-sdk-for-python/pull/44661))

 ### Other Changes

- Declare support for Python 3.13 and 3.14
([#44550](https://github.com/Azure/azure-sdk-for-python/pull/44550))