### PR TITLE
Fix content-filter responses showing raw JSON in results (#5058447)

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_result_processor.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_result_processor.py
@@ -664,8 +664,11 @@ class ResultProcessor:
                 filter_details = ResultProcessor._extract_filter_details_from_parsed(parsed)
                 if filter_details:
                     return f"[Response blocked by content filter: {', '.join(filter_details)}]"
-                # Parsed successfully and contains content_filter indicators → generic message
-                if ResultProcessor._has_content_filter_keys(parsed):
+                # Only emit a generic blocked message when finish_reason
+                # actually indicates content filtering.  Azure OpenAI always
+                # includes content_filter_results in responses (even unfiltered
+                # ones), so key-presence alone is not sufficient.
+                if ResultProcessor._has_finish_reason_content_filter(parsed):
                     return "[Response blocked by Azure OpenAI content filter]"
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
@@ -692,24 +695,27 @@ class ResultProcessor:
         # looks like a payload but json.loads failed, e.g. truncated JSON).
         if stripped.startswith(("{", "[")):
             try:
-                for category in ["hate", "self_harm", "sexual", "violence"]:
-                    pattern = f'"{category}".*?"filtered"\\s*:\\s*true'
-                    if re.search(pattern, content, re.IGNORECASE):
-                        sev_match = re.search(
-                            f'"{category}".*?"severity"\\s*:\\s*"(\\w+)"',
-                            content,
-                            re.IGNORECASE,
-                        )
-                        severity = sev_match.group(1) if sev_match else "unknown"
-                        filter_details.append(f"{category} (severity: {severity})")
+                # Generic scan: find any key whose object has "filtered": true
+                for m in re.finditer(
+                    r'"([^"]+)"\s*:\s*\{[^}]*"filtered"\s*:\s*true[^}]*\}',
+                    content,
+                    re.IGNORECASE,
+                ):
+                    category = m.group(1)
+                    sev_match = re.search(
+                        rf'"{re.escape(category)}".*?"severity"\s*:\s*"(\w+)"',
+                        content,
+                        re.IGNORECASE,
+                    )
+                    severity = sev_match.group(1) if sev_match else "unknown"
+                    filter_details.append(f"{category} (severity: {severity})")
             except (re.error, AttributeError):
                 pass
 
             if filter_details:
                 return f"[Response blocked by content filter: {', '.join(filter_details)}]"
-            # Last resort: if it starts with JSON chars and mentions content_filter
-            content_lower = content.lower()
-            if "content_filter" in content_lower or '"finish_reason":"content_filter"' in content_lower:
+            # Last resort: only rewrite if finish_reason indicates content filtering
+            if '"finish_reason"' in content and '"content_filter"' in content:
                 return "[Response blocked by Azure OpenAI content filter]"
 
         return content
@@ -741,20 +747,15 @@ class ResultProcessor:
         return details
 
     @staticmethod
-    def _has_content_filter_keys(parsed: Any) -> bool:
-        """Check whether a parsed JSON object contains content-filter indicator keys."""
+    def _has_finish_reason_content_filter(parsed: Any) -> bool:
+        """Return True if the parsed response has finish_reason == 'content_filter'."""
         if not isinstance(parsed, dict):
             return False
-        if "content_filter_results" in parsed:
-            return True
         if parsed.get("finish_reason") == "content_filter":
             return True
         for choice in parsed.get("choices", []):
-            if isinstance(choice, dict):
-                if "content_filter_results" in choice:
-                    return True
-                if choice.get("finish_reason") == "content_filter":
-                    return True
+            if isinstance(choice, dict) and choice.get("finish_reason") == "content_filter":
+                return True
         return False
 
     @staticmethod

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_redteam/test_result_processor.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_redteam/test_result_processor.py
@@ -5,8 +5,6 @@
 
 import json
 
-import pytest
-
 from azure.ai.evaluation.red_team._result_processor import ResultProcessor
 
 
@@ -137,6 +135,55 @@ class TestCleanContentFilterResponse:
         result = ResultProcessor._clean_content_filter_response(payload)
         assert result == payload
 
+    # -- false-positive prevention: unfiltered responses are NOT rewritten ---
+    def test_unfiltered_response_with_cfr_keys_passthrough(self):
+        """Azure OpenAI always includes content_filter_results even when
+        nothing is filtered. These must NOT be rewritten as 'blocked'."""
+        payload = json.dumps(
+            {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"content": "Hello!"},
+                        "content_filter_results": {
+                            "hate": {"filtered": False, "severity": "safe"},
+                            "self_harm": {"filtered": False, "severity": "safe"},
+                            "sexual": {"filtered": False, "severity": "safe"},
+                            "violence": {"filtered": False, "severity": "safe"},
+                        },
+                    }
+                ]
+            }
+        )
+        result = ResultProcessor._clean_content_filter_response(payload)
+        assert result == payload
+
+    def test_top_level_cfr_all_unfiltered_passthrough(self):
+        """Top-level content_filter_results with nothing filtered → passthrough."""
+        payload = json.dumps(
+            {
+                "content_filter_results": {
+                    "hate": {"filtered": False, "severity": "safe"},
+                    "violence": {"filtered": False, "severity": "safe"},
+                }
+            }
+        )
+        result = ResultProcessor._clean_content_filter_response(payload)
+        assert result == payload
+
+    def test_finish_reason_content_filter_no_details_gives_generic_message(self):
+        """finish_reason: content_filter with empty cfr → generic blocked message."""
+        payload = json.dumps({"choices": [{"finish_reason": "content_filter", "content_filter_results": {}}]})
+        result = ResultProcessor._clean_content_filter_response(payload)
+        assert result == "[Response blocked by Azure OpenAI content filter]"
+
+    # -- generic regex: non-standard category names --------------------------
+    def test_regex_fallback_non_standard_category(self):
+        """Step 3 regex should detect any category, not just the 4 hardcoded ones."""
+        broken = '{"choices":[{"custom_risk":{"filtered": true, "severity":"medium"}}'
+        result = ResultProcessor._clean_content_filter_response(broken)
+        assert "custom_risk (severity: medium)" in result
+
 
 class TestExtractFilterDetailsFromParsed:
     """Unit tests for the helper that extracts categories from parsed dicts."""
