### PR TITLE
[skill] Update emitter-package-update skill: align openai-typespec with spec repo

### DIFF
--- a/.github/skills/emitter-package-update/SKILL.md
+++ b/.github/skills/emitter-package-update/SKILL.md
@@ -63,6 +63,8 @@ Apply the version update:
 npx npm-check-updates --packageFile eng/emitter-package.json -u
 ```
 
+Align `@azure-tools/openai-typespec` with the version pinned in [azure-rest-api-specs/package.json](https://github.com/Azure/azure-rest-api-specs/blob/main/package.json) to ensure consistency between the emitter and the spec repo. Check the spec repo's version and update `eng/emitter-package.json` accordingly (e.g., set `"@azure-tools/openai-typespec": "1.8.0"` to match).
+
 Regenerate the lock file:
 
 ```bash


### PR DESCRIPTION
context is [here](https://teams.microsoft.com/l/message/19:b97d98e6d22c41e0970a1150b484d935@thread.skype/1770770747893?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1770743547831&teamName=Azure%20SDK&channelName=Language%20-%20Python&createdTime=1770770747893)

Add a step in the emitter-package-update skill to align `@azure-tools/openai-typespec` with the version pinned in [azure-rest-api-specs/package.json](https://github.com/Azure/azure-rest-api-specs/blob/main/package.json) after running npm-check-updates, ensuring version consistency between the emitter and the spec repo.