### PR TITLE
Remove Managed Services label and owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -679,9 +679,6 @@
 # ServiceLabel: %Managed Identity %Service Attention
 # ServiceOwners:          @varunkch
 
-# ServiceLabel: %Managed Services %Service Attention
-# ServiceOwners:          @Lighthouse-Azure
-
 # ServiceLabel: %MariaDB %Service Attention
 # ServiceOwners:          @ambhatna @savjani
 


### PR DESCRIPTION
Removed service label and owners for Managed Services.

This label doesn't map to a library path and it's owners aren't an Azure or microsoft GH team.