### PR TITLE
Fix apistub token path

### DIFF
--- a/eng/scripts/dispatch_checks.py
+++ b/eng/scripts/dispatch_checks.py
@@ -43,7 +43,15 @@ PROXY_STATUS_SUFFIX = "/Info/Available"
 PROXY_STARTUP_TIMEOUT = 60
 BASE_PROXY_PORT = 5050
 # Checks implemented via InstallAndTest all require shared recording restore behavior.
-INSTALL_AND_TEST_CHECKS = {"whl", "whl_no_aio", "sdist", "devtest", "optional", "latestdependency", "mindependency"}
+INSTALL_AND_TEST_CHECKS = {
+    "whl",
+    "whl_no_aio",
+    "sdist",
+    "devtest",
+    "optional",
+    "latestdependency",
+    "mindependency",
+}
 SHARED_RESTORE_ENV = "__shared_restore__"
 
 
@@ -76,7 +84,9 @@ def _compare_req_to_injected_reqs(parsed_req, injected_packages: List[str]) -> b
     return any(parsed_req.name in req for req in injected_packages)
 
 
-def _inject_custom_reqs(req_file: str, injected_packages: str, package_dir: str) -> None:
+def _inject_custom_reqs(
+    req_file: str, injected_packages: str, package_dir: str
+) -> None:
     req_lines = []
     injected_list = [p for p in re.split(r"[\s,]", injected_packages) if p]
 
@@ -105,7 +115,8 @@ def _inject_custom_reqs(req_file: str, injected_packages: str, package_dir: str)
         all_adjustments = installable + [
             line_tuple[0].strip()
             for line_tuple in req_lines
-            if line_tuple[0].strip() and not _compare_req_to_injected_reqs(line_tuple[1], all_filter_names)
+            if line_tuple[0].strip()
+            and not _compare_req_to_injected_reqs(line_tuple[1], all_filter_names)
         ]
     else:
         all_adjustments = installable
@@ -125,6 +136,7 @@ async def run_check(
     total: int,
     proxy_port: int,
     mark_arg: Optional[str],
+    dest_dir: Optional[str] = None,
 ) -> CheckResult:
     """Run a single check (subprocess) within a concurrency semaphore, capturing output and timing.
 
@@ -150,12 +162,16 @@ async def run_check(
         cmd = base_args + [check, "--isolate", package]
         if mark_arg:
             cmd += ["--mark_arg", mark_arg]
+        if dest_dir and check == "apistub":
+            cmd += ["--dest-dir", dest_dir]
         logger.info(f"[START {idx}/{total}] {check} :: {package}\nCMD: {' '.join(cmd)}")
         env = os.environ.copy()
         env["PROXY_URL"] = f"http://localhost:{proxy_port}"
 
         if in_ci():
-            env["PROXY_ASSETS_FOLDER"] = os.path.join(root_dir, ".assets_distributed", str(proxy_port))
+            env["PROXY_ASSETS_FOLDER"] = os.path.join(
+                root_dir, ".assets_distributed", str(proxy_port)
+            )
         try:
             logger.info(" ".join(cmd))
             proc = await asyncio.create_subprocess_exec(
@@ -175,7 +191,9 @@ async def run_check(
         stderr = stderr_b.decode(errors="replace")
         exit_code = proc.returncode or 0
         status = "OK" if exit_code == 0 else f"FAIL({exit_code})"
-        logger.info(f"[END   {idx}/{total}] {check} :: {package} -> {status} in {duration:.2f}s")
+        logger.info(
+            f"[END   {idx}/{total}] {check} :: {package} -> {status} in {duration:.2f}s"
+        )
         # Print captured output after completion to avoid interleaving
         header = f"===== OUTPUT: {check} :: {package} (exit {exit_code}) ====="
         trailer = "=" * len(header)
@@ -199,7 +217,9 @@ async def run_check(
         # finally, we need to clean up any temp dirs created by --isolate
         if in_ci():
             package_name = os.path.basename(os.path.normpath(package))
-            isolate_dir = os.path.join(root_dir, ".venv", package_name, f".venv_{check}")
+            isolate_dir = os.path.join(
+                root_dir, ".venv", package_name, f".venv_{check}"
+            )
             ISOLATE_DIRS_TO_CLEAN.append(isolate_dir)
         return CheckResult(package, check, exit_code, duration, stdout, stderr)
 
@@ -224,14 +244,26 @@ def summarize(results: List[CheckResult]) -> int:
     print("-" * len(header))
     for r in sorted(results, key=lambda x: (x.exit_code != 0, x.package, x.check)):
         status = "OK" if r.exit_code == 0 else f"FAIL({r.exit_code})"
-        print(f"{r.package.ljust(pkg_w)}  {r.check.ljust(chk_w)}  {status.ljust(8)}  {r.duration:>10.2f}")
+        print(
+            f"{r.package.ljust(pkg_w)}  {r.check.ljust(chk_w)}  {status.ljust(8)}  {r.duration:>10.2f}"
+        )
     worst = max((r.exit_code for r in results), default=0)
     failed = [r for r in results if r.exit_code != 0]
-    print(f"\nTotal checks: {len(results)} | Failed: {len(failed)} | Worst exit code: {worst}")
+    print(
+        f"\nTotal checks: {len(results)} | Failed: {len(failed)} | Worst exit code: {worst}"
+    )
     return worst
 
 
-async def run_all_checks(packages, checks, max_parallel, wheel_dir, mark_arg: Optional[str], injected_packages: str):
+async def run_all_checks(
+    packages,
+    checks,
+    max_parallel,
+    wheel_dir,
+    mark_arg: Optional[str],
+    injected_packages: str,
+    dest_dir: Optional[str] = None,
+):
     """Run all checks for all packages concurrently and return the worst exit code.
 
     :param packages: Iterable of package paths to run checks against.
