### PR TITLE
fix - passing None as data account should be handled gracefully

### DIFF
--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -37,29 +37,29 @@ steps:
       parameters:
         WorkingDirectory: ${{ parameters.SourceRootPath }}
 
-    - task: Powershell@2
-      inputs:
-        filePath: ${{ parameters.SourceRootPath }}/eng/common/scripts/Create-APIReview.ps1
-        arguments: >
-          -PackageInfoFiles ('${{ convertToJson(parameters.PackageInfoFiles) }}' | ConvertFrom-Json -NoEnumerate)
-          -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
-          -ArtifactPath '${{parameters.ArtifactPath}}'
-          -ArtifactName ${{ parameters.ArtifactName }}
-          -APIKey '$(azuresdk-apiview-apikey)'
-          -PackageName '${{parameters.PackageName}}'
-          -SourceBranch '$(Build.SourceBranchName)'
-          -DefaultBranch '$(DefaultBranch)'
-          -ConfigFileDir '${{parameters.ConfigFileDir}}'
-          -BuildId '$(Build.BuildId)'
-          -RepoName '$(Build.Repository.Name)'
-          -MarkPackageAsShipped $${{parameters.MarkPackageAsShipped}}
-        pwsh: true
-      displayName: Create API Review
-      condition: >-
-        and(
-          succeededOrFailed(),
-          ne(variables['Skip.CreateApiReview'], 'true'),
-          ne(variables['Build.Reason'],'PullRequest'),
-          eq(variables['System.TeamProject'], 'internal'),
-          not(endsWith(variables['Build.Repository.Name'], '-pr'))
-        )
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['Build.Repository.Name'], '-pr'))) }}:
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'APIView prod deployment'
+          scriptType: pscore
+          scriptLocation: scriptPath
+          scriptPath: ${{ parameters.SourceRootPath }}/eng/common/scripts/Create-APIReview.ps1
+          # PackageInfoFiles example: @('a/file1.json','a/file2.json')
+          arguments: >
+            -PackageInfoFiles @('${{ join(''',''', parameters.PackageInfoFiles) }}')
+            -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
+            -ArtifactPath '${{parameters.ArtifactPath}}'
+            -ArtifactName ${{ parameters.ArtifactName }}
+            -PackageName '${{parameters.PackageName}}'
+            -SourceBranch '$(Build.SourceBranchName)'
+            -DefaultBranch '$(DefaultBranch)'
+            -ConfigFileDir '${{parameters.ConfigFileDir}}'
+            -BuildId '$(Build.BuildId)'
+            -RepoName '$(Build.Repository.Name)'
+            -MarkPackageAsShipped $${{parameters.MarkPackageAsShipped}}
+        displayName: Create API Review
+        condition: >-
+          and(
+            succeededOrFailed(),
+            ne(variables['Skip.CreateApiReview'], 'true')
+          )

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -4,15 +4,13 @@ Param (
   [array] $ArtifactList,
   [Parameter(Mandatory=$True)]
   [string] $ArtifactPath,
-  [Parameter(Mandatory=$True)]
-  [string] $APIKey,
   [string] $SourceBranch,
   [string] $DefaultBranch,
   [string] $RepoName,
   [string] $BuildId,
   [string] $PackageName = "",
   [string] $ConfigFileDir = "",
-  [string] $APIViewUri = "https://apiview.dev/AutoReview",
+  [string] $APIViewUri = "https://apiview.dev/autoreview",
   [string] $ArtifactName = "packages",
   [bool] $MarkPackageAsShipped = $false,
   [Parameter(Mandatory=$False)]
@@ -20,8 +18,27 @@ Param (
 )
 
 Set-StrictMode -Version 3
+
 . (Join-Path $PSScriptRoot common.ps1)
 . (Join-Path $PSScriptRoot Helpers ApiView-Helpers.ps1)
+
+# Get Bearer token for APIView authentication
+# In Azure DevOps, this uses the service connection's Managed Identity/Service Principal
+function Get-ApiViewBearerToken()
+{
+    try {
+        $tokenResponse = az account get-access-token --resource "api://apiview" --output json 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to acquire access token: $tokenResponse"
+            return $null
+        }
+        return ($tokenResponse | ConvertFrom-Json).accessToken
+    }
+    catch {
+        Write-Error "Failed to acquire access token: $($_.Exception.Message)"
+        return $null
+    }
+}
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review
 function Upload-SourceArtifact($filePath, $apiLabel, $releaseStatus, $packageVersion, $packageType)
@@ -78,9 +95,17 @@ function Upload-SourceArtifact($filePath, $apiLabel, $releaseStatus, $packageVer
         Write-Host "Request param, compareAllRevisions: true"
     }
 
-    $uri = "${APIViewUri}/UploadAutoReview"
+    $uri = "${APIViewUri}/upload"
+    
+    # Get Bearer token for authentication
+    $bearerToken = Get-ApiViewBearerToken
+    if (-not $bearerToken) {
+        Write-Error "Failed to acquire Bearer token for APIView authentication."
+        return [System.Net.HttpStatusCode]::Unauthorized
+    }
+    
     $headers = @{
-        "ApiKey" = $apiKey;
+        "Authorization" = "Bearer $bearerToken";
         "content-type" = "multipart/form-data"
     }
 
@@ -115,20 +140,28 @@ function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $review
     if($MarkPackageAsShipped) {
         $params += "&setReleaseTag=true"
     }
-    $uri = "${APIViewUri}/CreateApiReview?${params}"
+    $uri = "${APIViewUri}/create?${params}"
     if ($releaseStatus -and ($releaseStatus -ne "Unreleased"))
     {
         $uri += "&compareAllRevisions=true"
     }
 
     Write-Host "Request to APIView: $uri"
+    
+    # Get Bearer token for authentication
+    $bearerToken = Get-ApiViewBearerToken
+    if (-not $bearerToken) {
+        Write-Error "Failed to acquire Bearer token for APIView authentication."
+        return [System.Net.HttpStatusCode]::Unauthorized
+    }
+    
     $headers = @{
-        "ApiKey" = $APIKey;
+        "Authorization" = "Bearer $bearerToken"
     }
 
     try
     {
-        $Response = Invoke-WebRequest -Method 'GET' -Uri $uri -Headers $headers
+        $Response = Invoke-WebRequest -Method 'POST' -Uri $uri -Headers $headers
         Write-Host "API review: $($Response.Content)"
         $StatusCode = $Response.StatusCode
     }

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -2,13 +2,8 @@
 
 ### 4.14.6 (Unreleased)
 
-#### Features Added
-
-#### Breaking Changes
-
 #### Bugs Fixed
-
-#### Other Changes
+* Fixed async client crash (`AttributeError: 'NoneType' object has no attribute '_WritableLocations'`) during region discovery when `database_account` was `None`. See [PR 44939](https://github.com/Azure/azure-sdk-for-python/pull/44939)
 
 ### 4.14.5 (2026-01-15)
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.14.6 (2026-01-30)
+### 4.14.6 (2026-02-02)
 
 #### Bugs Fixed
 * Fixed async client crash (`AttributeError: 'NoneType' object has no attribute '_WritableLocations'`) during region discovery when `database_account` was `None`. See [PR 44939](https://github.com/Azure/azure-sdk-for-python/pull/44939)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.14.6 (Unreleased)
+### 4.14.6 (2026-01-30)
 
 #### Bugs Fixed
 * Fixed async client crash (`AttributeError: 'NoneType' object has no attribute '_WritableLocations'`) during region discovery when `database_account` was `None`. See [PR 44939](https://github.com/Azure/azure-sdk-for-python/pull/44939)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -142,6 +142,10 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                     # background full refresh (database account + health checks)
                     self._start_background_refresh(self._refresh_database_account_and_health, kwargs)
                 else:
+                    # Fetch database account if not provided or explicitly None
+                    # This ensures callers can pass None and still get correct behavior
+                    if database_account is None:
+                        database_account = self._GetDatabaseAccount(**kwargs)
                     self.location_cache.perform_on_database_account_read(database_account)
                     self._start_background_refresh(self._endpoints_health_check, kwargs)
                     self.startup = False

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -145,7 +145,9 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                     # in background
                     self.refresh_task = asyncio.create_task(self._refresh_database_account_and_health())
                 else:
-                    if not self._aenter_used:
+                    # Fetch database account if not provided via async with pattern OR if explicitly None
+                    # This ensures callers can pass None and still get correct behavior
+                    if not self._aenter_used or database_account is None:
                         database_account = await self._GetDatabaseAccount(**kwargs)
                     self.location_cache.perform_on_database_account_read(database_account)
                     # this will perform only calls to check endpoint health

--- a/sdk/cosmos/azure-cosmos/tests/test_health_check_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_health_check_async.py
@@ -277,5 +277,111 @@ class TestHealthCheckAsync:
             db_acc.ConsistencyPolicy = {"defaultConsistencyLevel": "Session"}
             return db_acc
 
+
+    async def test_force_refresh_on_startup_with_none_should_fetch_database_account(self, setup):
+        """Verifies that calling force_refresh_on_startup(None) fetches the database account
+        instead of crashing with AttributeError on NoneType._WritableLocations.
+        """
+        self.original_getDatabaseAccountStub = _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub
+        mock_get_db_account = self.MockGetDatabaseAccount(REGIONS)
+        _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = mock_get_db_account
+
+        try:
+            client = CosmosClient(self.host, self.masterKey, preferred_locations=REGIONS)
+            await client.__aenter__()
+            gem = client.client_connection._global_endpoint_manager
+
+            # Simulate the startup state
+            gem.startup = True
+            gem.refresh_needed = True
+            gem._aenter_used = True  # Simulate that __aenter__ was used
+
+            # This should NOT crash - it should fetch the database account
+            await gem.force_refresh_on_startup(None)
+
+            # Verify the location cache was properly populated
+            read_contexts = gem.location_cache.read_regional_routing_contexts
+            assert len(read_contexts) > 0, "Location cache should have read endpoints after startup refresh"
+
+            await client.close()
+        finally:
+            _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = self.original_getDatabaseAccountStub
+
+    async def test_force_refresh_on_startup_with_valid_account_uses_provided_account(self, setup):
+        """Verifies that when a valid database account is provided to force_refresh_on_startup,
+        it uses that account directly without making another network call.
+        """
+        self.original_getDatabaseAccountStub = _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub
+        call_counter = {'count': 0}
+
+        async def counting_mock(self_gem, endpoint, **kwargs):
+            call_counter['count'] += 1
+            return await self.MockGetDatabaseAccount(REGIONS)(endpoint)
+
+        _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = counting_mock
+
+        try:
+            client = CosmosClient(self.host, self.masterKey, preferred_locations=REGIONS)
+            await client.__aenter__()
+            gem = client.client_connection._global_endpoint_manager
+
+            # Get a valid database account first
+            db_account = await gem._GetDatabaseAccount()
+            initial_call_count = call_counter['count']
+
+            # Reset startup state
+            gem.startup = True
+            gem.refresh_needed = True
+            gem._aenter_used = True
+
+            # Call with valid account - should NOT make another network call
+            await gem.force_refresh_on_startup(db_account)
+
+            # Since we provided a valid account, no additional GetDatabaseAccount call should be made
+
+            assert call_counter['count'] == initial_call_count, \
+                "Should not call _GetDatabaseAccount when valid account is provided"
+
+            await client.close()
+        finally:
+            _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = self.original_getDatabaseAccountStub
+
+    async def test_aenter_used_flag_with_none_still_fetches_account(self, setup):
+        """Verifies that even when _aenter_used=True, passing None to force_refresh_on_startup
+        still fetches the database account.
+        """
+        self.original_getDatabaseAccountStub = _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub
+        fetch_was_called = {'called': False}
+
+        async def tracking_mock(self_gem, endpoint, **kwargs):
+            fetch_was_called['called'] = True
+            return await self.MockGetDatabaseAccount(REGIONS)(endpoint)
+
+        _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = tracking_mock
+
+        try:
+            client = CosmosClient(self.host, self.masterKey, preferred_locations=REGIONS)
+            await client.__aenter__()
+            gem = client.client_connection._global_endpoint_manager
+
+            # Reset state to simulate the buggy scenario
+            gem.startup = True
+            gem.refresh_needed = True
+            gem._aenter_used = True  # This was causing the bug to skip fetching
+            fetch_was_called['called'] = False  # Reset tracking
+
+            # Call with None - should still fetch database account (this is the fix)
+            await gem.force_refresh_on_startup(None)
+
+            # This ensures that even with _aenter_used=True, if database_account is None,
+            # it fetches the database account
+            assert fetch_was_called['called'], \
+                "With _aenter_used=True and database_account=None, should still fetch database account"
+
+            await client.close()
+        finally:
+            _global_endpoint_manager_async._GlobalEndpointManager._GetDatabaseAccountStub = self.original_getDatabaseAccountStub
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The _aenter_used flag was introduced in SDK 4.14.2 to optimize the async with pattern. It tracks whether the CosmosClient was initialized using the async context manager (async with CosmosClient(...) as client)

When using async with, the SDK's aenter method fetches the database account before calling force_refresh_on_startup(). The _aenter_used flag tells the SDK "the database account was already fetched, don't fetch it again."

The problem occurs when external code calls force_refresh_on_startup(None) directly: this results in an AttributeError: 'NoneType' object has no attribute '_WritableLocations'
