### PR TITLE
Fix AgentReference to accept id field from hosted agent service

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/models/projects/_models.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/models/projects/_models.py
@@ -664,6 +664,8 @@ class AgentReference(_Model):
     :vartype name: str
     :ivar version: The version identifier of the agent.
     :vartype version: str
+    :ivar id: The unique identifier of the agent version.
+    :vartype id: str
     """
 
     type: Literal["agent_reference"] = rest_field(visibility=["read", "create", "update", "delete", "query"])
@@ -672,6 +674,8 @@ class AgentReference(_Model):
     """The name of the agent. Required."""
     version: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
     """The version identifier of the agent."""
+    id: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The unique identifier of the agent version."""
 
     @overload
     def __init__(
@@ -679,6 +683,7 @@ class AgentReference(_Model):
         *,
         name: str,
         version: Optional[str] = None,
+        id: Optional[str] = None,
     ) -> None: ...
 
     @overload

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/server/common/agent_run_context.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/server/common/agent_run_context.py
@@ -73,4 +73,7 @@ def _deserialize_create_response(payload: dict) -> CreateResponse:
 def _deserialize_agent_reference(payload: dict) -> AgentReference:
     if not payload:
         return None   # type: ignore
-    return AgentReference(**payload)
+    # Filter to known fields to avoid unexpected keyword argument errors
+    known_fields = {"type", "name", "version", "id"}
+    filtered = {k: v for k, v in payload.items() if k in known_fields}
+    return AgentReference(**filtered)


### PR DESCRIPTION
## Problem

When the hosted agent service routes requests to LangGraph (or other agentserver-based) containers, it includes an `id` field in the agent reference payload. The `AgentReference` model class does not accept this field, causing deserialization to fail:

```
AgentReference.__init__() got an unexpected keyword argument 'id'
```

This makes **all hosted LangGraph agents non-functional** — the container starts and becomes healthy, but every invocation fails with a `server_error` status.

## Root Cause

In `agent_run_context.py`, the `_deserialize_agent_reference` function splats the full service payload into `AgentReference(**payload)`. The service payload includes `{"id": "agent-name:1", "name": "agent-name", "version": "1", "type": "agent_reference"}`, but `AgentReference` only accepts `name`, `version`, and `type`.

**Note:** The `_models.py` change is to generated code (from TypeSpec at `Azure/azure-rest-api-specs`, `specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp:82`). The permanent fix needs to add `id?: string` to the `AgentReference` model in the TypeSpec. The `agent_run_context.py` change is hand-written code and provides a defensive fix that will persist across regenerations.

## Fix

1. **Add `id` as an optional field** on `AgentReference` model class (`_models.py` - generated, interim fix)
2. **Filter to known fields** in `_deserialize_agent_reference` (`agent_run_context.py` - hand-written, permanent fix)

## Testing

- Verified locally: `AgentReference(name='test', version='1', id='test:1')` succeeds
- Verified in Docker: deserialization of service payload with `id` field succeeds
- Tracked in ADO: https://dev.azure.com/msdata/Vienna/_workitems/edit/5047500