### PR TITLE
Fix: Handle empty schema type in LangGraph tool resolver

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-langgraph/azure/ai/agentserver/langgraph/tools/_resolver.py
+++ b/sdk/agentserver/azure-ai-agentserver-langgraph/azure/ai/agentserver/langgraph/tools/_resolver.py
@@ -4,6 +4,8 @@
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, overload
 
+import logging
+
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field, create_model
 
@@ -128,6 +130,10 @@ class FoundryLangChainToolResolver:
         field_definitions: Dict[str, Any] = {}
         required_fields = input_schema.required or set()
         for prop_name, prop in input_schema.properties.items():
+            if prop.type is None:
+                logging.getLogger(__name__).warning(
+                    "Skipping field '%s' in tool '%s': unknown or empty schema type.", prop_name, tool_name)
+                continue
             py_type = prop.type.py_type
             default = ... if prop_name in required_fields else None
             field_definitions[prop_name] = (py_type, Field(default, description=prop.description))


### PR DESCRIPTION
## Problem

Follow-up to PR #45051. The same empty schema type issue from MCP tool manifests (e.g. HuggingFace MCP Server returning `type: ""` for certain parameters) also affects the LangGraph tool resolver at `FoundryLangChainToolResolver._create_pydantic_model`.

When `SchemaProperty.type` is `None` (coerced from an empty string by the core fix in #45051), the LangGraph resolver crashes with:
```
AttributeError: 'NoneType' object has no attribute 'py_type'
```

## Fix

Added a guard in `_resolver.py` that skips properties with `None` type and logs a warning, matching the same pattern applied in the agentframework package.

## Changes
- `sdk/agentserver/azure-ai-agentserver-langgraph/azure/ai/agentserver/langgraph/tools/_resolver.py`