### PR TITLE
Fix: Handle empty schema type in MCP tool manifests

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-agentframework/azure/ai/agentserver/agentframework/_foundry_tools.py
+++ b/sdk/agentserver/azure-ai-agentserver-agentframework/azure/ai/agentserver/agentframework/_foundry_tools.py
@@ -71,6 +71,10 @@ class FoundryToolClient:
         # Build field definitions for the Pydantic model
         field_definitions: Dict[str, Any] = {}
         for field_name, field_info in properties.items():
+            if field_info.type is None:
+                logger.warning("Skipping field '%s' in tool '%s': unknown or empty schema type.",
+                               field_name, foundry_tool.name)
+                continue
             field_type = field_info.type.py_type
             field_description = field_info.description or ""
             is_required = field_name in required_fields

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/tools/client/_models.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/tools/client/_models.py
@@ -272,8 +272,20 @@ class SchemaProperty(BaseModel):
         keyword; it is *not* “this property is required in a parent object”.)
     """
 
-    type: SchemaType
+    type: Optional[SchemaType] = None
+    """The schema node type (e.g., ``string``, ``object``, ``array``). May be ``None``
+    if the upstream tool manifest supplies an empty or unrecognised type string."""
     description: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_empty_type(cls, data: Any) -> Any:
+        """Coerce an empty ``type`` string to ``None`` so that properties with
+        invalid or missing type information are still deserialised instead of
+        raising a validation error."""
+        if isinstance(data, dict) and data.get("type") == "":
+            data = {**data, "type": None}
+        return data
     items: Optional["SchemaProperty"] = None
     properties: Optional[Mapping[str, "SchemaProperty"]] = None
     default: Any = None


### PR DESCRIPTION
## Problem

Some MCP tool servers (e.g. HuggingFace MCP Server) return tool manifests where certain parameters have an empty string for their JSON Schema `type` field (e.g. `"seed": {"type": ""}`). This causes a `pydantic_core.ValidationError` when the SDK deserialises the `ListFoundryConnectedToolsResponse`, because `SchemaType` only accepts the six standard JSON Schema types (`string`, `number`, `integer`, `boolean`, `array`, `object`).

### Error
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ListFoundryConnectedToolsResponse
ResultType.tools.0.manifest.9.parameters.properties.seed.type
  Input should be 'string', 'number', 'integer', 'boolean', 'array' or 'object'
```

## Fix

### 1. `azure-ai-agentserver-core` - `_models.py`
- Changed `SchemaProperty.type` from `SchemaType` to `Optional[SchemaType]` with a default of `None`
- Added a `model_validator(mode='before')` that coerces empty type strings (`""`) to `None`

### 2. `azure-ai-agentserver-agentframework` - `_foundry_tools.py`
- Added a guard in `FoundryToolClient._create_ai_function` that skips parameters with `type is None` and logs a warning, instead of crashing with `AttributeError: 'NoneType' object has no attribute 'py_type'`

## Testing
- Verified locally with HuggingFace MCP Server (previously failing) — now works
- Verified MicrosoftLearn MCP Server still works (was never affected)
- No existing tests broken