### PR TITLE
[azpysdk] Log stderr and capture return code on black error

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/black.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/black.py
@@ -92,5 +92,8 @@ class black(Check):
 
             except subprocess.CalledProcessError as e:
                 logger.error(f"Unable to invoke black for {package_name}. Ran into exception {e}.")
+                if e.stderr:
+                    logger.error(e.stderr.decode("utf-8"))
+                results.append(e.returncode)
 
         return max(results) if results else 0


### PR DESCRIPTION
When black raises a CalledProcessError, log the stderr output for debugging and append the return code to results so failures are properly propagated.

Ran into this issue, when I was running `aspysdk black .` on a directory with a file with syntax errors that caused black to fail, but it wouldn't tell me why.