### PR TITLE
[Evaluation] Update CHANGELOG.md for azure-ai-evaluation 1.15.3

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed metadata leak of internal scorer fields (attack_success, attack_strategy, score) into results.json.
 - Improved error logging with run_id, display_name, and full stack traces for red team scan failures.
 - Fixed httpx read timeout errors during red team scans by configuring explicit HTTP timeout on PyRIT OpenAIChatTarget instances (default: 180s, configurable via `_http_timeout` scan kwarg).
+- Fixed `InvalidInputError` crash when evaluating agent tool output containing unresolvable relative image paths from Document Intelligence indexed PDFs, by gracefully falling back to text representation.
 
 ## 1.15.2 (2026-02-23)
 


### PR DESCRIPTION
## What
Add missing CHANGELOG entry for azure-ai-evaluation 1.15.3 (Unreleased).

## Why
PR #45522 (graceful handling of unresolvable relative image paths from Document Intelligence) was merged but its CHANGELOG entry was not included.

## What Changed
- Added entry: Fixed `InvalidInputError` crash when evaluating agent tool output containing unresolvable relative image paths from Document Intelligence indexed PDFs, by gracefully falling back to text representation.

## Risk
None — documentation-only change.