### PR TITLE
Exporter release 1.0.0b47

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b47 (2026-02-02)
+## 1.0.0b47 (2026-02-03)
 
 ### Features Added
 - Rename metric names for customer sdk stats and set it on by default


### PR DESCRIPTION
## 1.0.0b47 (2026-02-03)

### Features Added
- Rename metric names for customer sdk stats and set it on by default
  ([#44849](https://github.com/Azure/azure-sdk-for-python/pull/44849))
- Add auto detection for application ID from connection string if not set 
  ([#44644](https://github.com/Azure/azure-sdk-for-python/pull/44644))
- Add support for user id and authId
  ([#44662](https://github.com/Azure/azure-sdk-for-python/pull/44662))

### Bugs Fixed
- Add custom metric mapping for customer sdkstats metric names to preserve casing
  ([#44855](https://github.com/Azure/azure-sdk-for-python/pull/44855))
- Fix customer SDK stats metrics to display drop code and retry code enum values without the prefix
  ([#44852](https://github.com/Azure/azure-sdk-for-python/pull/44852))

### Other Changes
- Feature tracking for when customer sdkstats is disabled by the user
  ([#44888](https://github.com/Azure/azure-sdk-for-python/pull/44888))
- Update maximum size of custom properties
  ([#44684](https://github.com/Azure/azure-sdk-for-python/pull/44684))
- Declare support for Python 3.13 and 3.14
  ([#44550](https://github.com/Azure/azure-sdk-for-python/pull/44550))