### PR TITLE
Delete tsp-location.yaml

### DIFF
--- a/sdk/ai/azure-ai-projects/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects/tsp-location.yaml
@@ -1,4 +1,0 @@
-directory: specification/ai-foundry/data-plane/Foundry
-commit: 05c0bec52a73ca6cd87c700ea6f4d5f68b9b433b
-repo: Azure/azure-rest-api-specs
-additionalDirectories: 


### PR DESCRIPTION
Release pipeline https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5970872&view=logs&s=c7cd0118-f010-5861-eed7-c8ca08255019&j=36c22e71-c59f-54e9-f6da-f7b4409fd990 failed the Release stage because the TypeSpec commit is not in the Main branch.

Deleting tsp-location.ymal to avoid this check.