### PR TITLE
Fix full text policy test assertions to accommodate backend V2 read behavior

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_full_text_policy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_full_text_policy.py
@@ -230,8 +230,9 @@ class TestFullTextPolicy(unittest.TestCase):
             pytest.fail("Container creation should have failed for wrong supported language.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "The Full Text Policy contains an unsupported language spa-SPA. Supported languages are:"\
-                   in e.http_error_message
+            assert re.search(
+                    r"the full.text policy contains an unsupported language.*spa-SPA",
+                    e.http_error_message, re.IGNORECASE)
 
         # Pass a full text policy with an unsupported path language
         full_text_policy_wrong_default = {
@@ -252,8 +253,9 @@ class TestFullTextPolicy(unittest.TestCase):
             pytest.fail("Container creation should have failed for wrong supported language.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "The Full Text Policy contains an unsupported language spa-SPA. Supported languages are:"\
-                   in e.http_error_message
+            assert re.search(
+                    r"the full.text policy contains an unsupported language.*spa-SPA",
+                    e.http_error_message, re.IGNORECASE)
 
     def test_fail_create_full_text_indexing_policy(self):
         full_text_policy = {
@@ -302,7 +304,9 @@ class TestFullTextPolicy(unittest.TestCase):
             pytest.fail("Container creation should have failed for invalid path.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Full-text index specification at index (0) contains invalid path" in e.http_error_message
+            assert re.search(
+                    r"full.text index specification at index \(0\) contains invalid path",
+                    e.http_error_message, re.IGNORECASE)
 
         # Pass a full text indexing policy without a path field
         indexing_policy_no_path = {
@@ -320,7 +324,9 @@ class TestFullTextPolicy(unittest.TestCase):
             pytest.fail("Container creation should have failed for missing path.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Missing path in full-text index specification at index (0)" in e.http_error_message
+            assert re.search(
+                    r"missing path in full.text index specification at index \(0\)",
+                    e.http_error_message, re.IGNORECASE)
 
     # Skipped until testing pipeline is set up for full text multi-language support
     @pytest.mark.skip
@@ -625,7 +631,9 @@ class TestFullTextPolicy(unittest.TestCase):
                 pytest.fail("Container replacement should have failed for unsupported language.")
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == 400
-                assert "The Full Text Policy contains an unsupported language" in e.http_error_message
+                assert re.search(
+                        r"the full.text policy contains an unsupported language",
+                        e.http_error_message, re.IGNORECASE)
         finally:
             self.test_db.delete_container(container.id)
 

--- a/sdk/cosmos/azure-cosmos/tests/test_full_text_policy_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_full_text_policy_async.py
@@ -244,8 +244,9 @@ class TestFullTextPolicyAsync(unittest.IsolatedAsyncioTestCase):
             pytest.fail("Container creation should have failed for wrong supported language.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "The Full Text Policy contains an unsupported language spa-SPA. Supported languages are:" \
-                   in e.http_error_message
+            assert re.search(
+                    r"the full.text policy contains an unsupported language.*spa-SPA",
+                    e.http_error_message, re.IGNORECASE)
 
         # Pass a full text policy with an unsupported path language
         full_text_policy_wrong_default = {
@@ -266,8 +267,9 @@ class TestFullTextPolicyAsync(unittest.IsolatedAsyncioTestCase):
             pytest.fail("Container creation should have failed for wrong supported language.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "The Full Text Policy contains an unsupported language spa-SPA. Supported languages are:" \
-                   in e.http_error_message
+            assert re.search(
+                    r"the full.text policy contains an unsupported language.*spa-SPA",
+                    e.http_error_message, re.IGNORECASE)
 
     async def test_fail_create_full_text_indexing_policy_async(self):
         full_text_policy = {
@@ -316,7 +318,9 @@ class TestFullTextPolicyAsync(unittest.IsolatedAsyncioTestCase):
             pytest.fail("Container creation should have failed for invalid path.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Full-text index specification at index (0) contains invalid path" in e.http_error_message
+            assert re.search(
+                    r"full.text index specification at index \(0\) contains invalid path",
+                    e.http_error_message, re.IGNORECASE)
 
         # Pass a full text indexing policy without a path field
         indexing_policy_no_path = {
@@ -334,7 +338,9 @@ class TestFullTextPolicyAsync(unittest.IsolatedAsyncioTestCase):
             pytest.fail("Container creation should have failed for missing path.")
         except exceptions.CosmosHttpResponseError as e:
             assert e.status_code == 400
-            assert "Missing path in full-text index specification at index (0)" in e.http_error_message
+            assert re.search(
+                    r"missing path in full.text index specification at index \(0\)",
+                    e.http_error_message, re.IGNORECASE)
 
     # Skipped until testing pipeline is set up for full text multi-language support
     @pytest.mark.skip
@@ -494,7 +500,9 @@ class TestFullTextPolicyAsync(unittest.IsolatedAsyncioTestCase):
                 pytest.fail("Container replacement should have failed for unsupported language.")
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == 400
-                assert "The Full Text Policy contains an unsupported language" in e.http_error_message
+                assert re.search(
+                        r"the full.text policy contains an unsupported language",
+                        e.http_error_message, re.IGNORECASE)
         finally:
             await self.test_db.delete_container(container.id)
 


### PR DESCRIPTION
# Description

The full text policy tests were failing due to a backend change in how the full text policy is returned on reads. The backend now implements V2 of the full text policy while still accepting V1 for backward compatibility. However, the policy returned in the read response is no longer identical to what was sent during container creation.

The backend's updated read behavior now populates both defaultLanguage and defaultSpec fields:

1. If both defaultLanguage and defaultSpec are set:  returned as-is.
2. If both defaultLanguage and defaultSpec are missing: returned as-is.
3. If defaultLanguage is missing but defaultSpec is present: defaultLanguage is set to defaultSpec.language.
4. If defaultLanguage is present but defaultSpec is missing: defaultSpec.language is set to defaultLanguage.

Because the response may contain additional fields not present in the original request, tests now assert on individual fields (defaultLanguage, fullTextPaths) rather than comparing the entire policy object.

Full support for the V2 full text policy with defaultSpec will follow in a separate PR, as the backend is still finalizing additional V2 functionality.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
