### PR TITLE
Update azpysdk 'black' error message in CI

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/black.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/black.py
@@ -79,7 +79,9 @@ class black(Check):
 
                 if run_result.stderr and "reformatted" in run_result.stderr.decode("utf-8"):
                     if in_ci():
-                        logger.info(f"The package {package_name} needs reformat. Run `black` locally to reformat.")
+                        logger.info(
+                            f"The package {package_name} needs reformat. Run `azpysdk black .` locally from the package root to reformat."
+                        )
                         results.append(1)
                     else:
                         logger.info(f"The package {package_name} was reformatted.")


### PR DESCRIPTION
tell people to use 'azpysdk black' not just 'black' to resolve issues locally, when check fails in CI