### PR TITLE
Remove media ownership from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -443,9 +443,6 @@
 # PRLabel: %Tables
 /sdk/tables/                                                         @YalinLi0312
 
-# PRLabel: %Media
-/sdk/media/                                                          @naiteeks @giakas
-
 # AzureSdkOwners: @YalinLi0312
 # ServiceLabel: %Container Registry
 # ServiceOwners: @toddysm @northtyphoon


### PR DESCRIPTION
Label is tied to libraries only available in python and are both deprecated and no longer maintained.
