### PR TITLE
Clean up CODEOWNERS by removing unused entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -640,9 +640,6 @@
 # ServiceLabel: %Devtestlab %Service Attention
 # ServiceOwners:          @Tanmayeekamath
 
-# ServiceLabel: %Device Provisioning Service %Service Attention
-# ServiceOwners:          @nberdy
-
 # ServiceLabel: %Functions %Service Attention
 # ServiceOwners:          @ahmedelnably @fabiocav
 


### PR DESCRIPTION
Device Provisioning Service label doesn't exist. This never did anything.
