### PR TITLE
Fix KeyboardInterrupt traceback in sample scripts on Windows

### DIFF
--- a/sdk/voicelive/azure-ai-voicelive/samples/async_function_calling_sample.py
+++ b/sdk/voicelive/azure-ai-voicelive/samples/async_function_calling_sample.py
@@ -35,7 +35,6 @@ import json
 import datetime
 import logging
 import base64
-import signal
 import threading
 import queue
 from typing import Union, Optional, Dict, Any, Mapping, Callable, TYPE_CHECKING, cast
@@ -737,14 +736,6 @@ async def main():
         "Explain when you're using a function and include the results in your response naturally.",
     )
 
-    # Setup signal handlers for graceful shutdown
-    def signal_handler(sig, frame):
-        logger.info("Received shutdown signal")
-        raise KeyboardInterrupt()
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
     try:
         await client.run()
     except KeyboardInterrupt:
@@ -813,4 +804,7 @@ if __name__ == "__main__":
     print("=" * 65)
 
     # Run the async main function
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n👋 Voice Live function calling client shut down.")

--- a/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py
+++ b/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py
@@ -32,7 +32,6 @@ import sys
 import asyncio
 import logging
 import base64
-import signal
 import threading
 import queue
 from typing import Union, Optional, Any, Callable, TYPE_CHECKING, cast
@@ -674,14 +673,6 @@ async def main():
         instructions="You are a helpful AI assistant with access to some mcp server. ",
     )
 
-    # Setup signal handlers for graceful shutdown
-    def signal_handler(sig, frame):
-        logger.info("Received shutdown signal")
-        raise KeyboardInterrupt()
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
     try:
         await client.run()
     except KeyboardInterrupt:
@@ -750,4 +741,7 @@ if __name__ == "__main__":
     print("=" * 65)
 
     # Run the async main function
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n👋 Voice Live MCP shut down.")

--- a/sdk/voicelive/azure-ai-voicelive/samples/basic_voice_assistant_async.py
+++ b/sdk/voicelive/azure-ai-voicelive/samples/basic_voice_assistant_async.py
@@ -40,7 +40,6 @@ import base64
 from datetime import datetime
 import logging
 import queue
-import signal
 from typing import Union, Optional, TYPE_CHECKING, cast
 
 from azure.core.credentials import AzureKeyCredential
@@ -514,14 +513,6 @@ def main():
         voice=args.voice,
         instructions=args.instructions,
     )
-
-    # Setup signal handlers for graceful shutdown
-    def signal_handler(_sig, _frame):
-        logger.info("Received shutdown signal")
-        raise KeyboardInterrupt()
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
 
     # Start the assistant
     try:


### PR DESCRIPTION
The custom signal handlers in the sample scripts raised KeyboardInterrupt directly from the signal handler context, which interrupted the event loop's internal IOCP polling on Windows, producing an ugly traceback instead of a clean shutdown.

Changes:

- Remove custom signal handlers from async_mcp_sample.py, async_function_calling_sample.py, and basic_voice_assistant_async.py

- Wrap asyncio.run() with try/except KeyboardInterrupt at module level for clean Ctrl+C handling

- Remove unused 'import signal' from all three samples

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [] Pull request includes test coverage for the included changes.
