### PR TITLE
Update `ServiceDirectory` to fix missing passage in `build-test.yml`

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -113,6 +113,7 @@ jobs:
 
     - template: ../steps/build-test.yml
       parameters:
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
         TestMarkArgument: ${{ parameters.TestMarkArgument }}
         AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
         CoverageArg: $(CoverageArg)


### PR DESCRIPTION
See title. [Origin of this failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5961369&view=results)