### PR TITLE
Remove operational insights service label and owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -742,9 +742,6 @@
 # ServiceLabel: %Notification Hub %Service Attention
 # ServiceOwners:          @tjsomasundaram
 
-# ServiceLabel: %Operational Insights %Service Attention
-# ServiceOwners:          @AzmonLogA
-
 # ServiceLabel: %Policy %Service Attention
 # ServiceOwners:          @aperezcloud @kenieva
 


### PR DESCRIPTION
Label doesn't exist and isn't tied to any path in the repo.