### PR TITLE
Fix `AttributeError` in `_get_finish_reason_for_choice` when `finish_reason` is a string

### DIFF
--- a/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
+++ b/sdk/ai/azure-ai-inference/azure/ai/inference/tracing.py
@@ -280,10 +280,14 @@ class _AIInferenceInstrumentorPreview:
 
     def _get_finish_reason_for_choice(self, choice):
         finish_reason = getattr(choice, "finish_reason", None)
-        if finish_reason is not None:
+        if finish_reason is None:
+            return "none"
+        elif hasattr(finish_reason, "value"):
             return finish_reason.value
-
-        return "none"
+        elif isinstance(finish_reason, str):
+            return finish_reason
+        else:
+            return "none"
 
     def _add_response_chat_message_events(
         self, span: "AbstractSpan", result: _models.ChatCompletions, last_event_timestamp_ns: int


### PR DESCRIPTION
# Fix `AttributeError` in `_get_finish_reason_for_choice` when `finish_reason` is a string

## Description

This PR fixes a bug in `_get_finish_reason_for_choice()` that causes an `AttributeError` when the model returns `finish_reason` as a string instead of an enum.

Some models (e.g., Mistral Large 3 on Azure AI Foundry MaaS) return `finish_reason` as a raw string (`"stop"`) rather than a `CompletionsFinishReason` enum. The current implementation unconditionally calls `.value` on `finish_reason`, which fails with:

```
AttributeError: 'str' object has no attribute 'value'
```

## Root Cause

In `tracing.py`, `_get_finish_reason_for_choice()` assumes `finish_reason` is always an enum:

```python
def _get_finish_reason_for_choice(self, choice):
    finish_reason = getattr(choice, "finish_reason", None)
    if finish_reason is None:
        return "none"
    return finish_reason.value  # Fails when finish_reason is already a string
```

However, the similar method `_get_finish_reasons()` already handles both cases correctly:

```python
if hasattr(finish_reason, "value"):
    finish_reasons.append(finish_reason.value)
elif isinstance(finish_reason, str):
    finish_reasons.append(finish_reason)
```

## Fix

Apply the same defensive pattern to `_get_finish_reason_for_choice()`:

```python
def _get_finish_reason_for_choice(self, choice):
    finish_reason = getattr(choice, "finish_reason", None)
    if finish_reason is None:
        return "none"
    elif hasattr(finish_reason, "value"):
        return finish_reason.value
    elif isinstance(finish_reason, str):
        return finish_reason
    else:
        return "none"
```

## Impact

Without this fix, tracing fails for any model that returns string `finish_reason`, causing the entire API call to fail. Users must disable tracing (`AZURE_SDK_TRACING_IMPLEMENTATION=none` or `tracing_enabled=False`) as a workaround.
