### PR TITLE
Add timeout parameter to sdk_generator based on run mode

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -213,6 +213,7 @@ def main(generate_input, generate_output):
                 Path(sdk_code_path).absolute(),
                 enable_changelog=data.get("enableChangelog", True),
                 package_result=result[package_name],
+                timeout=900 if data.get("runMode") in ["spec-pull-request"] else 7200,
             )
 
             # update version in _version.py and CHANGELOG.md


### PR DESCRIPTION
This PR adds a `timeout` parameter to the SDK generator call. The timeout is set to:
- **900 seconds** (15 minutes) for `spec-pull-request` run mode
- **7200 seconds** (2 hours) for all other run modes

This ensures spec pull request validation runs have a shorter timeout, while full generation runs retain a longer timeout.