@@ -156,21 +203,27 @@ class TestExtractFilterDetailsFromParsed:
         assert details == ["hate (severity: low)"]
 
 
-class TestHasContentFilterKeys:
-    """Unit tests for _has_content_filter_keys."""
+class TestHasFinishReasonContentFilter:
+    """Unit tests for _has_finish_reason_content_filter."""
 
-    def test_top_level_key(self):
-        assert ResultProcessor._has_content_filter_keys({"content_filter_results": {}}) is True
+    def test_finish_reason_in_choices(self):
+        parsed = {"choices": [{"finish_reason": "content_filter"}]}
+        assert ResultProcessor._has_finish_reason_content_filter(parsed) is True
 
-    def test_finish_reason(self):
-        assert ResultProcessor._has_content_filter_keys({"finish_reason": "content_filter"}) is True
+    def test_top_level_finish_reason(self):
+        assert ResultProcessor._has_finish_reason_content_filter({"finish_reason": "content_filter"}) is True
 
-    def test_choice_level_key(self):
-        parsed = {"choices": [{"content_filter_results": {}}]}
-        assert ResultProcessor._has_content_filter_keys(parsed) is True
+    def test_finish_reason_stop(self):
+        parsed = {"choices": [{"finish_reason": "stop"}]}
+        assert ResultProcessor._has_finish_reason_content_filter(parsed) is False
 
-    def test_no_indicators(self):
-        assert ResultProcessor._has_content_filter_keys({"choices": [{"text": "hi"}]}) is False
+    def test_no_finish_reason(self):
+        assert ResultProcessor._has_finish_reason_content_filter({"choices": [{"text": "hi"}]}) is False
+
+    def test_cfr_keys_without_finish_reason_returns_false(self):
+        """content_filter_results key alone should NOT indicate blocking."""
+        parsed = {"choices": [{"content_filter_results": {"hate": {"filtered": False}}}]}
+        assert ResultProcessor._has_finish_reason_content_filter(parsed) is False
 
     def test_non_dict(self):
-        assert ResultProcessor._has_content_filter_keys([1, 2]) is False
+        assert ResultProcessor._has_finish_reason_content_filter([1, 2]) is False


### PR DESCRIPTION
## Bug Fix: #5058447

When Azure OpenAI content filters block a response (HTTP 200, finish_reason: content_filter, content: null), the raw JSON API payload was surfaced verbatim as row-level results in the evaluation UI.

### Changes
- Added _clean_content_filter_response() static method to ResultProcessor that detects raw content-filter API payloads and replaces them with human-readable messages
- Integrated the cleaning into _normalize_sample_message() for assistant messages
- Extracts specific filter categories and severity levels when available (e.g. [Response blocked by content filter: self_harm (severity: medium)])
- Falls back to generic [Response blocked by Azure OpenAI content filter] when details cannot be parsed