### PR TITLE
Classes `UpdateMemoriesLROPollingMethod` and `AsyncUpdateMemoriesLROPollingMethod` should be private.

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_memories_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_memories_async.py
@@ -20,8 +20,8 @@ from ...models import (
     ResponseUsageOutputTokensDetails,
     MemoryStoreUpdateCompletedResult,
     AsyncUpdateMemoriesLROPoller,
-    AsyncUpdateMemoriesLROPollingMethod,
 )
+from ...models._patch import _AsyncUpdateMemoriesLROPollingMethod
 from ...models._enums import _FoundryFeaturesOptInKeys
 from ._operations import JSON, _Unset, ClsType, BetaMemoryStoresOperations as GenerateBetaMemoryStoresOperations
 from ...operations._patch_memories import _serialize_memory_input_items
@@ -296,7 +296,9 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
 
         content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
         cls: ClsType[_models.MemoryStoreUpdateCompletedResult] = kwargs.pop("cls", None)
-        polling: Union[bool, AsyncUpdateMemoriesLROPollingMethod] = kwargs.pop("polling", True)
+        polling = kwargs.pop("polling", True)
+        if not isinstance(polling, bool):
+            raise TypeError("polling must be of type bool.")
         lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
         cont_token: Optional[str] = kwargs.pop("continuation_token", None)
         if cont_token is None:
@@ -348,17 +350,16 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
             "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
         }
 
-        if polling is True:
-            polling_method: AsyncUpdateMemoriesLROPollingMethod = AsyncUpdateMemoriesLROPollingMethod(
+        if polling:
+            polling_method: _AsyncUpdateMemoriesLROPollingMethod = _AsyncUpdateMemoriesLROPollingMethod(
                 lro_delay,
                 path_format_arguments=path_format_arguments,
                 headers={"Foundry-Features": _FoundryFeaturesOptInKeys.MEMORY_STORES_V1_PREVIEW.value},
                 **kwargs,
             )
-        elif polling is False:
-            polling_method = cast(AsyncUpdateMemoriesLROPollingMethod, AsyncNoPolling())
         else:
-            polling_method = polling
+            polling_method = cast(_AsyncUpdateMemoriesLROPollingMethod, AsyncNoPolling())
+
         if cont_token:
             return AsyncUpdateMemoriesLROPoller.from_continuation_token(
                 polling_method=polling_method,
@@ -366,6 +367,7 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
                 client=self._client,
                 deserialization_callback=get_long_running_output,
             )
+
         return AsyncUpdateMemoriesLROPoller(
             self._client,
             raw_result,  # type: ignore[possibly-undefined]

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
@@ -68,7 +68,7 @@ _FINISHED = frozenset(["completed", "superseded", "failed"])
 _FAILED = frozenset(["failed"])
 
 
-class UpdateMemoriesLROPollingMethod(LROBasePolling):
+class _UpdateMemoriesLROPollingMethod(LROBasePolling):
     """A custom polling method implementation for Memory Store updates."""
 
     @property
@@ -139,7 +139,7 @@ class UpdateMemoriesLROPollingMethod(LROBasePolling):
             _raise_if_bad_http_status_and_method(self._pipeline_response.http_response)
 
 
-class AsyncUpdateMemoriesLROPollingMethod(AsyncLROBasePolling):
+class _AsyncUpdateMemoriesLROPollingMethod(AsyncLROBasePolling):
     """A custom polling method implementation for Memory Store updates."""
 
     @property
@@ -213,7 +213,7 @@ class AsyncUpdateMemoriesLROPollingMethod(AsyncLROBasePolling):
 class UpdateMemoriesLROPoller(LROPoller[MemoryStoreUpdateCompletedResult]):
     """Custom LROPoller for Memory Store update operations."""
 
-    _polling_method: "UpdateMemoriesLROPollingMethod"
+    _polling_method: "_UpdateMemoriesLROPollingMethod"
 
     @property
     def update_id(self) -> str:
@@ -263,7 +263,7 @@ class UpdateMemoriesLROPoller(LROPoller[MemoryStoreUpdateCompletedResult]):
 class AsyncUpdateMemoriesLROPoller(AsyncLROPoller[MemoryStoreUpdateCompletedResult]):
     """Custom AsyncLROPoller for Memory Store update operations."""
 
-    _polling_method: "AsyncUpdateMemoriesLROPollingMethod"
+    _polling_method: "_AsyncUpdateMemoriesLROPollingMethod"
 
     @property
     def update_id(self) -> str:
@@ -315,8 +315,6 @@ class AsyncUpdateMemoriesLROPoller(AsyncLROPoller[MemoryStoreUpdateCompletedResu
 
 __all__: List[str] = [
     "CustomCredential",
-    "UpdateMemoriesLROPollingMethod",
-    "AsyncUpdateMemoriesLROPollingMethod",
     "UpdateMemoriesLROPoller",
     "AsyncUpdateMemoriesLROPoller",
 ]  # Add all objects you want publicly available to users at this package level

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_memories.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_memories.py
@@ -20,8 +20,8 @@ from ..models import (
     ResponseUsageOutputTokensDetails,
     MemoryStoreUpdateCompletedResult,
     UpdateMemoriesLROPoller,
-    UpdateMemoriesLROPollingMethod,
 )
+from ..models._patch import _UpdateMemoriesLROPollingMethod
 from ..models._enums import _FoundryFeaturesOptInKeys
 from ._operations import JSON, _Unset, ClsType, BetaMemoryStoresOperations as GenerateBetaMemoryStoresOperations
 from .._validation import api_version_validation
@@ -331,7 +331,9 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
 
         content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
         cls: ClsType[MemoryStoreUpdateCompletedResult] = kwargs.pop("cls", None)
-        polling: Union[bool, UpdateMemoriesLROPollingMethod] = kwargs.pop("polling", True)
+        polling = kwargs.pop("polling", True)
+        if not isinstance(polling, bool):
+            raise TypeError("polling must be of type bool.")
         lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
         cont_token: Optional[str] = kwargs.pop("continuation_token", None)
         if cont_token is None:
@@ -383,17 +385,16 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
             "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
         }
 
-        if polling is True:
-            polling_method: UpdateMemoriesLROPollingMethod = UpdateMemoriesLROPollingMethod(
+        if polling:
+            polling_method: _UpdateMemoriesLROPollingMethod = _UpdateMemoriesLROPollingMethod(
                 lro_delay,
                 path_format_arguments=path_format_arguments,
                 headers={"Foundry-Features": _FoundryFeaturesOptInKeys.MEMORY_STORES_V1_PREVIEW.value},
                 **kwargs,
             )
-        elif polling is False:
-            polling_method = cast(UpdateMemoriesLROPollingMethod, NoPolling())
         else:
-            polling_method = polling
+            polling_method = cast(_UpdateMemoriesLROPollingMethod, NoPolling())
+
         if cont_token:
             return UpdateMemoriesLROPoller.from_continuation_token(
                 polling_method=polling_method,
@@ -401,6 +402,7 @@ class BetaMemoryStoresOperations(GenerateBetaMemoryStoresOperations):
                 client=self._client,
                 deserialization_callback=get_long_running_output,
             )
+
         return UpdateMemoriesLROPoller(
             self._client,
             raw_result,  # type: ignore[possibly-undefined]


### PR DESCRIPTION
This is to address apiview.dev comment from Anna and Johan.

Also remove the option to externally provide a custom implementation of LROPoller. This was never tested and not known to be a required user scenario. We will bring back this option if/when needed.