### PR TITLE
Fix deprecation release for azure-mgmg-mixedreality

### DIFF
--- a/sdk/mixedreality/azure-mgmt-mixedreality/CHANGELOG.md
+++ b/sdk/mixedreality/azure-mgmt-mixedreality/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.0b3 (2026-02-26)
+
+### Other Changes
+
+  - Fixing error in the last release.
+
 ## 1.1.0b2 (2026-02-06)
 
 ### Other Changes

--- a/sdk/mixedreality/azure-mgmt-mixedreality/azure/mgmt/mixedreality/_version.py
+++ b/sdk/mixedreality/azure-mgmt-mixedreality/azure/mgmt/mixedreality/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "1.1.0b2"
+VERSION = "1.1.0b3"


### PR DESCRIPTION
There was a mishap in the last release and it might be fixed by just doing a fresh release with all the steps.

I forgot to trigger ./Prepare-Release.ps1 last time before triggering the release pipeline, which now seems to be in a broken state. I am not sure that re-releasing will fix it, but I'd rather try this once than to alert multiple people that have to go through logs and stuff.