### PR TITLE
Add optional timeout parameter to sdk_changelog tool

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -43,12 +43,15 @@ def execute_func_with_timeout(func, timeout: int = 900) -> Any:
     return multiprocessing.Pool(processes=1).apply_async(func).get(timeout)
 
 
-def get_changelog_content(package_path: Path, package_result: dict, enable_changelog: bool) -> tuple[str, str]:
+def get_changelog_content(
+    package_path: Path, package_result: dict, enable_changelog: bool, timeout: int = 900
+) -> tuple[str, str]:
     """Generate changelog content for the given package path.
     Args:
         package_path (Path): The path to the package directory.
         package_result (dict): The package result dictionary to store changelog info.
         enable_changelog (bool): Flag to enable or disable changelog generation.
+        timeout (int): Timeout in seconds for changelog generation. Defaults to 900.
     Returns:
         tuple[str, str]: A tuple containing the generated markdown content and the last version.
     NOTE:
@@ -79,7 +82,7 @@ def get_changelog_content(package_path: Path, package_result: dict, enable_chang
 
         try:
             if enable_changelog:
-                md_output = execute_func_with_timeout(change_log_func)
+                md_output = execute_func_with_timeout(change_log_func, timeout)
             else:
                 md_output = "skip changelog generation"
         except multiprocessing.TimeoutError:
@@ -104,7 +107,7 @@ def log_failed_message(message: str, enable_log_error: bool):
         _LOGGER.warning(message)
 
 
-def main(package_path: Path, *, enable_changelog: bool = True, package_result: dict = {}):
+def main(package_path: Path, *, enable_changelog: bool = True, package_result: dict = {}, timeout: int = 900):
 
     package_name = package_path.name
     # When package_result is provided, it means this function is called in pipeline and we should not log error
@@ -113,7 +116,7 @@ def main(package_path: Path, *, enable_changelog: bool = True, package_result: d
     # Changelog generation
     try:
         changelog_generation_start_time = time.time()
-        md_output, last_version = get_changelog_content(package_path, package_result, enable_changelog)
+        md_output, last_version = get_changelog_content(package_path, package_result, enable_changelog, timeout=timeout)
         _LOGGER.info(f"changelog generation cost time: {int(time.time() - changelog_generation_start_time)} seconds")
         if package_result:
             package_result["changelog"] = {
@@ -183,6 +186,12 @@ def generate_main():
         required=True,
         help="Absolute path to the package directory (e.g. c:/azure-sdk-for-python/sdk/<service>/<package_name>).",
     )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=900,
+        help="Timeout in seconds for changelog generation (default: 900).",
+    )
     parser.add_argument("--debug", dest="debug", action="store_true", help="Enable DEBUG logging")
 
     args = parser.parse_args()
@@ -198,7 +207,7 @@ def generate_main():
     if not package_path.is_absolute():
         raise ValueError("--package-path must be an absolute path")
 
-    main(package_path)
+    main(package_path, timeout=args.timeout)
 
 
 if __name__ == "__main__":

--- a/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
@@ -156,3 +156,27 @@ def test_invalid_changelog_no_log_for_non_arm_sdk(monkeypatch, temp_package):
 
     assert not called
     assert log_level is None, "Expected no error log for invalid changelog content in data-plane SDK"
+
+
+@patch("packaging_tools.sdk_changelog.get_changelog_content")
+def test_timeout_forwarded_to_get_changelog_content(mock_get_changelog_content, temp_package):
+    package_path, _ = temp_package
+    mock_get_changelog_content.return_value = ("### Features Added\n\n- New feature", "1.0.0")
+
+    changelog_main(package_path, timeout=60)
+
+    mock_get_changelog_content.assert_called_once()
+    _, kwargs = mock_get_changelog_content.call_args
+    assert kwargs["timeout"] == 60
+
+
+@patch("packaging_tools.sdk_changelog.get_changelog_content")
+def test_timeout_default_is_900(mock_get_changelog_content, temp_package):
+    package_path, _ = temp_package
+    mock_get_changelog_content.return_value = ("### Features Added\n\n- New feature", "1.0.0")
+
+    changelog_main(package_path)
+
+    mock_get_changelog_content.assert_called_once()
+    _, kwargs = mock_get_changelog_content.call_args
+    assert kwargs["timeout"] == 900


### PR DESCRIPTION
## What
Add an optional `--timeout` CLI argument (in seconds) to the `sdk_changelog` tool.

## Why
The changelog generation timeout was hardcoded to 900 seconds with no way for users to override it from the CLI or programmatic callers.

## Changes
- **`sdk_changelog.py`**: Added `--timeout` argument to CLI, threaded through `main()` -> `get_changelog_content()` -> `execute_func_with_timeout()`. Defaults to 900s when not specified.
- **`test_sdk_changelog.py`**: Added 2 tests verifying timeout forwarding and default behavior.

No changes needed to existing callers (`sdk_generator.py`, `sdk_update_version.py`, PS1 wrapper) since the parameter is optional with backward-compatible defaults.