### PR TITLE
Fix RedTeam scan returning null results due to invalid target_type parameter

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_model_tools/_generated_rai_client.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_model_tools/_generated_rai_client.py
@@ -162,7 +162,6 @@ class GeneratedRAIClient:
                 risk_category=risk_category,
                 lang=language,
                 strategy=strategy,
-                target_type=target,
                 headers=headers,
             )
 


### PR DESCRIPTION
Remove the target_type parameter from the get_attack_objectives call in GeneratedRAIClient, as the underlying RAISvcOperations.get_attack_objectives method does not accept this parameter. The parameter was being silently absorbed by **kwargs but not used, causing objectives selection to fail.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
