### PR TITLE
[auto release pipeline] Add ENABLE_SWAGGER parameter to prioritize readme.md over tspconfig.yaml

### DIFF
--- a/scripts/auto_release/PythonSdkLiveTest.yml
+++ b/scripts/auto_release/PythonSdkLiveTest.yml
@@ -94,6 +94,7 @@ jobs:
         export TARGET_DATE=$(TARGET_DATE)
         export TEST_FOLDER=$(TEST_FOLDER)
         export ISSUE_OWNER=$(ISSUE_OWNER)
+        export ENABLE_SWAGGER=$(ENABLE_SWAGGER)
 
         # install azure-sdk-tools
         python -m pip install $root_path/eng/tools/azure-sdk-tools[build,ghtools,sdkgenerator]

--- a/scripts/auto_release/main.py
+++ b/scripts/auto_release/main.py
@@ -78,6 +78,7 @@ class CodegenTestPR:
         self.target_date = os.getenv("TARGET_DATE", "")
         self.test_folder = os.getenv("TEST_FOLDER", "")
         self.issue_owner = os.getenv("ISSUE_OWNER", "")
+        self.enable_swagger = os.getenv("ENABLE_SWAGGER", "").lower() == "true"
 
         self.package_name = ""  # 'dns' of 'sdk/compute/azure-mgmt-dns'
         self.whole_package_name = ""  # 'azure-mgmt-dns'
@@ -133,6 +134,9 @@ class CodegenTestPR:
 
     @property
     def from_swagger(self) -> bool:
+        # When ENABLE_SWAGGER is true, prioritize readme.md instead of tspconfig.yaml
+        if self.enable_swagger:
+            return True
         return "readme.md" in self.spec_readme
 
     def generate_code(self):


### PR DESCRIPTION
This PR adds a new ENABLE_SWAGGER parameter to the auto-release pipeline. When set to 	rue, it prioritizes using eadme.md (swagger) instead of 	spconfig.yaml (TypeSpec) for SDK generation.

## Changes
- Added ENABLE_SWAGGER environment variable export in PythonSdkLiveTest.yml
- Added nable_swagger instance variable in main.py to read the environment variable
- Modified the rom_swagger property to return True when ENABLE_SWAGGER is enabled