@@ -256,10 +288,14 @@ async def run_all_checks(packages, checks, max_parallel, wheel_dir, mark_arg: Op
     dependency_tools_path = os.path.join(root_dir, "eng", "dependency_tools.txt")
 
     if in_ci():
-        logger.info("Replacing relative requirements in eng/test_tools.txt with prebuilt wheels.")
+        logger.info(
+            "Replacing relative requirements in eng/test_tools.txt with prebuilt wheels."
+        )
         replace_dev_reqs(test_tools_path, root_dir, wheel_dir)
 
-        logger.info("Replacing relative requirements in eng/dependency_tools.txt with prebuilt wheels.")
+        logger.info(
+            "Replacing relative requirements in eng/dependency_tools.txt with prebuilt wheels."
+        )
         replace_dev_reqs(dependency_tools_path, root_dir, wheel_dir)
 
     for pkg in packages:
@@ -281,7 +317,9 @@ async def run_all_checks(packages, checks, max_parallel, wheel_dir, mark_arg: Op
         if not is_check_enabled(package, check, CHECK_DEFAULTS.get(check, True)):
             logger.warning(f"Skipping disabled check {check} for package {package}")
             continue
-        logger.info(f"Assigning proxy port {next_proxy_port} to check {check} for package {package}")
+        logger.info(
+            f"Assigning proxy port {next_proxy_port} to check {check} for package {package}"
+        )
         scheduled.append((package, check, next_proxy_port))
         next_proxy_port += 1
 
@@ -289,7 +327,19 @@ async def run_all_checks(packages, checks, max_parallel, wheel_dir, mark_arg: Op
 
     for idx, (package, check, proxy_port) in enumerate(scheduled, start=1):
         tasks.append(
-            asyncio.create_task(run_check(semaphore, package, check, base_args, idx, total or 1, proxy_port, mark_arg))
+            asyncio.create_task(
+                run_check(
+                    semaphore,
+                    package,
+                    check,
+                    base_args,
+                    idx,
+                    total or 1,
+                    proxy_port,
+                    mark_arg,
+                    dest_dir,
+                )
+            )
         )
 
     # Handle Ctrl+C gracefully
@@ -309,7 +359,9 @@ async def run_all_checks(packages, checks, max_parallel, wheel_dir, mark_arg: Op
         elif isinstance(res, Exception):
             norm_results.append(CheckResult(package, check, 99, 0.0, "", str(res)))
         else:
-            norm_results.append(CheckResult(package, check, 98, 0.0, "", f"Unknown result type: {res}"))
+            norm_results.append(
+                CheckResult(package, check, 98, 0.0, "", f"Unknown result type: {res}")
+            )
     return summarize(norm_results)
 
 
@@ -385,11 +437,15 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         ),
     )
 
-    parser.add_argument("--disablecov", help=("Flag. Disables code coverage."), action="store_true")
+    parser.add_argument(
+        "--disablecov", help=("Flag. Disables code coverage."), action="store_true"
+    )
 
     parser.add_argument(
         "--service",
-        help=("Name of service directory (under sdk/) to test. Example: --service applicationinsights"),
+        help=(
+            "Name of service directory (under sdk/) to test. Example: --service applicationinsights"
+        ),
     )
 
     parser.add_argument(
@@ -456,7 +512,9 @@ In the case of an environment invoking `pytest`, results can be collected in a j
     else:
         target_dir = root_dir
 
-    logger.info(f"Beginning discovery for {args.service} and root dir {root_dir}. Resolving to {target_dir}.")
+    logger.info(
+        f"Beginning discovery for {args.service} and root dir {root_dir}. Resolving to {target_dir}."
+    )
 
     # ensure that recursive virtual envs aren't messed with by this call
     os.environ.pop("VIRTUAL_ENV", None)
@@ -473,7 +531,9 @@ In the case of an environment invoking `pytest`, results can be collected in a j
     )
 
     if len(targeted_packages) == 0:
-        logger.info(f"No packages collected for targeting string {args.glob_string} and root dir {root_dir}. Exit 0.")
+        logger.info(
+            f"No packages collected for targeting string {args.glob_string} and root dir {root_dir}. Exit 0."
+        )
         exit(0)
 
     logger.info(f"Executing checks with the executable {sys.executable}.")
@@ -505,7 +565,9 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         try:
             proxy_executable = prepare_local_tool(root_dir)
         except Exception as exc:
-            logger.error(f"Unable to prepare test proxy executable for recording restore: {exc}")
+            logger.error(
+                f"Unable to prepare test proxy executable for recording restore: {exc}"
+            )
             sys.exit(1)
 
     logger.info(
@@ -516,7 +578,9 @@ In the case of an environment invoking `pytest`, results can be collected in a j
     proxy_processes: List[ProxyProcess] = []
     try:
         if in_ci():
-            logger.info(f"Ensuring {len(checks)} test proxies are running for requested checks...")
+            logger.info(
+                f"Ensuring {len(checks)} test proxies are running for requested checks..."
+            )
         exit_code = asyncio.run(
             run_all_checks(
                 targeted_packages,
@@ -525,6 +589,7 @@ In the case of an environment invoking `pytest`, results can be collected in a j
                 temp_wheel_dir,
                 args.mark_arg,
                 args.injected_packages,
+                args.dest_dir,
             )
         )
     except KeyboardInterrupt:

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -125,11 +125,7 @@ class apistub(Check):
 
             dest_dir = getattr(args, "dest_dir", None)
             if dest_dir:
-                prebuilt_dir = os.getenv("PREBUILT_WHEEL_DIR")
-                if prebuilt_dir:
-                    out_token_path = os.path.join(dest_dir, os.path.basename(os.path.dirname(pkg_path)))
-                else:
-                    out_token_path = os.path.join(dest_dir, os.path.basename(package_dir))
+                out_token_path = os.path.join(dest_dir, package_name)
                 os.makedirs(out_token_path, exist_ok=True)
             else:
                 out_token_path = os.path.abspath(staging_directory)

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -130,6 +130,7 @@ class apistub(Check):
                     out_token_path = os.path.join(dest_dir, os.path.basename(os.path.dirname(pkg_path)))
                 else:
                     out_token_path = os.path.join(dest_dir, os.path.basename(package_dir))
+                os.makedirs(out_token_path, exist_ok=True)
             else:
                 out_token_path = os.path.abspath(staging_directory)
 

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -57,6 +57,12 @@ class apistub(Check):
         p = subparsers.add_parser(
             "apistub", parents=parents, help="Run the apistub check to generate an API stub for a package"
         )
+        p.add_argument(
+            "--dest-dir",
+            dest="dest_dir",
+            default=None,
+            help="Destination directory for generated API stub token files.",
+        )
         p.set_defaults(func=self.run)
 
     def run(self, args: argparse.Namespace) -> int:
@@ -117,7 +123,16 @@ class apistub(Check):
             pkg_path = get_package_wheel_path(package_dir)
             pkg_path = os.path.abspath(pkg_path)
 
-            out_token_path = os.path.abspath(staging_directory)
+            dest_dir = getattr(args, "dest_dir", None)
+            if dest_dir:
+                prebuilt_dir = os.getenv("PREBUILT_WHEEL_DIR")
+                if prebuilt_dir:
+                    out_token_path = os.path.join(dest_dir, os.path.basename(os.path.dirname(pkg_path)))
+                else:
+                    out_token_path = os.path.join(dest_dir, os.path.basename(package_dir))
+            else:
+                out_token_path = os.path.abspath(staging_directory)
+
             cross_language_mapping_path = get_cross_language_mapping_path(package_dir)
 
             if cross_language_mapping_path:


### PR DESCRIPTION
was not putting the APIstub generated json in the correct directory
- actually pass through `--dest-dir` arg from dispatch_checks and use it in apistub for the `--out-token-path`

pipelines
- cosmos https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5902366&view=artifacts&pathAsName=false&type=publishedArtifacts <- json is placed under packages_extended/azure-cosmos
- core: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5905199&view=artifacts&pathAsName=false&type=publishedArtifacts