### PR TITLE
COSMOS-45387: Fix bug of user_agent_overwrite preventing connection to comsosdb

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -246,7 +246,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             ),
         ]
         # after passing in the user_agent into the user agent policy the user_agent is no longer needed
+        # and user_agent_overwrite is also not needed
         kwargs.pop("user_agent", None)
+        kwargs.pop("user_agent_overwrite", None)
 
         transport = kwargs.pop("transport", None)
         self.pipeline_client: PipelineClient[HttpRequest, HttpResponse] = PipelineClient(


### PR DESCRIPTION
# Description
According to https://github.com/Azure/azure-sdk-for-python/issues/45387, the version of azure-cosmos python package 4.15.0 cannot run due to the user_agent_overwrite parameter reaching the request. This PR introduces a fix for it.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
