### PR TITLE
Remove Regression Run from PR

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -305,43 +305,44 @@ jobs:
         UnsupportedToxEnvironments: ${{ parameters.UnsupportedToxEnvironments }}
         TestProxy: ${{ parameters.TestProxy }}
 
-  - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-    parameters:
-      JobTemplatePath: /eng/pipelines/templates/jobs/regression.yml
-      OsVmImage: ubuntu-24.04
-      Pool: azsdk-pool
-      GenerateJobName: generate_regression_matrix
-      SparseCheckoutPaths: [ "scripts/", "sdk/", "eng/tools/azure-sdk-tools/" ]
-      MatrixConfigs:
-          - Name: Python_regression_envs
-            Path: eng/pipelines/templates/stages/regression-job-matrix.json
-            Selection: sparse
-            GenerateVMJobs: true
-      PreGenerationSteps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.12'
-        - template: /eng/pipelines/templates/steps/use-venv.yml
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-            $PSNativeCommandUseErrorActionPreference = $true
-            $(PIP_EXE) install "./eng/tools/azure-sdk-tools[build]"
-          displayName: 'Prep Environment'
-        - task: PythonScript@0
-          displayName: 'Ensure service coverage'
-          inputs:
-            scriptPath: '$(Build.SourcesDirectory)/scripts/devops_tasks/update_regression_services.py'
-            arguments: >-
-              "azure*"
-              --service="${{ parameters.ServiceDirectory }}"
-              --json=$(Build.SourcesDirectory)/eng/pipelines/templates/stages/regression-job-matrix.json
-      CloudConfig:
-        Cloud: Public
-      DependsOn:
-        - 'Build_Linux'
-        - 'Build_Windows'
-        - 'Build_MacOS'
-      AdditionalParameters:
-        BuildTargetingString: ${{ parameters.BuildTargetingString }}
-        ServiceDirectory: ${{ parameters.ServiceDirectory }}
-        TestTimeoutInMinutes: 90
+  - ${{ if ne(parameters.ServiceDirectory, 'auto') }}:
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        JobTemplatePath: /eng/pipelines/templates/jobs/regression.yml
+        OsVmImage: ubuntu-24.04
+        Pool: azsdk-pool
+        GenerateJobName: generate_regression_matrix
+        SparseCheckoutPaths: [ "scripts/", "sdk/", "eng/tools/azure-sdk-tools/" ]
+        MatrixConfigs:
+            - Name: Python_regression_envs
+              Path: eng/pipelines/templates/stages/regression-job-matrix.json
+              Selection: sparse
+              GenerateVMJobs: true
+        PreGenerationSteps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.12'
+          - template: /eng/pipelines/templates/steps/use-venv.yml
+          - pwsh: |
+              $ErrorActionPreference = 'Stop'
+              $PSNativeCommandUseErrorActionPreference = $true
+              $(PIP_EXE) install "./eng/tools/azure-sdk-tools[build]"
+            displayName: 'Prep Environment'
+          - task: PythonScript@0
+            displayName: 'Ensure service coverage'
+            inputs:
+              scriptPath: '$(Build.SourcesDirectory)/scripts/devops_tasks/update_regression_services.py'
+              arguments: >-
+                "azure*"
+                --service="${{ parameters.ServiceDirectory }}"
+                --json=$(Build.SourcesDirectory)/eng/pipelines/templates/stages/regression-job-matrix.json
+        CloudConfig:
+          Cloud: Public
+        DependsOn:
+          - 'Build_Linux'
+          - 'Build_Windows'
+          - 'Build_MacOS'
+        AdditionalParameters:
+          BuildTargetingString: ${{ parameters.BuildTargetingString }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          TestTimeoutInMinutes: 90


### PR DESCRIPTION
We're seeing a job failure currently [here](https://dev.azure.com/azure-sdk/public/public%20Team/_build/results?buildId=5855114&view=logs&j=2e8bded0-b06c-5a9b-286e-efb0e0fd18fa&t=b22a4fc6-fb73-537e-a56d-abc2644a158b&l=86) due to parsing through the packages.

@mccoyp has the proper fix out, but we need to get approval from the codeowners there.

This PR straight up removes this part of the run from PR.