### PR TITLE
[Storage] [STG 102] Arch Board Feedback

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -873,7 +873,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
 
         This method is deprecated, use func:`readall` instead.
 
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :return: The contents of the file as bytes.
         :rtype: bytes
@@ -896,7 +896,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
 
         This method is deprecated, use func:`readall` instead.
 
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :param str encoding:
             Test encoding to decode the downloaded bytes. Default is UTF-8.
@@ -924,7 +924,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
             The stream to download to. This can be an open file-handle,
             or any writable stream. The stream must be seekable if the download
             uses more than one parallel connection.
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :return: The properties of the downloaded blob.
         :rtype: Any

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -816,7 +816,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
 
         This method is deprecated, use func:`readall` instead.
 
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :return: The contents of the file as bytes.
         :rtype: bytes
@@ -839,7 +839,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
 
         This method is deprecated, use func:`readall` instead.
 
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :param str encoding:
             Test encoding to decode the downloaded bytes. Default is UTF-8.
@@ -867,7 +867,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
             The stream to download to. This can be an open file-handle,
             or any writable stream. The stream must be seekable if the download
             uses more than one parallel connection.
-        :param int max_concurrency:
+        :param Optional[int] max_concurrency:
             The number of parallel connections with which to download.
         :return: The properties of the downloaded blob.
         :rtype: Any


### PR DESCRIPTION
Per Arch Board feedback, the associated download methods have to specify `Optional[int]` for the `max_concurrency` type directly. The tests in CI are expected to fail as some recordings are missing, which will be fixed alongside other STG 102 PRs.