### PR TITLE
Add Missing Deps to SmokeTest Step

### DIFF
--- a/common/smoketest/requirements_async.txt
+++ b/common/smoketest/requirements_async.txt
@@ -1,1 +1,3 @@
 aiohttp==3.8.1
+packaging==24.2
+pip==24.0


### PR DESCRIPTION
This change is necessary to due to my change in #41973 

- We introduced two dependencies, packaging.requirement and pip.parse_requirement
- We didn't update the file that controls the requirements for this post-release step.

[Validated in release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5803890&view=logs&j=dd1c1bc8-d716-58cc-56dc-c5bab961d0f7&t=9d26e28c-5fe4-5910-b5e9-d7be2a830341&s=d72c8caf-7b34-5de3-4896-93b42c4b3f76)