### PR TITLE
Disable SBOM uploading on Conda Build for PRs

### DIFF
--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -38,7 +38,7 @@ steps:
       ArtifactPath: '$(Build.SourcesDirectory)/conda/assembled'
       ArtifactName: '${{ parameters.ArtifactPrefix }}distributions'
 
-  - ${{if eq(variables['System.TeamProject'], 'internal') }}:
+  - ${{if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'Upload Conda SBOM'
       condition: succeededOrFailed()


### PR DESCRIPTION
for Conda automation, the release update PR is submitted from a fork of the repo (by the azure-sdk account), which fails at the SBOM step since forks are disallowed from publishing artifacts

so we disable the step for PRs

- example automated PR run (the upload SBOM is correctly absent) https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5914075&view=logs&j=c42d4c44-ae5b-5770-175d-eebbfbbed8ab&t=65906408-9114-587b-6cd6-5695c9df93f4 
- (ignore the other build failure, that's being addressed elsewhere and is unrelated)