### PR TITLE
Add MGMT SDK code review rules to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,6 +129,37 @@ Ask the user for clarification if repository path or configuration file is ambig
 
 ---
 
+## MGMT SDK Code Review Rules
+
+### SCOPE
+These rules apply to management-plane SDK packages located at `sdk/*/azure-mgmt-*/`.
+
+### REVIEW EXCLUSIONS
+- **Skip** the `generated_samples/` and `generated_tests/` folders entirely — do not review generated sample or test code.
+- **Skip** source code under `azure/mgmt/**/` **except** `_client.py` — only review `_client.py` among the generated source files.
+
+### VERSION CONSISTENCY
+- The version string in `_version.py` **must** match the latest version listed in `CHANGELOG.md`.
+
+### CHANGELOG DATE
+- If the release date of the latest version in `CHANGELOG.md` is **more than 3 weeks in the future** from the current date, remind the author to verify and update the date.
+
+### PYPROJECT.TOML STABILITY FLAGS
+- **Stable version** (version string does **not** contain `b`):
+  - `is_stable` in `pyproject.toml` must be `true`
+  - `classifiers` must include `"Development Status :: 5 - Production/Stable"`
+- **Preview version** (version string contains `b`):
+  - `is_stable` in `pyproject.toml` must be `false`
+  - `classifiers` must include `"Development Status :: 4 - Beta"`
+
+### CLIENT SIGNATURE
+- The `__init__` method of the client class in `_client.py` must include the parameters `credential`, `subscription_id`, and `base_url` **in that order**. Default values are not checked.
+
+### README CODE SNIPPETS
+- Code snippets in `README.md` must follow the real client class signatures and usage patterns. Verify that sample code matches the actual client API.
+
+---
+
 ## SDK release
 
 For detailed workflow instructions, see [SDK Release](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/instructions/copilot/sdk-release.instructions.md).


### PR DESCRIPTION
## Summary

Adds a new **MGMT SDK Code Review Rules** section to .github/copilot-instructions.md for management-plane SDK packages (sdk/*/azure-mgmt-*/).

## Rules Added

- **Review exclusions**: Skip generated_samples/, generated_tests/, and source under zure/mgmt/**/ except _client.py`n- **Version consistency**: _version.py must match latest CHANGELOG.md version
- **CHANGELOG date**: Warn if release date is >3 weeks in the future
- **pyproject.toml stability flags**: is_stable and classifiers must match stable/preview version
- **Client signature**: credential, subscription_id, ase_url must appear in that order
- **README snippets**: Must match real client API signatures and usage