### PR TITLE
Mengla/fix-output-null

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-agentframework/azure/ai/agentserver/agentframework/models/agent_framework_output_streaming_converter.py
+++ b/sdk/agentserver/azure-ai-agentserver-agentframework/azure/ai/agentserver/agentframework/models/agent_framework_output_streaming_converter.py
@@ -459,6 +459,8 @@ class AgentFrameworkOutputStreamingConverter:
             "created_at": self._response_created_at,
             "conversation": self._context.get_conversation_object(),
         }
-        if status == "completed" and self._completed_output_items:
+
+        # set output even if _completed_output_items is empty, never leave the output as null
+        if status == "completed":
             response_data["output"] = self._completed_output_items
         return OpenAIResponse(response_data)


### PR DESCRIPTION
# Description

fix agentframework adapter to make sure the output in response complete event not null.

otherwise, it will cause agents service save response failed with exception: 
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Select[TSource,TResult](IEnumerable`1 source, Func`2 selector)
   at Azure.AI.Agents.Services.Storage.V2.Models.Extensions.ToStorageModel(Response apiModel, String projectId, IEnumerable`1 inputItemRefs, Dictionary`2 extensionData, IReadOnlyDictionary`2 additionalMetadata) in /mnt/vss/_work/1/s/src/azureml-api/src/Agents/Services/Storage/V2/Models/Extensions.cs:line 62
   at Azure.AI.Agents.Services.ContainerAgents.Core.Managers.ContainerResponseManager.SaveResponseAsync(Response response, AgentId agentId, List`1 inputItems, ProjectConnectionString connectionString, String conversationId, CancellationToken cancellationToken, Boolean existing, IReadOnlyDictionary`2 telemetryMetadata) in /mnt/vss/_work/1/s/src/azureml-api/src/Agents/Services/ContainerAgents/Core/Managers/ContainerResponseManager.cs:line 154

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
