### PR TITLE
[Evaluation] Release azure-ai-evaluation 1.16.0

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.16.0 (Unreleased)
+## 1.16.0 (2026-03-10)
 
 ### Bugs Fixed
 - Fixed `UnicodeDecodeError` on Windows when reading red team JSONL files containing non-ASCII characters (UnicodeConfusable strategy, CJK languages) by adding explicit `encoding="utf-8"` to all file open calls in the result processing path.


### PR DESCRIPTION
## Release PR for azure-ai-evaluation 1.16.0

Sets the CHANGELOG release date to 2026-03-10.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**