### PR TITLE
Add Evaluator Upload API for uploading custom evaluator code

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch.py
@@ -9,12 +9,12 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 """
 from typing import Any, List
 from ._patch_datasets_async import DatasetsOperations
+from ._patch_evaluators_async import EvaluatorsOperations as BetaEvaluatorsOperations
 from ._patch_telemetry_async import TelemetryOperations
 from ._patch_connections_async import ConnectionsOperations
 from ._patch_memories_async import BetaMemoryStoresOperations
 from ._operations import (
     BetaEvaluationTaxonomiesOperations,
-    BetaEvaluatorsOperations,
     BetaInsightsOperations,
     BetaRedTeamsOperations,
     BetaSchedulesOperations,
@@ -49,6 +49,8 @@ class BetaOperations(GeneratedBetaOperations):
         super().__init__(*args, **kwargs)
         # Replace with patched class that includes begin_update_memories
         self.memory_stores = BetaMemoryStoresOperations(self._client, self._config, self._serialize, self._deserialize)
+        # Replace with patched class that includes upload
+        self.evaluators = BetaEvaluatorsOperations(self._client, self._config, self._serialize, self._deserialize)
 
 
 __all__: List[str] = [

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_evaluators_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_evaluators_async.py
@@ -1,0 +1,141 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Customize generated code here.
+
+Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
+"""
+import os
+import logging
+from typing import Any, IO, Tuple, Optional, Union
+from pathlib import Path
+from azure.storage.blob.aio import ContainerClient
+from azure.core.tracing.decorator_async import distributed_trace_async
+from ._operations import BetaEvaluatorsOperations as EvaluatorsOperationsGenerated, JSON
+from ...models._models import (
+    EvaluatorVersion,
+    PendingUploadRequest,
+    PendingUploadResponse,
+    PendingUploadType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluatorsOperations(EvaluatorsOperationsGenerated):
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azure.ai.projects.aio.AIProjectClient`'s
+        :attr:`beta.evaluators` attribute.
+    """
+
+    async def _start_pending_upload_and_get_container_client(
+        self,
+        name: str,
+        version: str,
+        connection_name: Optional[str] = None,
+    ) -> Tuple[ContainerClient, str]:
+        """Call startPendingUpload to get a SAS URI and return a ContainerClient."""
+
+        pending_upload_response: PendingUploadResponse = await self.pending_upload(
+            name=name,
+            version=version,
+            pending_upload_request=PendingUploadRequest(
+                pending_upload_type=PendingUploadType.BLOB_REFERENCE,
+                connection_name=connection_name,
+            ),
+        )
+
+        if not pending_upload_response.blob_reference:
+            raise ValueError("Blob reference is not present")
+        if not pending_upload_response.blob_reference.credential:
+            raise ValueError("SAS credential are not present")
+        if not pending_upload_response.blob_reference.credential.sas_uri:
+            raise ValueError("SAS URI is missing or empty")
+
+        return (
+            ContainerClient.from_container_url(
+                container_url=pending_upload_response.blob_reference.credential.sas_uri,
+            ),
+            version,
+        )
+
+    @distributed_trace_async
+    async def upload(
+        self,
+        name: str,
+        version: str,
+        evaluator_version: Union[EvaluatorVersion, JSON, IO[bytes]],
+        *,
+        folder: str,
+        connection_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> EvaluatorVersion:
+        """Upload all files in a folder to blob storage and create a code-based evaluator version
+        that references the uploaded code.
+
+        This method uses the ``ContainerClient.upload_blob`` method from the azure-storage-blob
+        package to upload each file. Any extra keyword arguments are forwarded to ``upload_blob``.
+
+        :param name: The name of the evaluator. Required.
+        :type name: str
+        :param version: The version identifier for the evaluator. Required.
+        :type version: str
+        :param evaluator_version: The evaluator version definition. This is the same object accepted
+         by ``create_version``. The definition should include an ``entry_point`` specifying the main
+         Python file of the uploaded code. Is one of the following types: EvaluatorVersion, JSON,
+         IO[bytes]. Required.
+        :type evaluator_version: ~azure.ai.projects.models.EvaluatorVersion or JSON or IO[bytes]
+        :keyword folder: Path to the folder containing the evaluator Python code. Required.
+        :paramtype folder: str
+        :keyword connection_name: The name of an Azure Storage Account connection where the files
+         should be uploaded. If not specified, the default Azure Storage Account connection will be
+         used. Optional.
+        :paramtype connection_name: str
+        :return: The created evaluator version.
+        :rtype: ~azure.ai.projects.models.EvaluatorVersion
+        :raises ~azure.core.exceptions.HttpResponseError: If an error occurs during the HTTP request.
+        """
+        path_folder = Path(folder)
+        if not path_folder.exists():
+            raise ValueError(f"The provided folder `{folder}` does not exist.")
+        if path_folder.is_file():
+            raise ValueError("The provided path is a file, not a folder.")
+
+        container_client, output_version = await self._start_pending_upload_and_get_container_client(
+            name=name,
+            version=version,
+            connection_name=connection_name,
+        )
+
+        async with container_client:
+            files_uploaded: bool = False
+            for root, _, files in os.walk(folder):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    blob_name = os.path.relpath(file_path, folder).replace("\\", "/")
+                    logger.debug(
+                        "[upload] Start uploading file `%s` as blob `%s`.",
+                        file_path,
+                        blob_name,
+                    )
+                    with open(file=file_path, mode="rb") as data:
+                        await container_client.upload_blob(name=str(blob_name), data=data, **kwargs)
+                    logger.debug("[upload] Done uploading file")
+                    files_uploaded = True
+            logger.debug("[upload] Done uploading all files.")
+
+            if not files_uploaded:
+                raise ValueError("The provided folder is empty.")
+
+            result = await self.create_version(
+                name=name,
+                evaluator_version=evaluator_version,
+            )
+
+        return result

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch.py
@@ -9,12 +9,12 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 """
 from typing import Any, List
 from ._patch_datasets import DatasetsOperations
+from ._patch_evaluators import EvaluatorsOperations as BetaEvaluatorsOperations
 from ._patch_telemetry import TelemetryOperations
 from ._patch_connections import ConnectionsOperations
 from ._patch_memories import BetaMemoryStoresOperations
 from ._operations import (
     BetaEvaluationTaxonomiesOperations,
-    BetaEvaluatorsOperations,
     BetaInsightsOperations,
     BetaRedTeamsOperations,
     BetaSchedulesOperations,
@@ -49,6 +49,8 @@ class BetaOperations(GeneratedBetaOperations):
         super().__init__(*args, **kwargs)
         # Replace with patched class that includes begin_update_memories
         self.memory_stores = BetaMemoryStoresOperations(self._client, self._config, self._serialize, self._deserialize)
+        # Replace with patched class that includes upload
+        self.evaluators = BetaEvaluatorsOperations(self._client, self._config, self._serialize, self._deserialize)
 
 
 __all__: List[str] = [

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_evaluators.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_evaluators.py
@@ -1,0 +1,141 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Customize generated code here.
+
+Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
+"""
+import os
+import logging
+from typing import Any, IO, Tuple, Optional, Union
+from pathlib import Path
+from azure.storage.blob import ContainerClient
+from azure.core.tracing.decorator import distributed_trace
+from ._operations import BetaEvaluatorsOperations as EvaluatorsOperationsGenerated, JSON
+from ..models._models import (
+    EvaluatorVersion,
+    PendingUploadRequest,
+    PendingUploadResponse,
+    PendingUploadType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluatorsOperations(EvaluatorsOperationsGenerated):
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azure.ai.projects.AIProjectClient`'s
+        :attr:`beta.evaluators` attribute.
+    """
+
+    def _start_pending_upload_and_get_container_client(
+        self,
+        name: str,
+        version: str,
+        connection_name: Optional[str] = None,
+    ) -> Tuple[ContainerClient, str]:
+        """Call startPendingUpload to get a SAS URI and return a ContainerClient."""
+
+        pending_upload_response: PendingUploadResponse = self.pending_upload(
+            name=name,
+            version=version,
+            pending_upload_request=PendingUploadRequest(
+                pending_upload_type=PendingUploadType.BLOB_REFERENCE,
+                connection_name=connection_name,
+            ),
+        )
+
+        if not pending_upload_response.blob_reference:
+            raise ValueError("Blob reference is not present")
+        if not pending_upload_response.blob_reference.credential:
+            raise ValueError("SAS credential are not present")
+        if not pending_upload_response.blob_reference.credential.sas_uri:
+            raise ValueError("SAS URI is missing or empty")
+
+        return (
+            ContainerClient.from_container_url(
+                container_url=pending_upload_response.blob_reference.credential.sas_uri,
+            ),
+            version,
+        )
+
+    @distributed_trace
+    def upload(
+        self,
+        name: str,
+        version: str,
+        evaluator_version: Union[EvaluatorVersion, JSON, IO[bytes]],
+        *,
+        folder: str,
+        connection_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> EvaluatorVersion:
+        """Upload all files in a folder to blob storage and create a code-based evaluator version
+        that references the uploaded code.
+
+        This method uses the ``ContainerClient.upload_blob`` method from the azure-storage-blob
+        package to upload each file. Any extra keyword arguments are forwarded to ``upload_blob``.
+
+        :param name: The name of the evaluator. Required.
+        :type name: str
+        :param version: The version identifier for the evaluator. Required.
+        :type version: str
+        :param evaluator_version: The evaluator version definition. This is the same object accepted
+         by ``create_version``. The definition should include an ``entry_point`` specifying the main
+         Python file of the uploaded code. Is one of the following types: EvaluatorVersion, JSON,
+         IO[bytes]. Required.
+        :type evaluator_version: ~azure.ai.projects.models.EvaluatorVersion or JSON or IO[bytes]
+        :keyword folder: Path to the folder containing the evaluator Python code. Required.
+        :paramtype folder: str
+        :keyword connection_name: The name of an Azure Storage Account connection where the files
+         should be uploaded. If not specified, the default Azure Storage Account connection will be
+         used. Optional.
+        :paramtype connection_name: str
+        :return: The created evaluator version.
+        :rtype: ~azure.ai.projects.models.EvaluatorVersion
+        :raises ~azure.core.exceptions.HttpResponseError: If an error occurs during the HTTP request.
+        """
+        path_folder = Path(folder)
+        if not path_folder.exists():
+            raise ValueError(f"The provided folder `{folder}` does not exist.")
+        if path_folder.is_file():
+            raise ValueError("The provided path is a file, not a folder.")
+
+        container_client, output_version = self._start_pending_upload_and_get_container_client(
+            name=name,
+            version=version,
+            connection_name=connection_name,
+        )
+
+        with container_client:
+            files_uploaded: bool = False
+            for root, _, files in os.walk(folder):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    blob_name = os.path.relpath(file_path, folder).replace("\\", "/")
+                    logger.debug(
+                        "[upload] Start uploading file `%s` as blob `%s`.",
+                        file_path,
+                        blob_name,
+                    )
+                    with open(file=file_path, mode="rb") as data:
+                        container_client.upload_blob(name=str(blob_name), data=data, **kwargs)
+                    logger.debug("[upload] Done uploading file")
+                    files_uploaded = True
+            logger.debug("[upload] Done uploading all files.")
+
+            if not files_uploaded:
+                raise ValueError("The provided folder is empty.")
+
+            result = self.create_version(
+                name=name,
+                evaluator_version=evaluator_version,
+            )
+
+        return result

--- a/sdk/ai/azure-ai-projects/samples/evaluations/custom_evaluator/answer_length_evaluator.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/custom_evaluator/answer_length_evaluator.py
@@ -1,0 +1,13 @@
+"""Custom evaluator that measures the length of a response."""
+
+
+class AnswerLengthEvaluator:
+    def __init__(self, *, model_config):
+        self.model_config = model_config
+
+    def __call__(self, *args, **kwargs):
+        return {"result": evaluate_answer_length(kwargs.get("response"))}
+
+
+def evaluate_answer_length(answer: str):
+    return len(answer)

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_upload_custom_evaluator.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_upload_custom_evaluator.py
@@ -1,0 +1,95 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""
+DESCRIPTION:
+    Given an AIProjectClient, this sample demonstrates how to upload a local
+    folder containing custom evaluator Python code and register it as a
+    code-based evaluator version using the `evaluators.upload()` method.
+
+USAGE:
+    python sample_eval_upload_custom_evaluator.py
+
+    Before running the sample:
+
+    pip install "azure-ai-projects>=2.0.0b4" azure-storage-blob python-dotenv
+
+    Set these environment variables with your own values:
+    1) AZURE_AI_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
+       Microsoft Foundry project. It has the form: https://<account_name>.services.ai.azure.com/api/projects/<project_name>.
+"""
+
+import os
+from pathlib import Path
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+    CodeBasedEvaluatorDefinition,
+    EvaluatorCategory,
+    EvaluatorType,
+    EvaluatorVersion,
+)
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
+
+# The folder containing the custom evaluator code, relative to this sample file.
+local_upload_folder = str(Path(__file__).parent / "custom_evaluator")
+
+with (
+    DefaultAzureCredential() as credential,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+):
+
+    evaluator_version = EvaluatorVersion(
+        evaluator_type=EvaluatorType.CUSTOM,
+        categories=[EvaluatorCategory.QUALITY],
+        display_name="my_custom_evaluator",
+        description="Custom evaluator to calculate length of content",
+        definition=CodeBasedEvaluatorDefinition(entry_point="answer_length_evaluator.py"),
+        init_parameters={
+            "type": "object",
+            "properties": {"model_config": {"type": "string"}},
+            "required": ["model_config"],
+        },
+        data_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "response": {"type": "string"},
+            },
+            "required": ["query", "response"],
+        },
+        metrics={
+            "score": {
+                "type": "ordinal",
+                "desirable_direction": "increase",
+                "min_value": 1,
+                "max_value": 5,
+            }
+        },
+    )
+
+    print("Uploading custom evaluator code and creating evaluator version...")
+    code_evaluator = project_client.beta.evaluators.upload(
+        name="answer_length_evaluator",
+        version="1",
+        evaluator_version=evaluator_version,
+        folder=local_upload_folder,
+    )
+
+    print(f"Evaluator created: name={code_evaluator.name}, version={code_evaluator.version}")
+    print(f"Evaluator ID: {code_evaluator.id}")
+
+    print("\nCleaning up - deleting the created evaluator version")
+    project_client.beta.evaluators.delete_version(
+        name=code_evaluator.name,
+        version=code_evaluator.version,
+    )
+    print("Done.")


### PR DESCRIPTION
Add upload convenience method to EvaluatorsOperations (patching the generated BetaEvaluatorsOperations) that uploads a local folder of custom evaluator Python code to blob storage and creates a code-based evaluator version. The method accepts the same EvaluatorVersion object as create_version, with entry_point in the definition referencing the main Python file of the uploaded code.

- Add sync _patch_evaluators.py with EvaluatorsOperations class
- Add async _patch_evaluators_async.py counterpart
- Wire patched classes into BetaOperations.__init__ (sync + async)
- Add sample evaluator (answer_length_evaluator.py) and upload script

Depends on TypeSpec PR Azure/azure-rest-api-specs#40955 for startPendingUpload and getCredentials operations on evaluators.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
