### PR TITLE
Improve red team failure telemetry logging

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_mlflow_integration.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_mlflow_integration.py
@@ -366,6 +366,8 @@ class MLflowIntegration:
                                 self.logger.debug(f"Logged metric: {risk_category}_{key} = {value}")
 
             if self._one_dp_project:
+                run_id = getattr(eval_run, "id", "unknown")
+                run_display_name = getattr(eval_run, "display_name", None) or "unknown"
                 # Step 1: Upload evaluation results (blob upload + version create)
                 evaluation_result_id = None
                 try:
@@ -379,7 +381,10 @@ class MLflowIntegration:
                     )
                     evaluation_result_id = create_evaluation_result_response.id
                 except Exception as e:
-                    self.logger.error(f"Failed to create evaluation result: {str(e)}")
+                    self.logger.error(
+                        f"Failed to create evaluation result for run {run_id} ({run_display_name}): {str(e)}",
+                        exc_info=True,
+                    )
 
                 # Step 2: Always update the run status, even if result upload failed
                 outputs = None
@@ -399,7 +404,7 @@ class MLflowIntegration:
                     )
                     self.logger.debug(f"Updated UploadRun: {update_run_response.id}")
                 except Exception as e:
-                    self.logger.error(f"Failed to update red team run status: {str(e)}")
+                    self.logger.error(f"Failed to update red team run status for run {run_id}: {str(e)}", exc_info=True)
             else:
                 # Log the entire directory to MLFlow
                 try:
@@ -431,19 +436,23 @@ class MLflowIntegration:
         """
         if not self._one_dp_project:
             return
+        run_id = getattr(eval_run, "id", "unknown")
+        run_display_name = getattr(eval_run, "display_name", None)
         try:
             self.generated_rai_client._evaluation_onedp_client.update_red_team_run(
                 name=eval_run.id,
                 red_team=RedTeamUpload(
                     id=eval_run.id,
-                    display_name=getattr(eval_run, "display_name", None)
-                    or f"redteam-agent-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
+                    display_name=run_display_name or f"redteam-agent-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
                     status=status,
                 ),
             )
-            self.logger.info(f"Updated red team run status to '{status}'")
+            self.logger.info(f"Updated red team run {run_id} status to '{status}'")
         except Exception as e:
-            self.logger.error(f"Failed to update red team run status to '{status}': {str(e)}")
+            self.logger.error(
+                f"Failed to update red team run {run_id} status to '{status}': {str(e)}",
+                exc_info=True,
+            )
 
     def _build_instance_results_payload(
         self,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
@@ -1432,7 +1432,11 @@ class RedTeam:
 
                 # Process and return results
                 return await self._finalize_results(skip_upload, skip_evals, eval_run, output_path, scan_name)
-            except Exception:
+            except Exception as e:
+                self.logger.error(
+                    f"Red team scan execution failed for run {getattr(eval_run, 'id', 'unknown')}: {str(e)}",
+                    exc_info=True,
+                )
                 # Ensure the run status is updated to Failed if an upload was started
                 if not skip_upload and self.mlflow_integration is not None:
                     self.mlflow_integration.update_run_status(eval_run, "Failed")


### PR DESCRIPTION
Add run identifiers and exception traceback logging for OneDP create/update failure paths, include run context in update_run_status logs, and log scan execution failures before fallback status updates.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
