### PR TITLE
Remove internal _http_timeout from public docstring

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_red_team.py
@@ -1291,9 +1291,6 @@ class RedTeam:
         :type timeout: int
         :param skip_evals: Whether to skip the evaluation process
         :type skip_evals: bool
-        :keyword _http_timeout: Internal. HTTP timeout in seconds for the underlying httpx client
-            used by PyRIT's OpenAIChatTarget. Must be a positive int or float. Defaults to 180.
-        :paramtype _http_timeout: Optional[Union[int, float]]
         :return: The output from the red team scan
         :rtype: RedTeamResult
         """


### PR DESCRIPTION
The _http_timeout keyword argument is an internal implementation detail passed via **kwargs. It should not be documented in the public docstring of the scan() method as it is not a public parameter.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
