### PR TITLE
Re-emit from latest TypeSpec, fixing enum values

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_enums.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_enums.py
@@ -256,14 +256,14 @@ class ConnectionType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 class ContainerMemoryLimit(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Type of ContainerMemoryLimit."""
 
-    ENUM_1_G = "1g"
-    """1_G."""
-    ENUM_4_G = "4g"
-    """4_G."""
-    ENUM_16_G = "16g"
-    """16_G."""
-    ENUM_64_G = "64g"
-    """64_G."""
+    MEMORY_1GB = "1g"
+    """MEMORY_1GB."""
+    MEMORY_4GB = "4g"
+    """MEMORY_4GB."""
+    MEMORY_16GB = "16g"
+    """MEMORY_16GB."""
+    MEMORY_64GB = "64g"
+    """MEMORY_64GB."""
 
 
 class CredentialType(str, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/sdk/ai/azure-ai-projects/post-emitter-fixes.cmd
+++ b/sdk/ai/azure-ai-projects/post-emitter-fixes.cmd
@@ -13,10 +13,6 @@ git restore pyproject.toml
 REM Looks like this is no longer needed:
 REM git restore azure\ai\projects\_version.py
 
-REM Rename "A2_A_PREVIEW" to "A2A_PREVIEW". Since this value is an extension to OpenAI.ToolType enum, we can't use @className in client.tsp to do the rename.
-powershell -Command "(Get-Content azure\ai\projects\models\_models.py) -replace 'A2_A_PREVIEW', 'A2A_PREVIEW' | Set-Content azure\ai\projects\models\_models.py"
-powershell -Command "(Get-Content azure\ai\projects\models\_enums.py) -replace 'A2_A_PREVIEW', 'A2A_PREVIEW' | Set-Content azure\ai\projects\models\_enums.py"
-
 REM Rename `"items_property": items`, to `"items": items` in search_memories and begin_update_memories methods. "items" is specified in TypeSpec, but Python emitter does not allow it.
 powershell -Command "(Get-Content azure\ai\projects\aio\operations\_operations.py) -replace '\"items_property\": items', '\"items\": items' | Set-Content azure\ai\projects\aio\operations\_operations.py"
 powershell -Command "(Get-Content azure\ai\projects\operations\_operations.py) -replace '\"items_property\": items', '\"items\": items' | Set-Content azure\ai\projects\operations\_operations.py"

--- a/sdk/ai/azure-ai-projects/samples/agents/tools/sample_agent_code_interpreter_with_files.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/tools/sample_agent_code_interpreter_with_files.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long,useless-suppression
 # ------------------------------------
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.

--- a/sdk/ai/azure-ai-projects/samples/agents/tools/sample_agent_code_interpreter_with_files_async.py
+++ b/sdk/ai/azure-ai-projects/samples/agents/tools/sample_agent_code_interpreter_with_files_async.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long,useless-suppression
 # ------------------------------------
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.


### PR DESCRIPTION
Re-emit from latest TypeSpec, including changes in this TypeSpec PR: https://github.com/Azure/azure-rest-api-specs/pull/40576/changes