### PR TITLE
Improve azure-ai-ml unit test branch coverage from 58% to 85%

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/test_artifact_utilities_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_artifact_utilities_gaps.py
@@ -1,0 +1,747 @@
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from types import SimpleNamespace
+
+from azure.ai.ml.constants._common import SHORT_URI_FORMAT
+from azure.core.exceptions import HttpResponseError
+
+from azure.ai.ml._artifacts import _artifact_utilities as artifact_utilities
+from azure.ai.ml._artifacts._artifact_utilities import DatastoreType, MlException, get_datastore_info, list_logs_in_datastore
+
+def test_get_datastore_info_blob_credentials_and_override(monkeypatch):
+    monkeypatch.setattr(artifact_utilities, "_get_storage_endpoint_from_metadata", lambda: "region")
+    datastore = SimpleNamespace(
+        type=DatastoreType.AZURE_BLOB,
+        account_name="acct",
+        credentials=SimpleNamespace(),
+        container_name="blob-container",
+    )
+
+    class DummyOperations:
+        def __init__(self, datastore):
+            self._datastore = datastore
+            self._credential = "fallback-identity"
+
+        def get(self, name):
+            return self._datastore
+
+        def _list_secrets(self, name, expirable_secret):
+            return SimpleNamespace(sas_token="sas-token")
+
+    operations = DummyOperations(datastore)
+    info = get_datastore_info(operations, "store", container_name="override-container")
+
+    assert info["storage_type"] == DatastoreType.AZURE_BLOB
+    assert info["credential"] == "sas-token"
+    assert info["container_name"] == "override-container"
+
+def test_get_datastore_info_data_lake_handles_http_error(monkeypatch):
+    monkeypatch.setattr(artifact_utilities, "_get_storage_endpoint_from_metadata", lambda: "region")
+    datastore = SimpleNamespace(
+        type=DatastoreType.AZURE_DATA_LAKE_GEN2,
+        account_name="acct",
+        credentials=SimpleNamespace(),
+        filesystem="lakefs",
+    )
+
+    class DummyOperations:
+        def __init__(self, datastore):
+            self._datastore = datastore
+            self._credential = "backup-token"
+
+        def get(self, name):
+            return self._datastore
+
+        def get_default(self):
+            return self._datastore
+
+        def _list_secrets(self, name, expirable_secret):
+            raise HttpResponseError(response=None, message="boom")
+
+    operations = DummyOperations(datastore)
+    info = get_datastore_info(operations, None)
+
+    assert info["storage_type"] == DatastoreType.AZURE_DATA_LAKE_GEN2
+    assert info["credential"] == "backup-token"
+    assert info["container_name"] == "lakefs"
+
+def test_get_datastore_info_unsupported_type_raises(monkeypatch):
+    monkeypatch.setattr(artifact_utilities, "_get_storage_endpoint_from_metadata", lambda: "region")
+    datastore = SimpleNamespace(
+        type="unsupported",
+        account_name="acct",
+        credentials=SimpleNamespace(),
+        container_name="ignore",
+    )
+    monkeypatch.setitem(artifact_utilities.STORAGE_ACCOUNT_URLS, datastore.type, "https://{0}.storage.{1}")
+
+    class DummyOperations:
+        def __init__(self, datastore):
+            self._datastore = datastore
+            self._credential = "backup-token"
+
+        def get(self, name):
+            return self._datastore
+
+        def _list_secrets(self, name, expirable_secret):
+            return SimpleNamespace(sas_token="unused")
+
+    operations = DummyOperations(datastore)
+
+    with pytest.raises(MlException) as excinfo:
+        get_datastore_info(operations, "store")
+
+    assert "not supported for uploads" in str(excinfo.value)
+
+def test_list_logs_in_datastore_blob_generates_sas_urls(monkeypatch):
+    prefix = "run-id"
+    legacy = "/legacy/"
+    ds_info = {
+        "storage_type": DatastoreType.AZURE_BLOB,
+        "storage_account": "account",
+        "account_url": "https://storage.region",
+        "container_name": "blob-container",
+        "credential": "key",
+    }
+
+    class FakeBlobStorageClient:
+        def __init__(self):
+            self.container = ds_info["container_name"]
+            self.container_client = SimpleNamespace(
+                get_blob_client=lambda blob: SimpleNamespace(set_blob_metadata=lambda metadata: None)
+            )
+            self._calls = 0
+
+        def list(self, starts_with):
+            self._calls += 1
+            return [f"{starts_with}log{self._calls}"]
+
+    monkeypatch.setattr(artifact_utilities, "BlobStorageClient", FakeBlobStorageClient)
+    monkeypatch.setattr(artifact_utilities, "get_storage_client", lambda **kwargs: FakeBlobStorageClient())
+    monkeypatch.setattr(artifact_utilities, "generate_blob_sas", lambda **kwargs: "blob-token")
+
+    result = list_logs_in_datastore(ds_info, prefix, legacy)
+
+    assert set(result.keys()) == {"user_logs/log1", "legacy/log2"}
+    for url in result.values():
+        assert url.startswith("https://storage.region/blob-container/")
+        assert url.endswith("?blob-token")
+
+def test_list_logs_in_datastore_gen2_generates_sas_urls(monkeypatch):
+    prefix = "run-id"
+    legacy = "/legacy/"
+    ds_info = {
+        "storage_type": DatastoreType.AZURE_DATA_LAKE_GEN2,
+        "storage_account": "account",
+        "account_url": "https://storage.region",
+        "container_name": "lakefs",
+        "credential": "key",
+    }
+
+    class FakeGen2StorageClient:
+        def __init__(self):
+            self.file_system = ds_info["container_name"]
+            self._calls = 0
+
+        def list(self, starts_with):
+            self._calls += 1
+            return [f"{starts_with}log{self._calls}"]
+
+    monkeypatch.setattr(artifact_utilities, "Gen2StorageClient", FakeGen2StorageClient)
+    monkeypatch.setattr(artifact_utilities, "get_storage_client", lambda **kwargs: FakeGen2StorageClient())
+    monkeypatch.setattr(artifact_utilities, "generate_file_sas", lambda **kwargs: "file-token")
+
+    result = list_logs_in_datastore(ds_info, prefix, legacy)
+
+    assert set(result.keys()) == {"user_logs/log1", "legacy/log2"}
+    for url in result.values():
+        assert url.startswith("https://storage.region/lakefs/")
+        assert url.endswith("?file-token")
+
+def test_upload_to_datastore_respects_provided_ignore_and_hash(monkeypatch, tmp_path):
+    test_path = tmp_path / "asset"
+    validate_calls = []
+
+    def fake_validate_path(path, _type):
+        validate_calls.append((path, _type))
+
+    def fail_get_ignore(path):
+        raise AssertionError("get_ignore_file should not be called when ignore_file is provided")
+
+    def fail_get_hash(path, ignore_file):
+        raise AssertionError("get_object_hash should not be called when asset_hash is provided")
+
+    class DummyArtifact:
+        def __init__(self):
+            self.storage_account_url = "initial"
+            self.relative_path = "remote"
+            self.datastore_arm_id = "arm"
+            self.indicator_file = "indicator"
+
+    dummy_artifact = DummyArtifact()
+
+    def fake_upload_artifact(local_path, datastore_operation, operation_scope, datastore_name, asset_hash=None, show_progress=True, asset_name=None, asset_version=None, ignore_file=None, sas_uri=None):
+        assert local_path == str(test_path)
+        assert asset_hash == "provided-hash"
+        assert ignore_file == "provided-ignore"
+        return dummy_artifact
+
+    monkeypatch.setattr(artifact_utilities, "_validate_path", fake_validate_path)
+    monkeypatch.setattr(artifact_utilities, "get_ignore_file", fail_get_ignore)
+    monkeypatch.setattr(artifact_utilities, "get_object_hash", fail_get_hash)
+    monkeypatch.setattr(artifact_utilities, "upload_artifact", fake_upload_artifact)
+
+    artifact = artifact_utilities._upload_to_datastore(
+        operation_scope="opscope",
+        datastore_operation="dsop",
+        path=test_path,
+        artifact_type="artifact-type",
+        datastore_name="datastore",
+        asset_hash="provided-hash",
+        show_progress=False,
+        asset_name="asset",
+        asset_version="1",
+        ignore_file="provided-ignore",
+        blob_uri="https://override",
+    )
+
+    assert validate_calls == [(test_path, "artifact-type")]
+    assert artifact.storage_account_url == "https://override"
+
+def test_upload_to_datastore_generates_ignore_and_hash(monkeypatch, tmp_path):
+    test_path = tmp_path / "artifact"
+    called = {}
+
+    def fake_validate_path(path, _type):
+        called["validate"] = (path, _type)
+
+    def fake_get_ignore(path):
+        called["ignore"] = str(path)
+        return "generated-ignore"
+
+    def fake_get_hash(path, ignore_file):
+        called["hash"] = (str(path), ignore_file)
+        return "generated-hash"
+
+    class DummyArtifact:
+        def __init__(self):
+            self.storage_account_url = "initial"
+            self.relative_path = "remote"
+            self.datastore_arm_id = "arm"
+            self.indicator_file = "indicator"
+
+    dummy_artifact = DummyArtifact()
+
+    def fake_upload_artifact(local_path, datastore_operation, operation_scope, datastore_name, asset_hash=None, show_progress=True, asset_name=None, asset_version=None, ignore_file=None, sas_uri=None):
+        assert asset_hash == "generated-hash"
+        assert ignore_file == "generated-ignore"
+        assert local_path == str(test_path)
+        return dummy_artifact
+
+    monkeypatch.setattr(artifact_utilities, "_validate_path", fake_validate_path)
+    monkeypatch.setattr(artifact_utilities, "get_ignore_file", fake_get_ignore)
+    monkeypatch.setattr(artifact_utilities, "get_object_hash", fake_get_hash)
+    monkeypatch.setattr(artifact_utilities, "upload_artifact", fake_upload_artifact)
+
+    artifact_utilities._upload_to_datastore(
+        operation_scope="opscope",
+        datastore_operation="dsop",
+        path=test_path,
+        artifact_type="artifact-type",
+        datastore_name="datastore",
+        asset_name="asset",
+        asset_version="2",
+        show_progress=True,
+    )
+
+    assert called["validate"] == (test_path, "artifact-type")
+    assert called["ignore"] == str(test_path)
+    assert called["hash"] == (str(test_path), "generated-ignore")
+
+def test_upload_and_generate_remote_uri_formats_short_uri(monkeypatch):
+    class DummyArtifact:
+        relative_path = "files/blob"
+        datastore_arm_id = "arm/id"
+
+    def fake_upload_to_datastore(operation_scope, datastore_operation, path, datastore_name, asset_name=None, asset_version=None, artifact_type=None, show_progress=None):
+        assert operation_scope == "opscope"
+        assert datastore_operation == "dsop"
+        assert str(path) == "local-path"
+        assert datastore_name == "store"
+        assert asset_name == "fixed-asset"
+        assert artifact_type == artifact_utilities.ErrorTarget.ARTIFACT
+        assert show_progress is False
+        return DummyArtifact()
+
+    class DummyUUID:
+        def __str__(self):
+            return "fixed-asset"
+
+    class DummyArmId:
+        def __init__(self, arm_id):
+            assert arm_id == "arm/id"
+            self.asset_name = "datastore-name"
+
+    monkeypatch.setattr(artifact_utilities, "_upload_to_datastore", fake_upload_to_datastore)
+    monkeypatch.setattr(artifact_utilities.uuid, "uuid4", lambda: DummyUUID())
+    monkeypatch.setattr(artifact_utilities, "AMLNamedArmId", DummyArmId)
+
+    result = artifact_utilities._upload_and_generate_remote_uri(
+        operation_scope="opscope",
+        datastore_operation="dsop",
+        path="local-path",
+        datastore_name="store",
+        show_progress=False,
+    )
+
+    assert result == artifact_utilities.SHORT_URI_FORMAT.format("datastore-name", "files/blob")
+
+def test_update_metadata_invokes_blob_metadata(monkeypatch):
+    class DummyBlobClient:
+        pass
+
+    dummy_client = DummyBlobClient()
+    monkeypatch.setattr(artifact_utilities, "BlobStorageClient", DummyBlobClient)
+    monkeypatch.setattr(artifact_utilities, "Gen2StorageClient", type("StubGen2", (), {}))
+    monkeypatch.setattr(artifact_utilities, "get_storage_client", lambda **kwargs: dummy_client)
+
+    called = {}
+
+    def fake_blob_metadata(name, version, indicator_file, storage_client):
+        called["blob"] = (name, version, indicator_file, storage_client)
+
+    def fail_gen2(*args, **kwargs):
+        raise AssertionError("gen2 branch should not run in blob scenario")
+
+    monkeypatch.setattr(artifact_utilities, "_update_blob_metadata", fake_blob_metadata)
+    monkeypatch.setattr(artifact_utilities, "_update_gen2_metadata", fail_gen2)
+
+    artifact_utilities._update_metadata("env", "1", "indicator", {})
+
+    assert called["blob"] == ("env", "1", "indicator", dummy_client)
+
+def test_update_metadata_invokes_gen2_metadata(monkeypatch):
+    class DummyGen2Client:
+        pass
+
+    dummy_client = DummyGen2Client()
+    monkeypatch.setattr(artifact_utilities, "Gen2StorageClient", DummyGen2Client)
+    monkeypatch.setattr(artifact_utilities, "BlobStorageClient", type("StubBlob", (), {}))
+    monkeypatch.setattr(artifact_utilities, "get_storage_client", lambda **kwargs: dummy_client)
+
+    called = {}
+
+    def fail_blob(*args, **kwargs):
+        raise AssertionError("blob branch should not run in gen2 scenario")
+
+    def fake_gen2_metadata(name, version, indicator_file, storage_client):
+        called["gen2"] = (name, version, indicator_file, storage_client)
+
+    monkeypatch.setattr(artifact_utilities, "_update_blob_metadata", fail_blob)
+    monkeypatch.setattr(artifact_utilities, "_update_gen2_metadata", fake_gen2_metadata)
+
+    artifact_utilities._update_metadata("environment", "2", "indicator", {})
+
+    assert called["gen2"] == ("environment", "2", "indicator", dummy_client)
+
+
+class _StubArtifactStorageInfo:
+    def __init__(self, name, version, relative_path, datastore_arm_id, indicator_file, full_storage_path="https://fake/storage"):
+        self.name = name
+        self.version = version
+        self.relative_path = relative_path
+        self.datastore_arm_id = datastore_arm_id
+        self.indicator_file = indicator_file
+        self.full_storage_path = full_storage_path
+        self.storage_account_url = full_storage_path
+
+
+class _StubStorageClient:
+    def __init__(self):
+        self.container = "container"
+        self.file_system = "filesystem"
+        self.container_client = self
+        self.file_system_client = self
+        self._metadata = None
+
+    def upload(self, local_path, **kwargs):
+        return {
+            "name": "uploaded-name",
+            "version": "1",
+            "remote path": f"rel/{Path(local_path).name}",
+            "indicator file": f"indicator/{Path(local_path).name}",
+        }
+
+    def get_blob_client(self, blob):
+        return self
+
+    def set_blob_metadata(self, metadata):
+        self._metadata = metadata
+
+    def get_directory_client(self, indicator_file):
+        return self
+
+    def set_metadata(self, metadata):
+        self._metadata = metadata
+
+
+class _StubOperations:
+    def __init__(self):
+        self._operation_scope = object()
+        self._datastore_operation = object()
+        self._credential = "cred"
+        self.calls = []
+
+
+class _StubArtifact:
+    def __init__(self):
+        self.datastore = "default"
+        self.local_path = None
+        self.path = "code"
+        self.base_path = os.getcwd()
+        self.name = "asset"
+        self.version = 1
+        self._upload_hash = "hash"
+        self._ignore_file = None
+        self._is_anonymous = True
+        self._path_updated_with = None
+
+    def _update_path(self, uploaded_artifact):
+        self._path_updated_with = uploaded_artifact
+
+
+class _StubEnvironment:
+    def __init__(self):
+        self.path = "context"
+        self.name = "env"
+        self.version = 2
+        self.datastore = "default"
+        self._upload_hash = "hash"
+        self.build = type("Build", (), {"path": None})()
+
+def test_upload_and_generate_remote_uri_formats_short_uri_with_short_uri_constant(monkeypatch):
+    uploaded = _StubArtifactStorageInfo(
+        name="uploaded-name",
+        version="42",
+        relative_path="rel/path",
+        datastore_arm_id="/subscriptions/1/resourceGroups/g/providers/Microsoft.MachineLearningServices/workspaces/w/datastores/default",
+        indicator_file="indicator",
+    )
+
+    monkeypatch.setattr(artifact_utilities, "_upload_to_datastore", lambda **kwargs: uploaded)
+    monkeypatch.setattr(artifact_utilities, "AMLNamedArmId", lambda arm_id: type("Id", (), {"asset_name": "datastore-name"})())
+    monkeypatch.setattr(uuid, "uuid4", lambda: "fixed-uuid")
+
+    result = artifact_utilities._upload_and_generate_remote_uri(
+        operation_scope=object(),
+        datastore_operation=object(),
+        path="some-path",
+    )
+
+    assert result == SHORT_URI_FORMAT.format("datastore-name", "rel/path")
+
+def test_update_metadata_for_blob_and_gen2(monkeypatch):
+    blob_client = _StubStorageClient()
+    gen2_client = _StubStorageClient()
+
+    monkeypatch.setattr(artifact_utilities, "BlobStorageClient", _StubStorageClient)
+    monkeypatch.setattr(artifact_utilities, "Gen2StorageClient", _StubStorageClient)
+
+    def fake_get_storage_client(*args, **kwargs):
+        if kwargs.get("storage_type") == artifact_utilities.DatastoreType.AZURE_BLOB:
+            return blob_client
+        return gen2_client
+
+    monkeypatch.setattr(artifact_utilities, "get_storage_client", fake_get_storage_client)
+
+    datastore_info_blob = {"storage_type": artifact_utilities.DatastoreType.AZURE_BLOB, "credential": "cred", "storage_account": "acc", "container_name": "container"}
+    datastore_info_gen2 = {"storage_type": artifact_utilities.DatastoreType.AZURE_DATA_LAKE_GEN2, "credential": "cred", "storage_account": "acc", "container_name": "filesystem"}
+
+    artifact_utilities._update_metadata("name", "1", "container/indicator", datastore_info_blob)
+    assert blob_client._metadata["name"] == "name"
+    assert blob_client._metadata["version"] == "1"
+
+    artifact_utilities._update_metadata("name", "2", "indicator", datastore_info_gen2)
+    assert gen2_client._metadata["name"] == "name"
+    assert gen2_client._metadata["version"] == "2"
+
+def test_check_and_upload_path_uploads(monkeypatch, tmp_path):
+    artifact = _StubArtifact()
+    artifact.local_path = str(tmp_path / "file.txt")
+    Path(artifact.local_path).write_text("data")
+
+    operations = _StubOperations()
+    uploaded = _StubArtifactStorageInfo(
+        name="new-name",
+        version="2",
+        relative_path="rel/path",
+        datastore_arm_id="/subscriptions/1/resourceGroups/g/providers/Microsoft.MachineLearningServices/workspaces/w/datastores/default",
+        indicator_file="indicator",
+        full_storage_path="https://storage/rel"
+    )
+
+    def fake_upload(*args, **kwargs):
+        uploaded.storage_account_url = kwargs.get("blob_uri", uploaded.storage_account_url)
+        return uploaded
+
+    monkeypatch.setattr(artifact_utilities, "_upload_to_datastore", fake_upload)
+
+    result_artifact, indicator = artifact_utilities._check_and_upload_path(
+        artifact=artifact,
+        asset_operations=operations,
+        artifact_type="Code",
+        blob_uri="https://override",
+        show_progress=False,
+    )
+
+    assert result_artifact.name == "new-name"
+    assert result_artifact.version == "2"
+    assert indicator == "indicator"
+    assert result_artifact._path_updated_with is uploaded
+    assert uploaded.storage_account_url == "https://override"
+
+def test_check_and_upload_env_build_context_updates_build_path(monkeypatch):
+    environment = _StubEnvironment()
+    operations = _StubOperations()
+
+    uploaded = _StubArtifactStorageInfo(
+        name="env-name",
+        version="3",
+        relative_path="rel/path",
+        datastore_arm_id="/subscriptions/1/resourceGroups/g/providers/Microsoft.MachineLearningServices/workspaces/w/datastores/default",
+        indicator_file="indicator",
+        full_storage_path="https://storage/rel"
+    )
+
+    monkeypatch.setattr(artifact_utilities, "_upload_to_datastore", lambda *args, **kwargs: uploaded)
+
+    updated = artifact_utilities._check_and_upload_env_build_context(environment, operations, sas_uri="https://sas")
+
+    assert updated.build.path == "https://storage/rel/"
+
+def test_get_snapshot_path_info_resolves_path(monkeypatch, tmp_path):
+    file_path = tmp_path / "asset"
+    file_path.write_text("content")
+
+    artifact = type("Artifact", (), {
+        "local_path": str(file_path),
+        "path": None,
+        "base_path": str(tmp_path),
+    })()
+
+    monkeypatch.setattr(artifact_utilities, "_validate_path", lambda path, _type: None)
+    monkeypatch.setattr(artifact_utilities, "get_ignore_file", lambda path: "ignore")
+    monkeypatch.setattr(artifact_utilities, "get_content_hash", lambda path, ignore: "hash-value")
+
+    resolved_path, ignore_file, asset_hash = artifact_utilities._get_snapshot_path_info(artifact)
+
+    assert resolved_path == Path(str(file_path))
+    assert ignore_file == "ignore"
+    assert asset_hash == "hash-value"
+
+def test_check_and_upload_path_resolves_relative(monkeypatch, tmp_path):
+    monkeypatch.setattr(artifact_utilities, '_validate_path', lambda path, _type=None: None)
+    monkeypatch.setattr(artifact_utilities, 'get_ignore_file', lambda path: 'ignore-file')
+    monkeypatch.setattr(artifact_utilities, 'get_object_hash', lambda path, ignore_file=None: 'object-hash')
+    captured = {}
+
+    def fake_upload_to_datastore(
+        operation_scope,
+        datastore_operation,
+        path,
+        **kwargs,
+    ):
+        captured['path'] = path
+        return SimpleNamespace(
+            relative_path='remote/path',
+            indicator_file='indicator.txt',
+            name='name',
+            version='1',
+            datastore_arm_id='arm-id',
+            full_storage_path='https://account/container/remote',
+            storage_account_url='https://account',
+            container_name='container',
+        )
+
+    monkeypatch.setattr(artifact_utilities, '_upload_to_datastore', fake_upload_to_datastore)
+
+    class DummyArtifact:
+        def __init__(self):
+            self.name = 'artifact-name'
+            self.version = '1'
+            self.datastore = 'datastore'
+            self.base_path = tmp_path
+            self.path = 'subdir/file'
+            self.local_path = None
+            self._is_anonymous = False
+            self._upload_hash = None
+            self._ignore_file = None
+
+        def _update_path(self, uploaded_artifact):
+            self.updated_path = uploaded_artifact.relative_path
+
+    artifact = DummyArtifact()
+    operations = SimpleNamespace(
+        _operation_scope='scope',
+        _datastore_operation='datastore-operation',
+    )
+
+    result_artifact, indicator_file = artifact_utilities._check_and_upload_path(
+        artifact,
+        operations,
+        artifact_type='artifact-type',
+        datastore_name='datastore-name',
+        show_progress=False,
+    )
+
+    assert result_artifact is artifact
+    assert indicator_file == 'indicator.txt'
+    assert artifact.updated_path == 'remote/path'
+    assert captured['path'] == (tmp_path / 'subdir' / 'file').resolve()
+
+def test_check_and_upload_path_updates_anonymous_artifact(monkeypatch, tmp_path):
+    monkeypatch.setattr(artifact_utilities, '_validate_path', lambda path, _type=None: None)
+    monkeypatch.setattr(artifact_utilities, 'get_ignore_file', lambda path: 'ignore-file')
+    monkeypatch.setattr(artifact_utilities, 'get_object_hash', lambda path, ignore_file=None: 'object-hash')
+
+    def fake_upload_to_datastore(
+        operation_scope,
+        datastore_operation,
+        path,
+        **kwargs,
+    ):
+        return SimpleNamespace(
+            relative_path='remote/path',
+            indicator_file='indicator.txt',
+            name='anonymous-name',
+            version='2',
+            datastore_arm_id='arm-id',
+            full_storage_path='https://account/remote',
+            storage_account_url='https://account',
+            container_name='container',
+        )
+
+    monkeypatch.setattr(artifact_utilities, '_upload_to_datastore', fake_upload_to_datastore)
+
+    class DummyArtifact:
+        def __init__(self):
+            self.name = 'artifact-name'
+            self.version = '1'
+            self.datastore = 'datastore'
+            self.base_path = tmp_path
+            self.path = 'subdir/file'
+            self.local_path = None
+            self._is_anonymous = True
+            self._upload_hash = None
+            self._ignore_file = None
+
+        def _update_path(self, uploaded_artifact):
+            self.updated_path = uploaded_artifact.relative_path
+
+    artifact = DummyArtifact()
+    operations = SimpleNamespace(
+        _operation_scope='scope',
+        _datastore_operation='datastore-operation',
+    )
+
+    artifact_utilities._check_and_upload_path(
+        artifact,
+        operations,
+        artifact_type='artifact-type',
+        datastore_name='datastore-name',
+        show_progress=False,
+    )
+
+    assert artifact.name == 'anonymous-name'
+    assert artifact.version == '2'
+
+def test_check_and_upload_env_build_context_updates_build_path(monkeypatch, tmp_path):
+    def fake_upload_to_datastore(
+        operation_scope,
+        datastore_operation,
+        path,
+        **kwargs,
+    ):
+        return SimpleNamespace(
+            full_storage_path='https://account/path'
+        )
+
+    monkeypatch.setattr(artifact_utilities, '_upload_to_datastore', fake_upload_to_datastore)
+
+    environment = SimpleNamespace(
+        path=str(tmp_path / 'env-src'),
+        name='env-name',
+        version='3',
+        datastore='datastore',
+        build=SimpleNamespace(path=None),
+        _upload_hash='hash',
+    )
+    operations = SimpleNamespace(
+        _operation_scope='scope',
+        _datastore_operation='datastore-operation',
+    )
+
+    result = artifact_utilities._check_and_upload_env_build_context(environment, operations)
+
+    assert result is environment
+    assert environment.build.path == 'https://account/path/'
+
+def test_check_and_upload_env_build_context_skips_when_path_missing(monkeypatch):
+    called = {'upload': False}
+
+    def fake_upload_to_datastore(*args, **kwargs):
+        called['upload'] = True
+        return SimpleNamespace(full_storage_path='unused')
+
+    monkeypatch.setattr(artifact_utilities, '_upload_to_datastore', fake_upload_to_datastore)
+
+    environment = SimpleNamespace(
+        path=None,
+        name='env-name',
+        version='3',
+        datastore='datastore',
+        build=SimpleNamespace(path='existing'),
+        _upload_hash='hash',
+    )
+    operations = SimpleNamespace(
+        _operation_scope='scope',
+        _datastore_operation='datastore-operation',
+    )
+
+    result = artifact_utilities._check_and_upload_env_build_context(environment, operations)
+
+    assert result is environment
+    assert called['upload'] is False
+    assert environment.build.path == 'existing'
+
+def test_get_snapshot_path_info_returns_components(monkeypatch, tmp_path):
+    monkeypatch.setattr(artifact_utilities, '_validate_path', lambda path, _type=None: None)
+    monkeypatch.setattr(artifact_utilities, 'get_ignore_file', lambda path: 'ignore-file')
+    monkeypatch.setattr(artifact_utilities, 'get_content_hash', lambda path, ignore_file: 'content-hash')
+
+    artifact = SimpleNamespace(
+        path='relative/code',
+        base_path=tmp_path,
+        local_path=None,
+    )
+
+    path, ignore_file, asset_hash = artifact_utilities._get_snapshot_path_info(artifact)
+
+    assert path == (tmp_path / 'relative' / 'code').resolve()
+    assert ignore_file == 'ignore-file'
+    assert asset_hash == 'content-hash'
+
+def test_get_snapshot_path_info_returns_none_for_url(monkeypatch):
+    monkeypatch.setattr(artifact_utilities, 'is_url', lambda value: True)
+    monkeypatch.setattr(artifact_utilities, 'is_mlflow_uri', lambda value: False)
+
+    artifact = SimpleNamespace(
+        path='https://example.com/asset',
+        base_path=Path('/unused'),
+        local_path=None,
+    )
+
+    assert artifact_utilities._get_snapshot_path_info(artifact) is None

--- a/sdk/ml/azure-ai-ml/tests/test_artifact_utils_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_artifact_utils_gaps.py
@@ -1,0 +1,879 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from azure.ai.ml.constants._common import DefaultOpenEncoding
+from azure.ai.ml._utils._artifact_utils import ArtifactCache
+
+def test_artifact_cache_singleton_initializes_once(monkeypatch):
+    call_counts = {"value": 0}
+
+    def fake_check():
+        call_counts["value"] += 1
+
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(fake_check))
+    ArtifactCache._instance = None
+    first = ArtifactCache()
+    second = ArtifactCache()
+    assert first is second
+    assert call_counts["value"] == 1
+
+def test_check_artifact_extension_raises_on_failure(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stderr="extension missing")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        ArtifactCache.check_artifact_extension()
+    assert "Auto-installation failed" in str(excinfo.value)
+
+def test_format_organization_name_replaces_invalid_chars():
+    formatted = ArtifactCache._format_organization_name("org<>name")
+    assert formatted == "org__name"
+
+def test_get_organization_project_by_git_dev_azure_url(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="https://dev.azure.com/testorg/testproj\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    organization, project = ArtifactCache.get_organization_project_by_git()
+    assert organization == "https://dev.azure.com/testorg"
+    assert project == "testproj"
+
+def test_get_organization_project_by_git_visualstudio_url(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="https://myorg.visualstudio.com/collection/testproj/_git/repo\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    organization, project = ArtifactCache.get_organization_project_by_git()
+    assert organization == "https://myorg.visualstudio.com"
+    assert project == "testproj"
+
+def test_get_organization_project_by_git_non_git_directory(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="fatal: not a git repo")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        ArtifactCache.get_organization_project_by_git()
+    assert "fatal: not a git repo" in str(excinfo.value)
+
+def test_get_organization_project_by_git_unrecognized_url_raises(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="https://example.com/repo", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        ArtifactCache.get_organization_project_by_git()
+    assert "Cannot get organization and project" in str(excinfo.value)
+
+def test_download_artifacts_raises_after_retries(monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    cache = ArtifactCache()
+
+    def fake_redirect(_organization):
+        raise RuntimeError("redirect failure")
+
+    cache._redirect_artifacts_tool_path = fake_redirect
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stderr="stderr", stdout="stdout")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        cache._download_artifacts(["cmd"], None, "package", "1.0", "feed", max_retries=1)
+    message = str(excinfo.value)
+    assert "Download package package:1.0 from the feed feed failed 1 times" in message
+    assert "stdout" in message
+
+def test_check_artifacts_missing_directory_returns_false(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    cache = ArtifactCache()
+    missing = tmp_path / "missing"
+    assert cache._check_artifacts(missing) is False
+
+def test_check_artifacts_checksum_mismatch_returns_false(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    cache = ArtifactCache()
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    file_path = artifact_dir / "file.txt"
+    file_path.write_text("content", encoding=DefaultOpenEncoding.WRITE)
+    checksum_path = cache._get_checksum_path(artifact_dir)
+    checksum_path.write_text("wrongvalue", encoding=DefaultOpenEncoding.WRITE)
+    assert cache._check_artifacts(artifact_dir) is False
+
+def test_check_artifacts_checksum_match_returns_true(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    cache = ArtifactCache()
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    file_path = artifact_dir / "file.txt"
+    file_path.write_text("content", encoding=DefaultOpenEncoding.WRITE)
+    expected_hash = ArtifactCache.hash_files_content([file_path])
+    checksum_path = cache._get_checksum_path(artifact_dir)
+    checksum_path.write_text(expected_hash, encoding=DefaultOpenEncoding.WRITE)
+    assert cache._check_artifacts(artifact_dir) is True
+
+def test_set_calls_download_artifacts_on_artifacttool_missing(monkeypatch, tmp_path):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    temp_dirs = []
+
+    def fake_mkdtemp():
+        path = tmp_path / f"temp_{len(temp_dirs)}"
+        path.mkdir(exist_ok=True)
+        temp_dirs.append(path)
+        return str(path)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    download_calls = []
+
+    def fake_download(self, download_cmd, organization, name, version, feed, max_retries=3):
+        download_calls.append(
+            (download_cmd[:], organization, name, version, feed),
+        )
+
+    monkeypatch.setattr(ArtifactCache, "_download_artifacts", fake_download)
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1,
+            stderr="No such file or directory: /path/artifacttool",
+            stdout="",
+        ),
+    )
+
+    cache = ArtifactCache()
+    artifact_path = cache.set(
+        feed="feed",
+        name="package",
+        version="1.0",
+        scope="project",
+        organization="https://dev.azure.com/org",
+        project="proj",
+    )
+    assert download_calls
+    assert artifact_path.exists()
+    checksum_file = artifact_path.parent / f"1.0_{ArtifactCache.POSTFIX_CHECKSUM}"
+    assert checksum_file.exists()
+
+def test_set_raises_runtime_error_when_download_fails(monkeypatch, tmp_path):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    monkeypatch.setattr(shutil, "which", lambda value: value)
+
+    temp_dirs = []
+
+    def fake_mkdtemp():
+        path = tmp_path / f"temp_{len(temp_dirs)}"
+        path.mkdir(exist_ok=True)
+        temp_dirs.append(path)
+        return str(path)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stderr="generic failure", stdout=""),
+    )
+
+    cache = ArtifactCache()
+    with pytest.raises(RuntimeError) as excinfo:
+        cache.set(
+            feed="feed",
+            name="package",
+            version="1.0",
+            scope="project",
+            organization="https://dev.azure.com/org",
+            project="proj",
+        )
+    assert "generic failure" in str(excinfo.value)
+
+def test_set_handles_artifacttool_not_found_and_writes_checksum(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", lambda: None)
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache_dir")
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/az")
+    download_cmd = {}
+
+    def fake_download_artifacts(self, download_cmd_arg, organization_arg, name_arg, version_arg, feed_arg, max_retries=3):
+        download_cmd["cmd"] = list(download_cmd_arg)
+        assert download_cmd["cmd"][-1] == "--debug"
+
+    monkeypatch.setattr(ArtifactCache, "_download_artifacts", fake_download_artifacts)
+    temp_calls = [
+        {"path": tmp_path / "download_temp", "with_file": True},
+        {"path": tmp_path / "checksum_temp", "with_file": False},
+    ]
+
+    def fake_mkdtemp(*args, **kwargs):
+        if not temp_calls:
+            raise RuntimeError("mkdtemp called more times than expected")
+        info = temp_calls.pop(0)
+        info["path"].mkdir(parents=True, exist_ok=True)
+        if info["with_file"]:
+            (info["path"] / "payload.txt").write_text("value")
+        return str(info["path"])
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    class FakeResult:
+        def __init__(self):
+            self.returncode = 1
+            self.stderr = "No such file or directory: artifacttool"
+            self.stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: FakeResult())
+    cache = ArtifactCache()
+    returned_path = cache.set(
+        feed="feed",
+        name="package",
+        version="1.0",
+        scope="project",
+        organization="https://example.visualstudio.com",
+        project="proj",
+    )
+    expected_path = (
+        cache.DEFAULT_DISK_CACHE_DIRECTORY
+        / ArtifactCache._format_organization_name("https://example.visualstudio.com")
+        / "proj"
+        / "feed"
+        / "package"
+        / "1.0"
+    )
+    assert returned_path == expected_path
+    assert expected_path.exists()
+    checksum_path = expected_path.parent / f"1.0_{ArtifactCache.POSTFIX_CHECKSUM}"
+    file_list = [path for path in expected_path.rglob("*") if path.is_file()]
+    assert checksum_path.read_text() == ArtifactCache.hash_files_content(file_list)
+    assert download_cmd["cmd"][-1] == "--debug"
+
+def test_set_raises_runtime_error_when_download_fails_without_artifacttool_error(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", lambda: None)
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache_dir")
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/az")
+
+    def fake_mkdtemp(*args, **kwargs):
+        path = tmp_path / "unused_temp"
+        path.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    class FakeResult:
+        def __init__(self):
+            self.returncode = 1
+            self.stderr = "Some other error"
+            self.stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: FakeResult())
+    cache = ArtifactCache()
+    with pytest.raises(RuntimeError, match="Download package package:1.0 from the feed feed failed: Some other error"):
+        cache.set(
+            feed="feed",
+            name="package",
+            version="1.0",
+            scope="project",
+            organization="https://example.visualstudio.com",
+            project="proj",
+        )
+
+def test_set_handles_os_rename_errors_and_still_returns_path(tmp_path, monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", lambda: None)
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache_dir")
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/az")
+    temp_calls = [
+        {"path": tmp_path / "download_temp", "with_file": True},
+        {"path": tmp_path / "checksum_temp", "with_file": False},
+    ]
+
+    def fake_mkdtemp(*args, **kwargs):
+        if not temp_calls:
+            raise RuntimeError("mkdtemp called more times than expected")
+        info = temp_calls.pop(0)
+        info["path"].mkdir(parents=True, exist_ok=True)
+        if info["with_file"]:
+            (info["path"] / "payload.txt").write_text("value")
+        return str(info["path"])
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    class FakeResult:
+        def __init__(self):
+            self.returncode = 0
+            self.stderr = ""
+            self.stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: FakeResult())
+    original_rename = os.rename
+    rename_calls = {"count": 0}
+
+    def fake_rename(src, dst):
+        rename_calls["count"] += 1
+        if rename_calls["count"] == 1:
+            raise FileExistsError("destination exists")
+        original_rename(src, dst)
+
+    monkeypatch.setattr(os, "rename", fake_rename)
+    cache = ArtifactCache()
+    returned_path = cache.set(
+        feed="feed",
+        name="package",
+        version="1.0",
+        scope="project",
+        organization="https://example.visualstudio.com",
+        project="proj",
+    )
+    expected_path = (
+        cache.DEFAULT_DISK_CACHE_DIRECTORY
+        / ArtifactCache._format_organization_name("https://example.visualstudio.com")
+        / "proj"
+        / "feed"
+        / "package"
+        / "1.0"
+    )
+    assert returned_path == expected_path
+    assert rename_calls["count"] == 1
+    assert not expected_path.exists()
+
+def test_download_artifacts_retries_until_max_retries(monkeypatch):
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", lambda: None)
+    cache = ArtifactCache()
+    redirect_calls = {"count": 0}
+
+    def fake_redirect(self, organization):
+        redirect_calls["count"] += 1
+        raise RuntimeError("redirect failure")
+
+    monkeypatch.setattr(ArtifactCache, "_redirect_artifacts_tool_path", fake_redirect)
+    run_calls = {"count": 0}
+
+    class FakeResult:
+        def __init__(self, seq):
+            self.returncode = 1
+            self.stderr = f"stderr {seq}"
+            self.stdout = f"stdout {seq}"
+
+    def fake_run(*args, **kwargs):
+        run_calls["count"] += 1
+        return FakeResult(run_calls["count"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="failed 1 times: stderr 1"):
+        cache._download_artifacts(
+            ["cmd"],
+            "https://example.visualstudio.com",
+            "package",
+            "1.0",
+            "feed",
+            max_retries=1,
+        )
+    assert run_calls["count"] == 1
+    assert redirect_calls["count"] == 1
+
+def test_set_raises_runtime_error_when_download_command_fails_without_artifacttool_pattern(monkeypatch, tmp_path):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    ArtifactCache._instance = None
+    cache = ArtifactCache()
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stderr="unexpected failure", stdout=""),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        cache.set(feed="feed", name="name", version="1.0", scope="project", organization="https://org", project="proj")
+    assert (
+        "Download package name:1.0 from the feed feed failed: unexpected failure"
+        == str(excinfo.value)
+    )
+
+def test_set_retries_download_artifacts_when_artifacttool_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    ArtifactCache._instance = None
+    cache = ArtifactCache()
+    org_project_calls = []
+
+    def fake_get_org_project():
+        org_project_calls.append(True)
+        return "https://org.visualstudio.com", "project"
+
+    monkeypatch.setattr(ArtifactCache, "get_organization_project_by_git", staticmethod(fake_get_org_project))
+    download_calls = []
+
+    def fake_download_artifacts(self, download_cmd, organization, name, version, feed):
+        download_calls.append(list(download_cmd))
+
+    monkeypatch.setattr(ArtifactCache, "_download_artifacts", fake_download_artifacts)
+    tempdir_paths = [tmp_path / "tempdir", tmp_path / "checksum_temp"]
+    mkdtemp_counter = 0
+
+    def fake_mkdtemp():
+        nonlocal mkdtemp_counter
+        if mkdtemp_counter >= len(tempdir_paths):
+            raise AssertionError("Unexpected mkdtemp call")
+        path = tempdir_paths[mkdtemp_counter]
+        path.mkdir(parents=True, exist_ok=True)
+        if mkdtemp_counter == 0:
+            (path / "dummy.txt").write_text("content")
+        mkdtemp_counter += 1
+        return str(path)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    class Result:
+        def __init__(self, returncode, stderr="", stdout=""):
+            self.returncode = returncode
+            self.stderr = stderr
+            self.stdout = stdout
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: Result(
+            1, stderr="No such file or directory: /usr/bin/artifacttool", stdout=""
+        ),
+    )
+    path = cache.set(feed="feed", name="name", version="1.0", scope="project")
+    assert len(download_calls) == 1
+    assert "--debug" in download_calls[0]
+    assert len(org_project_calls) == 1
+    expected_path = (
+        Path(cache.DEFAULT_DISK_CACHE_DIRECTORY)
+        / cache._format_organization_name("https://org.visualstudio.com")
+        / "project"
+        / "feed"
+        / "name"
+        / "1.0"
+    ).absolute().resolve()
+    assert path == expected_path
+    checksum_path = expected_path.parent / f"1.0_{cache.POSTFIX_CHECKSUM}"
+    assert checksum_path.exists()
+    assert checksum_path.read_text().strip() == cache.hash_files_content(
+        [str(expected_path / "dummy.txt")]
+    )
+
+def test_set_returns_path_even_if_rename_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    ArtifactCache._instance = None
+    cache = ArtifactCache()
+    version = "2.0"
+    tempdir_paths = [tmp_path / "tempdir_fail", tmp_path / "checksum_fail"]
+    mkdtemp_counter = 0
+
+    def fake_mkdtemp():
+        nonlocal mkdtemp_counter
+        if mkdtemp_counter >= len(tempdir_paths):
+            raise AssertionError("Unexpected mkdtemp call")
+        path = tempdir_paths[mkdtemp_counter]
+        path.mkdir(parents=True, exist_ok=True)
+        if mkdtemp_counter == 0:
+            (path / "dummy.txt").write_text("content")
+        mkdtemp_counter += 1
+        return str(path)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""),
+    )
+    expected_path = (
+        Path(cache.DEFAULT_DISK_CACHE_DIRECTORY)
+        / cache._format_organization_name("https://org.visualstudio.com")
+        / "project"
+        / "feed"
+        / "name"
+        / version
+    )
+    expected_resolved = expected_path.absolute()
+    original_rename = os.rename
+    rename_failed = False
+
+    def fake_rename(src, dst):
+        nonlocal rename_failed
+        dst_str = os.fspath(dst)
+        if dst_str.endswith(f"{version}_{cache.POSTFIX_CHECKSUM}"):
+            return original_rename(src, dst)
+        if not rename_failed and os.path.normpath(dst_str) == str(expected_resolved):
+            rename_failed = True
+            raise FileExistsError("target is in use")
+        return original_rename(src, dst)
+
+    monkeypatch.setattr(os, "rename", fake_rename)
+    path = cache.set(
+        feed="feed",
+        name="name",
+        version=version,
+        scope="project",
+        organization="https://org.visualstudio.com",
+        project="project",
+    )
+    assert path == expected_resolved
+    assert rename_failed
+    assert not expected_resolved.exists()
+
+def test_download_artifacts_warns_then_succeeds(monkeypatch):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    cache = ArtifactCache()
+    redirect_calls = []
+
+    def fake_redirect(self, organization):
+        redirect_calls.append(organization)
+        raise ValueError("redirect failure")
+
+    monkeypatch.setattr(ArtifactCache, "_redirect_artifacts_tool_path", fake_redirect)
+    results = [
+        SimpleNamespace(returncode=1, stderr="error1", stdout="stdout1"),
+        SimpleNamespace(returncode=0, stderr="", stdout=""),
+    ]
+    run_calls = []
+
+    def fake_run(*args, **kwargs):
+        run_calls.append(args[0])
+        return results.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    cache._download_artifacts(["cmd"], "org", "name", "1.0", "feed", max_retries=2)
+    assert len(redirect_calls) == 2
+    assert len(run_calls) == 2
+
+def test_download_artifacts_raises_after_multiple_retries(monkeypatch):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    cache = ArtifactCache()
+    monkeypatch.setattr(ArtifactCache, "_redirect_artifacts_tool_path", lambda self, organization: None)
+    responses = [
+        SimpleNamespace(returncode=1, stderr="err1", stdout="out1"),
+        SimpleNamespace(returncode=1, stderr="err2", stdout="out2"),
+    ]
+
+    def fake_run(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        cache._download_artifacts(["cmd"], "org", "name", "1.0", "feed", max_retries=2)
+    assert "Download artifact debug info" in str(excinfo.value)
+    assert "out2" in str(excinfo.value)
+
+def test_download_artifacts_retries_and_handles_redirect_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    cache = ArtifactCache()
+
+    redirect_calls = []
+
+    def fake_redirect(self, organization):
+        redirect_calls.append(organization)
+        if len(redirect_calls) == 1:
+            raise RuntimeError("redirect fail")
+    monkeypatch.setattr(ArtifactCache, "_redirect_artifacts_tool_path", fake_redirect)
+
+    run_calls = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        if len(run_calls) == 1:
+            return SimpleNamespace(returncode=1, stderr="retry", stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cache._download_artifacts(["az", "artifacts"], "https://org.visualstudio.com", "package", "1.0", "feed", max_retries=2)
+
+    assert len(redirect_calls) == 2
+    assert len(run_calls) == 2
+
+def test_download_artifacts_raises_after_exhausting_retries(monkeypatch, tmp_path):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", tmp_path / "cache")
+    cache = ArtifactCache()
+
+    redirect_count = {"value": 0}
+
+    def fake_redirect(self, organization):
+        redirect_count["value"] += 1
+    monkeypatch.setattr(ArtifactCache, "_redirect_artifacts_tool_path", fake_redirect)
+
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=1, stderr="fatal", stdout="info")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        cache._download_artifacts(["az", "artifacts"], "https://dev.azure.com/org", "package", "1.0", "feed", max_retries=1)
+    assert "Download package" in str(excinfo.value)
+    assert redirect_count["value"] == 1
+
+def test_set_handles_missing_org_project_and_writes_checksum(tmp_path, monkeypatch):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", cache_dir)
+    monkeypatch.setattr(shutil, "which", lambda tool: "/usr/bin/git" if tool == "git" else "/usr/bin/az")
+    monkeypatch.setattr(ArtifactCache, "get_organization_project_by_git", staticmethod(lambda: ("https://my<org>.visualstudio.com", "proj")))
+    mkdtemp_calls = {"value": 0}
+
+    def fake_mkdtemp():
+        path = tmp_path / f"temp{mkdtemp_calls['value']}"
+        path.mkdir(parents=True, exist_ok=True)
+        if mkdtemp_calls["value"] == 0:
+            (path / "payload.txt").write_text("data")
+        mkdtemp_calls["value"] += 1
+        return str(path)
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""))
+
+    cache = ArtifactCache()
+    artifact_path = cache.set(feed="feed", name="package", version="1.2.3", scope="project")
+
+    payload_file = artifact_path / "payload.txt"
+    assert payload_file.read_text() == "data"
+    expected_checksum = ArtifactCache.hash_files_content([str(payload_file)])
+    checksum_file = artifact_path.parent / f"1.2.3_{ArtifactCache.POSTFIX_CHECKSUM}"
+    assert checksum_file.read_text() == expected_checksum
+    sanitized_organization = ArtifactCache._format_organization_name("https://my<org>.visualstudio.com")
+    expected_path = (cache_dir / sanitized_organization / "proj" / "feed" / "package" / "1.2.3").resolve()
+    assert artifact_path == expected_path
+
+def test_set_retries_after_artifacttool_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    cache_dir = tmp_path / "cache2"
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", cache_dir)
+    monkeypatch.setattr(shutil, "which", lambda tool: "/usr/bin/az")
+    mkdtemp_calls = {"value": 0}
+
+    def fake_mkdtemp():
+        path = tmp_path / f"temp_retry{mkdtemp_calls['value']}"
+        path.mkdir(parents=True, exist_ok=True)
+        if mkdtemp_calls["value"] == 0:
+            (path / "retry.txt").write_text("retry payload")
+        mkdtemp_calls["value"] += 1
+        return str(path)
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    download_calls = []
+
+    def fake_download_artifacts(self, download_cmd, organization, name, version, feed, max_retries=3):
+        download_calls.append(list(download_cmd))
+    monkeypatch.setattr(ArtifactCache, "_download_artifacts", fake_download_artifacts)
+
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=1, stderr="No such file or directory: /usr/bin/artifacttool", stdout="stdout")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cache = ArtifactCache()
+    artifact_path = cache.set(
+        feed="feed",
+        name="pkg",
+        version="2.0",
+        scope="organization",
+        organization="https://org.visualstudio.com",
+        project="proj",
+    )
+
+    assert len(download_calls) == 1
+    assert "--debug" in download_calls[0]
+    payload_file = artifact_path / "retry.txt"
+    assert payload_file.read_text() == "retry payload"
+    checksum_file = artifact_path.parent / f"2.0_{ArtifactCache.POSTFIX_CHECKSUM}"
+    expected_checksum = ArtifactCache.hash_files_content([str(payload_file)])
+    assert checksum_file.read_text() == expected_checksum
+
+def test_set_ignores_rename_errors(tmp_path, monkeypatch):
+    monkeypatch.setattr(ArtifactCache, "check_artifact_extension", staticmethod(lambda: None))
+    ArtifactCache._instance = None
+    cache_dir = tmp_path / "cache3"
+    monkeypatch.setattr(ArtifactCache, "DEFAULT_DISK_CACHE_DIRECTORY", cache_dir)
+    monkeypatch.setattr(shutil, "which", lambda tool: "/usr/bin/az")
+    mkdtemp_calls = {"value": 0}
+
+    def fake_mkdtemp():
+        path = tmp_path / f"temp_error{mkdtemp_calls['value']}"
+        path.mkdir(parents=True, exist_ok=True)
+        if mkdtemp_calls["value"] == 0:
+            (path / "error.txt").write_text("data")
+        mkdtemp_calls["value"] += 1
+        return str(path)
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    rename_calls = {"value": 0}
+
+    def fake_rename(src, dst):
+        rename_calls["value"] += 1
+        if rename_calls["value"] == 1:
+            raise FileExistsError("dest already exists")
+        return None
+    monkeypatch.setattr(os, "rename", fake_rename)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""))
+
+    cache = ArtifactCache()
+    artifact_path = cache.set(
+        feed="feed",
+        name="pkg",
+        version="3.0",
+        scope="project",
+        organization="https://org.visualstudio.com",
+        project="proj",
+    )
+
+    sanitized_organization = ArtifactCache._format_organization_name("https://org.visualstudio.com")
+    expected_path = (cache_dir / sanitized_organization / "proj" / "feed" / "pkg" / "3.0").resolve()
+    assert artifact_path == expected_path
+    assert rename_calls["value"] == 1
+
+def test_set_populates_cache_and_checksum(tmp_path, monkeypatch):
+    monkeypatch.setattr(ArtifactCache, '_instance', None)
+    monkeypatch.setattr(ArtifactCache, 'check_artifact_extension', staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, 'DEFAULT_DISK_CACHE_DIRECTORY', tmp_path / 'cache')
+    monkeypatch.setattr(shutil, 'which', lambda _: '/bin/az')
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout='', stderr='')
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    download_dir = tmp_path / 'download-1'
+    checksum_dir = tmp_path / 'checksum-1'
+    mkdtemp_state = {'calls': 0}
+
+    def fake_mkdtemp(*args, **kwargs):
+        mkdtemp_state['calls'] += 1
+        if mkdtemp_state['calls'] == 1:
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / 'payload.bin').write_bytes(b'payload')
+            return str(download_dir)
+        checksum_dir.mkdir(parents=True, exist_ok=True)
+        return str(checksum_dir)
+
+    monkeypatch.setattr(tempfile, 'mkdtemp', fake_mkdtemp)
+
+    cache = ArtifactCache()
+    result = cache.set(
+        feed='feed',
+        name='name',
+        version='v1',
+        scope='project',
+        organization='https://contoso.visualstudio.com',
+        project='proj',
+    )
+
+    expected_path = (
+        ArtifactCache.DEFAULT_DISK_CACHE_DIRECTORY
+        / ArtifactCache._format_organization_name('https://contoso.visualstudio.com')
+        / 'proj'
+        / 'feed'
+        / 'name'
+        / 'v1'
+    )
+    expected_absolute_path = expected_path.absolute().resolve()
+    assert result == expected_absolute_path
+    assert (expected_path / 'payload.bin').read_bytes() == b'payload'
+    checksum_path = expected_path.parent / f'v1_{ArtifactCache.POSTFIX_CHECKSUM}'
+    assert checksum_path.read_text() == ArtifactCache.hash_files_content([str(expected_path / 'payload.bin')])
+
+def test_set_swallows_rename_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(ArtifactCache, '_instance', None)
+    monkeypatch.setattr(ArtifactCache, 'check_artifact_extension', staticmethod(lambda: None))
+    monkeypatch.setattr(ArtifactCache, 'DEFAULT_DISK_CACHE_DIRECTORY', tmp_path / 'cache')
+    monkeypatch.setattr(shutil, 'which', lambda _: '/bin/az')
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout='', stderr='')
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    download_dir = tmp_path / 'download-2'
+    checksum_dir = tmp_path / 'checksum-2'
+    mkdtemp_state = {'calls': 0}
+
+    def fake_mkdtemp(*args, **kwargs):
+        mkdtemp_state['calls'] += 1
+        if mkdtemp_state['calls'] == 1:
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / 'payload.bin').write_bytes(b'payload')
+            return str(download_dir)
+        checksum_dir.mkdir(parents=True, exist_ok=True)
+        return str(checksum_dir)
+
+    monkeypatch.setattr(tempfile, 'mkdtemp', fake_mkdtemp)
+
+    real_rename = os.rename
+    rename_state = {'count': 0}
+
+    def fake_rename(src, dst):
+        rename_state['count'] += 1
+        if rename_state['count'] == 1:
+            raise OSError('cannot rename')
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(os, 'rename', fake_rename)
+
+    cache = ArtifactCache()
+    result = cache.set(
+        feed='feed',
+        name='name',
+        version='v1',
+        scope='project',
+        organization='https://contoso.visualstudio.com',
+        project='proj',
+    )
+
+    expected_path = (
+        ArtifactCache.DEFAULT_DISK_CACHE_DIRECTORY
+        / ArtifactCache._format_organization_name('https://contoso.visualstudio.com')
+        / 'proj'
+        / 'feed'
+        / 'name'
+        / 'v1'
+    )
+    expected_absolute_path = expected_path.absolute().resolve()
+    assert result == expected_absolute_path
+    assert rename_state['count'] == 1
+    assert not expected_path.exists()
+    checksum_path = expected_path.parent / f'v1_{ArtifactCache.POSTFIX_CHECKSUM}'
+    assert not checksum_path.exists()

--- a/sdk/ml/azure-ai-ml/tests/test_asset_utils_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_asset_utils_gaps.py
@@ -1,0 +1,497 @@
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from azure.ai.ml._artifacts._constants import (
+    UPLOAD_CONFIRMATION,
+    ARTIFACT_ORIGIN,
+    WORKSPACE_MANAGED_DATASTORE,
+    WORKSPACE_MANAGED_DATASTORE_WITH_SLASH,
+    AUTO_DELETE_SETTING_NOT_ALLOWED_ERROR_NO_PERSONAL_DATA,
+    INVALID_MANAGED_DATASTORE_PATH_ERROR_NO_PERSONAL_DATA,
+    BLOB_STORAGE_CLIENT_NAME,
+    GEN2_STORAGE_CLIENT_NAME,
+)
+from azure.ai.ml.exceptions import (
+    ValidationException,
+    AssetPathException,
+    ValidationErrorType,
+    ErrorTarget,
+    ErrorCategory,
+    EmptyDirectoryError,
+)
+from azure.ai.ml._utils.utils import snake_to_camel
+from azure.core.exceptions import ResourceNotFoundError
+import azure.ai.ml._utils._asset_utils as asset_utils
+from azure.ai.ml._restclient.v2023_04_01.models import PendingUploadRequestDto
+
+from azure.ai.ml._utils._asset_utils import (
+    EMPTY_DIRECTORY_ERROR,
+    IgnoreFile,
+    _build_metadata_dict,
+    get_content_hash,
+    traverse_directory,
+    generate_asset_id,
+    _validate_workspace_managed_datastore,
+    _validate_auto_delete_setting_in_data_output,
+    _check_or_modify_auto_delete_setting,
+    _get_latest,
+    _get_latest_version_from_container,
+    _get_next_latest_versions_from_container,
+    _resolve_label_to_asset,
+    DirectoryUploadProgressBar,
+    upload_directory,
+    upload_file,
+    FileUploadProgressBar,
+    _create_or_update_autoincrement,
+    _get_next_version_from_container,
+    _archive_or_restore,
+    get_storage_info_for_non_registry_asset,
+    _get_existing_asset_name_and_version,
+)
+
+
+def test_build_metadata_dict_success_and_name_none():
+    name = "my_asset"
+    version = "1"
+    metadata = _build_metadata_dict(name, version)
+    assert metadata["name"] == name
+    assert metadata["version"] == version
+    for k, v in UPLOAD_CONFIRMATION.items():
+        assert metadata[k] == v
+
+    with pytest.raises(ValidationException) as ex:
+        _build_metadata_dict("", version)
+    assert ex.value.error_type == ValidationErrorType.INVALID_VALUE
+    assert ex.value.target == ErrorTarget.ASSET
+
+
+def test_get_content_hash_returns_none_for_nonexistent_path(tmp_path):
+    non_existent = tmp_path / "does_not_exist.txt"
+    result = get_content_hash(str(non_existent))
+    assert result is None
+
+
+class DummyIgnoreFile(IgnoreFile):
+    def __init__(self, paths_to_ignore):  # type: ignore[no-untyped-def]
+        self._paths_to_ignore = {str(p) for p in paths_to_ignore}
+
+    def is_file_excluded(self, file_path):  # type: ignore[no-untyped-def]
+        return str(file_path) in self._paths_to_ignore
+
+
+def test_traverse_directory_respects_ignore_file(tmp_path):
+    root = tmp_path
+    included_file = root / "included.txt"
+    excluded_file = root / "excluded.txt"
+    included_file.write_text("included", encoding="utf-8")
+    excluded_file.write_text("excluded", encoding="utf-8")
+
+    files = [included_file.name, excluded_file.name]
+    ignore_file = DummyIgnoreFile([excluded_file])
+
+    results = list(
+        traverse_directory(
+            root=str(root),
+            files=files,
+            prefix="prefix",
+            ignore_file=ignore_file,
+        )
+    )
+
+    paths = [src for src, _ in results]
+    assert str(included_file.resolve()) in paths
+    assert str(excluded_file.resolve()) not in paths
+
+
+def test_generate_asset_id_include_directory_flag():
+    asset_hash = "abc123"
+
+    with_dir = generate_asset_id(asset_hash, include_directory=True)
+    assert with_dir == "/".join((ARTIFACT_ORIGIN, asset_hash))
+
+    without_dir = generate_asset_id(asset_hash, include_directory=False)
+    assert without_dir == asset_hash
+
+
+def test_validate_workspace_managed_datastore_valid_invalid_and_other():
+    # Valid managed datastore path (exact match)
+    result = _validate_workspace_managed_datastore(WORKSPACE_MANAGED_DATASTORE)
+    assert result == WORKSPACE_MANAGED_DATASTORE + "/paths"
+
+    # Invalid managed datastore path (starts with managed datastore but extra segment)
+    invalid_path = WORKSPACE_MANAGED_DATASTORE_WITH_SLASH + "foo"
+    with pytest.raises(AssetPathException) as ex:
+        _validate_workspace_managed_datastore(invalid_path)
+    assert ex.value.message == INVALID_MANAGED_DATASTORE_PATH_ERROR_NO_PERSONAL_DATA
+
+    # Non-managed datastore path should pass through unchanged
+    other_path = "some/other/path"
+    assert _validate_workspace_managed_datastore(other_path) == other_path
+
+
+def test_validate_auto_delete_setting_in_data_output():
+    with pytest.raises(ValidationException) as ex:
+        _validate_auto_delete_setting_in_data_output({"some": "value"})
+    assert ex.value.message == AUTO_DELETE_SETTING_NOT_ALLOWED_ERROR_NO_PERSONAL_DATA
+    assert ex.value.error_category == ErrorCategory.USER_ERROR  # type: ignore[attr-defined]
+
+    # None should be allowed (no exception)
+    _validate_auto_delete_setting_in_data_output(None)
+
+
+class AutoDeleteObject:
+    def __init__(self, condition):  # type: ignore[no-untyped-def]
+        self.condition = condition
+
+
+def test_check_or_modify_auto_delete_setting_object_and_dict():
+    obj = AutoDeleteObject("match_any")
+    _check_or_modify_auto_delete_setting(obj)
+    assert obj.condition == snake_to_camel("match_any")
+
+    setting_dict = {"condition": "match_all"}
+    _check_or_modify_auto_delete_setting(setting_dict)
+    assert setting_dict["condition"] == snake_to_camel("match_all")
+
+    # None should be a no-op
+    _check_or_modify_auto_delete_setting(None)
+
+
+class FakeVersionOperationNoResults:
+    def list(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return self
+
+    def next(self):  # type: ignore[no-untyped-def]
+        raise StopIteration
+
+
+def test_get_latest_raises_when_no_versions():
+    version_operation = FakeVersionOperationNoResults()
+
+    with pytest.raises(ValidationException) as ex:
+        _get_latest(
+            asset_name="asset1",
+            version_operation=version_operation,
+            resource_group_name="rg",
+            workspace_name="ws",
+        )
+
+    err = ex.value
+    assert err.error_type == ValidationErrorType.RESOURCE_NOT_FOUND
+    assert err.target == ErrorTarget.ASSET
+    assert "does not exist in workspace ws" in err.message
+
+
+class FakeContainerOperationNotFound:
+    def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        raise ResourceNotFoundError("not found")
+
+
+def test_get_latest_version_from_container_raises_when_not_found():
+    container_operation = FakeContainerOperationNotFound()
+
+    with pytest.raises(ValidationException) as ex:
+        _get_latest_version_from_container(
+            asset_name="asset2",
+            container_operation=container_operation,
+            resource_group_name="rg",
+            registry_name="reg",
+        )
+
+    err = ex.value
+    assert err.error_type == ValidationErrorType.RESOURCE_NOT_FOUND
+    assert err.target == ErrorTarget.ASSET
+    assert "does not exist in registry reg" in err.message
+
+
+class FakeAssetOperations:
+    def __init__(self, resolver_map, registry_name=None):  # type: ignore[no-untyped-def]
+        self._managed_label_resolver = resolver_map
+        self._registry_name = registry_name
+
+
+def test_resolve_label_to_asset_not_found_and_success():
+    name = "my_asset"
+    label = "latest"
+
+    # Case 1: no resolver found -> ValidationException
+    ops_no_resolver = FakeAssetOperations({}, registry_name=None)
+    with pytest.raises(ValidationException) as ex:
+        _resolve_label_to_asset(ops_no_resolver, name, label)
+    msg = "Asset {} with version label {} does not exist in {}.".format(name, label, "workspace")
+    assert ex.value.message == msg
+
+    # Case 2: resolver present -> returns asset
+    expected_result = ("resolved", name)
+
+    def resolver(asset_name):  # type: ignore[no-untyped-def]
+        return ("resolved", asset_name)
+
+    ops_with_resolver = FakeAssetOperations({label: resolver}, registry_name="reg")
+    result = _resolve_label_to_asset(ops_with_resolver, name, label)
+    assert result == expected_result
+
+
+class DummyDirectoryClient:
+    def __init__(self):
+        self.created_subdirs = []
+        self.last_file_client = None
+
+    def create_sub_directory(self, name):
+        self.created_subdirs.append(name)
+        return DummySubDirectoryClient(self)
+
+
+class DummySubDirectoryClient:
+    def __init__(self, directory_client: DummyDirectoryClient):
+        self._directory_client = directory_client
+
+    def create_sub_directory(self, name):
+        self._directory_client.created_subdirs.append(name)
+        return self
+
+    def create_file(self, name):
+        self._directory_client.last_file_client = DummyFileClient()
+        return self._directory_client.last_file_client
+
+
+class DummyFileClient:
+    def __init__(self):
+        self.upload_calls = []
+
+    def upload_data(self, **kwargs):
+        self.upload_calls.append(kwargs)
+
+
+def _make_gen2_storage_client():
+    Gen2ClientClass = type(GEN2_STORAGE_CLIENT_NAME, (), {})
+    client = Gen2ClientClass()
+    client.directory_client = DummyDirectoryClient()
+    client.temp_sub_directory_client = None
+    client.file_client = None
+    client.uploaded_file_count = 0
+    return client
+
+
+class DummyContainerClient:
+    def __init__(self):
+        self.upload_calls = []
+
+    def upload_blob(
+        self,
+        name,
+        data,
+        validate_content,
+        overwrite,
+        raw_response_hook,
+        max_concurrency,
+        connection_timeout,
+    ):
+        if raw_response_hook is not None:
+            class Response:
+                pass
+
+            response = Response()
+            response.context = {
+                "upload_stream_current": 10,
+                "data_stream_total": 10,
+            }
+            raw_response_hook(response)
+        self.upload_calls.append(
+            {
+                "name": name,
+                "validate_content": validate_content,
+                "overwrite": overwrite,
+                "max_concurrency": max_concurrency,
+                "connection_timeout": connection_timeout,
+            }
+        )
+
+
+def _make_blob_storage_client():
+    BlobClientClass = type(BLOB_STORAGE_CLIENT_NAME, (), {})
+    client = BlobClientClass()
+    client.container_client = DummyContainerClient()
+    client.overwrite = True
+    client.uploaded_file_count = 0
+    client.total_file_count = 0
+    client.indicator_file = None
+    client._check_blob_exists_called = False
+
+    def check_blob_exists():
+        client._check_blob_exists_called = True
+
+    client.check_blob_exists = check_blob_exists
+    return client
+
+
+def test_upload_file_gen2_in_directory_creates_subdirs_and_uploads():
+    storage_client = _make_gen2_storage_client()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "file.txt"
+        file_path.write_text("content", encoding="utf-8")
+        dest = os.path.join("LocalUpload", "assetid", "dir1", "dir2", "file.txt")
+
+        upload_file(
+            storage_client=storage_client,
+            source=str(file_path),
+            dest=dest,
+            msg=None,
+            size=os.path.getsize(file_path),
+            show_progress=False,
+            in_directory=True,
+        )
+
+        assert storage_client.uploaded_file_count == 1
+        assert storage_client.directory_client.created_subdirs == ["dir1", "dir2"]
+        file_client = storage_client.directory_client.last_file_client
+        assert isinstance(file_client, DummyFileClient)
+        assert len(file_client.upload_calls) == 1
+        call_kwargs = file_client.upload_calls[0]
+        assert call_kwargs["overwrite"] is True
+        assert call_kwargs["validate_content"] is True
+
+
+def test_upload_file_blob_with_and_without_progress():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path_small = Path(tmpdir) / "small.txt"
+        file_path_small.write_text("small", encoding="utf-8")
+
+        # First call: no progress bar
+        storage_client_no_progress = _make_blob_storage_client()
+        upload_file(
+            storage_client=storage_client_no_progress,
+            source=str(file_path_small),
+            dest="container/path/small.txt",
+            msg="Upload small",
+            size=os.path.getsize(file_path_small),
+            show_progress=False,
+            in_directory=False,
+        )
+        assert storage_client_no_progress.uploaded_file_count == 1
+        assert len(storage_client_no_progress.container_client.upload_calls) == 1
+        call_kwargs = storage_client_no_progress.container_client.upload_calls[0]
+        assert call_kwargs["name"] == "container/path/small.txt"
+        assert call_kwargs["validate_content"] is True
+        assert call_kwargs["overwrite"] is True
+
+        # Second call: with progress bar (non-directory)
+        storage_client_progress = _make_blob_storage_client()
+        upload_file(
+            storage_client=storage_client_progress,
+            source=str(file_path_small),
+            dest="container/path/small2.txt",
+            msg="Uploading small2",
+            size=os.path.getsize(file_path_small),
+            show_progress=True,
+            in_directory=False,
+        )
+        assert storage_client_progress.uploaded_file_count == 1
+        assert len(storage_client_progress.container_client.upload_calls) == 1
+        progress_call_kwargs = storage_client_progress.container_client.upload_calls[0]
+        assert progress_call_kwargs["name"] == "container/path/small2.txt"
+        assert progress_call_kwargs["validate_content"] is True
+
+
+def test_upload_directory_empty_raises_empty_directory_error():
+    storage_client = _make_blob_storage_client()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(EmptyDirectoryError) as exc:
+            upload_directory(
+                storage_client=storage_client,
+                source=tmpdir,
+                dest="",
+                msg="Uploading dir",
+                show_progress=False,
+                ignore_file=IgnoreFile(None),
+            )
+        assert tmpdir in exc.value.message
+
+
+def test_upload_directory_non_empty_blob_sets_indicator_and_uploads():
+    storage_client = _make_blob_storage_client()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "file.txt"
+        file_path.write_text("data", encoding="utf-8")
+
+        upload_directory(
+            storage_client=storage_client,
+            source=tmpdir,
+            dest="destprefix",
+            msg="Uploading dir",
+            show_progress=False,
+            ignore_file=IgnoreFile(None),
+        )
+
+        assert storage_client.total_file_count == 1
+        assert storage_client.uploaded_file_count == 1
+        assert storage_client.indicator_file is not None
+        assert storage_client._check_blob_exists_called is True
+
+
+def test_directory_upload_progress_bar_update_to_branches():
+    bar = DirectoryUploadProgressBar(dir_size=100, msg="dir upload")
+
+    class Response:
+        def __init__(self, current):
+            self.context = {
+                "upload_stream_current": current,
+            }
+
+    # When current is positive, completed and n should be updated
+    response_positive = Response(40)
+    bar.update_to(response_positive)
+    assert bar.completed == 40
+    assert bar.n == 40
+
+    # When current is zero, nothing should change
+    bar_zero = DirectoryUploadProgressBar(dir_size=100, msg="dir upload 2")
+    response_zero = Response(0)
+    bar_zero.update_to(response_zero)
+    assert bar_zero.completed == 0
+    assert bar_zero.n == 0
+
+
+class DummyProperties:
+    def __init__(self, next_version=None, latest_version=None, is_archived=False):
+        self.next_version = next_version
+        self.latest_version = latest_version
+        self.is_archived = is_archived
+
+
+class DummyContainer:
+    def __init__(self, next_version=None, latest_version=None, is_archived=False):
+        self.properties = DummyProperties(next_version=next_version, latest_version=latest_version, is_archived=is_archived)
+
+
+class DummyContainerOperation:
+    def __init__(self, container=None, raise_not_found=False):
+        self.container = container
+        self.raise_not_found = raise_not_found
+        self.called_with = {}
+
+    def get(self, **kwargs):
+        self.called_with = kwargs.copy()
+        if self.raise_not_found:
+            raise ResourceNotFoundError("not found")
+        return self.container or DummyContainer(next_version="1", latest_version="1")
+
+
+class DummyVersionOperation:
+    def __init__(self, result=None):
+        self.result = result
+        self.called_with = {}
+
+    def create_or_update(self, **kwargs):
+        self.called_with = kwargs.copy()
+        return self.result
+
+
+...

--- a/sdk/ml/azure-ai-ml/tests/test_batch_endpoint_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_batch_endpoint_operations_gaps.py
@@ -1,0 +1,494 @@
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import azure.ai.ml.operations._batch_endpoint_operations as batch_endpoint_module
+from azure.ai.ml.constants._common import AzureMLResourceType, AssetTypes, InputTypes, AZUREML_REGEX_FORMAT, SHORT_URI_REGEX_FORMAT
+from azure.ai.ml.entities._inputs_outputs import Input
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException, ValidationException, ValidationErrorType
+from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope, OperationsContainer
+import types
+
+
+def _build_operations(batch_endpoints=None, batch_deployments=None):
+    operation_scope = OperationScope('sub', 'rg', 'workspace')
+    operation_config = OperationConfig(False, False)
+    workspace_operations = MagicMock()
+    workspace_operations.get.return_value = SimpleNamespace(location='eastus')
+    container = OperationsContainer()
+    container.add(AzureMLResourceType.WORKSPACE, workspace_operations)
+    container.add(AzureMLResourceType.DATASTORE, MagicMock())
+    if batch_endpoints is None:
+        batch_endpoints = MagicMock()
+    if batch_deployments is None:
+        batch_deployments = MagicMock()
+        batch_deployments.list.return_value = []
+    service_client = SimpleNamespace(
+        batch_endpoints=batch_endpoints,
+        batch_deployments=batch_deployments,
+    )
+    requests_pipeline = MagicMock()
+    return (
+        batch_endpoint_module.BatchEndpointOperations(
+            operation_scope,
+            operation_config,
+            service_client,
+            container,
+            credentials=None,
+            service_client_09_2020_dataplanepreview=SimpleNamespace(batch_job_endpoint=MagicMock()),
+            requests_pipeline=requests_pipeline,
+        ),
+        batch_endpoints,
+        batch_deployments,
+    )
+
+
+class _FakeBatchEndpoint:
+    def __init__(self):
+        self.name = 'endpoint'
+
+    def _to_rest_batch_endpoint(self, location):
+        return {'location': location}
+
+
+def test_begin_create_or_update_logs_validation_error(monkeypatch):
+    ops, batch_endpoints, _ = _build_operations()
+    validation_exception = ValidationException(
+        message='validation failed',
+        no_personal_data_message='validation failed',
+        target=ErrorTarget.BATCH_ENDPOINT,
+        error_category=ErrorCategory.USER_ERROR,
+        error_type=ValidationErrorType.INVALID_VALUE,
+    )
+    batch_endpoints.begin_create_or_update.side_effect = validation_exception
+
+    captured = {}
+
+    def fake_log_and_raise_error(exc):
+        captured['called'] = True
+        raise exc
+
+    monkeypatch.setattr(batch_endpoint_module, 'log_and_raise_error', fake_log_and_raise_error)
+
+    with pytest.raises(ValidationException) as excinfo:
+        ops.begin_create_or_update(_FakeBatchEndpoint())
+
+    assert captured.get('called', False) is True
+    assert excinfo.value is validation_exception
+
+
+def test_resolve_input_empty_path_raises(monkeypatch):
+    ops, _, _ = _build_operations()
+
+    class DummyInput:
+        def __init__(self, path, type):
+            self.path = path
+            self.type = type
+
+    monkeypatch.setattr(batch_endpoint_module, 'Input', DummyInput)
+
+    entry = batch_endpoint_module.Input(path='', type=AssetTypes.URI_FILE)
+
+    with pytest.raises(MlException) as excinfo:
+        ops._resolve_input(entry, os.getcwd())
+
+    assert "Input path can't be empty for batch endpoint invoke" in str(excinfo.value)
+
+
+def test_resolve_input_numeric_type_returns(monkeypatch):
+    ops, _, _ = _build_operations()
+
+    class DummyInput:
+        def __init__(self, path, type):
+            self.path = path
+            self.type = type
+
+    monkeypatch.setattr(batch_endpoint_module, 'Input', DummyInput)
+
+    entry = batch_endpoint_module.Input(path='1', type=InputTypes.NUMBER)
+
+    assert ops._resolve_input(entry, os.getcwd()) is None
+
+
+def test_resolve_input_absolute_folder_appends_slash(monkeypatch):
+    class DummyInput:
+        def __init__(self, path, type):
+            self.path = path
+            self.type = type
+
+    monkeypatch.setattr(batch_endpoint_module, 'Input', DummyInput)
+    monkeypatch.setattr(
+        batch_endpoint_module.BatchEndpointOperations,
+        '_datastore_operations',
+        property(lambda self: MagicMock()),
+    )
+
+    def fake_upload(scope, datastore, path):
+        return 'https://mystorage/folder'
+
+    monkeypatch.setattr(batch_endpoint_module, '_upload_and_generate_remote_uri', fake_upload)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ops, _, _ = _build_operations()
+        entry = batch_endpoint_module.Input(path=tmp_dir, type=AssetTypes.URI_FOLDER)
+        ops._resolve_input(entry, os.getcwd())
+        assert entry.path == 'https://mystorage/folder/'
+
+
+def test_resolve_input_relative_path_transforms_to_validation_error(monkeypatch):
+    class DummyInput:
+        def __init__(self, path, type):
+            self.path = path
+            self.type = type
+
+    monkeypatch.setattr(batch_endpoint_module, 'Input', DummyInput)
+    monkeypatch.setattr(
+        batch_endpoint_module.BatchEndpointOperations,
+        '_datastore_operations',
+        property(lambda self: MagicMock()),
+    )
+
+    def fake_upload(*args, **kwargs):
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr(batch_endpoint_module, '_upload_and_generate_remote_uri', fake_upload)
+
+    ops, _, _ = _build_operations()
+
+    entry = batch_endpoint_module.Input(path='relative/path', type=AssetTypes.URI_FOLDER)
+
+    with pytest.raises(ValidationException) as excinfo:
+        ops._resolve_input(entry, os.getcwd())
+
+    exception_text = str(excinfo.value)
+    assert 'RuntimeError' in exception_text
+    assert 'boom' in exception_text
+    assert 'Supported input path value are' in exception_text
+
+
+def _make_batch_endpoint_operations():
+    operations = batch_endpoint_module.BatchEndpointOperations.__new__(batch_endpoint_module.BatchEndpointOperations)
+    operations._operation_scope = object()
+    operations._operation_config = object()
+    operations._all_operations = types.SimpleNamespace(
+        all_operations={AzureMLResourceType.DATASTORE: object()}
+    )
+    return operations
+
+
+def test_resolve_input_registered_short_uri_returns(monkeypatch):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="dummy:short", type=AssetTypes.URI_FILE)
+    original_path = entry.path
+
+    def fake_match(pattern, string, *args, **kwargs):
+        if pattern == batch_endpoint_module.SHORT_URI_REGEX_FORMAT:
+            return object()
+        return None
+
+    monkeypatch.setattr(batch_endpoint_module.re, "match", fake_match)
+    monkeypatch.setattr(batch_endpoint_module, "is_private_preview_enabled", lambda: False)
+
+    operations._resolve_input(entry, ".")
+    assert entry.path == original_path
+
+
+def test_resolve_input_registered_private_preview_returns(monkeypatch):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="prefix@resource", type=AssetTypes.URI_FILE)
+    original_path = entry.path
+
+    def fake_match(pattern, string, *args, **kwargs):
+        if pattern == batch_endpoint_module.AZUREML_REGEX_FORMAT:
+            return object()
+        return None
+
+    monkeypatch.setattr(batch_endpoint_module.re, "match", fake_match)
+    monkeypatch.setattr(batch_endpoint_module, "is_private_preview_enabled", lambda: True)
+
+    operations._resolve_input(entry, ".")
+    assert entry.path == original_path
+
+
+def test_resolve_input_registered_datastore_path_uses_orchestrator(monkeypatch):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="registry:asset", type=AssetTypes.URI_FILE)
+
+    monkeypatch.setattr(batch_endpoint_module.re, "match", lambda *args, **kwargs: None)
+    monkeypatch.setattr(batch_endpoint_module, "is_private_preview_enabled", lambda: False)
+    monkeypatch.setattr(batch_endpoint_module, "remove_aml_prefix", lambda value: value.replace("registry:", ""))
+
+    class _FakeOperationOrchestrator:
+        def __init__(self, all_operations, operation_scope, operation_config):
+            self.all_operations = all_operations
+            self.operation_scope = operation_scope
+            self.operation_config = operation_config
+
+        def get_asset_arm_id(self, path, asset_type):
+            assert asset_type == AzureMLResourceType.DATA
+            return f"arm://{path}"
+
+    monkeypatch.setattr(batch_endpoint_module, "OperationOrchestrator", _FakeOperationOrchestrator)
+
+    operations._resolve_input(entry, ".")
+    assert entry.path == "arm://asset"
+
+
+def test_resolve_input_relative_path_uploads_folder_suffix(monkeypatch, tmp_path):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="folder", type=AssetTypes.URI_FOLDER)
+
+    monkeypatch.setattr(
+        batch_endpoint_module,
+        "_upload_and_generate_remote_uri",
+        lambda scope, datastore_ops, path: "https://storage/container",
+    )
+
+    operations._resolve_input(entry, str(tmp_path))
+    assert entry.path == "https://storage/container/"
+
+
+def test_resolve_input_relative_path_validation_exception(monkeypatch, tmp_path):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="folder", type=AssetTypes.URI_FILE)
+
+    def raising(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(batch_endpoint_module, "_upload_and_generate_remote_uri", raising)
+
+    with pytest.raises(ValidationException) as exc_info:
+        operations._resolve_input(entry, str(tmp_path))
+
+    assert exc_info.value.error_type == ValidationErrorType.INVALID_VALUE
+
+
+def test_resolve_input_relative_path_ml_exception_is_propagated(monkeypatch, tmp_path):
+    operations = _make_batch_endpoint_operations()
+    entry = Input(path="folder", type=AssetTypes.URI_FILE)
+
+    def raising(*args, **kwargs):
+        raise MlException(
+            message="fail",
+            no_personal_data_message="fail",
+            target=ErrorTarget.BATCH_ENDPOINT,
+        )
+
+    monkeypatch.setattr(batch_endpoint_module, "_upload_and_generate_remote_uri", raising)
+
+    with pytest.raises(MlException):
+        operations._resolve_input(entry, str(tmp_path))
+
+
+def _make_operations():
+    operations, _, _ = _build_operations()
+    return operations
+
+
+def test_resolve_input_short_uri_skips_upload():
+    operations = _make_operations()
+    entry = Input(path='datastore:/artifact', type=AssetTypes.URI_FOLDER)
+
+    def fake_match(pattern, string):
+        if pattern == SHORT_URI_REGEX_FORMAT and string == entry.path:
+            return object()
+        return None
+
+    with patch('azure.ai.ml.operations._batch_endpoint_operations.re.match', side_effect=fake_match):
+        operations._resolve_input(entry, base_path='.')
+    assert entry.path == 'datastore:/artifact'
+
+
+def test_resolve_input_private_preview_short_circuits():
+    operations = _make_operations()
+    entry = Input(path='@private/asset', type=AssetTypes.URI_FOLDER)
+
+    def fake_match(pattern, string):
+        if pattern == AZUREML_REGEX_FORMAT:
+            return object()
+        return None
+
+    with patch('azure.ai.ml.operations._batch_endpoint_operations.re.match', side_effect=fake_match):
+        with patch(
+            'azure.ai.ml.operations._batch_endpoint_operations.is_private_preview_enabled', return_value=True
+        ):
+            operations._resolve_input(entry, base_path='.')
+    assert entry.path == '@private/asset'
+
+
+def test_resolve_input_registered_datastore_converts_to_arm_id():
+    operations = _make_operations()
+    entry = Input(path='datastore:asset', type=AssetTypes.URI_FOLDER)
+    orchestrator_instance = MagicMock()
+    orchestrator_instance.get_asset_arm_id.return_value = 'arm://asset'
+
+    def fake_match(pattern, string):
+        return None
+
+    with patch('azure.ai.ml.operations._batch_endpoint_operations.re.match', side_effect=fake_match):
+        with patch(
+            'azure.ai.ml.operations._batch_endpoint_operations.is_private_preview_enabled', return_value=False
+        ):
+            with patch(
+                'azure.ai.ml.operations._batch_endpoint_operations.remove_aml_prefix', return_value='asset'
+            ):
+                with patch(
+                    'azure.ai.ml.operations._batch_endpoint_operations.OperationOrchestrator',
+                    return_value=orchestrator_instance,
+                ):
+                    operations._resolve_input(entry, base_path='.')
+    orchestrator_instance.get_asset_arm_id.assert_called_once_with('asset', AzureMLResourceType.DATA)
+    assert entry.path == 'arm://asset'
+
+
+def test_resolve_input_relative_path_uploads_and_appends_slash():
+    operations = _make_operations()
+    entry = Input(path='relative/folder', type=AssetTypes.URI_FOLDER)
+    with patch(
+        'azure.ai.ml.operations._batch_endpoint_operations._upload_and_generate_remote_uri',
+        return_value='https://upload/result',
+    ):
+        operations._resolve_input(entry, base_path='.')
+    assert entry.path == 'https://upload/result/'
+
+
+def test_resolve_input_relative_path_upload_error_wraps_validation_exception():
+    operations = _make_operations()
+    entry = Input(path='relative/folder', type=AssetTypes.URI_FOLDER)
+
+    def raise_error(*args, **kwargs):
+        raise RuntimeError('boom')
+
+    with patch(
+        'azure.ai.ml.operations._batch_endpoint_operations._upload_and_generate_remote_uri',
+        side_effect=raise_error,
+    ):
+        with pytest.raises(ValidationException) as exc_info:
+            operations._resolve_input(entry, base_path='.')
+    assert 'RuntimeError' in str(exc_info.value)
+
+
+class DummyInput:
+    def __init__(self, path, type):
+        self.path = path
+        self.type = type
+
+
+class FakeRe:
+    def __init__(self, matcher):
+        self._matcher = matcher
+
+    def match(self, pattern, string):
+        return self._matcher(pattern, string)
+
+
+from azure.ai.ml.operations._batch_endpoint_operations import BatchEndpointOperations
+
+
+def _make_batch_operations():
+    service_client_10 = MagicMock()
+    service_client_10.batch_endpoints = MagicMock()
+    service_client_10.batch_deployments = MagicMock()
+    service_client_09 = MagicMock()
+    service_client_09.batch_job_endpoint = MagicMock()
+    requests_pipeline = MagicMock()
+    operation_scope = OperationScope("sub", "rg", "ws")
+    operation_config = OperationConfig(False, False)
+    container = OperationsContainer()
+    container.add(AzureMLResourceType.DATASTORE, MagicMock())
+    container.add(AzureMLResourceType.WORKSPACE, MagicMock())
+    return BatchEndpointOperations(
+        operation_scope,
+        operation_config,
+        service_client_10,
+        container,
+        requests_pipeline=requests_pipeline,
+        service_client_09_2020_dataplanepreview=service_client_09,
+    )
+
+
+def test_resolve_input_short_uri_skips_operations(monkeypatch):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    matcher = lambda pattern, string: pattern == batch_endpoint_module.SHORT_URI_REGEX_FORMAT
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(matcher))
+    entry = DummyInput("short:data", "uri_file")
+    operations._resolve_input(entry, base_path=".")
+    assert entry.path == "short:data"
+
+
+def test_resolve_input_long_uri_skips_operations(monkeypatch):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    matcher = lambda pattern, string: pattern == batch_endpoint_module.LONG_URI_REGEX_FORMAT
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(matcher))
+    entry = DummyInput("long:data", "uri_folder")
+    operations._resolve_input(entry, base_path=".")
+    assert entry.path == "long:data"
+
+
+def test_resolve_input_private_preview_short_circuits(monkeypatch):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    monkeypatch.setattr(batch_endpoint_module, "is_private_preview_enabled", lambda: True)
+
+    def matcher(pattern, string):
+        return pattern == batch_endpoint_module.AZUREML_REGEX_FORMAT
+
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(matcher))
+    entry = DummyInput("preview:data", "uri_folder")
+    operations._resolve_input(entry, base_path=".")
+    assert entry.path == "preview:data"
+
+
+def test_resolve_input_datastore_registered_asset(monkeypatch):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(lambda pattern, string: False))
+    monkeypatch.setattr(batch_endpoint_module, "is_private_preview_enabled", lambda: False)
+    monkeypatch.setattr(batch_endpoint_module, "remove_aml_prefix", lambda value: value.replace("azureml://", ""))
+
+    class DummyOrchestrator:
+        def __init__(self, all_operations, operation_scope, operation_config):
+            self.calls = (all_operations, operation_scope, operation_config)
+
+        def get_asset_arm_id(self, path, asset_type):
+            return f"arm_id://{path}"
+
+    monkeypatch.setattr(batch_endpoint_module, "OperationOrchestrator", DummyOrchestrator)
+    entry = DummyInput("azureml://datastore/asset", "uri_folder")
+    operations._resolve_input(entry, base_path=".")
+    assert entry.path == "arm_id://datastore/asset"
+
+
+def test_resolve_input_relative_folder_upload(monkeypatch, tmp_path):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(lambda pattern, string: False))
+
+    def fake_upload(scope, datastore_ops, path):
+        return "https://storage/location"
+
+    monkeypatch.setattr(batch_endpoint_module, "_upload_and_generate_remote_uri", fake_upload)
+    entry = DummyInput("relative/path", AssetTypes.URI_FOLDER)
+    operations._resolve_input(entry, base_path=str(tmp_path))
+    assert entry.path == "https://storage/location/"
+
+
+def test_resolve_input_relative_upload_raises_validation(monkeypatch, tmp_path):
+    operations = _make_batch_operations()
+    monkeypatch.setattr(batch_endpoint_module, "Input", DummyInput)
+    monkeypatch.setattr(batch_endpoint_module, "re", FakeRe(lambda pattern, string: False))
+
+    def raising_upload(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(batch_endpoint_module, "_upload_and_generate_remote_uri", raising_upload)
+    entry = DummyInput("relative/error", "uri_folder")
+    with pytest.raises(ValidationException) as excinfo:
+        operations._resolve_input(entry, base_path=str(tmp_path))
+    assert "ValueError" in str(excinfo.value)
+    assert "Met" in str(excinfo.value)

--- a/sdk/ml/azure-ai-ml/tests/test_blob_storage_helper_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_blob_storage_helper_gaps.py
@@ -1,0 +1,506 @@
+# pytest tests for azure/ai/ml/_artifacts/_blob_storage_helper.py
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from azure.ai.ml._artifacts import _blob_storage_helper as helper
+from azure.ai.ml._artifacts._blob_storage_helper import BlobStorageClient, _blob_is_hdi_folder
+from azure.ai.ml._artifacts._constants import (
+    ARTIFACT_ORIGIN,
+    BLOB_DATASTORE_IS_HDI_FOLDER_KEY,
+    FILE_SIZE_WARNING,
+    KEY_AUTHENTICATION_ERROR_CODE,
+    LEGACY_ARTIFACT_DIRECTORY,
+    MAX_CONCURRENCY,
+    SAS_KEY_AUTHENTICATION_ERROR_MSG,
+    UPLOAD_CONFIRMATION,
+)
+from azure.ai.ml._azure_environments import _get_cloud_details
+from azure.ai.ml._utils._asset_utils import (
+    AssetNotChangedError,
+    IgnoreFile,
+    _build_metadata_dict,
+    generate_asset_id,
+    get_directory_size,
+    upload_directory,
+    upload_file,
+)
+from azure.ai.ml.constants._common import STORAGE_AUTH_MISMATCH_ERROR
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException, ValidationException
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+
+class DummyBlobClient:
+    def __init__(self, metadata=None, exception=None):
+        self.metadata = metadata or {}
+        self.exception = exception
+
+    def get_blob_properties(self):
+        if self.exception:
+            raise self.exception
+        return {"metadata": self.metadata}
+
+    def set_blob_metadata(self, metadata):
+        self.metadata = metadata
+
+
+class DummyContainerClient:
+    def __init__(self):
+        self.calls = []
+        self.blobs = {}
+
+    def get_blob_client(self, blob=None):
+        return DummyBlobClient(metadata=self.blobs.get(blob, {}))
+
+    def list_blobs(self, name_starts_with=None, include=None):
+        return []
+
+    def download_blob(self, item):
+        class DummyDownload:
+            size = 1
+
+            def content_as_bytes(self, max_concurrency):
+                return b""
+
+        return DummyDownload()
+
+    def walk_blobs(self, name_starts_with=None, delimiter=None):
+        return iter([])
+
+
+@pytest.fixture(autouse=True)
+def patch_blob_storage(monkeypatch):
+    container_client = DummyContainerClient()
+    monkeypatch.setattr(BlobStorageClient, "container_client", container_client, raising=False)
+    return container_client
+
+
+def test_blob_is_hdi_folder_true():
+    class DummyBlob:
+        metadata = {BLOB_DATASTORE_IS_HDI_FOLDER_KEY: "true"}
+
+    assert _blob_is_hdi_folder(DummyBlob())
+
+
+def test_blob_is_hdi_folder_false():
+    class DummyBlob:
+        metadata = {}
+
+    assert not _blob_is_hdi_folder(DummyBlob())
+
+
+def test_upload_sets_indicator_and_handles_asset_not_changed(monkeypatch, tmp_path):
+    client = BlobStorageClient(credential="cred", account_url="https://account.blob.core.windows.net", container_name="cont")
+    monkeypatch.setattr(client, "check_blob_exists", lambda: None)
+    monkeypatch.setattr("azure.ai.ml._artifacts._blob_storage_helper.get_directory_size", lambda source, ignore_file: (101 * 10**6, None))
+
+    def dummy_upload_file(storage_client, **kwargs):
+        storage_client.uploaded_file_count = storage_client.total_file_count
+
+    monkeypatch.setattr("azure.ai.ml._artifacts._blob_storage_helper.upload_file", dummy_upload_file)
+    monkeypatch.setattr("azure.ai.ml._artifacts._blob_storage_helper.AssetNotChangedError", AssetNotChangedError)
+    monkeypatch.setattr("azure.ai.ml._artifacts._blob_storage_helper._get_cloud_details", lambda: {"storage_endpoint": "core.windows.net"})
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper.BlobStorageClient._set_confirmation_metadata",
+        lambda self, name, version: None,
+    )
+
+    tmp_file = tmp_path / "file.txt"
+    tmp_file.write_text("content")
+
+    artifact_info = client.upload(str(tmp_file), name="name", version="v1")
+
+    assert artifact_info["name"] == "name"
+    assert artifact_info["version"] == "v1"
+    assert artifact_info["indicator file"] is not None
+
+
+def test_download_warns_on_large_download(monkeypatch, tmp_path):
+    client = BlobStorageClient(credential="cred", account_url="https://account.blob.core.windows.net", container_name="cont")
+    class DummyItem:
+        name = "blob"
+        metadata = {}
+
+    class DummyContent:
+        size = 101 * 10**6
+
+        def content_as_bytes(self, max_concurrency):
+            return b"data"
+
+    client.container_client = DummyContainerClient()
+    client.container_client.list_blobs = lambda name_starts_with, include: [DummyItem()]
+    client.container_client.download_blob = lambda item: DummyContent()
+    monkeypatch.setattr("azure.ai.ml._artifacts._blob_storage_helper._get_cloud_details", lambda: {"storage_endpoint": "core.windows.net"})
+
+    target_path = tmp_path / "output"
+    client.download("prefix", target_path)
+
+    assert target_path.exists()
+
+
+def test_exists_returns_true_for_existing_blob(monkeypatch):
+    client = BlobStorageClient(credential="cred", account_url="https://account.blob.core.windows.net", container_name="cont")
+    class DummyBean:
+        def exists(self):
+            return True
+
+    client.container_client = DummyContainerClient()
+    client.container_client.get_blob_client = lambda blobpath: DummyBean()
+
+    assert client.exists("path")
+
+
+class DummyBlob:
+    def __init__(self, name, metadata=None):
+        self.name = name
+        self.metadata = metadata
+
+
+def test_set_confirmation_metadata_sets_metadata(monkeypatch):
+    class DummyBlobClient:
+        def __init__(self):
+            self.metadata = None
+
+        def set_blob_metadata(self, metadata):
+            self.metadata = metadata
+
+    class DummyContainer:
+        def __init__(self):
+            self.requested_blob = None
+            self.blob_client = DummyBlobClient()
+
+        def get_blob_client(self, blob):
+            self.requested_blob = blob
+            return self.blob_client
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.container_client = DummyContainer()
+    client.indicator_file = "indicator/path"
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper._build_metadata_dict",
+        lambda name, version: {"foo": name, "bar": version},
+    )
+
+    client._set_confirmation_metadata("demo", "v1")
+
+    assert client.container_client.requested_blob == "indicator/path"
+    assert client.container_client.blob_client.metadata == {"foo": "demo", "bar": "v1"}
+
+
+def test_download_handles_hdi_folder_and_warns(tmp_path, monkeypatch):
+    class FolderBlob(DummyBlob):
+        def __init__(self):
+            super().__init__("prefix/folder", {BLOB_DATASTORE_IS_HDI_FOLDER_KEY: "1"})
+
+    class FileBlob(DummyBlob):
+        def __init__(self):
+            super().__init__("prefix/file.txt", {})
+
+    class FakeDownload:
+        def __init__(self):
+            self.size = 150 * 10**6
+
+        def content_as_bytes(self, max_concurrency):
+            return b"payload"
+
+    class DummyContainer:
+        def __init__(self):
+            self.items = [FolderBlob(), FileBlob()]
+
+        def list_blobs(self, name_starts_with, include):
+            return self.items
+
+        def download_blob(self, item):
+            return FakeDownload()
+
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper._get_cloud_details",
+        lambda: {"storage_endpoint": "test"},
+    )
+    warnings = []
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper.module_logger.warning",
+        lambda message, *args, **kwargs: warnings.append(message),
+    )
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.account_name = "accttest"
+    client.container = "container"
+    client.container_client = DummyContainer()
+
+    client.download("prefix", destination=tmp_path)
+
+    assert (tmp_path / "file.txt").read_bytes() == b"payload"
+    assert (tmp_path / "folder").is_dir()
+    expected_warning = FILE_SIZE_WARNING.format(
+        source=f"https://{client.account_name}.blob.test/{client.container}/prefix",
+        destination=tmp_path,
+    )
+    assert warnings == [expected_warning]
+
+
+def test_download_reraises_os_error():
+    class DummyContainer:
+        def list_blobs(self, name_starts_with, include):
+            raise OSError("disk full")
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.account_name = "acc"
+    client.container = "container"
+    client.container_client = DummyContainer()
+
+    with pytest.raises(OSError) as excinfo:
+        client.download("prefix")
+
+    assert str(excinfo.value) == "disk full"
+
+
+def test_download_raises_ml_exception_for_unexpected_error():
+    class DummyContainer:
+        def list_blobs(self, name_starts_with, include):
+            raise ValueError("boom")
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.account_name = "acc"
+    client.container = "container"
+    client.container_client = DummyContainer()
+
+    with pytest.raises(MlException) as excinfo:
+        client.download("prefix")
+
+    assert "Saving blob with prefix" in str(excinfo.value)
+
+
+def test_list_returns_blob_names():
+    class DummyContainer:
+        def __init__(self):
+            self.name = None
+
+        def list_blobs(self, name_starts_with):
+            self.name = name_starts_with
+            return [DummyBlob("prefix/one"), DummyBlob("prefix/two")]
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.container_client = DummyContainer()
+
+    result = client.list("prefix")
+
+    assert result == ["prefix/one", "prefix/two"]
+    assert client.container_client.name == "prefix"
+
+
+def test_exists_returns_true_when_blob_exists():
+    class BlobClient:
+        def exists(self):
+            return True
+
+    class DummyContainer:
+        def __init__(self):
+            self.requested = None
+
+        def get_blob_client(self, blobpath):
+            self.requested = blobpath
+            return BlobClient()
+
+        def walk_blobs(self, name_starts_with, delimiter):
+            return iter([])
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.container_client = DummyContainer()
+
+    assert client.exists("blob/path")
+    assert client.container_client.requested == "blob/path"
+
+
+def test_exists_returns_true_for_virtual_directory():
+    class BlobClient:
+        def exists(self):
+            return False
+
+    class DummyContainer:
+        def get_blob_client(self, blobpath):
+            return BlobClient()
+
+        def walk_blobs(self, name_starts_with, delimiter):
+            yield DummyBlob(name_starts_with + "child")
+
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.container_client = DummyContainer()
+
+    assert client.exists("dir")
+
+
+def test_blob_is_hdi_folder_returns_true_for_metadata():
+    blob = DummyBlob("folder", {BLOB_DATASTORE_IS_HDI_FOLDER_KEY: "1"})
+
+    assert _blob_is_hdi_folder(blob)
+
+
+def test_blob_is_hdi_folder_returns_false_without_metadata():
+    blob = DummyBlob("file")
+
+    assert not _blob_is_hdi_folder(blob)
+
+
+class FakeBlobItem:
+    def __init__(self, name, metadata=None):
+        self.name = name
+        self.metadata = metadata or {}
+
+
+class FakeBlobContent:
+    def __init__(self, size, payload):
+        self.size = size
+        self._payload = payload
+
+    def content_as_bytes(self, max_concurrency):
+        return self._payload
+
+
+class FakeDownloadContainerClient:
+    def __init__(self, blobs, blob_content):
+        self._blobs = blobs
+        self._blob_content = blob_content
+
+    def list_blobs(self, **kwargs):
+        return self._blobs
+
+    def download_blob(self, item):
+        return self._blob_content
+
+
+class FakeErrorContainerClient:
+    def __init__(self, error):
+        self._error = error
+
+    def list_blobs(self, **kwargs):
+        raise self._error
+
+
+class FakeListContainerClient:
+    def __init__(self, names):
+        self._names = names
+
+    def list_blobs(self, **kwargs):
+        return [FakeBlobItem(name) for name in self._names]
+
+
+class FakeExistsContainerClient:
+    def __init__(self, exists_value, walk_entries=None):
+        self._exists_value = exists_value
+        self._walk_entries = walk_entries or []
+
+    def get_blob_client(self, blobpath):
+        class BlobClient:
+            def __init__(self, exists_value):
+                self._exists_value = exists_value
+
+            def exists(self):
+                return self._exists_value
+
+        return BlobClient(self._exists_value)
+
+    def walk_blobs(self, name_starts_with=None, delimiter=None):
+        return iter(self._walk_entries)
+
+
+def test_download_warns_when_size_threshold_exceeded(tmp_path, monkeypatch):
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.account_name = "account"
+    client.container = "container"
+    blobs = [
+        FakeBlobItem("prefix/blob1"),
+        FakeBlobItem("prefix/folder", metadata={BLOB_DATASTORE_IS_HDI_FOLDER_KEY: "true"}),
+    ]
+    content = FakeBlobContent(size=150 * 10**6, payload=b"payload")
+    client.container_client = FakeDownloadContainerClient(blobs, content)
+
+    monkeypatch.setattr(helper, "_get_cloud_details", lambda: {"storage_endpoint": "test.endpoint"})
+    warnings = []
+    monkeypatch.setattr(helper.module_logger, "warning", lambda message: warnings.append(message))
+
+    client.download("prefix", destination=tmp_path)
+
+    assert warnings
+    assert (tmp_path / "blob1").read_bytes() == b"payload"
+
+
+def test_download_wraps_generic_exception_in_ml_exception(tmp_path):
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.account_name = "account"
+    client.container = "container"
+    client.container_client = FakeErrorContainerClient(ValueError("bad"))
+
+    with pytest.raises(MlException) as excinfo:
+        client.download("prefix", destination=tmp_path)
+
+    assert "Saving blob with prefix prefix" in excinfo.value.message
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+def test_exists_returns_false_when_no_blob_or_directory():
+    client = BlobStorageClient.__new__(BlobStorageClient)
+    client.container_client = FakeExistsContainerClient(False, walk_entries=[])
+
+    assert not client.exists("missing")
+
+
+def test_blob_is_hdi_folder_identifies_folder_metadata():
+    folder_blob = FakeBlobItem("folder", metadata={BLOB_DATASTORE_IS_HDI_FOLDER_KEY: "true"})
+    assert _blob_is_hdi_folder(folder_blob)
+    file_blob = FakeBlobItem("file")
+    assert not _blob_is_hdi_folder(file_blob)
+
+
+def build_blob_storage_client(container_client):
+    client = object.__new__(BlobStorageClient)
+    client.account_name = "testaccount"
+    client.container = "testcontainer"
+    client.container_client = container_client
+    client.total_file_count = 1
+    client.uploaded_file_count = 0
+    client.indicator_file = None
+    return client
+
+
+def test_download_propagates_os_error(monkeypatch, tmp_path):
+    class DummyContainer:
+        def list_blobs(self, *args, **kwargs):
+            raise OSError("simulated failure")
+
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper._get_cloud_details",
+        lambda: {"storage_endpoint": "core.windows.net"},
+    )
+    client = build_blob_storage_client(DummyContainer())
+    with pytest.raises(OSError) as excinfo:
+        client.download(starts_with="prefix", destination=tmp_path)
+    assert str(excinfo.value) == "simulated failure"
+
+
+def test_download_wraps_unexpected_exception_in_ml_exception(monkeypatch, tmp_path):
+    class DummyBlobItem:
+        def __init__(self):
+            self.name = "prefix/blob.txt"
+            self.metadata = {}
+
+    class DummyContainer:
+        def list_blobs(self, *args, **kwargs):
+            return [DummyBlobItem()]
+
+        def download_blob(self, blob):
+            raise ValueError("download failure")
+
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._blob_storage_helper._get_cloud_details",
+        lambda: {"storage_endpoint": "core.windows.net"},
+    )
+    client = build_blob_storage_client(DummyContainer())
+    with pytest.raises(MlException) as excinfo:
+        client.download(starts_with="prefix", destination=tmp_path)
+    expected_message = "Saving blob with prefix prefix was unsuccessful. exception=download failure"
+    assert excinfo.value.args[0] == expected_message
+    assert isinstance(excinfo.value.__cause__, ValueError)

--- a/sdk/ml/azure-ai-ml/tests/test_component_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_component_operations_gaps.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+import types
+import collections
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from typing import Optional
+
+import pytest
+from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
+
+from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope, OperationsContainer
+from azure.ai.ml.constants._common import DEFAULT_COMPONENT_VERSION, DEFAULT_LABEL_NAME, AzureMLResourceType
+from azure.ai.ml.entities import Component
+from azure.ai.ml.entities._component.command_component import CommandComponent
+from azure.ai.ml.entities._component.pipeline_component import PipelineComponent
+from azure.ai.ml.exceptions import ValidationException, ErrorTarget, ComponentException
+from azure.ai.ml._utils._asset_utils import IgnoreFile
+from azure.ai.ml.entities._component.code import ComponentCodeMixin
+
+from azure.ai.ml.operations._component_operations import ComponentOperations
+from azure.ai.ml.operations._component_operations import _get_latest, _archive_or_restore
+import azure.ai.ml.operations._component_operations as component_ops_mod
+
+
+class DummyServiceClient:
+    def __init__(self):
+        self.component_versions = object()
+        self.component_containers = object()
+
+
+def _create_component_operations(workspace_name="test-ws", registry_name=None):
+    operation_scope = OperationScope(
+        subscription_id="sub-id",
+        resource_group_name="rg-name",
+        workspace_name=workspace_name,
+        registry_name=registry_name,
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = DummyServiceClient()
+    all_operations = OperationsContainer()
+    preflight_operation = None
+    return ComponentOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        all_operations=all_operations,
+        preflight_operation=preflight_operation,
+    )
+
+
+def _build_component_operations_for_resolve_dependencies():
+    scope = OperationScope("sub", "rg", "ws")
+    config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = SimpleNamespace(
+        component_versions=MagicMock(),
+        component_containers=MagicMock(),
+    )
+    operations_container = OperationsContainer()
+    for resource_type in (
+        AzureMLResourceType.COMPONENT,
+        AzureMLResourceType.CODE,
+        AzureMLResourceType.ENVIRONMENT,
+        AzureMLResourceType.WORKSPACE,
+        AzureMLResourceType.JOB,
+    ):
+        operations_container.add(resource_type, MagicMock())
+    return ComponentOperations(scope, config, service_client, operations_container)
+
+
+def test_resolve_dependencies_for_component_short_circuits_for_automl(monkeypatch):
+    component_ops = _build_component_operations_for_resolve_dependencies()
+
+    class _StubAutoMLComponent:
+        pass
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._component_operations.AutoMLComponent",
+        _StubAutoMLComponent,
+    )
+
+    stub_component = _StubAutoMLComponent()
+    result = component_ops._resolve_dependencies_for_component(
+        stub_component,
+        resolver=lambda value, azureml_type=None: value,
+    )
+    assert result is None
+
+
+def test_resolve_dependencies_for_component_invalid_type_raises(monkeypatch):
+    component_ops = _build_component_operations_for_resolve_dependencies()
+
+    class _StubAutoMLComponent:
+        pass
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._component_operations.AutoMLComponent",
+        _StubAutoMLComponent,
+    )
+
+    with pytest.raises(ValidationException) as exc_info:
+        component_ops._resolve_dependencies_for_component(
+            object(),
+            resolver=lambda value, azureml_type=None: value,
+        )
+    assert "Non supported component type" in str(exc_info.value)
+
+
+def test_resolve_pipeline_component_jobs_unsupported_job_raises(monkeypatch):
+    component_ops = _build_component_operations_for_resolve_dependencies()
+    component = PipelineComponent(name="pipeline", version="1")
+    component._jobs = {"bad_job": object()}
+    component._base_path = "base"
+    unsupported_job = component._jobs["bad_job"]
+
+    monkeypatch.setattr(
+        ComponentOperations,
+        "_resolve_inputs_for_pipeline_component_jobs",
+        lambda self, jobs, base_path: None,
+    )
+    monkeypatch.setattr(
+        ComponentOperations,
+        "_divide_nodes_to_resolve_into_layers",
+        lambda self, component_arg, extra_operations: [[("bad_job", unsupported_job)]],
+    )
+    monkeypatch.setattr(
+        ComponentOperations,
+        "_get_client_key",
+        lambda self: "dummy-client",
+    )
+
+    class _StubCachedResolver:
+        def __init__(self, resolver, client_key):
+            self._resolver = resolver
+            self._client_key = client_key
+
+        def register_node_for_lazy_resolution(self, node):
+            pass
+
+        def resolve_nodes(self):
+            pass
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._component_operations.CachedNodeResolver",
+        _StubCachedResolver,
+    )
+
+    with pytest.raises(ComponentException) as exc_info:
+        component_ops._resolve_dependencies_for_pipeline_component_jobs(
+            component,
+            resolver=lambda value, azureml_type=None: value,
+        )
+    assert "Non supported job type in Pipeline" in str(exc_info.value)

--- a/sdk/ml/azure-ai-ml/tests/test_data_index_func_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_data_index_func_gaps.py
@@ -1,0 +1,661 @@
+import inspect
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+import azure.ai.ml.entities._indexes.data_index_func as data_index_func
+import azure.ai.ml.entities._indexes.data_index_func as data_index_func_module
+from azure.ai.ml.constants._component import LLMRAGComponentUri
+from azure.ai.ml.constants import AssetTypes
+from azure.ai.ml.constants._common import DataIndexTypes
+from azure.ai.ml.entities._indexes import utils as indexes_utils
+from azure.ai.ml.entities._indexes.data_index_func import (
+    _build_data_index,
+    index_data,
+    data_index_incremental_update_hosted,
+    get_component_obj,
+    _resolve_connection_id,
+    DataIndex,
+    DataIndexTypes as DataIndexTypesAlias,
+    data_index_faiss,
+    data_index_hosted,
+    optional_pipeline_input_provided,
+    use_automatic_compute,
+)
+from azure.ai.ml.entities._inputs_outputs import Input, Output
+from azure.ai.ml.constants import AssetTypes as AssetTypesAlias
+from azure.ai.ml.exceptions import ValidationException
+
+
+def test_data_index_func_module_importable():
+    assert data_index_func is not None
+
+
+def test_data_index_func_has_docstring():
+    # Module-level docstring may be absent; when present, it must be a string.
+    assert (data_index_func.__doc__ is None) or isinstance(data_index_func.__doc__, str)
+
+
+def test_data_index_func_has_public_members():
+    public_members = [name for name in dir(data_index_func) if not name.startswith("_")]
+    assert len(public_members) > 0
+
+
+def test_data_index_func_all_is_consistent_if_present():
+    if hasattr(data_index_func, "__all__"):
+        exported = set(data_index_func.__all__)
+        for name in exported:
+            assert hasattr(data_index_func, name)
+    else:
+        pytest.skip("__all__ not defined on data_index_func module")
+
+
+@pytest.mark.parametrize("name", [
+    "build_data_index_function" if hasattr(data_index_func, "build_data_index_function") else None,
+    "DataIndexFunction" if hasattr(data_index_func, "DataIndexFunction") else None,
+])
+def test_selected_symbols_are_callable_or_class(name):
+    if name is None:
+        pytest.skip("Symbol not present in this version of data_index_func module")
+    obj = getattr(data_index_func, name)
+    assert inspect.isfunction(obj) or inspect.isclass(obj)
+
+
+class DummyConnections:
+    def __init__(self, connection_to_return=None):
+        self.connection_to_return = connection_to_return
+        self.last_requested_name = None
+
+    def get(self, name):
+        self.last_requested_name = name
+        return self.connection_to_return
+
+
+class DummyConnectionObject:
+    def __init__(self, id_value):
+        self.id = id_value
+
+
+class DummyRegistryComponents:
+    def __init__(self, result):
+        self._result = result
+        self.last_name = None
+        self.last_kwargs = None
+
+    def get(self, name, **kwargs):
+        self.last_name = name
+        self.last_kwargs = kwargs
+        return self._result
+
+
+class DummyRegistryMLClient:
+    def __init__(self, subscription_id=None, resource_group_name=None, credential=None, registry_name=None):
+        self.subscription_id = subscription_id
+        self.resource_group_name = resource_group_name
+        self._credential = credential
+        self.registry_name = registry_name
+        self.components = DummyRegistryComponents(result="dummy_component_from_registry")
+
+
+def install_dummy_azure_ai_ml_module_with_mlclient_and_loader(mlclient_cls, load_component_func=None):
+    azure_module = sys.modules.setdefault("azure", types.ModuleType("azure"))
+    ai_module = sys.modules.setdefault("azure.ai", types.ModuleType("azure.ai"))
+    ml_module = sys.modules.setdefault("azure.ai.ml", types.ModuleType("azure.ai.ml"))
+    ai_module.ml = ml_module
+    setattr(ml_module, "MLClient", mlclient_cls)
+    if load_component_func is not None:
+        setattr(ml_module, "load_component", load_component_func)
+
+
+def install_dummy_arm_id_utils_module(asset_name_value="conn_name"):
+    module_name = "azure.ai.ml._utils._arm_id_utils"
+    parent_azure = sys.modules.setdefault("azure", types.ModuleType("azure"))
+    parent_ai = sys.modules.setdefault("azure.ai", types.ModuleType("azure.ai"))
+    parent_ml = sys.modules.setdefault("azure.ai.ml", types.ModuleType("azure.ai.ml"))
+    parent_utils = sys.modules.setdefault("azure.ai.ml._utils", types.ModuleType("azure.ai.ml._utils"))
+    setattr(parent_ai, "ml", parent_ml)
+    sys.modules["azure.ai.ml._utils"] = parent_utils
+    arm_module = types.ModuleType(module_name)
+
+    class AMLNamedArmId:
+        def __init__(self, arm_id):
+            self.arm_id = arm_id
+            self.asset_name = asset_name_value
+
+    arm_module.AMLNamedArmId = AMLNamedArmId
+    sys.modules[module_name] = arm_module
+
+
+class DummyDataIndexForBuild:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_build_data_index_none_returns_none():
+    assert _build_data_index(None) is None
+
+
+def test_build_data_index_passes_through_dataindex_instance(monkeypatch):
+    monkeypatch.setattr(data_index_func, "DataIndex", DummyDataIndexForBuild)
+    di = DummyDataIndexForBuild(a=1)
+    result = _build_data_index(di)
+    assert result is di
+
+
+def test_build_data_index_dict_creates_dataindex(monkeypatch):
+    created = {}
+
+    class RecordingDummyDataIndex:
+        def __init__(self, **kwargs):
+            created.update(kwargs)
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(data_index_func, "DataIndex", RecordingDummyDataIndex)
+    io_dict = {"foo": "bar", "num": 3}
+    result = _build_data_index(io_dict)
+    assert isinstance(result, RecordingDummyDataIndex)
+    assert created == io_dict
+
+
+def test_build_data_index_invalid_type_raises_validation_exception():
+    with pytest.raises(ValidationException) as exc_info:
+        _build_data_index([1, 2, 3])
+    assert "data_index only support dict and DataIndex" in str(exc_info.value)
+
+
+class DummyConfiguredComponent:
+    def __init__(self, tag):
+        self.tag = tag
+        self.properties = {}
+
+
+class DummyDataIndexForIndexData:
+    def __init__(self, index_type, name="idx-name"):
+        class Index:
+            def __init__(self, t):
+                self.type = t
+
+        self.index = Index(index_type)
+        self.name = name
+
+
+def test_index_data_routes_to_faiss_and_sets_properties(monkeypatch):
+    called = {}
+
+    def fake_data_index_faiss(ml_client, data_index, *args, **kwargs):
+        called["fn"] = "faiss"
+        called["type"] = data_index.index.type
+        return DummyConfiguredComponent("faiss")
+
+    monkeypatch.setattr(data_index_func, "data_index_faiss", fake_data_index_faiss)
+    monkeypatch.setattr(data_index_func, "DataIndex", DummyDataIndexForIndexData)
+
+    di = DummyDataIndexForIndexData(index_type=data_index_func.DataIndexTypes.FAISS, name="my-index")
+    result = index_data(data_index=di)
+
+    assert isinstance(result, DummyConfiguredComponent)
+    assert called["fn"] == "faiss"
+    assert result.properties["azureml.mlIndexAssetName"] == "my-index"
+    assert result.properties["azureml.mlIndexAssetKind"] == di.index.type
+    assert result.properties["azureml.mlIndexAssetSource"] == "Data Asset"
+
+
+def test_index_data_routes_to_incremental_update_for_acs(monkeypatch):
+    calls = {"faiss": 0, "inc": 0, "hosted": 0}
+
+    def fake_faiss(ml_client, data_index, *args, **kwargs):
+        calls["faiss"] += 1
+        return DummyConfiguredComponent("faiss")
+
+    def fake_inc(ml_client, data_index, *args, **kwargs):
+        calls["inc"] += 1
+        return DummyConfiguredComponent("inc")
+
+    def fake_hosted(ml_client, data_index, *args, **kwargs):
+        calls["hosted"] += 1
+        return DummyConfiguredComponent("hosted")
+
+    monkeypatch.setattr(data_index_func, "data_index_faiss", fake_faiss)
+    monkeypatch.setattr(data_index_func, "data_index_incremental_update_hosted", fake_inc)
+    monkeypatch.setattr(data_index_func, "data_index_hosted", fake_hosted)
+    monkeypatch.setattr(data_index_func, "DataIndex", DummyDataIndexForIndexData)
+
+    di = DummyDataIndexForIndexData(index_type=data_index_func.DataIndexTypes.ACS, name="acs-index")
+    result = index_data(data_index=di, incremental_update=True)
+
+    assert isinstance(result, DummyConfiguredComponent)
+    assert result.tag == "inc"
+    assert calls == {"faiss": 0, "inc": 1, "hosted": 0}
+
+
+def test_index_data_routes_to_hosted_for_acs_without_incremental(monkeypatch):
+    calls = {"faiss": 0, "inc": 0, "hosted": 0}
+
+    def fake_faiss(ml_client, data_index, *args, **kwargs):
+        calls["faiss"] += 1
+        return DummyConfiguredComponent("faiss")
+
+    def fake_inc(ml_client, data_index, *args, **kwargs):
+        calls["inc"] += 1
+        return DummyConfiguredComponent("inc")
+
+    def fake_hosted(ml_client, data_index, *args, **kwargs):
+        calls["hosted"] += 1
+        return DummyConfiguredComponent("hosted")
+
+    monkeypatch.setattr(data_index_func, "data_index_faiss", fake_faiss)
+    monkeypatch.setattr(data_index_func, "data_index_incremental_update_hosted", fake_inc)
+    monkeypatch.setattr(data_index_func, "data_index_hosted", fake_hosted)
+    monkeypatch.setattr(data_index_func, "DataIndex", DummyDataIndexForIndexData)
+
+    di = DummyDataIndexForIndexData(index_type=data_index_func.DataIndexTypes.ACS, name="acs-index")
+    result = index_data(data_index=di)
+
+    assert isinstance(result, DummyConfiguredComponent)
+    assert result.tag == "hosted"
+    assert calls == {"faiss": 0, "inc": 0, "hosted": 1}
+
+
+def test_index_data_unsupported_type_raises_value_error(monkeypatch):
+    monkeypatch.setattr(data_index_func, "data_index_faiss", lambda *args, **kwargs: None)
+    monkeypatch.setattr(data_index_func, "data_index_incremental_update_hosted", lambda *a, **k: None)
+    monkeypatch.setattr(data_index_func, "data_index_hosted", lambda *a, **k: None)
+    monkeypatch.setattr(data_index_func, "DataIndex", DummyDataIndexForIndexData)
+
+    di = DummyDataIndexForIndexData(index_type="UNSUPPORTED", name="bad-index")
+    with pytest.raises(ValueError) as exc_info:
+        index_data(data_index=di)
+    assert "Unsupported index type" in str(exc_info.value)
+
+
+class DummySource:
+    def __init__(
+        self,
+        input_type,
+        path,
+        input_glob,
+        chunk_size,
+        chunk_overlap,
+        citation_url,
+        has_regex,
+    ):
+        class InputData:
+            def __init__(self, t, p):
+                self.type = t
+                self.path = p
+
+        self.input_data = InputData(input_type, path)
+        self.input_glob = input_glob
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.citation_url = citation_url
+        if has_regex:
+            class Regex:
+                def _to_dict(self):
+                    return {"pattern": "x"}
+
+            self.citation_url_replacement_regex = Regex()
+        else:
+            self.citation_url_replacement_regex = None
+
+
+class DummyPipelineInputForOptional:
+    def __init__(self, data=None):
+        self._data = data
+
+
+def test_optional_pipeline_input_provided_variants():
+    assert optional_pipeline_input_provided(None) is False
+
+    empty_input = DummyPipelineInputForOptional()
+    assert optional_pipeline_input_provided(empty_input) is False
+
+    filled_input = DummyPipelineInputForOptional(data="value")
+    assert optional_pipeline_input_provided(filled_input) is True
+
+
+def test_use_automatic_compute_sets_resources_and_returns_component():
+    class DummyComponent:
+        def __init__(self):
+            self.calls = []
+
+        def set_resources(self, instance_count=None, instance_type=None, properties=None):
+            self.calls.append(
+                {
+                    "instance_count": instance_count,
+                    "instance_type": instance_type,
+                    "properties": properties,
+                }
+            )
+            return self
+
+    comp = DummyComponent()
+    returned = use_automatic_compute(comp, instance_count=3, instance_type="Standard_DS3_v2")
+
+    assert returned is comp
+    assert len(comp.calls) == 1
+    call = comp.calls[0]
+    assert call["instance_count"] == 3
+    assert call["instance_type"] == "Standard_DS3_v2"
+    assert call["properties"] == {"compute_specification": {"automatic": True}}
+
+
+class _DummyPipelineInput:
+    def __init__(self, data):
+        self._data = data
+
+
+def test_optional_pipeline_input_provided_detects_values():
+    assert not optional_pipeline_input_provided(None)
+    assert not optional_pipeline_input_provided(_DummyPipelineInput(None))
+    assert optional_pipeline_input_provided(_DummyPipelineInput("value"))
+
+
+class _StubComponent:
+    def __init__(self):
+        self.resources = None
+        self.last_resources = None
+
+    def set_resources(self, instance_count=None, instance_type=None, properties=None):
+        resources = {
+            "instance_count": instance_count,
+            "instance_type": instance_type,
+            "properties": properties,
+        }
+        self.resources = resources
+        self.last_resources = resources
+        return self
+
+
+def test_use_automatic_compute_applies_resources():
+    component = _StubComponent()
+    result = use_automatic_compute(component, instance_count=2, instance_type="auto-type")
+    assert result is component
+    assert component.resources["instance_count"] == 2
+    assert component.resources["instance_type"] == "auto-type"
+    assert component.resources["properties"] == {"compute_specification": {"automatic": True}}
+
+
+def test_get_component_obj_returns_non_str_component():
+    sentinel = object()
+    assert get_component_obj(None, sentinel) is sentinel
+
+
+def test_get_component_obj_loads_local_component(monkeypatch):
+    loaded = {}
+
+    def fake_load_component(source):
+        loaded["source"] = source
+        return "local"
+
+    monkeypatch.setattr("azure.ai.ml.load_component", fake_load_component)
+    result = get_component_obj(object(), "local/path")
+    assert result == "local"
+    assert loaded["source"] == "local/path"
+
+
+def test_get_component_obj_fetches_from_registry(monkeypatch):
+    class FakeMLClient:
+        last_created = None
+
+        def __init__(self, subscription_id, resource_group_name, credential, registry_name):
+            self.subscription_id = subscription_id
+            self.resource_group_name = resource_group_name
+            self.credential = credential
+            self.registry_name = registry_name
+            FakeMLClient.last_created = self
+            self.components = self
+            self.last_get = None
+
+        def get(self, name, **kwargs):
+            self.last_get = (name, kwargs)
+            return "registry-obj"
+
+    monkeypatch.setattr("azure.ai.ml.MLClient", FakeMLClient)
+    ml_caller = type("CallerClient", (), {"subscription_id": "sub", "resource_group_name": "rg", "_credential": "cred"})()
+    uri = "azureml://registries/reg/components/mycomp/versions/v1"
+    result = get_component_obj(ml_caller, uri)
+    assert result == "registry-obj"
+    assert FakeMLClient.last_created.registry_name == "reg"
+    assert FakeMLClient.last_created.last_get == ("mycomp", {"version": "v1"})
+
+
+def test_resolve_connection_id_returns_none_for_missing(monkeypatch):
+    class FakeArmId:
+        def __init__(self, connection):
+            self.asset_name = "missing"
+
+    class FakeConnections:
+        def get(self, name):
+            assert name == "missing"
+            return None
+
+    class FakeClient:
+        connections = FakeConnections()
+
+    monkeypatch.setattr("azure.ai.ml._utils._arm_id_utils.AMLNamedArmId", FakeArmId)
+    assert _resolve_connection_id(FakeClient(), "some") is None
+
+
+def test_resolve_connection_id_returns_id(monkeypatch):
+    class FakeArmId:
+        def __init__(self, connection):
+            self.asset_name = "present"
+
+    class FakeConnection:
+        id = "conn-id"
+
+    class FakeConnections:
+        def get(self, name):
+            assert name == "present"
+            return FakeConnection()
+
+    class FakeClient:
+        connections = FakeConnections()
+
+    monkeypatch.setattr("azure.ai.ml._utils._arm_id_utils.AMLNamedArmId", FakeArmId)
+    assert _resolve_connection_id(FakeClient(), "value") == "conn-id"
+
+
+def test_resolve_connection_id_returns_none_for_no_connection():
+    assert _resolve_connection_id(object(), None) is None
+
+
+class _DummyArmId:
+    def __init__(self, identifier):
+        self.asset_name = f"parsed-{identifier}"
+
+
+class _DummyConnections:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def get(self, name):
+        return self._mapping.get(name)
+
+
+class _DummyRegistryClient:
+    def __init__(self, subscription_id, resource_group_name, credential, registry_name, capture):
+        capture["subscription_id"] = subscription_id
+        capture["resource_group_name"] = resource_group_name
+        capture["credential"] = credential
+        capture["registry_name"] = registry_name
+        self.components = self
+        self.capture = capture
+
+    def get(self, component_name, **kwargs):
+        self.capture["component_name"] = component_name
+        self.capture["identifier_kwargs"] = kwargs
+        return f"{component_name}-loaded-{kwargs}"
+
+
+def test_optional_pipeline_input_varied_states():
+    assert not data_index_func.optional_pipeline_input_provided(None)
+    assert not data_index_func.optional_pipeline_input_provided(_DummyPipelineInput(None))
+    assert data_index_func.optional_pipeline_input_provided(_DummyPipelineInput("value"))
+
+
+def test_use_automatic_compute_applies_resources():
+    component = _StubComponent()
+    result = data_index_func.use_automatic_compute(component, instance_count=5, instance_type="small")
+    assert result is component
+    assert component.last_resources["instance_count"] == 5
+    assert component.last_resources["instance_type"] == "small"
+    assert component.last_resources["properties"] == {"compute_specification": {"automatic": True}}
+
+
+def test_get_component_obj_returns_non_string_directly():
+    sentinel = object()
+    assert data_index_func.get_component_obj(None, sentinel) is sentinel
+
+
+def test_get_component_obj_loads_local_component(monkeypatch):
+    captured = {}
+
+    def fake_load_component(source):
+        captured["source"] = source
+        return "local-component"
+
+    monkeypatch.setattr("azure.ai.ml.load_component", fake_load_component)
+    result = data_index_func.get_component_obj(None, "components/component.yml")
+    assert result == "local-component"
+    assert captured["source"] == "components/component.yml"
+
+
+def test_get_component_obj_fetches_registry_component(monkeypatch):
+    capture = {}
+
+    def fake_ml_client(subscription_id, resource_group_name, credential, registry_name):
+        return _DummyRegistryClient(subscription_id, resource_group_name, credential, registry_name, capture)
+
+    monkeypatch.setattr("azure.ai.ml.MLClient", fake_ml_client)
+    MlClientType = type(
+        "MlClient",
+        (),
+        {
+            "subscription_id": "sub-id",
+            "resource_group_name": "rg",
+            "_credential": "cred",
+        },
+    )
+    ml_client = MlClientType()
+    uri = "azureml://registries/my-reg/components/my-comp/versions/v1"
+    result = data_index_func.get_component_obj(ml_client, uri)
+    assert capture["registry_name"] == "my-reg"
+    assert capture["component_name"] == "my-comp"
+    assert capture["identifier_kwargs"] == {"version": "v1"}
+    assert result == "my-comp-loaded-{'version': 'v1'}"
+
+
+def test_resolve_connection_id_handles_variants(monkeypatch):
+    monkeypatch.setattr("azure.ai.ml._utils._arm_id_utils.AMLNamedArmId", _DummyArmId)
+    ml_client_missing = type("MlClientMissing", (), {"connections": _DummyConnections({})})()
+    assert data_index_func._resolve_connection_id(ml_client_missing, None) is None
+    assert data_index_func._resolve_connection_id(ml_client_missing, "missing") is None
+
+    ml_client_found = type(
+        "MlClientFound",
+        (),
+        {"connections": _DummyConnections({"parsed-present": type("Conn", (), {"id": "found-id"})()})},
+    )()
+    assert data_index_func._resolve_connection_id(ml_client_found, "present") == "found-id"
+
+
+
+class _Batch1DummyComponent:
+    def __init__(self):
+        self.captured_resources = None
+
+    def set_resources(self, **kwargs):
+        self.captured_resources = kwargs
+        return self
+
+
+def test_optional_pipeline_input_provided_variants_additional():
+    assert optional_pipeline_input_provided(None) is False
+    assert optional_pipeline_input_provided(_DummyPipelineInput(None)) is False
+    assert optional_pipeline_input_provided(_DummyPipelineInput("value")) is True
+
+
+def test_use_automatic_compute_sets_automatic_resources_additional():
+    component = _Batch1DummyComponent()
+    returned = use_automatic_compute(component, instance_count=3, instance_type="Standard_A1")
+    assert returned is component
+    assert component.captured_resources == {
+        "instance_count": 3,
+        "instance_type": "Standard_A1",
+        "properties": {"compute_specification": {"automatic": True}},
+    }
+
+
+def test_get_component_obj_returns_same_object_when_not_string_additional():
+    sentinel = object()
+    assert get_component_obj(None, sentinel) is sentinel
+
+
+def test_get_component_obj_loads_local_component_additional(monkeypatch):
+    captured = {}
+
+    def fake_load_component(source=None):
+        captured["source"] = source
+        return "local-component"
+
+    monkeypatch.setattr("azure.ai.ml.load_component", fake_load_component)
+    result = get_component_obj(None, "local/component.yml")
+    assert result == "local-component"
+    assert captured["source"] == "local/component.yml"
+
+
+def test_get_component_obj_resolves_registry_component_additional(monkeypatch):
+    captured = {}
+
+    class _FakeRegistryClient:
+        def __init__(self, subscription_id=None, resource_group_name=None, credential=None, registry_name=None):
+            captured["registry_name"] = registry_name
+            self.components = self
+
+        def get(self, component_name, **kwargs):
+            captured["component_name"] = component_name
+            captured["kwargs"] = kwargs
+            return "registry-component"
+
+    monkeypatch.setattr("azure.ai.ml.MLClient", _FakeRegistryClient)
+    ml_client = type("Client", (), {
+        "subscription_id": "subid",
+        "resource_group_name": "rg",
+        "_credential": "cred",
+    })()
+    component_uri = "azureml://registries/some-registry/components/test-component/versions/v1"
+    result = get_component_obj(ml_client, component_uri)
+    assert result == "registry-component"
+    assert captured["registry_name"] == "some-registry"
+    assert captured["component_name"] == "test-component"
+    assert captured["kwargs"] == {"version": "v1"}
+
+
+def test_resolve_connection_id_returns_expected_values(monkeypatch):
+    class _DummyAMLNamedArmId:
+        def __init__(self, arm_id):
+            self.asset_name = arm_id
+
+    monkeypatch.setattr("azure.ai.ml._utils._arm_id_utils.AMLNamedArmId", _DummyAMLNamedArmId)
+
+    class _DummyMLClient:
+        def __init__(self):
+            self.connections = self
+            self.connection_calls = []
+
+        def get(self, name):
+            self.connection_calls.append(name)
+            if name == "missing":
+                return None
+            return type("Connection", (), {"id": f"id-{name}"})
+
+    ml_client = _DummyMLClient()
+    assert _resolve_connection_id(ml_client, None) is None
+    assert _resolve_connection_id(ml_client, "missing") is None
+    assert _resolve_connection_id(ml_client, "present") == "id-present"
+    assert ml_client.connection_calls == ["missing", "present"]

--- a/sdk/ml/azure-ai-ml/tests/test_data_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_data_operations_gaps.py
@@ -1,0 +1,192 @@
+import os
+import tempfile
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from azure.ai.ml.constants._common import AssetTypes
+from azure.ai.ml.exceptions import MlException, ValidationErrorType, ValidationException
+from azure.ai.ml.operations import _data_operations as data_ops_module
+from azure.ai.ml.operations._data_operations import DataOperations, _assert_local_path_matches_asset_type
+
+
+def _build_data_operations_for_validate():
+    operations = object.__new__(DataOperations)
+    operations._datastore_operation = object()
+    operations._requests_pipeline = object()
+    operations._operation_scope = SimpleNamespace(
+        _resource_group_name="rg",
+        _subscription_id="sub",
+        _workspace_name="ws",
+        registry_name=None,
+    )
+    operations._scope_kwargs = {}
+    operations._init_kwargs = {}
+    return operations
+
+
+def _build_data_operations_stub():
+    data_operations = DataOperations.__new__(DataOperations)
+    data_operations._datastore_operation = SimpleNamespace()
+    data_operations._requests_pipeline = SimpleNamespace()
+    data_operations._operation_scope = SimpleNamespace(
+        _subscription_id="sub",
+        _resource_group_name="rg",
+        _workspace_name="ws",
+        registry_name=None,
+    )
+    data_operations._scope_kwargs = {}
+    data_operations._init_kwargs = {}
+    return data_operations
+
+
+def test_get_with_version_and_label_raises():
+    operations = object.__new__(DataOperations)
+    with pytest.raises(MlException) as error:
+        operations.get(name="data", version="1", label="latest")
+    assert "Cannot specify both version and label." in str(error.value)
+
+
+def test_get_without_version_or_label_raises():
+    operations = object.__new__(DataOperations)
+    with pytest.raises(MlException) as error:
+        operations.get(name="data")
+    assert "Must provide either version or label." in str(error.value)
+
+
+def test_validate_remote_mltable_read_failure_skips_validation(monkeypatch):
+    operations = _build_data_operations_for_validate()
+    data = SimpleNamespace(
+        path="https://example.com/mltable",
+        type=AssetTypes.MLTABLE,
+        base_path="",
+        _mltable_schema_url=None,
+        _skip_validation=False,
+    )
+    monkeypatch.setattr(data_ops_module, "is_url", lambda _value: True)
+
+    def _raise(*_, **__):
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr(
+        data_ops_module,
+        "read_remote_mltable_metadata_contents",
+        _raise,
+    )
+    assert operations._validate(data) is None
+
+
+def test_validate_remote_non_mltable_skips_validation(monkeypatch):
+    operations = _build_data_operations_for_validate()
+    data = SimpleNamespace(
+        path="https://example.com/data",
+        type=AssetTypes.URI_FOLDER,
+        base_path="",
+        _mltable_schema_url=None,
+        _skip_validation=False,
+    )
+    monkeypatch.setattr(data_ops_module, "is_url", lambda _value: True)
+    assert operations._validate(data) is None
+
+
+def test_validate_absolute_path_mismatch_raises(monkeypatch):
+    operations = _build_data_operations_for_validate()
+    random_path = os.path.join(tempfile.gettempdir(), f"missing_{uuid.uuid4().hex}")
+    assert not os.path.exists(random_path)
+    data = SimpleNamespace(
+        path=random_path,
+        type=AssetTypes.URI_FOLDER,
+        base_path="",
+        _mltable_schema_url=None,
+        _skip_validation=False,
+    )
+    monkeypatch.setattr(data_ops_module, "is_url", lambda _value: False)
+    with pytest.raises(ValidationException) as error:
+        operations._validate(data)
+    assert "File path does not match asset type" in str(error.value)
+
+
+def test_assert_local_path_matches_asset_type_folder_mismatch():
+    random_path = os.path.join(tempfile.gettempdir(), f"missing_folder_{uuid.uuid4().hex}")
+    assert not os.path.exists(random_path)
+    with pytest.raises(ValidationException) as error:
+        _assert_local_path_matches_asset_type(random_path, AssetTypes.URI_FOLDER)
+    assert "File path does not match asset type" in str(error.value)
+
+
+def test_assert_local_path_matches_asset_type_file_mismatch():
+    random_path = os.path.join(tempfile.gettempdir(), f"missing_file_{uuid.uuid4().hex}")
+    assert not os.path.exists(random_path)
+    with pytest.raises(ValidationException) as error:
+        _assert_local_path_matches_asset_type(random_path, AssetTypes.URI_FILE)
+    assert "File path does not match asset type" in str(error.value)
+
+
+def test_validate_returns_none_when_remote_mltable_metadata_cannot_be_read(monkeypatch):
+    data_operations = _build_data_operations_stub()
+    remote_data = SimpleNamespace(
+        path="https://example.com/fake",
+        type=AssetTypes.MLTABLE,
+        base_path=".",
+        _mltable_schema_url=None,
+        _skip_validation=False,
+    )
+
+    def _raise_error(*_, **__):
+        raise RuntimeError("test failure")
+
+    monkeypatch.setattr(
+        data_ops_module,
+        "read_remote_mltable_metadata_contents",
+        _raise_error,
+    )
+    result = data_operations._validate(remote_data)
+    assert result is None
+
+
+def test_try_get_mltable_metadata_jsonschema_returns_schema_when_available(monkeypatch):
+    data_operations = _build_data_operations_stub()
+    pipeline = SimpleNamespace()
+    data_operations._requests_pipeline = pipeline
+    expected_schema = {"example": "schema"}
+    captured = {}
+
+    def _download(url, requests_pipeline):
+        captured["url"] = url
+        captured["pipeline"] = requests_pipeline
+        return expected_schema
+
+    monkeypatch.setattr(
+        data_ops_module,
+        "download_mltable_metadata_schema",
+        _download,
+    )
+    result = data_operations._try_get_mltable_metadata_jsonschema(None)
+    assert result is expected_schema
+    assert captured["pipeline"] is pipeline
+
+
+def test_try_get_mltable_metadata_jsonschema_returns_none_when_download_fails(monkeypatch):
+    data_operations = _build_data_operations_stub()
+    pipeline = SimpleNamespace()
+    data_operations._requests_pipeline = pipeline
+
+    def _download(_, __):
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr(
+        data_ops_module,
+        "download_mltable_metadata_schema",
+        _download,
+    )
+    result = data_operations._try_get_mltable_metadata_jsonschema("https://custom/schema")
+    assert result is None
+
+
+def test_assert_local_path_matches_asset_type_raises_when_folder_missing(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("content")
+    with pytest.raises(ValidationException) as excinfo:
+        _assert_local_path_matches_asset_type(str(file_path), AssetTypes.URI_FOLDER)
+    assert excinfo.value.error_type == ValidationErrorType.FILE_OR_FOLDER_NOT_FOUND

--- a/sdk/ml/azure-ai-ml/tests/test_deployment_template_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_deployment_template_gaps.py
@@ -1,0 +1,881 @@
+import json
+import pytest
+from types import SimpleNamespace
+
+from azure.ai.ml.entities._deployment.deployment_template import DeploymentTemplate
+
+
+class DummySettings:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def _to_dict(self):
+        return self.__dict__
+
+
+class DummyEnvWithId:
+    def __init__(self, id_value):
+        self.id = id_value
+
+
+class DummyEnvWithName:
+    def __init__(self, name_value):
+        self.name = name_value
+
+
+class _StubRequestSettings:
+    def __init__(self, request_timeout_ms=None):
+        self.request_timeout_ms = request_timeout_ms
+
+
+class _StubProbeSettings:
+    def __init__(self, initial_delay=None, period=None, timeout=None):
+        self.initial_delay = initial_delay
+        self.period = period
+        self.timeout = timeout
+
+
+class DummyDictConvertible:
+    def __init__(self, data):
+        self._data = data
+
+    def _to_dict(self):
+        return self._data
+
+
+def test_dump_with_all_optional_fields_and_environment_string():
+    request_settings = DummySettings(a=1, b="two")
+    liveness_probe = DummySettings(x=10)
+    readiness_probe = DummySettings(y=20)
+
+    template = DeploymentTemplate(
+        name="test-template",
+        version="1.0",
+        description="a description",
+        environment="env-string",
+        request_settings=request_settings,
+        liveness_probe=liveness_probe,
+        readiness_probe=readiness_probe,
+        instance_count=3,
+        instance_type="Standard_DS3_v2",
+        model="model-id",
+        code_configuration={"code": "config"},
+        environment_variables={"ENV_VAR": "value"},
+        app_insights_enabled=True,
+    )
+
+    result = template.dump()
+
+    assert result["name"] == "test-template"
+    assert result["version"] == "1.0"
+    assert result["description"] == "a description"
+    assert result["environment"] == "env-string"
+    assert result["request_settings"] == request_settings.__dict__
+    assert result["liveness_probe"] == liveness_probe.__dict__
+    assert result["readiness_probe"] == readiness_probe.__dict__
+    assert result["instance_count"] == 3
+    assert result["instance_type"] == "Standard_DS3_v2"
+    assert result["model"] == "model-id"
+    assert result["code_configuration"] == {"code": "config"}
+    assert result["environment_variables"] == {"ENV_VAR": "value"}
+    assert result["app_insights_enabled"] is True
+
+
+def test_dump_without_description_and_environment_object_with_id():
+    env_obj = DummyEnvWithId("env-id-123")
+
+    template = DeploymentTemplate(
+        name="no-desc-template",
+        version="2.0",
+        environment=env_obj,
+        instance_count=0,
+    )
+
+    result = template.dump()
+
+    assert "description" not in result
+    assert result["environment"] == "env-id-123"
+    assert result["name"] == "no-desc-template"
+    assert result["version"] == "2.0"
+    assert result["instance_count"] == 0
+    assert "app_insights_enabled" not in result
+
+
+def test_dump_environment_object_with_name_only():
+    env_obj = DummyEnvWithName("env-name-only")
+
+    template = DeploymentTemplate(
+        name="name-env-template",
+        version="3.0",
+        environment=env_obj,
+    )
+
+    result = template.dump()
+
+    assert result["environment"] == "env-name-only"
+    assert result["name"] == "name-env-template"
+    assert result["version"] == "3.0"
+
+
+def test_to_rest_object_with_stage_deployment_type_environment_id_and_allowed_instance_types_string():
+    template = DeploymentTemplate(
+        name="rest-deployment",
+        version="1",
+        stage="Active",
+        deployment_template_type="standard",
+        environment="ignored-env",
+        allowed_instance_types="Standard_DS1_v2 Standard_DS2_v2",
+    )
+
+    template.environment_id = "env-id-999"
+    template.tags = {"team": "ml"}
+
+    rest_obj = template._to_rest_object()
+
+    assert rest_obj["name"] == "rest-deployment"
+    assert rest_obj["version"] == "1"
+    assert rest_obj["stage"] == "Active"
+    assert rest_obj["deploymentTemplateType"] == "standard"
+    assert rest_obj["environmentId"] == "env-id-999"
+    assert rest_obj["tags"] == {"team": "ml"}
+    assert rest_obj["allowedInstanceTypes"] == ["Standard_DS1_v2", "Standard_DS2_v2"]
+
+
+def test_to_rest_object_with_allowed_instance_types_list_and_environment_string():
+    template = DeploymentTemplate(
+        name="rest-deployment-list",
+        version="1",
+        environment="env-string-123",
+        allowed_instance_types=["Standard_F4s_v2", "Standard_F8s_v2"],
+    )
+
+    rest_obj = template._to_rest_object()
+
+    assert rest_obj["environmentId"] == "env-string-123"
+    assert rest_obj["allowedInstanceTypes"] == ["Standard_F4s_v2", "Standard_F8s_v2"]
+
+
+def test_to_rest_object_and_to_dict_with_other_allowed_instance_types_and_scoring():
+    template = DeploymentTemplate(
+        name="rest-deployment-mixed",
+        version="1",
+        allowed_instance_types=123,
+        scoring_path="/score",
+        scoring_port=8080,
+        instance_count=0,
+        instance_type="Standard_DS3_v2",
+    )
+
+    rest_obj = template._to_rest_object()
+
+    assert rest_obj["defaultInstanceType"] == "Standard_DS3_v2"
+    assert rest_obj["instanceCount"] == 0
+    assert rest_obj["scoringPath"] == "/score"
+    assert rest_obj["scoringPort"] == 8080
+    assert rest_obj["allowedInstanceTypes"] == ["123"]
+
+    dict_obj = template._to_dict()
+
+    assert dict_obj["name"] == "rest-deployment-mixed"
+    assert dict_obj["version"] == "1"
+    assert dict_obj["defaultInstanceType"] == "Standard_DS3_v2"
+    assert dict_obj["instanceCount"] == 0
+    assert dict_obj["scoringPath"] == "/score"
+    assert dict_obj["scoringPort"] == 8080
+    assert dict_obj["allowedInstanceTypes"] == 123
+
+
+def test_dump_with_all_optional_fields_and_environment_string_generated():
+    template = DeploymentTemplate(
+        name="test-name",
+        version="1",
+        description="a description",
+        environment="env-id",
+        request_settings=DummySettings(timeout=100),
+        liveness_probe=DummySettings(interval=5),
+        readiness_probe=DummySettings(interval=10),
+        instance_count=0,
+        instance_type="Standard_DS3_v2",
+        model="model-id",
+        code_configuration={"path": "./code"},
+        environment_variables={"A": "1"},
+        app_insights_enabled=False,
+    )
+
+    result = template.dump()
+
+    assert result["name"] == "test-name"
+    assert result["version"] == "1"
+    assert result["description"] == "a description"
+    assert result["environment"] == "env-id"
+    assert result["request_settings"] == {"timeout": 100}
+    assert result["liveness_probe"] == {"interval": 5}
+    assert result["readiness_probe"] == {"interval": 10}
+    assert result["instance_count"] == 0
+    assert result["instance_type"] == "Standard_DS3_v2"
+    assert result["model"] == "model-id"
+    assert result["code_configuration"] == {"path": "./code"}
+    assert result["environment_variables"] == {"A": "1"}
+    assert result["app_insights_enabled"] is False
+
+
+def test_dump_without_description_and_environment_object_with_id_generated():
+    env = DummyEnvWithId("env-resource-id")
+    template = DeploymentTemplate(
+        name="test-no-desc",
+        version="2",
+        environment=env,
+        request_settings=DummySettings(x=1),
+        liveness_probe=DummySettings(y=2),
+        readiness_probe=DummySettings(z=3),
+        instance_count=5,
+    )
+
+    result = template.dump()
+
+    assert "description" not in result
+    assert result["environment"] == "env-resource-id"
+    assert result["request_settings"] == {"x": 1}
+    assert result["liveness_probe"] == {"y": 2}
+    assert result["readiness_probe"] == {"z": 3}
+    assert result["instance_count"] == 5
+    assert "instance_type" not in result
+    assert "model" not in result
+    assert "code_configuration" not in result
+    assert "environment_variables" not in result
+    assert "app_insights_enabled" not in result
+
+
+def test_dump_environment_object_with_name_only_generated():
+    env = DummyEnvWithName("env-name")
+    template = DeploymentTemplate(
+        name="name",
+        version="3",
+        environment=env,
+    )
+
+    result = template.dump()
+
+    assert result["environment"] == "env-name"
+
+
+def test_to_rest_object_with_stage_deployment_type_environment_id_and_allowed_instance_types_string_generated():
+    template = DeploymentTemplate(
+        name="rest1",
+        version="1.0",
+        description="desc",
+        environment="env-string",
+        environment_variables={"K": "V"},
+        allowed_instance_types="Standard_DS1_v2 Standard_DS2_v2",
+        instance_type="Standard_DS3_v2",
+        instance_count=2,
+        scoring_path="/score",
+        scoring_port=5001,
+        model="model-1",
+        code_configuration={"code": "path"},
+        app_insights_enabled=True,
+        deployment_template_type="Online",
+        stage="Active",
+        type="customType",
+    )
+    template.tags = {"t1": "v1"}
+    template.environment_id = "env-from-id"
+    template.model_mount_path = "/mnt/model"
+    template.request_settings = DummySettings(a=1)
+    template.liveness_probe = DummySettings(b=2)
+    template.readiness_probe = DummySettings(c=3)
+
+    rest_obj = template._to_rest_object()
+
+    assert rest_obj["name"] == "rest1"
+    assert rest_obj["version"] == "1.0"
+    assert rest_obj["type"] == "customType"
+    assert rest_obj["description"] == "desc"
+    assert rest_obj["stage"] == "Active"
+    assert rest_obj["deploymentTemplateType"] == "Online"
+    assert rest_obj["tags"] == {"t1": "v1"}
+    assert rest_obj["environmentId"] == "env-from-id"
+    assert rest_obj["environmentVariables"] == {"K": "V"}
+    assert rest_obj["modelMountPath"] == "/mnt/model"
+    assert rest_obj["requestSettings"] == {"a": 1}
+    assert rest_obj["livenessProbe"] == {"b": 2}
+    assert rest_obj["readinessProbe"] == {"c": 3}
+    assert rest_obj["defaultInstanceType"] == "Standard_DS3_v2"
+    assert rest_obj["instanceCount"] == 2
+    assert rest_obj["scoringPath"] == "/score"
+    assert rest_obj["scoringPort"] == 5001
+    assert rest_obj["model"] == "model-1"
+    assert rest_obj["codeConfiguration"] == {"code": "path"}
+    assert rest_obj["appInsightsEnabled"] is True
+    assert rest_obj["allowedInstanceTypes"] == ["Standard_DS1_v2", "Standard_DS2_v2"]
+
+
+def test_to_rest_object_with_allowed_instance_types_list_and_environment_string_generated():
+    template = DeploymentTemplate(
+        name="rest2",
+        version="2.0",
+        environment="env-str-2",
+        environment_variables={"A": "B"},
+        allowed_instance_types=["Standard_F4s_v2", "Standard_F8s_v2"],
+        instance_type="Standard_F2s_v2",
+        instance_count=0,
+        scoring_path="/score2",
+        scoring_port=6000,
+    )
+    template.request_settings = DummySettings(x=10)
+
+    rest_obj = template._to_rest_object()
+
+    assert rest_obj["environmentId"] == "env-str-2"
+    assert rest_obj["environmentVariables"] == {"A": "B"}
+    assert rest_obj["defaultInstanceType"] == "Standard_F2s_v2"
+    assert rest_obj["instanceCount"] == 0
+    assert rest_obj["scoringPath"] == "/score2"
+    assert rest_obj["scoringPort"] == 6000
+    assert rest_obj["requestSettings"] == {"x": 10}
+    assert rest_obj["allowedInstanceTypes"] == ["Standard_F4s_v2", "Standard_F8s_v2"]
+
+
+def test_to_rest_object_and_to_dict_with_other_allowed_instance_types_and_scoring_generated():
+    template = DeploymentTemplate(
+        name="rest3",
+        version="3.0",
+        instance_type="Standard_X1",
+        instance_count=3,
+        scoring_path="/path3",
+        scoring_port=7000,
+        allowed_instance_types=123,
+    )
+
+    rest_obj = template._to_rest_object()
+    dict_obj = template._to_dict()
+
+    assert rest_obj["defaultInstanceType"] == "Standard_X1"
+    assert rest_obj["instanceCount"] == 3
+    assert rest_obj["scoringPath"] == "/path3"
+    assert rest_obj["scoringPort"] == 7000
+    assert rest_obj["allowedInstanceTypes"] == ["123"]
+
+    assert dict_obj["defaultInstanceType"] == "Standard_X1"
+    assert dict_obj["instanceCount"] == 3
+    assert dict_obj["scoringPath"] == "/path3"
+    assert dict_obj["scoringPort"] == 7000
+    assert dict_obj["allowedInstanceTypes"] == 123
+
+
+def test_request_timeout_getter_various_cases():
+    template = DeploymentTemplate(name="rt", version="1")
+
+    assert template.request_timeout is None
+
+    class DummyReqNoAttr:
+        def __init__(self, value):
+            self.request_timeout_ms = value
+
+    template.request_settings = DummyReqNoAttr("1000")
+    assert template.request_timeout == "1000"
+
+    template.request_settings = DummyReqNoAttr(5000)
+    assert template.request_timeout == 5
+
+    template.request_settings = DummyReqNoAttr(0)
+    assert template.request_timeout is None
+
+
+def test_request_timeout_setter_creates_and_updates_settings():
+    template = DeploymentTemplate(name="rt2", version="1")
+
+    template.request_timeout = 7
+    assert template.request_settings.request_timeout_ms == 7000
+    assert template.request_timeout == 7
+
+    template.request_timeout = 3
+    assert template.request_settings.request_timeout_ms == 3000
+    assert template.request_timeout == 3
+
+
+def test_liveness_probe_properties_create_and_update():
+    template = DeploymentTemplate(name="live", version="1")
+
+    assert template.liveness_probe_initial_delay is None
+    assert template.liveness_probe_period is None
+    assert template.liveness_probe_timeout is None
+
+    template.liveness_probe_initial_delay = 10
+    assert template.liveness_probe_initial_delay == 10
+
+    template.liveness_probe_period = 5
+    assert template.liveness_probe_period == 5
+
+    template.liveness_probe_timeout = 2
+    assert template.liveness_probe_timeout == 2
+
+    template.liveness_probe_initial_delay = 15
+    assert template.liveness_probe_initial_delay == 15
+
+    class DummyProbeNoAttr:
+        pass
+
+    template.liveness_probe = DummyProbeNoAttr()
+    assert template.liveness_probe_initial_delay is None
+
+
+def test_readiness_probe_properties_create_and_update():
+    template = DeploymentTemplate(name="ready", version="1")
+
+    assert template.readiness_probe_initial_delay is None
+    assert template.readiness_probe_period is None
+    assert template.readiness_probe_timeout is None
+
+    template.readiness_probe_initial_delay = 8
+    assert template.readiness_probe_initial_delay == 8
+
+    template.readiness_probe_period = 4
+    assert template.readiness_probe_period == 4
+
+    template.readiness_probe_timeout = 1
+    assert template.readiness_probe_timeout == 1
+
+    template.readiness_probe_initial_delay = 12
+    assert template.readiness_probe_initial_delay == 12
+
+    class DummyProbeNoAttr:
+        pass
+
+    template.readiness_probe = DummyProbeNoAttr()
+    assert template.readiness_probe_period is None
+
+
+def test_from_rest_object_parses_string_fields_and_sets_metadata():
+    rest_obj = {
+        "id": "rest-id",
+        "model": "my-model",
+        "code_configuration": {"code": "cfg"},
+        "app_insights_enabled": True,
+        "template": "tmpl",
+        "code_id": "code123",
+        "additional_properties": {"name": "add_name", "version": "2.0"},
+        "properties": {
+            "name": None,
+            "version": None,
+            "description": "desc",
+            "tags": "{\"k\": \"v\"}",
+            "environmentId": "env-id",
+            "environmentVariables": "{'a': 'b'}",
+            "requestSettings": {},
+            "livenessProbe": {},
+            "readinessProbe": {},
+            "instanceCount": "3",
+            "defaultInstanceType": "Standard_DS3_v2",
+            "deploymentTemplateType": "Managed",
+            "allowedInstanceTypes": "['A', 'B']",
+            "scoringPort": "8080",
+            "scoringPath": "/score",
+            "modelMountPath": "/mnt",
+            "stage": "Active",
+            "type": "restType",
+        },
+    }
+
+    template = DeploymentTemplate._from_rest_object(rest_obj)
+
+    assert template.name == "add_name"
+    assert template.version == "2.0"
+    assert template.description == "desc"
+    assert template.tags == {"k": "v"}
+    assert template.environment == "env-id"
+    assert template.environment_variables == {"a": "b"}
+    assert template.instance_count == 3
+    assert template.default_instance_type == "Standard_DS3_v2"
+    assert template.deployment_template_type == "Managed"
+    assert template.allowed_instance_types == ["A", "B"]
+    assert template.scoring_port == 8080
+    assert template.scoring_path == "/score"
+    assert template.model_mount_path == "/mnt"
+    assert template.stage == "Active"
+    assert template.type == "restType"
+
+    assert template._from_service is True
+    assert template.environment_id == "env-id"
+    assert template.template == "tmpl"
+    assert template.code_id == "code123"
+
+    original = template._original_immutable_fields
+    assert original["environment_id"] == "env-id"
+    assert original["environment_variables"] == {"a": "b"}
+    assert original["instance_count"] == 3
+    assert original["default_instance_type"] == "Standard_DS3_v2"
+    assert original["deployment_template_type"] == "Managed"
+    assert original["allowed_instance_types"] == ["A", "B"]
+    assert original["scoring_port"] == 8080
+    assert original["scoring_path"] == "/score"
+    assert original["model_mount_path"] == "/mnt"
+    assert original["stage"] == "Active"
+    assert original["type"] == "restType"
+
+
+def test_from_rest_object_handles_invalid_allowed_instance_types_string():
+    rest_obj = {
+        "properties": {
+            "name": "n1",
+            "version": "1.0",
+            "allowedInstanceTypes": "not a python literal",
+        }
+    }
+
+    template = DeploymentTemplate._from_rest_object(rest_obj)
+
+    assert template.name == "n1"
+    assert template.version == "1.0"
+    assert template.allowed_instance_types is None
+    assert template._original_immutable_fields["allowed_instance_types"] is None
+
+
+def test_to_dict_includes_metadata_and_capabilities():
+    template = DeploymentTemplate(
+        name="meta-tmpl",
+        version="1",
+        environment="env-meta",
+        environment_variables={"X": "1"},
+    )
+    template.created_by = "user1"
+    template.created_time = "2024-01-01T00:00:00Z"
+    template.modified_time = "2024-01-02T00:00:00Z"
+    template.capabilities = ["cap1"]
+    template.model_mount_path = "/mnt/meta"
+    template.request_settings = DummySettings(req="v")
+    template.liveness_probe = DummySettings(live=True)
+    template.readiness_probe = DummySettings(ready=True)
+
+    dct = template._to_dict()
+
+    assert dct["createdBy"] == "user1"
+    assert dct["createdTime"] == "2024-01-01T00:00:00Z"
+    assert dct["modifiedTime"] == "2024-01-02T00:00:00Z"
+    assert dct["capabilities"] == ["cap1"]
+    assert dct["environmentVariables"] == {"X": "1"}
+    assert dct["modelMountPath"] == "/mnt/meta"
+    assert dct["requestSettings"]["req"] == "v"
+    assert dct["livenessProbe"]["live"] is True
+    assert dct["readinessProbe"]["ready"] is True
+
+    template.capabilities = []
+    dct2 = template._to_dict()
+    assert dct2["capabilities"] == []
+
+
+def test_str_and_repr_use_to_dict_json():
+    template = DeploymentTemplate(
+        name="str-tmpl",
+        version="1",
+        stage="Active",
+        deployment_template_type="Online",
+        environment="env-str",
+        environment_variables={"Y": "2"},
+        instance_count=2,
+        instance_type="Standard_DS1",
+        scoring_path="/score",
+        scoring_port=7000,
+    )
+
+    dict_repr = template._to_dict()
+
+    s = str(template)
+    r = repr(template)
+
+    loaded_s = json.loads(s)
+    loaded_r = json.loads(r)
+
+    assert loaded_s == dict_repr
+    assert loaded_r == dict_repr
+    assert r == s
+
+
+def test_request_timeout_without_settings_returns_none():
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.request_timeout is None
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("3000", "3000"),
+        (4500, 4),
+        (0, None),
+    ],
+)
+def test_request_timeout_handles_various_request_settings_values(value, expected):
+    template = DeploymentTemplate(name="template", version="1")
+    template.request_settings = SimpleNamespace(request_timeout_ms=value)
+    assert template.request_timeout == expected
+
+
+def test_request_timeout_setter_creates_and_updates(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.OnlineRequestSettings",
+        _StubRequestSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    template.request_timeout = 3
+    assert isinstance(template.request_settings, _StubRequestSettings)
+    assert template.request_settings.request_timeout_ms == 3000
+
+    template.request_settings = SimpleNamespace(request_timeout_ms=1000)
+    template.request_timeout = 2
+    assert template.request_settings.request_timeout_ms == 2000
+
+
+def test_liveness_probe_initial_delay_getter_and_setter(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.ProbeSettings",
+        _StubProbeSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.liveness_probe_initial_delay is None
+
+    template.liveness_probe_initial_delay = 5
+    assert isinstance(template.liveness_probe, _StubProbeSettings)
+    assert template.liveness_probe.initial_delay == 5
+
+    template.liveness_probe_initial_delay = 9
+    assert template.liveness_probe.initial_delay == 9
+
+
+def test_liveness_probe_period_getter_and_setter(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.ProbeSettings",
+        _StubProbeSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.liveness_probe_period is None
+
+    template.liveness_probe_period = 10
+    assert template.liveness_probe.period == 10
+    assert template.liveness_probe_period == 10
+
+    template.liveness_probe_period = 20
+    assert template.liveness_probe.period == 20
+
+
+def test_liveness_probe_timeout_getter_and_setter(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.ProbeSettings",
+        _StubProbeSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.liveness_probe_timeout is None
+
+    template.liveness_probe_timeout = 12
+    assert template.liveness_probe.timeout == 12
+    assert template.liveness_probe_timeout == 12
+
+    template.liveness_probe_timeout = 18
+    assert template.liveness_probe.timeout == 18
+
+
+def test_readiness_probe_initial_delay_getter_and_setter(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.ProbeSettings",
+        _StubProbeSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.readiness_probe_initial_delay is None
+
+    template.readiness_probe_initial_delay = 7
+    assert isinstance(template.readiness_probe, _StubProbeSettings)
+    assert template.readiness_probe.initial_delay == 7
+
+    template.readiness_probe_initial_delay = 14
+    assert template.readiness_probe.initial_delay == 14
+
+
+def test_readiness_probe_period_and_timeout_behaviors(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml.entities._deployment.deployment_template.ProbeSettings",
+        _StubProbeSettings,
+    )
+    template = DeploymentTemplate(name="template", version="1")
+    assert template.readiness_probe_period is None
+    assert template.readiness_probe_timeout is None
+
+    template.readiness_probe_period = 4
+    template.readiness_probe_timeout = 8
+    assert template.readiness_probe.period == 4
+    assert template.readiness_probe.timeout == 8
+    assert template.readiness_probe_period == 4
+    assert template.readiness_probe_timeout == 8
+
+    template.readiness_probe_period = 6
+    template.readiness_probe_timeout = 10
+    assert template.readiness_probe.period == 6
+    assert template.readiness_probe.timeout == 10
+
+def test_to_rest_object_includes_optional_fields():
+    template = DeploymentTemplate(name="template", version="1")
+    template.stage = "Archived"
+    template.deployment_template_type = "custom"
+    template.tags = {"tier": "prod"}
+    template.environment_id = "env-id"
+    template.environment = "ignored"
+    template.model_mount_path = "/model"
+    template.request_settings = DummyDictConvertible({"timeout": 100})
+    template.liveness_probe = DummyDictConvertible({"initialDelaySeconds": 5})
+    template.readiness_probe = DummyDictConvertible({"timeoutSeconds": 7})
+    template.instance_type = "standard"
+    template.instance_count = 3
+    template.scoring_path = "/score"
+    template.scoring_port = 8080
+    template.model = "my-model"
+    template.code_configuration = {"code": "repository"}
+    template.app_insights_enabled = False
+    result = template._to_rest_object()
+    assert result["stage"] == "Archived"
+    assert result["deploymentTemplateType"] == "custom"
+    assert result["tags"] == {"tier": "prod"}
+    assert result["environmentId"] == "env-id"
+    assert result["modelMountPath"] == "/model"
+    assert result["requestSettings"] == {"timeout": 100}
+    assert result["livenessProbe"] == {"initialDelaySeconds": 5}
+    assert result["readinessProbe"] == {"timeoutSeconds": 7}
+    assert result["defaultInstanceType"] == "standard"
+    assert result["instanceCount"] == 3
+    assert result["scoringPath"] == "/score"
+    assert result["scoringPort"] == 8080
+    assert result["model"] == "my-model"
+    assert result["codeConfiguration"] == {"code": "repository"}
+    assert result["appInsightsEnabled"] is False
+
+def test_to_rest_object_allowed_instance_types_variants():
+    template = DeploymentTemplate(name="template", version="1")
+    template.allowed_instance_types = "small medium"
+    result = template._to_rest_object()
+    assert result["allowedInstanceTypes"] == ["small", "medium"]
+    template.allowed_instance_types = ["x-large"]
+    result = template._to_rest_object()
+    assert result["allowedInstanceTypes"] == ["x-large"]
+    template.allowed_instance_types = 5
+    result = template._to_rest_object()
+    assert result["allowedInstanceTypes"] == ["5"]
+
+def test_to_dict_includes_metadata_and_environment_fallback():
+    template = DeploymentTemplate(name="template", version="1")
+    template.environment = "env-str"
+    template.tags = {"team": "ml"}
+    template.stage = "Active"
+    template.deployment_template_type = "stage"
+    template.created_by = "creator"
+    template.created_time = "created-time"
+    template.modified_time = "modified-time"
+    template.capabilities = ["cap1"]
+    template.environment_variables = {"ENV": "value"}
+    template.model_mount_path = "/mnt"
+    template.request_settings = DummyDictConvertible({"timeout": 100})
+    template.liveness_probe = DummyDictConvertible({"threshold": 1})
+    template.readiness_probe = DummyDictConvertible({"threshold": 2})
+    template.allowed_instance_types = ["A", "B"]
+    template.instance_type = "standard"
+    template.instance_count = 2
+    template.scoring_path = "/score"
+    template.scoring_port = 9001
+    result = template._to_dict()
+    assert result["stage"] == "Active"
+    assert result["deploymentTemplateType"] == "stage"
+    assert result["tags"] == {"team": "ml"}
+    assert result["environmentId"] == "env-str"
+    assert result["createdBy"] == "creator"
+    assert result["createdTime"] == "created-time"
+    assert result["modifiedTime"] == "modified-time"
+    assert result["capabilities"] == ["cap1"]
+    assert result["environmentVariables"] == {"ENV": "value"}
+    assert result["modelMountPath"] == "/mnt"
+    assert result["requestSettings"] == {"timeout": 100}
+    assert result["livenessProbe"] == {"threshold": 1}
+    assert result["readinessProbe"] == {"threshold": 2}
+    assert result["allowedInstanceTypes"] == ["A", "B"]
+    assert result["defaultInstanceType"] == "standard"
+    assert result["instanceCount"] == 2
+    assert result["scoringPath"] == "/score"
+    assert result["scoringPort"] == 9001
+
+def test_to_rest_object_includes_stage_and_template_type_and_allowed_instance_types():
+    template = DeploymentTemplate(
+        name="tpl",
+        version="1.0",
+        stage="Archived",
+        deployment_template_type="custom",
+    )
+    template.environment_id = "env-123"
+    template.environment = "should-not-appear"
+    template.allowed_instance_types = "typeA typeB"
+    template.environment_variables = {"ENV": "VALUE"}
+    template.request_settings = DummyDictConvertible({"timeout": 100})
+    template.model_mount_path = "/model"
+    template.model = "model123"
+    template.code_configuration = {"entry_script": "score.py"}
+    template.app_insights_enabled = True
+
+    result = template._to_rest_object()
+
+    assert result["stage"] == "Archived"
+    assert result["deploymentTemplateType"] == "custom"
+    assert result["environmentId"] == "env-123"
+    assert result["environmentVariables"] == {"ENV": "VALUE"}
+    assert result["requestSettings"] == {"timeout": 100}
+    assert result["modelMountPath"] == "/model"
+    assert result["model"] == "model123"
+    assert result["codeConfiguration"] == {"entry_script": "score.py"}
+    assert result["appInsightsEnabled"] is True
+    assert result["allowedInstanceTypes"] == ["typeA", "typeB"]
+
+def test_to_rest_object_uses_environment_when_environment_id_missing():
+    template = DeploymentTemplate(name="tpl", version="2.0")
+    template.environment = "env-fallback"
+
+    result = template._to_rest_object()
+
+    assert "stage" not in result
+    assert result["environmentId"] == "env-fallback"
+
+def test_to_dict_includes_metadata_and_probe_settings_with_default_instance():
+    template = DeploymentTemplate(name="tpl", version="3.0")
+    template.environment_id = "env-id"
+    template.created_by = "creator"
+    template.created_time = "2025-01-01T00:00:00Z"
+    template.modified_time = "2025-02-02T00:00:00Z"
+    template.capabilities = []
+    template.environment_variables = {"VAR": "VAL"}
+    template.model_mount_path = "/mounted"
+    template.request_settings = DummyDictConvertible({"timeoutMs": 30})
+    template.liveness_probe = DummyDictConvertible({"initial_delay": 5})
+    template.readiness_probe = DummyDictConvertible({"timeout": 10})
+    template.allowed_instance_types = ["typeA", "typeB"]
+    template.default_instance_type = "default-size"
+    template.instance_count = 4
+    template.scoring_path = "/score"
+    template.scoring_port = 9000
+
+    result = template._to_dict()
+
+    assert result["createdBy"] == "creator"
+    assert result["createdTime"] == "2025-01-01T00:00:00Z"
+    assert result["modifiedTime"] == "2025-02-02T00:00:00:00Z" if False else result["modifiedTime"] == "2025-02-02T00:00:00Z"
+    assert result["capabilities"] == []
+    assert result["environmentVariables"] == {"VAR": "VAL"}
+    assert result["modelMountPath"] == "/mounted"
+    assert result["requestSettings"] == {"timeoutMs": 30}
+    assert result["livenessProbe"] == {"initial_delay": 5}
+    assert result["readinessProbe"] == {"timeout": 10}
+    assert result["allowedInstanceTypes"] == ["typeA", "typeB"]
+    assert result["defaultInstanceType"] == "default-size"
+    assert result["instanceCount"] == 4
+    assert result["scoringPath"] == "/score"
+    assert result["scoringPort"] == 9000
+
+def test_to_dict_uses_instance_type_when_default_missing():
+    template = DeploymentTemplate(name="tpl", version="4.0")
+    template.instance_type = "standard"
+
+    result = template._to_dict()
+
+    assert result["defaultInstanceType"] == "standard"

--- a/sdk/ml/azure-ai-ml/tests/test_exception_helper_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_exception_helper_gaps.py
@@ -1,0 +1,392 @@
+import sys
+import types
+
+import pytest
+from marshmallow.exceptions import ValidationError as SchemaValidationError
+
+from azure.ai.ml import _exception_helper as exception_helper
+from azure.ai.ml.constants._common import YAML_CREATION_ERROR_DESCRIPTION
+from azure.ai.ml.exceptions import ErrorTarget, MlException, ValidationErrorType, ValidationException
+
+module_definitions = {
+    "azure.ai.ml._schema._datastore": [
+        "AzureBlobSchema",
+        "AzureDataLakeGen1Schema",
+        "AzureDataLakeGen2Schema",
+        "AzureFileSchema",
+    ],
+    "azure.ai.ml._schema._sweep": ["SweepJobSchema"],
+    "azure.ai.ml._schema.assets.data": ["DataSchema"],
+    "azure.ai.ml._schema.assets.environment": ["EnvironmentSchema"],
+    "azure.ai.ml._schema.assets.model": ["ModelSchema"],
+    "azure.ai.ml._schema.job": ["CommandJobSchema"],
+}
+
+for module_name, class_names in module_definitions.items():
+    module = types.ModuleType(module_name)
+    for class_name in class_names:
+        setattr(module, class_name, type(class_name, (), {}))
+    sys.modules[module_name] = module
+
+REF_DOC_ERROR_MESSAGE_MAP = {}
+util_module = types.ModuleType("azure.ai.ml.entities._util")
+util_module.REF_DOC_ERROR_MESSAGE_MAP = REF_DOC_ERROR_MESSAGE_MAP
+sys.modules["azure.ai.ml.entities._util"] = util_module
+
+azure_datastore_module = sys.modules["azure.ai.ml._schema._datastore"]
+assets_module = sys.modules["azure.ai.ml._schema.assets.data"]
+environment_assets_module = sys.modules["azure.ai.ml._schema.assets.environment"]
+model_assets_module = sys.modules["azure.ai.ml._schema.assets.model"]
+sweep_module = sys.modules["azure.ai.ml._schema._sweep"]
+job_module = sys.modules["azure.ai.ml._schema.job"]
+
+REF_DOC_ERROR_MESSAGE_MAP.update(
+    {
+        model_assets_module.ModelSchema: "Model schema guidance",
+        assets_module.DataSchema: "Data schema guidance",
+        job_module.CommandJobSchema: "Command job schema guidance",
+        sweep_module.SweepJobSchema: "Sweep schema guidance",
+        azure_datastore_module.AzureBlobSchema: "Datastore guidance",
+        azure_datastore_module.AzureDataLakeGen1Schema: "Gen1 datastore guidance",
+        azure_datastore_module.AzureDataLakeGen2Schema: "Gen2 datastore guidance",
+        azure_datastore_module.AzureFileSchema: "File datastore guidance",
+        environment_assets_module.EnvironmentSchema: "Environment schema guidance",
+        "": "Default guidance",
+    }
+)
+
+ENTITY_EXPECTATIONS = [
+    (ErrorTarget.MODEL, "Model schema guidance"),
+    (ErrorTarget.DATA, "Data schema guidance"),
+    (ErrorTarget.COMMAND_JOB, "Command job schema guidance"),
+    (ErrorTarget.SWEEP_JOB, "Sweep schema guidance"),
+    (ErrorTarget.BLOB_DATASTORE, "Datastore guidance"),
+    (ErrorTarget.DATASTORE, "Datastore guidance"),
+    (ErrorTarget.GEN1_DATASTORE, "Gen1 datastore guidance"),
+    (ErrorTarget.GEN2_DATASTORE, "Gen2 datastore guidance"),
+    (ErrorTarget.FILE_DATASTORE, "File datastore guidance"),
+    (ErrorTarget.ENVIRONMENT, "Environment schema guidance"),
+    (ErrorTarget.CODE, "Default guidance"),
+]
+
+@pytest.mark.parametrize("entity_type,expected_doc", ENTITY_EXPECTATIONS)
+def test_format_create_validation_error_yaml_operation_appends_ref_doc_entries(
+    monkeypatch, entity_type, expected_doc
+):
+    monkeypatch.setattr(exception_helper, "get_entity_type", lambda error: (entity_type, "details"))
+    monkeypatch.setattr(
+        exception_helper, "format_details_section", lambda error, details, entity_type: ({}, "formatted details")
+    )
+    monkeypatch.setattr(
+        exception_helper,
+        "format_errors_and_resolutions_sections",
+        lambda entity_type, error_types, cli: ("errors", "base resolutions"),
+    )
+
+    formatted = exception_helper.format_create_validation_error("ignored", yaml_operation=True)
+
+    assert expected_doc in formatted
+
+
+def test_log_and_raise_error_wraps_schema_validation_error_and_respects_yaml_flag(monkeypatch):
+    traced = {}
+
+    def fake_format(arg, yaml_operation=False, cli=False, raw_error=None):
+        traced["args"] = (arg, yaml_operation, cli, raw_error)
+        return "formatted schema failure"
+
+    monkeypatch.setattr(exception_helper, "format_create_validation_error", fake_format)
+
+    schema_error = SchemaValidationError([{"field": ["error"]}])
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(schema_error, yaml_operation=True)
+
+    assert "formatted schema failure" in str(excinfo.value)
+    assert traced["args"][0] == schema_error.messages[0]
+    assert traced["args"][1] is True
+
+
+def test_log_and_raise_error_schema_validation_error_falls_back_on_not_implemented(monkeypatch):
+    def fake_format(*args, **kwargs):
+        raise NotImplementedError
+
+    monkeypatch.setattr(exception_helper, "format_create_validation_error", fake_format)
+
+    schema_error = SchemaValidationError([{"fallback": ["missing"]}])
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(schema_error)
+
+    assert "fallback" in str(excinfo.value)
+
+
+class _GenericValidationException(ValidationException):
+    def __init__(self):
+        self.error_type = ValidationErrorType.GENERIC
+        self.target = ErrorTarget.MODEL
+        self.message = "generic validation failure"
+        self.exc_msg = "GenericValidationException"
+
+
+def test_log_and_raise_error_generic_validation_exception_preserves_original(monkeypatch):
+    monkeypatch.setattr(
+        exception_helper,
+        "format_create_validation_error",
+        lambda *args, **kwargs: pytest.fail("Should not be invoked for generic errors"),
+    )
+
+    error = _GenericValidationException()
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error)
+
+    assert excinfo.value.no_personal_data_message is error
+    assert excinfo.value.no_personal_data_message.message == "generic validation failure"
+
+
+class _NonGenericValidationException(ValidationException):
+    def __init__(self):
+        self.error_type = ValidationErrorType.MISSING_FIELD
+        self.target = ErrorTarget.MODEL
+        self.message = "non generic validation failure"
+        self.exc_msg = "NonGenericValidationException"
+
+
+def test_log_and_raise_error_non_generic_validation_exception_uses_formatting(monkeypatch):
+    recorded = {}
+
+    def fake_format(error_arg, yaml_operation=False, cli=False, raw_error=None):
+        recorded["error"] = error_arg
+        return "formatted validation failure"
+
+    monkeypatch.setattr(exception_helper, "format_create_validation_error", fake_format)
+
+    error = _NonGenericValidationException()
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error)
+
+    assert "formatted validation failure" in str(excinfo.value)
+    assert recorded["error"] is error
+
+
+def test_log_and_raise_error_propagates_other_exceptions():
+    with pytest.raises(ValueError):
+        exception_helper.log_and_raise_error(ValueError("boom"))
+
+
+class _ModelSchema:
+    pass
+
+class _DataSchema:
+    pass
+
+class _CommandJobSchema:
+    pass
+
+class _SweepJobSchema:
+    pass
+
+class _AzureBlobSchema:
+    pass
+
+class _AzureDataLakeGen1Schema:
+    pass
+
+class _AzureDataLakeGen2Schema:
+    pass
+
+class _AzureFileSchema:
+    pass
+
+class _EnvironmentSchema:
+    pass
+
+MODEL_SCHEMA = _ModelSchema
+DATA_SCHEMA = _DataSchema
+COMMAND_JOB_SCHEMA = _CommandJobSchema
+SWEEP_JOB_SCHEMA = _SweepJobSchema
+AZURE_BLOB_SCHEMA = _AzureBlobSchema
+AZURE_GEN1_SCHEMA = _AzureDataLakeGen1Schema
+AZURE_GEN2_SCHEMA = _AzureDataLakeGen2Schema
+AZURE_FILE_SCHEMA = _AzureFileSchema
+ENVIRONMENT_SCHEMA = _EnvironmentSchema
+
+
+def _install_schema_stubs(monkeypatch, ref_doc_map):
+    datastore_module = types.ModuleType('azure.ai.ml._schema._datastore')
+    datastore_module.AzureBlobSchema = AZURE_BLOB_SCHEMA
+    datastore_module.AzureDataLakeGen1Schema = AZURE_GEN1_SCHEMA
+    datastore_module.AzureDataLakeGen2Schema = AZURE_GEN2_SCHEMA
+    datastore_module.AzureFileSchema = AZURE_FILE_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema._datastore', datastore_module)
+
+    sweep_module = types.ModuleType('azure.ai.ml._schema._sweep')
+    sweep_module.SweepJobSchema = SWEEP_JOB_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema._sweep', sweep_module)
+
+    data_module = types.ModuleType('azure.ai.ml._schema.assets.data')
+    data_module.DataSchema = DATA_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema.assets.data', data_module)
+
+    environment_module = types.ModuleType('azure.ai.ml._schema.assets.environment')
+    environment_module.EnvironmentSchema = ENVIRONMENT_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema.assets.environment', environment_module)
+
+    model_module = types.ModuleType('azure.ai.ml._schema.assets.model')
+    model_module.ModelSchema = MODEL_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema.assets.model', model_module)
+
+    job_module = types.ModuleType('azure.ai.ml._schema.job')
+    job_module.CommandJobSchema = COMMAND_JOB_SCHEMA
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml._schema.job', job_module)
+
+    entities_module = types.ModuleType('azure.ai.ml.entities._util')
+    entities_module.REF_DOC_ERROR_MESSAGE_MAP = ref_doc_map
+    monkeypatch.setitem(sys.modules, 'azure.ai.ml.entities._util', entities_module)
+
+
+class _MapRecorder(dict):
+    def __init__(self):
+        super().__init__()
+        self.last_key = None
+
+    def get(self, key, default=None):
+        self.last_key = key
+        return default or ''
+
+REF_DOC_GUIDANCE = {
+    MODEL_SCHEMA: 'model guidance',
+    DATA_SCHEMA: 'data guidance',
+    COMMAND_JOB_SCHEMA: 'command guidance',
+    SWEEP_JOB_SCHEMA: 'sweep guidance',
+    AZURE_BLOB_SCHEMA: 'blob guidance',
+    AZURE_GEN1_SCHEMA: 'gen1 guidance',
+    AZURE_GEN2_SCHEMA: 'gen2 guidance',
+    AZURE_FILE_SCHEMA: 'file guidance',
+    ENVIRONMENT_SCHEMA: 'env guidance',
+}
+
+ENTITY_GUIDANCE_CASES = [
+    (ErrorTarget.MODEL, 'model guidance'),
+    (ErrorTarget.DATA, 'data guidance'),
+    (ErrorTarget.COMMAND_JOB, 'command guidance'),
+    (ErrorTarget.SWEEP_JOB, 'sweep guidance'),
+    (ErrorTarget.BLOB_DATASTORE, 'blob guidance'),
+    (ErrorTarget.DATASTORE, 'blob guidance'),
+    (ErrorTarget.GEN1_DATASTORE, 'gen1 guidance'),
+    (ErrorTarget.GEN2_DATASTORE, 'gen2 guidance'),
+    (ErrorTarget.FILE_DATASTORE, 'file guidance'),
+    (ErrorTarget.ENVIRONMENT, 'env guidance'),
+]
+
+@pytest.mark.parametrize('entity_type, expected_guidance', ENTITY_GUIDANCE_CASES)
+def test_format_create_validation_error_appends_ref_doc_for_yaml_entity_types(monkeypatch, entity_type, expected_guidance):
+    _install_schema_stubs(monkeypatch, ref_doc_map=REF_DOC_GUIDANCE)
+    monkeypatch.setattr(exception_helper, 'get_entity_type', lambda _: (entity_type, 'details'))
+    monkeypatch.setattr(exception_helper, 'format_details_section', lambda *args, **kwargs: ({}, 'details'))
+    monkeypatch.setattr(
+        exception_helper,
+        'format_errors_and_resolutions_sections',
+        lambda *args, **kwargs: ('errors', 'resolutions'),
+    )
+    result = exception_helper.format_create_validation_error('ignored', yaml_operation=True)
+    assert expected_guidance in result
+
+
+def test_format_create_validation_error_uses_empty_schema_type_for_unmatched_entity(monkeypatch):
+    recorder = _MapRecorder()
+    _install_schema_stubs(monkeypatch, ref_doc_map=recorder)
+    monkeypatch.setattr(exception_helper, 'get_entity_type', lambda _: (ErrorTarget.JOB, 'details'))
+    monkeypatch.setattr(exception_helper, 'format_details_section', lambda *args, **kwargs: ({}, 'details'))
+    monkeypatch.setattr(
+        exception_helper,
+        'format_errors_and_resolutions_sections',
+        lambda *args, **kwargs: ('errors', 'resolutions'),
+    )
+    exception_helper.format_create_validation_error('ignored', yaml_operation=True)
+    assert recorder.last_key == ''
+
+
+def test_format_create_validation_error_without_yaml_description(monkeypatch):
+    monkeypatch.setattr(exception_helper, 'get_entity_type', lambda _: (ErrorTarget.MODEL, 'details'))
+    monkeypatch.setattr(exception_helper, 'format_details_section', lambda *args, **kwargs: ({}, 'details'))
+    monkeypatch.setattr(
+        exception_helper,
+        'format_errors_and_resolutions_sections',
+        lambda *args, **kwargs: ('errors', 'resolutions'),
+    )
+    result = exception_helper.format_create_validation_error('ignored', yaml_operation=False)
+    unexpected_description = YAML_CREATION_ERROR_DESCRIPTION.format(entity_type=ErrorTarget.MODEL)
+    assert unexpected_description not in result
+
+
+class _DummyValidationException:
+    def __init__(self, error_type):
+        self.error_type = error_type
+
+
+def test_log_and_raise_with_schema_validation_error_uses_formatter_and_debug(monkeypatch):
+    error = SchemaValidationError('issue')
+    error.messages = ['payload']
+    monkeypatch.setattr(exception_helper.module_logger, 'error', lambda *args, **kwargs: None)
+    monkeypatch.setattr(exception_helper.module_logger, 'debug', lambda *args, **kwargs: None)
+    monkeypatch.setattr(exception_helper, 'format_create_validation_error', lambda *args, **kwargs: 'formatted')
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error, debug=True)
+    assert excinfo.value.message == 'formatted'
+
+
+def test_log_and_raise_with_schema_validation_error_handles_not_implemented(monkeypatch):
+    error = SchemaValidationError('issue')
+    error.messages = ['payload']
+
+    def _raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError
+
+    monkeypatch.setattr(exception_helper.module_logger, 'debug', lambda *args, **kwargs: None)
+    monkeypatch.setattr(exception_helper, 'format_create_validation_error', _raise_not_implemented)
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error)
+    assert excinfo.value.message == 'issue'
+    assert excinfo.value.no_personal_data_message is error
+
+
+def test_log_and_raise_with_validation_exception_generic_skips_formatter(monkeypatch):
+    monkeypatch.setattr(exception_helper, 'ValidationException', _DummyValidationException)
+    monkeypatch.setattr(exception_helper.module_logger, 'debug', lambda *args, **kwargs: None)
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError('formatter should not be invoked')
+
+    monkeypatch.setattr(exception_helper, 'format_create_validation_error', _fail_if_called)
+    generic_error = _DummyValidationException(ValidationErrorType.GENERIC)
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(generic_error)
+    assert excinfo.value.no_personal_data_message is generic_error
+
+
+def test_log_and_raise_with_validation_exception_uses_formatter(monkeypatch):
+    monkeypatch.setattr(exception_helper, 'ValidationException', _DummyValidationException)
+    monkeypatch.setattr(exception_helper.module_logger, 'debug', lambda *args, **kwargs: None)
+    monkeypatch.setattr(exception_helper, 'format_create_validation_error', lambda *args, **kwargs: 'validation formatted')
+    error = _DummyValidationException(ValidationErrorType.INVALID_VALUE)
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error)
+    assert excinfo.value.message == 'validation formatted'
+
+
+def test_log_and_raise_with_validation_exception_handles_not_implemented(monkeypatch):
+    monkeypatch.setattr(exception_helper, 'ValidationException', _DummyValidationException)
+    monkeypatch.setattr(exception_helper.module_logger, 'debug', lambda *args, **kwargs: None)
+
+    def _raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError
+
+    monkeypatch.setattr(exception_helper, 'format_create_validation_error', _raise_not_implemented)
+    error = _DummyValidationException(ValidationErrorType.INVALID_VALUE)
+    with pytest.raises(MlException) as excinfo:
+        exception_helper.log_and_raise_error(error)
+    assert excinfo.value.message == str(error)
+
+
+def test_log_and_raise_error_propagates_other_exceptions():
+    with pytest.raises(ValueError):
+        exception_helper.log_and_raise_error(ValueError('boom'))

--- a/sdk/ml/azure-ai-ml/tests/test_fileshare_storage_helper_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_fileshare_storage_helper_gaps.py
@@ -1,0 +1,344 @@
+import logging
+import pytest
+
+from azure.ai.ml._artifacts import _fileshare_storage_helper as helper
+from azure.ai.ml._artifacts._fileshare_storage_helper import delete, recursive_download
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException
+from azure.storage.fileshare import ShareFileClient
+
+
+def test_upload_truncates_long_source_name_and_warns_on_large_file(tmp_path, caplog, monkeypatch, capsys):
+    caplog.set_level(logging.WARNING, logger=helper.__name__)
+    source_file = tmp_path / ("a" * 52)
+    source_file.write_text("content")
+    asset_id = "artifact123"
+
+    monkeypatch.setattr(helper, "generate_asset_id", lambda asset_hash, include_directory=False: asset_id)
+    monkeypatch.setattr(helper, "get_directory_size", lambda source: (150 * 10**6, None))
+    monkeypatch.setattr(helper.time, "sleep", lambda _: None)
+    monkeypatch.setattr(helper.FileStorageClient, "exists", lambda self, asset_id_arg: False)
+    recorded = {}
+
+    def fake_upload_file(
+        self,
+        source,
+        dest,
+        show_progress=False,
+        msg=None,
+        in_directory=False,
+        subdirectory_client=None,
+        callback=None,
+    ):
+        recorded["msg"] = msg
+        self.uploaded_file_count = self.total_file_count
+
+    monkeypatch.setattr(helper.FileStorageClient, "upload_file", fake_upload_file)
+
+    confirmation = {}
+
+    def fake_set_confirmation_metadata(self, source, dest, name, version):
+        confirmation["called_with"] = (source, dest, name, version)
+
+    monkeypatch.setattr(helper.FileStorageClient, "_set_confirmation_metadata", fake_set_confirmation_metadata)
+
+    warning_called = {}
+    original_warning = helper.module_logger.warning
+
+    def fake_warning(message):
+        warning_called["message"] = message
+        return original_warning(message)
+
+    monkeypatch.setattr(helper.module_logger, "warning", fake_warning)
+
+    client = helper.FileStorageClient.__new__(helper.FileStorageClient)
+    client.directory_client = type(
+        "DummyDirectoryClient",
+        (),
+        {"list_directories_and_files": lambda self, *args, **kwargs: []},
+    )()
+    client.legacy_directory_client = client.directory_client
+    client.file_share = "share"
+    client.total_file_count = 1
+    client.uploaded_file_count = 0
+    client.name = None
+    client.version = None
+    client.legacy = False
+    client.subdirectory_client = None
+
+    artifact_info = client.upload(str(source_file), name="name", version="version", show_progress=True)
+
+    stderr_output = capsys.readouterr().err
+
+    expected_msg = "Uploading " + source_file.name[:47] + "..."
+    assert recorded["msg"] == expected_msg
+    assert artifact_info["remote path"] == f"{asset_id}/{source_file.name}"
+    assert confirmation["called_with"] == (str(source_file), asset_id, "name", "version")
+    warning_prefix = helper.FILE_SIZE_WARNING.split("\n\n")[0]
+    warning_logged = any(helper.FILE_SIZE_WARNING in record.getMessage() for record in caplog.records)
+    warning_message = warning_called.get("message", "")
+    assert warning_logged or warning_prefix in stderr_output or warning_prefix in warning_message
+
+
+def test_exists_deletes_incomplete_asset_when_legacy_directory_missing(monkeypatch):
+    asset_id = "artifact123"
+    default_client = type(
+        "DefaultDirectoryClient",
+        (),
+        {"list_directories_and_files": lambda self, *args, **kwargs: [{"name": asset_id, "is_directory": False}]},
+    )()
+
+    class LegacyDirectoryClient:
+        def __init__(self):
+            self.called = False
+
+        def list_directories_and_files(self, *args, **kwargs):
+            self.called = True
+            raise helper.ResourceNotFoundError("missing")
+
+    legacy_client = LegacyDirectoryClient()
+    metadata_target = object()
+    metadata_properties = {"metadata": {}}
+
+    def fake_get_asset_metadata(self, asset_id_arg, default_items, legacy_items):
+        return metadata_target, metadata_properties
+
+    monkeypatch.setattr(helper.FileStorageClient, "_get_asset_metadata", fake_get_asset_metadata)
+    deleted = []
+
+    def fake_delete(client_arg):
+        deleted.append(client_arg)
+
+    monkeypatch.setattr(helper, "delete", fake_delete)
+
+    client = helper.FileStorageClient.__new__(helper.FileStorageClient)
+    client.directory_client = default_client
+    client.legacy_directory_client = legacy_client
+    client.file_share = "share"
+    client.total_file_count = 1
+    client.uploaded_file_count = 0
+    client.name = None
+    client.version = None
+    client.legacy = False
+    client.subdirectory_client = None
+
+    result = helper.FileStorageClient.exists(client, asset_id)
+
+    assert legacy_client.called
+    assert deleted == [metadata_target]
+    assert result is False
+
+
+def test_recursive_download_writes_files_and_traverses_nested_directories(tmp_path):
+    class DummyStream:
+        def __init__(self, data):
+            self._data = data
+
+        def readall(self):
+            return self._data
+
+    class DummyFileClient:
+        def __init__(self, content):
+            self._content = content
+
+        def download_file(self, max_concurrency):
+            return DummyStream(self._content)
+
+    class DummyDirectoryClient:
+        def __init__(self, items, file_contents=None, subclients=None):
+            self._items = items
+            self._file_contents = file_contents or {}
+            self._subclients = subclients or {}
+
+        def list_directories_and_files(self, name_starts_with=""):
+            return self._items
+
+        def get_file_client(self, name):
+            return DummyFileClient(self._file_contents[name])
+
+        def get_subdirectory_client(self, name):
+            if name not in self._subclients:
+                self._subclients[name] = DummyDirectoryClient([])
+            return self._subclients[name]
+
+    inner_client = DummyDirectoryClient(
+        items=[{"name": "inner.txt", "is_directory": False}],
+        file_contents={"inner.txt": b"inner bytes"},
+    )
+    root_client = DummyDirectoryClient(
+        items=[
+            {"name": "file.txt", "is_directory": False},
+            {"name": "nested", "is_directory": True},
+        ],
+        file_contents={"file.txt": b"root bytes"},
+        subclients={"nested": inner_client},
+    )
+
+    destination = str(tmp_path / "downloads")
+    recursive_download(
+        client=root_client,
+        destination=destination,
+        max_concurrency=1,
+    )
+
+    assert (tmp_path / "downloads" / "file.txt").read_bytes() == b"root bytes"
+    assert (tmp_path / "downloads" / "nested" / "inner.txt").read_bytes() == b"inner bytes"
+
+
+def test_recursive_download_raises_ml_exception_on_list_failure(tmp_path):
+    class FailingDirectoryClient:
+        def list_directories_and_files(self, name_starts_with=""):
+            raise RuntimeError("boom")
+
+    with pytest.raises(MlException) as excinfo:
+        recursive_download(
+            client=FailingDirectoryClient(),
+            destination=str(tmp_path / "dest"),
+            max_concurrency=1,
+            starts_with="pref",
+        )
+
+    assert excinfo.value.message == "Saving fileshare directory with prefix pref was unsuccessful."
+    assert excinfo.value.no_personal_data_message == "Saving fileshare directory with prefix pref was unsuccessful."
+    assert excinfo.value.target == ErrorTarget.ARTIFACT
+    assert excinfo.value.error_category == ErrorCategory.SYSTEM_ERROR
+
+
+class _DummyShareFileClient(ShareFileClient):
+    def __init__(self):
+        self.delete_calls = 0
+
+    def delete_file(self):
+        self.delete_calls += 1
+
+
+class _DummyTrackingDirectoryClient:
+    def __init__(self, name, files=None, directories=None):
+        self.name = name
+        self.files = files or []
+        self.directories = directories or {}
+        self.deleted_files = []
+        self.deleted_directories = []
+
+    def list_directories_and_files(self, name_starts_with=None):
+        items = [{'name': file_name, 'is_directory': False} for file_name in self.files]
+        items.extend({'name': dir_name, 'is_directory': True} for dir_name in self.directories)
+        return items
+
+    def delete_file(self, name=None):
+        self.deleted_files.append(name)
+
+    def get_subdirectory_client(self, name):
+        return self.directories[name]
+
+    def delete_directory(self):
+        self.deleted_directories.append(self.name)
+
+
+class _DummyFileContent:
+    def __init__(self, data):
+        self._data = data
+
+    def readall(self):
+        return self._data
+
+
+class _DummyFileClient:
+    def __init__(self, data):
+        self._data = data
+        self.download_calls = []
+
+    def download_file(self, max_concurrency):
+        self.download_calls.append(max_concurrency)
+        return _DummyFileContent(self._data)
+
+
+class _DummyShareDirectoryClient:
+    def __init__(self, files=None, directories=None):
+        self._files = files or {}
+        self._directories = directories or {}
+        self.list_calls = []
+
+    def list_directories_and_files(self, name_starts_with=None):
+        self.list_calls.append(name_starts_with)
+        items = [{'name': name, 'is_directory': False} for name in self._files]
+        items.extend({'name': name, 'is_directory': True} for name in self._directories)
+        return items
+
+    def get_file_client(self, name):
+        return _DummyFileClient(self._files[name])
+
+    def get_subdirectory_client(self, name):
+        return self._directories[name]
+
+
+class _FailingShareDirectoryClient:
+    def list_directories_and_files(self, name_starts_with=None):
+        raise RuntimeError('cannot list contents')
+
+
+def test_delete_share_file_client_deletes_single_file():
+    file_client = _DummyShareFileClient()
+
+    delete(file_client)
+
+    assert file_client.delete_calls == 1
+
+
+def test_delete_directory_without_contents_only_deletes_directory():
+    client = _DummyTrackingDirectoryClient(name='empty')
+
+    delete(client)
+
+    assert client.deleted_files == []
+    assert client.deleted_directories == ['empty']
+
+
+def test_delete_directory_with_contents_recurses_over_files_and_directories():
+    child = _DummyTrackingDirectoryClient(name='nested', files=['deep.txt'])
+    parent = _DummyTrackingDirectoryClient(
+        name='parent',
+        files=['root.txt'],
+        directories={'nested': child},
+    )
+
+    delete(parent)
+
+    assert parent.deleted_files == ['root.txt']
+    assert parent.deleted_directories == ['parent']
+    assert child.deleted_files == ['deep.txt']
+    assert child.deleted_directories == ['nested']
+
+
+def test_recursive_download_writes_nested_files(tmp_path):
+    nested = _DummyShareDirectoryClient(files={'nested.txt': b'nested'})
+    root = _DummyShareDirectoryClient(
+        files={'root.txt': b'root'},
+        directories={'nested': nested},
+    )
+    destination = tmp_path / 'downloaded'
+
+    recursive_download(root, destination=str(destination), max_concurrency=2)
+
+    root_file = destination / 'root.txt'
+    nested_file = destination / 'nested' / 'nested.txt'
+
+    assert root_file.read_bytes() == b'root'
+    assert nested_file.read_bytes() == b'nested'
+
+
+def test_recursive_download_raises_ml_exception_on_list_failure():
+    failing_client = _FailingShareDirectoryClient()
+
+    with pytest.raises(MlException) as excinfo:
+        recursive_download(
+            failing_client,
+            destination='unused',
+            max_concurrency=1,
+            starts_with='prefix',
+        )
+
+    exception = excinfo.value
+    assert exception.message == 'Saving fileshare directory with prefix prefix was unsuccessful.'
+    assert exception.no_personal_data_message == 'Saving fileshare directory with prefix prefix was unsuccessful.'
+    assert exception.target == ErrorTarget.ARTIFACT
+    assert exception.error_category == ErrorCategory.SYSTEM_ERROR

--- a/sdk/ml/azure-ai-ml/tests/test_gen2_storage_helper_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_gen2_storage_helper_gaps.py
@@ -1,0 +1,284 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from colorama import Fore
+
+import azure.ai.ml._artifacts._gen2_storage_helper as helper_module
+from azure.ai.ml._artifacts._gen2_storage_helper import FILE_SIZE_WARNING, Gen2StorageClient
+from azure.ai.ml.exceptions import MlException
+
+
+class DummyDirectoryClient:
+    def __init__(self):
+        self._metadata = {}
+
+    def exists(self):
+        return False
+
+    def get_directory_properties(self):
+        return SimpleNamespace(metadata=self._metadata)
+
+    def set_metadata(self, metadata):
+        self._metadata = metadata
+
+
+class DummyFileSystemClient:
+    def __init__(self, directory_client):
+        self._directory_client = directory_client
+
+    def create_file_system(self):
+        return None
+
+    def get_directory_client(self, asset_id):
+        return self._directory_client
+
+
+class DummyDataLakeServiceClient:
+    def __init__(self, account_url, credential, api_version=None):
+        self._file_system_client = DummyFileSystemClient(DummyDirectoryClient())
+
+    def get_file_system_client(self, file_system):
+        return self._file_system_client
+
+
+def test_upload_truncates_long_source_name_and_warns_large_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(helper_module, "DataLakeServiceClient", DummyDataLakeServiceClient)
+    monkeypatch.setattr(helper_module, "generate_asset_id", lambda asset_hash, include_directory=True: "asset123")
+    monkeypatch.setattr(helper_module, "get_directory_size", lambda source: (150 * 10**6, 0))
+    monkeypatch.setattr(helper_module, "_get_cloud_details", lambda: {"storage_endpoint": "test.endpoint"})
+    warning_calls = []
+    monkeypatch.setattr(helper_module.module_logger, "warning", lambda msg: warning_calls.append(msg))
+    long_name = "a" * 60
+    source = tmp_path / long_name
+    captured = {}
+
+    def fake_upload_directory(**kwargs):
+        captured["msg"] = kwargs["msg"]
+        kwargs["storage_client"].uploaded_file_count = kwargs["storage_client"].total_file_count
+
+    monkeypatch.setattr(helper_module, "upload_directory", fake_upload_directory)
+    monkeypatch.setattr(helper_module, "upload_file", lambda **kwargs: pytest.fail("upload_file should not be called"))
+    monkeypatch.setattr(helper_module.os.path, "isdir", lambda path: path == str(source))
+
+    client = Gen2StorageClient("cred", "fs", "https://example.dfs.core.windows.net")
+    client.total_file_count = 0
+
+    artifact_info = client.upload(str(source), name="asset", version="1.0")
+
+    expected_msg = Fore.GREEN + "Uploading " + ("a" * 47 + "...")
+    assert captured["msg"] == expected_msg
+
+    expected_remote_path = f"asset123/{long_name}"
+    assert artifact_info["remote path"] == expected_remote_path
+
+    expected_destination = (
+        f"https://{client.account_name}.dfs.test.endpoint/{client.file_system}/{artifact_info['remote path']}"
+    )
+    expected_warning = FILE_SIZE_WARNING.format(source=str(source), destination=expected_destination)
+    assert warning_calls == [expected_warning]
+
+
+def test_upload_uses_short_source_name_for_file_upload(monkeypatch, tmp_path):
+    monkeypatch.setattr(helper_module, "DataLakeServiceClient", DummyDataLakeServiceClient)
+    monkeypatch.setattr(helper_module, "generate_asset_id", lambda asset_hash, include_directory=True: "asset123")
+    monkeypatch.setattr(helper_module, "get_directory_size", lambda source: (50 * 10**6, 0))
+    monkeypatch.setattr(helper_module, "_get_cloud_details", lambda: {"storage_endpoint": "test.endpoint"})
+    warning_calls = []
+    monkeypatch.setattr(helper_module.module_logger, "warning", lambda msg: warning_calls.append(msg))
+    captured = {}
+
+    def fake_upload_file(**kwargs):
+        captured["msg"] = kwargs["msg"]
+        kwargs["storage_client"].uploaded_file_count = kwargs["storage_client"].total_file_count
+
+    monkeypatch.setattr(helper_module, "upload_directory", lambda **kwargs: pytest.fail("upload_directory should not be called"))
+    monkeypatch.setattr(helper_module, "upload_file", fake_upload_file)
+    monkeypatch.setattr(helper_module.os.path, "isdir", lambda path: False)
+
+    client = Gen2StorageClient("cred", "fs", "https://example.dfs.core.windows.net")
+    client.total_file_count = 0
+
+    artifact_info = client.upload(str(tmp_path / "file.txt"), name="asset", version="2.0")
+
+    expected_msg = Fore.GREEN + "Uploading file.txt"
+    assert captured["msg"] == expected_msg
+    assert warning_calls == []
+    expected_remote_path = "asset123/file.txt"
+    assert artifact_info["remote path"] == expected_remote_path
+
+
+class FakeFileClient:
+    def __init__(self, size, content):
+        self._size = size
+        self._content = content
+
+    def get_file_properties(self):
+        return SimpleNamespace(size=self._size)
+
+    def download_file(self):
+        return SimpleNamespace(readall=lambda: self._content)
+
+
+class FakeFileSystemClient:
+    def __init__(self, paths=None, file_clients=None, raise_os=False, raise_exception=None):
+        self._paths = paths or []
+        self._file_clients = file_clients or {}
+        self._raise_os = raise_os
+        self._raise_exception = raise_exception
+
+    def get_paths(self, path):
+        if self._raise_os:
+            raise OSError("boom")
+        if self._raise_exception:
+            raise self._raise_exception
+        return self._paths
+
+    def get_file_client(self, name):
+        return self._file_clients[name]
+
+
+def _build_client(paths=None, file_clients=None, **kwargs):
+    client = object.__new__(Gen2StorageClient)
+    client.account_name = "account"
+    client.file_system = "filesystem"
+    client.file_system_client = FakeFileSystemClient(paths=paths, file_clients=file_clients, **kwargs)
+    return client
+
+
+def _patch_cloud(monkeypatch):
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._gen2_storage_helper._get_cloud_details",
+        lambda: {"storage_endpoint": "test.endpoint"},
+    )
+
+
+def test_download_warns_and_writes_file_when_size_exceeds_limit(tmp_path, monkeypatch):
+    _patch_cloud(monkeypatch)
+    paths = [
+        SimpleNamespace(name="prefix/dir", is_directory=True),
+        SimpleNamespace(name="prefix/file.txt", is_directory=False),
+    ]
+    file_client = FakeFileClient(size=200 * 10**6, content=b"payload")
+    client = _build_client(paths=paths, file_clients={"prefix/file.txt": file_client})
+
+    warning_calls = []
+    monkeypatch.setattr(helper_module.module_logger, "warning", lambda msg: warning_calls.append(msg))
+
+    def _raise_file_exists(path, exist_ok=False):
+        Path(path).mkdir(parents=True, exist_ok=True)
+        raise FileExistsError("exists")
+
+    monkeypatch.setattr("os.makedirs", _raise_file_exists)
+    client.download("prefix", destination=tmp_path)
+
+    assert (tmp_path / "dir").is_dir()
+    assert (tmp_path / "file.txt").read_bytes() == b"payload"
+    assert warning_calls
+    warning_text = warning_calls[0]
+    assert "https://account.dfs.test.endpoint/filesystem/prefix" in warning_text
+    assert str(tmp_path) in warning_text
+
+
+def test_download_propagates_os_error():
+    client = _build_client(raise_os=True)
+    with pytest.raises(OSError):
+        client.download("prefix", destination="dest")
+
+
+def test_download_wraps_non_os_errors_in_ml_exception(monkeypatch):
+    _patch_cloud(monkeypatch)
+    error = ValueError("boom")
+    client = _build_client(raise_exception=error)
+    with pytest.raises(MlException) as excinfo:
+        client.download("prefix", destination="dest")
+    assert "Saving output with prefix prefix was unsuccessful" in str(excinfo.value)
+
+
+class FileSystemClientStub:
+    def __init__(self, paths=None, file_client=None):
+        self.paths = paths or []
+        self.file_client = file_client
+        self.file_system = None
+        self.requested_path = None
+        self.requested_client_path = None
+        self.created = False
+
+    def create_file_system(self):
+        self.created = True
+
+    def get_paths(self, path):
+        self.requested_path = path
+        return self.paths
+
+    def get_file_client(self, path):
+        self.requested_client_path = path
+        if self.file_client is not None:
+            self.file_client.requested_path = path
+        return self.file_client
+
+
+class FileClientStub:
+    def __init__(self, exists_value):
+        self.exists_value = exists_value
+        self.requested_path = None
+
+    def exists(self):
+        self.exists_called = True
+        return self.exists_value
+
+
+def _build_client_with_fs_client(monkeypatch, *, paths=None, file_client=None):
+    file_client = file_client or FileClientStub(False)
+    fs_client = FileSystemClientStub(paths=paths, file_client=file_client)
+
+    class DataLakeServiceClientStub:
+        def __init__(self, account_url, credential, api_version=None):
+            self.account_url = account_url
+            self.credential = credential
+            self.api_version = api_version
+
+        def get_file_system_client(self, file_system):
+            fs_client.file_system = file_system
+            return fs_client
+
+    monkeypatch.setattr(
+        "azure.ai.ml._artifacts._gen2_storage_helper.DataLakeServiceClient",
+        DataLakeServiceClientStub,
+    )
+    client = Gen2StorageClient(
+        credential="credential",
+        file_system="filesystem",
+        account_url="https://account.dfs.azure.com",
+    )
+    return client, fs_client
+
+
+def test_list_returns_names(monkeypatch):
+    client, fs_client = _build_client_with_fs_client(
+        monkeypatch,
+        paths=[{"name": "prefix/file1"}, {"name": "prefix/file2"}],
+    )
+    result = client.list("prefix")
+    assert result == ["prefix/file1", "prefix/file2"]
+    assert fs_client.requested_path == "prefix"
+
+
+def test_exists_returns_true(monkeypatch):
+    file_client = FileClientStub(True)
+    client, fs_client = _build_client_with_fs_client(monkeypatch, file_client=file_client)
+
+    result = client.exists("some/path")
+    assert result is True
+    assert file_client.requested_path == "some/path"
+    assert fs_client.requested_client_path == "some/path"
+
+
+def test_exists_returns_false(monkeypatch):
+    file_client = FileClientStub(False)
+    client, _ = _build_client_with_fs_client(monkeypatch, file_client=file_client)
+
+    result = client.exists("other/path")
+    assert result is False
+    assert file_client.requested_path == "other/path"

--- a/sdk/ml/azure-ai-ml/tests/test_job_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_job_operations_gaps.py
@@ -1,0 +1,1050 @@
+from pathlib import Path
+import pytest
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock
+
+from azure.ai.ml.operations._job_operations import (
+    JobOperations,
+    _get_job_compute_id,
+    module_logger,
+    ops_logger,
+    RunOperations,
+    DatasetDataplaneOperations,
+    ModelDataplaneOperations,
+    BATCH_JOB_CHILD_RUN_OUTPUT_NAME,
+    DEFAULT_ARTIFACT_STORE_OUTPUT_NAME,
+    SHORT_URI_FORMAT,
+)
+from azure.ai.ml.constants._common import (
+    AzureMLResourceType,
+    LEVEL_ONE_NAMED_RESOURCE_ID_FORMAT,
+    AZUREML_RESOURCE_PROVIDER,
+    LOCAL_COMPUTE_TARGET,
+    WorkspaceDiscoveryUrlKey,
+    AssetTypes,
+    DEFAULT_ARTIFACT_STORE_OUTPUT_NAME,
+    SHORT_URI_FORMAT,
+    BATCH_JOB_CHILD_RUN_OUTPUT_NAME,
+    SWEEP_JOB_BEST_CHILD_RUN_ID_PROPERTY_NAME,
+)
+from azure.ai.ml.constants._job.pipeline import PipelineConstants
+from azure.ai.ml._scope_dependent_operations import OperationScope, OperationConfig, OperationsContainer
+from azure.ai.ml.entities import Job, ValidationResult
+from azure.ai.ml.entities._job.automl.automl_job import AutoMLJob
+from azure.ai.ml.entities._job.finetuning.finetuning_job import FineTuningJob
+from azure.ai.ml.entities._job.distillation.distillation_job import DistillationJob
+from azure.ai.ml.entities._builders import Spark, Command
+from azure.ai.ml.entities._inputs_outputs import Input
+from azure.ai.ml.operations import _job_operations as job_ops_module
+
+
+class _DummyServiceClient:
+    def __init__(self):
+        class _Jobs:
+            def __init__(self) -> None:
+                self.create_or_update_calls = []
+
+            def create_or_update(self, id, resource_group_name, workspace_name, body, **kwargs):  # pylint: disable=unused-argument
+                self.create_or_update_calls.append((id, resource_group_name, workspace_name, body, kwargs))
+                return body
+
+        self.jobs = _Jobs()
+
+
+class _DummyCredential:
+    def get_token(self, *scopes, **kwargs):  # pylint: disable=unused-argument
+        class _Token:
+            def __init__(self) -> None:
+                self.token = "dummy-token"
+
+        return _Token()
+
+
+def _create_job_operations_for_compute_tests() -> JobOperations:
+    operation_scope = OperationScope(
+        subscription_id="sub-id",
+        resource_group_name="rg-name",
+        workspace_name="ws-name",
+    )
+    operation_config = OperationConfig(show_progress=True, enable_telemetry=True)
+
+    class _DummyOperationsContainer:
+        def __init__(self, operation_scope, operation_config):
+            self._operation_scope = operation_scope
+            self._operation_config = operation_config
+            self.all_operations = {}
+
+        def get_operation(self, azureml_type, condition):  # pylint: disable=unused-argument
+            # For these tests we don't need actual operations; just return None.
+            return None
+
+    all_operations_container = _DummyOperationsContainer(operation_scope, operation_config)
+
+    service_client_2023 = _DummyServiceClient()
+    service_client_2024_01 = _DummyServiceClient()
+    service_client_2024_10 = _DummyServiceClient()
+    service_client_2025_01 = _DummyServiceClient()
+    credential = _DummyCredential()
+    requests_pipeline = object()
+
+    job_ops = JobOperations(
+        operation_scope,
+        operation_config,
+        service_client_2023,
+        all_operations_container,
+        credential,
+        requests_pipeline=requests_pipeline,
+        service_client_01_2024_preview=service_client_2024_01,
+        service_client_10_2024_preview=service_client_2024_10,
+        service_client_01_2025_preview=service_client_2025_01,
+    )
+    return job_ops
+
+
+def test_ops_logger_and_module_logger_initialized():
+    # Accessing ops_logger and module_logger ensures their module-level initialization lines are executed
+    assert ops_logger is not None
+    assert module_logger is not None
+
+
+def test_runs_operations_lazy_initialization_and_caching():
+    job_ops = _create_job_operations_for_compute_tests()
+    job_ops._api_base_url = "https://dummy-api"  # avoid calling _get_workspace_url
+
+    assert job_ops._runs_operations_client is None
+    first_client = job_ops._runs_operations
+    assert isinstance(first_client, RunOperations)
+    second_client = job_ops._runs_operations
+    assert first_client is second_client
+
+
+def test_dataset_dataplane_operations_lazy_initialization_and_caching():
+    job_ops = _create_job_operations_for_compute_tests()
+    job_ops._api_base_url = "https://dummy-api"  # avoid calling _get_workspace_url
+
+    assert job_ops._dataset_dataplane_operations_client is None
+    first_client = job_ops._dataset_dataplane_operations
+    assert isinstance(first_client, DatasetDataplaneOperations)
+    second_client = job_ops._dataset_dataplane_operations
+    assert first_client is second_client
+
+
+def test_model_dataplane_operations_lazy_initialization_and_caching():
+    job_ops = _create_job_operations_for_compute_tests()
+    job_ops._api_base_url = "https://dummy-api"  # avoid calling _get_workspace_url
+
+    assert job_ops._model_dataplane_operations_client is None
+    first_client = job_ops._model_dataplane_operations
+    assert isinstance(first_client, ModelDataplaneOperations)
+    second_client = job_ops._model_dataplane_operations
+    assert first_client is second_client
+
+
+def test_api_url_caching_uses_get_workspace_url_once(monkeypatch):
+    job_ops = _create_job_operations_for_compute_tests()
+    calls = []
+
+    def fake_get_workspace_url(url_key):  # pylint: disable=unused-argument
+        calls.append(url_key)
+        return "https://api.first.call"
+
+    monkeypatch.setattr(job_ops, "_get_workspace_url", fake_get_workspace_url)
+
+    first = job_ops._api_url
+    second = job_ops._api_url
+
+    assert first == "https://api.first.call"
+    assert second == "https://api.first.call"
+    assert calls == [WorkspaceDiscoveryUrlKey.API]
+
+
+def test_resolve_compute_id_returns_local_without_resolving():
+    job_ops = _create_job_operations_for_compute_tests()
+    resolver_calls = []
+
+    def resolver(name, azureml_type, sub_workspace_resource=False):  # pylint: disable=unused-argument
+        resolver_calls.append((name, azureml_type, sub_workspace_resource))
+        raise AssertionError("resolver should not be called for local compute")
+
+    result = job_ops._resolve_compute_id(resolver, LOCAL_COMPUTE_TARGET.upper())
+
+    assert result == LOCAL_COMPUTE_TARGET
+    assert resolver_calls == []
+
+
+def test_resolve_compute_id_virtualcluster_uses_vc_arm_id_and_type():
+    job_ops = _create_job_operations_for_compute_tests()
+    received = {}
+
+    def resolver(name, azureml_type, sub_workspace_resource=False):
+        received["name"] = name
+        received["type"] = azureml_type
+        received["sub_workspace_resource"] = sub_workspace_resource
+        return "resolved-vc-id"
+
+    target = AzureMLResourceType.VIRTUALCLUSTER + "/my-vc"
+
+    result = job_ops._resolve_compute_id(resolver, target)
+
+    expected_name = LEVEL_ONE_NAMED_RESOURCE_ID_FORMAT.format(
+        job_ops._operation_scope.subscription_id,
+        job_ops._operation_scope.resource_group_name,
+        AZUREML_RESOURCE_PROVIDER,
+        AzureMLResourceType.VIRTUALCLUSTER,
+        "my-vc",
+    )
+
+    assert result == "resolved-vc-id"
+    assert received["name"] == expected_name
+    assert received["type"] == AzureMLResourceType.VIRTUALCLUSTER
+    assert received["sub_workspace_resource"] is False
+
+
+def test_resolve_compute_id_falls_back_to_compute_and_get_job_compute_id():
+    job_ops = _create_job_operations_for_compute_tests()
+    resolver_calls = []
+
+    def resolver(name, azureml_type, sub_workspace_resource=False):
+        resolver_calls.append((name, azureml_type, sub_workspace_resource))
+        if azureml_type == AzureMLResourceType.VIRTUALCLUSTER:
+            raise RuntimeError("no virtual cluster")
+        return "resolved-compute-id"
+
+    target = "cpu-cluster"
+
+    result = job_ops._resolve_compute_id(resolver, target)
+
+    assert result == "resolved-compute-id"
+    assert resolver_calls[0][0] == target
+    assert resolver_calls[0][1] == AzureMLResourceType.VIRTUALCLUSTER
+    assert resolver_calls[1][0] == target
+    assert resolver_calls[1][1] == AzureMLResourceType.COMPUTE
+
+    class DummyJob:
+        def __init__(self) -> None:
+            self.compute = "another-cluster"
+
+    job = DummyJob()
+    _get_job_compute_id(job, resolver)
+    assert job.compute == "resolved-compute-id"
+
+
+def test_list_with_parent_job_uses_runs_children(monkeypatch):
+    job_ops = _create_job_operations_for_compute_tests()
+
+    parent_job = SimpleNamespace(name="parent-job-name")
+    monkeypatch.setattr(job_ops, "get", lambda name: parent_job)
+
+    class DummyRunsOperations:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def get_run_children(self, name, max_results=None):  # pylint: disable=unused-argument
+            self.calls.append((name, max_results))
+            return ["child1", "child2"]
+
+    dummy_runs = DummyRunsOperations()
+    job_ops._runs_operations_client = dummy_runs
+
+    result = list(job_ops.list(parent_job_name="parent-job-name", max_results=5))
+
+    assert result == ["child1", "child2"]
+    assert dummy_runs.calls == [("parent-job-name", 5)]
+
+
+def test_list_without_parent_job_uses_service_client_and_handle_errors(monkeypatch):
+    job_ops = _create_job_operations_for_compute_tests()
+
+    class DummyJobs:
+        def __init__(self) -> None:
+            self.list_calls = []
+
+        def list(self, resource_group_name, workspace_name, cls, list_view_type, scheduled, schedule_id, **kwargs):
+            self.list_calls.append(
+                {
+                    "resource_group_name": resource_group_name,
+                    "workspace_name": workspace_name,
+                    "list_view_type": list_view_type,
+                    "scheduled": scheduled,
+                    "schedule_id": schedule_id,
+                    "kwargs": kwargs,
+                }
+            )
+            objs = ["obj1", "obj2"]
+            return cls(objs)
+
+    dummy_jobs = DummyJobs()
+    job_ops.service_client_01_2024_preview.jobs = dummy_jobs
+
+    handled = []
+
+    def fake_handle_rest_errors(self, obj):  # pylint: disable=unused-argument
+        handled.append(f"handled-{obj}")
+        return f"handled-{obj}"
+
+    monkeypatch.setattr(JobOperations, "_handle_rest_errors", fake_handle_rest_errors)
+
+    result = list(
+        job_ops.list(
+            schedule_defined=True,
+            scheduled_job_name="sched-job",
+            extra_param="value",
+        )
+    )
+
+    assert result == ["handled-obj1", "handled-obj2"]
+    assert len(dummy_jobs.list_calls) == 1
+    call = dummy_jobs.list_calls[0]
+    assert call["resource_group_name"] == job_ops._operation_scope.resource_group_name
+    assert call["workspace_name"] == job_ops._workspace_name
+    assert call["scheduled"] is True
+    assert call["schedule_id"] == "sched-job"
+    assert call["kwargs"]["extra_param"] == "value"
+
+
+def test_resolve_arm_id_or_upload_dependencies_spark_branch_calls_resolve_job_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"resolver_job": None, "entries": None, "base_path": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # pylint: disable=unused-argument
+        called["resolver_job"] = job
+        return job
+
+    def fake_resolve_job_inputs(entries, base_path):
+        called["entries"] = list(entries)
+        called["base_path"] = base_path
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_job_inputs", fake_resolve_job_inputs)
+
+    class DummySpark(Spark):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+    spark_job = DummySpark()
+    spark_job._job_inputs = {"input1": "value1"}
+    spark_job._base_path = "base/path"
+
+    job_operations._resolve_arm_id_or_upload_dependencies(spark_job)
+
+    assert called["resolver_job"] is spark_job
+    assert called["entries"] == ["value1"]
+    assert called["base_path"] == "base/path"
+
+
+def test_resolve_arm_id_or_upload_dependencies_command_branch_calls_resolve_job_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"resolver_job": None, "entries": None, "base_path": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # pylint: disable=unused-argument
+        called["resolver_job"] = job
+        return job
+
+    def fake_resolve_job_inputs(entries, base_path):
+        called["entries"] = list(entries)
+        called["base_path"] = base_path
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_job_inputs", fake_resolve_job_inputs)
+
+    class DummyCommand(Command):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+    command_job = DummyCommand()
+    command_job._job_inputs = {"input1": "value1", "input2": "value2"}
+    command_job._base_path = "base/command"
+
+    job_operations._resolve_arm_id_or_upload_dependencies(command_job)
+
+    assert called["resolver_job"] is command_job
+    assert set(called["entries"]) == {"value1", "value2"}
+    assert called["base_path"] == "base/command"
+
+
+def test_resolve_arm_id_or_upload_dependencies_automl_branch_calls_resolve_automl_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"automl_job": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # type: ignore[no-untyped-def]
+        return job
+
+    def fake_resolve_automl_job_inputs(job):
+        called["automl_job"] = job
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_automl_job_inputs", fake_resolve_automl_job_inputs)
+
+    class DummyAutoMLJob(AutoMLJob):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            # Minimal init; AutoMLJob has abstract members we override below.
+            self._base_path = "base/automl"
+
+        def _to_dict(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+        @property
+        def training_data(self):  # type: ignore[no-untyped-def]
+            return None
+
+        @training_data.setter
+        def training_data(self, value):  # type: ignore[no-untyped-def]
+            pass
+
+        @property
+        def validation_data(self):  # type: ignore[no-untyped-def]
+            return None
+
+        @validation_data.setter
+        def validation_data(self, value):  # type: ignore[no-untyped-def]
+            pass
+
+        @property
+        def test_data(self):  # type: ignore[no-untyped-def]
+            return None
+
+        @test_data.setter
+        def test_data(self, value):  # type: ignore[no-untyped-def]
+            pass
+
+    automl_job = DummyAutoMLJob()
+
+    job_operations._resolve_arm_id_or_upload_dependencies(automl_job)
+
+    assert called["automl_job"] is automl_job
+
+
+def test_resolve_arm_id_or_upload_dependencies_finetuning_branch_calls_resolve_finetuning_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"finetuning_job": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # type: ignore[unused-argument]
+        return job
+
+    def fake_resolve_finetuning_job_inputs(job):
+        called["finetuning_job"] = job
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_finetuning_job_inputs", fake_resolve_finetuning_job_inputs)
+
+    class DummyFineTuningJob(FineTuningJob):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def _to_dict(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+    finetuning_job = DummyFineTuningJob()
+
+    job_operations._resolve_arm_id_or_upload_dependencies(finetuning_job)
+
+    assert called["finetuning_job"] is finetuning_job
+
+
+def test_resolve_arm_id_or_upload_dependencies_distillation_branch_calls_resolve_distillation_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"distillation_job": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # type: ignore[unused-argument]
+        return job
+
+    def fake_resolve_distillation_job_inputs(job):
+        called["distillation_job"] = job
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_distillation_job_inputs", fake_resolve_distillation_job_inputs)
+
+    class DummyDistillationJob(DistillationJob):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+    distillation_job = DummyDistillationJob()
+
+    job_operations._resolve_arm_id_or_upload_dependencies(distillation_job)
+
+    assert called["distillation_job"] is distillation_job
+
+
+def test_resolve_arm_id_or_upload_dependencies_else_branch_with_inputs_calls_resolve_job_inputs(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"entries": None, "base_path": None}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # type: ignore[unused-argument]
+        return job
+
+    def fake_resolve_job_inputs(entries, base_path):
+        called["entries"] = list(entries)
+        called["base_path"] = base_path
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_job_inputs", fake_resolve_job_inputs)
+
+    class OtherJob:
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            self.inputs = {"a": 1, "b": 2}
+            self._base_path = "else/base"
+
+    other_job = OtherJob()
+
+    job_operations._resolve_arm_id_or_upload_dependencies(other_job)  # type: ignore[arg-type]
+
+    assert set(called["entries"]) == {1, 2}
+    assert called["base_path"] == "else/base"
+
+
+def test_resolve_arm_id_or_upload_dependencies_else_branch_without_inputs_swallows_attribute_error(monkeypatch):
+    job_operations = _create_job_operations_for_compute_tests()
+
+    called = {"called": False}
+
+    def fake_resolve_arm_id_or_azureml_id(job, resolver):  # type: ignore[unused-argument]
+        return job
+
+    def fake_resolve_job_inputs(entries, base_path):  # pylint: disable=unused-argument
+        called["called"] = True
+
+    monkeypatch.setattr(job_operations, "_resolve_arm_id_or_azureml_id", fake_resolve_arm_id_or_azureml_id)
+    monkeypatch.setattr(job_operations, "_resolve_job_inputs", fake_resolve_job_inputs)
+
+    class OtherJobNoInputs:
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            self._base_path = "no/inputs"
+
+    other_job = OtherJobNoInputs()
+
+    job_operations._resolve_arm_id_or_upload_dependencies(other_job)  # type: ignore[arg-type]
+
+    assert called["called"] is False
+
+
+class SimpleJobOperations(JobOperations):
+    def __init__(self):  # type: ignore[no-untyped-def]
+        # Bypass parent initialization for isolated unit tests
+        pass
+
+
+def test_validate_non_path_aware_job_returns_empty_validation_result():
+    ops = SimpleJobOperations()
+    # Dummy job object that is not PathAwareSchemaValidatableMixin
+    job = object()
+
+    result = ops._validate(job, raise_on_failure=False)
+
+    assert isinstance(result, ValidationResult)
+    assert result.passed is True
+
+
+def test_resolve_automl_job_inputs_without_optional_validation_or_test_data():
+    ops = SimpleJobOperations()
+
+    calls = []
+
+    def fake_resolve_job_input(self, entry, base_path):  # type: ignore[no-untyped-def]
+        calls.append((entry, base_path))
+
+    ops._resolve_job_input = fake_resolve_job_input.__get__(ops, SimpleJobOperations)
+
+    class DummyAutoMLJob(AutoMLJob):
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            # Bypass parent initialization; just set the attributes used by _resolve_automl_job_inputs.
+            self._training_data = None
+            self._validation_data = None
+            self._test_data = None
+            self._base_path = "base_path"
+
+        def _to_dict(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+        @property
+        def training_data(self):  # type: ignore[no-untyped-def]
+            return self._training_data
+
+        @training_data.setter
+        def training_data(self, value):  # type: ignore[no-untyped-def]
+            self._training_data = value
+
+        @property
+        def validation_data(self):  # type: ignore[no-untyped-def]
+            return self._validation_data
+
+        @validation_data.setter
+        def validation_data(self, value):  # type: ignore[no-untyped-def]
+            self._validation_data = value
+
+        @property
+        def test_data(self):  # type: ignore[no-untyped-def]
+            return self._test_data
+
+        @test_data.setter
+        def test_data(self, value):  # type: ignore[no-untyped-def]
+            self._test_data = value
+
+    job = DummyAutoMLJob()
+    job.training_data = "train_data"
+    job.validation_data = None
+    job.test_data = None
+
+    ops._resolve_automl_job_inputs(job)
+
+    assert calls == [("train_data", "base_path")]
+
+
+def test_resolve_finetuning_job_inputs_ignores_non_vertical_jobs():
+    ops = SimpleJobOperations()
+
+    def failing_resolve_job_input(self, entry, base_path):  # type: ignore[no-untyped-def]
+        raise RuntimeError("_resolve_job_input should not be called for non-vertical finetuning job")
+
+    ops._resolve_job_input = failing_resolve_job_input.__get__(ops, SimpleJobOperations)
+
+    class DummyFineTuningJob:
+        def __init__(self) -> None:  # type: ignore[no-untyped-def]
+            self.training_data = "train_data"
+            self.validation_data = "val_data"
+            self._base_path = "base_path"
+
+    job = DummyFineTuningJob()
+
+    # Should not raise, and _resolve_job_input must not be invoked
+    ops._resolve_finetuning_job_inputs(job)  # type: ignore[arg-type]
+
+
+def test_resolve_distillation_job_inputs_only_validation_data_when_training_missing():
+    ops = SimpleJobOperations()
+
+    calls = []
+
+    def fake_resolve_job_input(self, entry, base_path):  # type: ignore[no-untyped-def]
+        calls.append((entry, base_path))
+
+    ops._resolve_job_input = fake_resolve_job_input.__get__(ops, SimpleJobOperations)
+
+    job = DistillationJob.__new__(DistillationJob)
+    job.training_data = None
+    job.validation_data = "val_data"
+    job._base_path = "base_path"
+
+    ops._resolve_distillation_job_inputs(job)
+
+    assert calls == [("val_data", "base_path")]
+
+
+def test_resolve_job_inputs_arm_id_resolves_input_paths_with_orchestrator():
+    ops = SimpleJobOperations()
+
+    class DummyOrchestrator:
+        def __init__(self):  # type: ignore[no-untyped-def]
+            self.calls = []
+
+        def resolve_azureml_id(self, path):  # type: ignore[no-untyped-def]
+            self.calls.append(path)
+            return "resolved:" + path
+
+    orchestrator = DummyOrchestrator()
+    ops._orchestrators = orchestrator  # type: ignore[attr-defined]
+
+    input_obj = Input(type=AssetTypes.URI_FILE, path="azureml:mydata@1")
+
+    class DummyJob:
+        pass
+
+    job = DummyJob()
+    job.inputs = {"input1": input_obj}
+
+    ops._resolve_job_inputs_arm_id(job)
+
+    assert orchestrator.calls == ["azureml:mydata@1"]
+    assert input_obj.path == "resolved:azureml:mydata@1"
+
+
+class DummyDatastore:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class DummyDatastoreOperations:
+    def __init__(self, default_name: str = "defaultdatastore"):
+        self._default = DummyDatastore(default_name)
+
+    def get_default(self) -> DummyDatastore:
+        return self._default
+
+
+class DummyRunsOperations:
+    def __init__(self, children):
+        self._children = children
+
+    def get_run_children(self, job_name):  # pylint: disable=unused-argument
+        return self._children
+
+
+class MinimalJobOperations(JobOperations):
+    def __init__(self, runs_operations, datastore_operations):  # type: ignore[no-untyped-def]
+        # Do not call super().__init__ to avoid real client initialization
+        self._runs_operations_override = runs_operations
+        self._datastore_operations_override = datastore_operations
+        self._dataset_dataplane_operations_override = object()
+        self._model_dataplane_operations_override = object()
+        self._requests_pipeline = None
+        # attributes used in other helpers but not in the tested methods
+        self._all_operations = type("AllOps", (), {"all_operations": {}})()
+
+    @property
+    def _runs_operations(self):  # type: ignore[override]
+        return self._runs_operations_override
+
+    @property
+    def _datastore_operations(self):  # type: ignore[override]
+        return self._datastore_operations_override
+
+    @property
+    def _dataset_dataplane_operations(self):  # type: ignore[override]
+        return self._dataset_dataplane_operations_override
+
+    @property
+    def _model_dataplane_operations(self):  # type: ignore[override]
+        return self._model_dataplane_operations_override
+
+
+def test_get_named_output_uri_iterable_no_default_in_missing(monkeypatch):
+    job_name = "job1"
+
+    def fake_get_outputs(job_name_arg, runs_ops, dataset_ops, model_ops, output_names=None):  # pylint: disable=unused-argument
+        # Return exactly the requested output so missing_outputs will be empty
+        return {"foo": "uri://foo"}
+
+    monkeypatch.setattr(
+        job_ops_module,
+        "get_job_output_uris_from_dataplane",
+        fake_get_outputs,
+    )
+
+    # datastore operations will not be used because missing_outputs is empty
+    op = MinimalJobOperations(runs_operations=None, datastore_operations=DummyDatastoreOperations())
+
+    outputs = op._get_named_output_uri(job_name, output_names=["foo"])
+
+    assert outputs == {"foo": "uri://foo"}
+    # Ensure default artifact output is not added when it's not requested and not missing
+    assert DEFAULT_ARTIFACT_STORE_OUTPUT_NAME not in outputs
+
+
+def test_get_named_output_uri_default_short_uri_on_attribute_error(monkeypatch):
+    job_name = "job2"
+
+    def fake_get_outputs(job_name_arg, runs_ops, dataset_ops, model_ops, output_names=None):  # pylint: disable=unused-argument
+        # No outputs returned from dataplane
+        return {}
+
+    monkeypatch.setattr(
+        job_ops_module,
+        "get_job_output_uris_from_dataplane",
+        fake_get_outputs,
+    )
+
+    class JobWithoutOutputs:
+        # Object without an `outputs` attribute to trigger AttributeError
+        def __init__(self, name):
+            self.name = name
+
+    op = MinimalJobOperations(runs_operations=None, datastore_operations=DummyDatastoreOperations())
+
+    def fake_get(self, name):  # pylint: disable=unused-argument
+        return JobWithoutOutputs(name)
+
+    op.get = fake_get.__get__(op, MinimalJobOperations)
+
+    outputs = op._get_named_output_uri(job_name)
+
+    expected_default_uri = SHORT_URI_FORMAT.format(
+        "workspaceartifactstore",
+        f"ExperimentRun/dcid.{job_name}/",
+    )
+    assert outputs[DEFAULT_ARTIFACT_STORE_OUTPUT_NAME] == expected_default_uri
+
+
+def test_get_named_output_uri_missing_outputs_and_batch_scoring_no_uri(monkeypatch):
+    job_name = "job3"
+
+    def fake_get_outputs(job_name_arg, runs_ops, dataset_ops, model_ops, output_names=None):  # pylint: disable=unused-argument
+        # Simulate that no outputs are returned for requested names
+        return {}
+
+    monkeypatch.setattr(
+        job_ops_module,
+        "get_job_output_uris_from_dataplane",
+        fake_get_outputs,
+    )
+
+    def fake_aml_datastore_path_exists(potential_uri, datastore_ops):  # pylint: disable=unused-argument
+        # Force path existence checks to fail so outputs remain missing
+        return False
+
+    monkeypatch.setattr(
+        job_ops_module,
+        "aml_datastore_path_exists",
+        fake_aml_datastore_path_exists,
+    )
+
+    datastore_ops = DummyDatastoreOperations(default_name="defaultstore")
+
+    child = type("Child", (), {"name": "child1"})()
+    runs_ops = DummyRunsOperations(children=[child])
+
+    op = MinimalJobOperations(runs_operations=runs_ops, datastore_operations=datastore_ops)
+
+    # Monkeypatch named output URI resolution for batch scoring to always return no URI
+    def fake_get_named_output_uri(job_name_arg, output_names=None):  # pylint: disable=unused-argument
+        return {}
+
+    op._get_named_output_uri = fake_get_named_output_uri  # type: ignore[assignment]
+
+    outputs = op._get_named_output_uri(job_name, output_names=["missing_output"])
+    assert outputs == {}
+
+    scoring_uri = op._get_batch_job_scoring_output_uri(job_name)
+    assert scoring_uri is None
+
+
+class _DummyDatastoreOperations:
+    def __init__(self, default_name: str = "workspaceartifactstore") -> None:
+        self._default = SimpleNamespace(name=default_name)
+
+    def get_default(self) -> SimpleNamespace:
+        return self._default
+
+
+def _build_job_operations() -> JobOperations:
+    job_ops = object.__new__(JobOperations)
+    job_ops._kwargs = {}
+    job_ops._runs_operations_client = SimpleNamespace(get_run_children=lambda _: [])
+    job_ops._dataset_dataplane_operations_client = SimpleNamespace()
+    job_ops._model_dataplane_operations_client = SimpleNamespace()
+    datastore_ops = _DummyDatastoreOperations()
+    job_ops._all_operations = SimpleNamespace(all_operations={AzureMLResourceType.DATASTORE: datastore_ops})
+    job_ops._datastore_operations_override = datastore_ops
+    job_ops._operation_scope = SimpleNamespace(
+        subscription_id="sub-id",
+        resource_group_name="rg-name",
+        workspace_name="workspace",
+    )
+    job_ops._operation_config = SimpleNamespace(show_progress=False)
+    job_ops._requests_pipeline = None
+    return job_ops
+
+
+def test_get_named_output_uri_prefers_job_default(monkeypatch):
+    job_ops = _build_job_operations()
+
+    def _fake_job_output_uris(job_name, runs, dataset_ops, model_ops, output_names=None):
+        return {}
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.get_job_output_uris_from_dataplane",
+        _fake_job_output_uris,
+    )
+    job = SimpleNamespace(outputs={DEFAULT_ARTIFACT_STORE_OUTPUT_NAME: SimpleNamespace(path="https://default-artifact")})
+    job_ops.get = lambda name: job
+    result = job_ops._get_named_output_uri("job-1")
+    assert result[DEFAULT_ARTIFACT_STORE_OUTPUT_NAME] == "https://default-artifact"
+
+
+def test_get_named_output_uri_falls_back_to_short_uri_for_missing_job_outputs(monkeypatch):
+    job_ops = _build_job_operations()
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.get_job_output_uris_from_dataplane",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.aml_datastore_path_exists",
+        lambda uri, datastore_ops: True,
+    )
+    job_ops.get = lambda name: SimpleNamespace()
+    job_name = "job-2"
+    result = job_ops._get_named_output_uri(
+        job_name,
+        output_names=[DEFAULT_ARTIFACT_STORE_OUTPUT_NAME, "custom_output"],
+    )
+    expected_default = SHORT_URI_FORMAT.format(
+        "workspaceartifactstore",
+        f"ExperimentRun/dcid.{job_name}/",
+    )
+    assert result[DEFAULT_ARTIFACT_STORE_OUTPUT_NAME] == expected_default
+    expected_custom = SHORT_URI_FORMAT.format(
+        "workspaceartifactstore",
+        f"azureml/{job_name}/custom_output/",
+    )
+    assert result["custom_output"] == expected_custom
+
+
+def test_get_batch_job_scoring_output_uri_returns_first_child():
+    job_ops = _build_job_operations()
+    job_ops._runs_operations_client = SimpleNamespace(
+        get_run_children=lambda name: [SimpleNamespace(name="child-1"), SimpleNamespace(name="child-2")]
+    )
+    called_children = []
+
+    def _fake_named_output_uri(self, run_name, output_names=None):
+        called_children.append(run_name)
+        if run_name == "child-1":
+            return {BATCH_JOB_CHILD_RUN_OUTPUT_NAME: "scoring-uri"}
+        return {}
+
+    job_ops._get_named_output_uri = MethodType(_fake_named_output_uri, job_ops)
+    result = job_ops._get_batch_job_scoring_output_uri("parent-job")
+    assert result == "scoring-uri"
+    assert called_children == ["child-1"]
+
+
+def _make_job_operations():
+    job_ops = object.__new__(JobOperations)
+    datastore_ops = SimpleNamespace(get_default=MagicMock(return_value=SimpleNamespace(name="workspaceartifactstore")))
+    job_ops._all_operations = SimpleNamespace(all_operations={AzureMLResourceType.DATASTORE: datastore_ops})
+    job_ops._runs_operations_client = SimpleNamespace()
+    job_ops._dataset_dataplane_operations_client = SimpleNamespace()
+    job_ops._model_dataplane_operations_client = SimpleNamespace()
+    job_ops._operation_scope = SimpleNamespace(
+        resource_group_name="rg",
+        workspace_name="ws",
+        subscription_id="sub",
+    )
+    job_ops._kwargs = {}
+    job_ops._requests_pipeline = MagicMock()
+    job_ops._orchestrators = SimpleNamespace(
+        get_asset_arm_id=MagicMock(),
+        resolve_azureml_id=MagicMock(),
+    )
+    job_ops._operation_config = SimpleNamespace(show_progress=False)
+    return job_ops
+
+
+def test_download_reuses_previous_job(monkeypatch):
+    job_ops = _make_job_operations()
+    parent_job = SimpleNamespace(
+        name="parent",
+        properties={
+            PipelineConstants.REUSED_FLAG_FIELD: PipelineConstants.REUSED_FLAG_TRUE,
+            PipelineConstants.REUSED_JOB_ID: "child",
+        },
+        status="Completed",
+        tags={},
+        outputs={},
+    )
+    child_job = SimpleNamespace(
+        name="child",
+        properties={},
+        status="Completed",
+        tags={},
+        outputs={DEFAULT_ARTIFACT_STORE_OUTPUT_NAME: SimpleNamespace(path="uri")},
+    )
+    job_ops.get = MagicMock(side_effect=[parent_job, child_job])
+    job_ops._get_named_output_uri = MagicMock(return_value={DEFAULT_ARTIFACT_STORE_OUTPUT_NAME: "uri"})
+    destinations = []
+
+    def _fake_download_artifact_from_aml_uri(*, uri, destination, datastore_operation):
+        destinations.append(destination)
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.download_artifact_from_aml_uri",
+        _fake_download_artifact_from_aml_uri,
+    )
+
+    job_ops.download("parent", download_path=Path("out"))
+    assert job_ops._get_named_output_uri.call_args_list[-1][0] == ("child", DEFAULT_ARTIFACT_STORE_OUTPUT_NAME)
+    assert destinations == [Path("out") / "artifacts"]
+
+
+def test_download_sweep_job_uses_best_child(monkeypatch):
+    job_ops = _make_job_operations()
+
+    class FakeSweepJob:
+        pass
+
+    monkeypatch.setattr("azure.ai.ml.operations._job_operations.SweepJob", FakeSweepJob)
+    best_child_run_id = "child-run"
+    parent_job = FakeSweepJob()
+    parent_job.name = "sweep-run"
+    parent_job.properties = {SWEEP_JOB_BEST_CHILD_RUN_ID_PROPERTY_NAME: best_child_run_id}
+    parent_job.status = "Completed"
+    parent_job.tags = {}
+    parent_job.outputs = {}
+    child_job = SimpleNamespace(
+        name=best_child_run_id,
+        properties={},
+        status="Completed",
+        tags={},
+        outputs={DEFAULT_ARTIFACT_STORE_OUTPUT_NAME: SimpleNamespace(path="uri")},
+    )
+    job_ops.get = MagicMock(side_effect=[parent_job, child_job])
+    job_ops._get_named_output_uri = MagicMock(return_value={DEFAULT_ARTIFACT_STORE_OUTPUT_NAME: "uri"})
+    destinations = []
+
+    def _fake_download_artifact_from_aml_uri(*, uri, destination, datastore_operation):
+        destinations.append(destination)
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.download_artifact_from_aml_uri",
+        _fake_download_artifact_from_aml_uri,
+    )
+
+    job_ops.download(parent_job.name, download_path=Path("dest"))
+    assert job_ops.get.call_args_list[1][0][0] == best_child_run_id
+    assert destinations == [Path("dest") / "artifacts", Path("dest") / "hd-artifacts"]
+
+
+def test_download_batch_job_uses_scoring_uri(monkeypatch):
+    job_ops = _make_job_operations()
+    job = SimpleNamespace(
+        name="batch",
+        properties={},
+        status="Completed",
+        tags={"azureml.batchrun": "true", "azureml.jobtype": "command"},
+        outputs={},
+    )
+    job_ops.get = MagicMock(return_value=job)
+    job_ops._get_batch_job_scoring_output_uri = MagicMock(return_value="score-blob")
+    records = []
+
+    def _fake_download_artifact_from_aml_uri(*, uri, destination, datastore_operation):
+        records.append((uri, destination))
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.download_artifact_from_aml_uri",
+        _fake_download_artifact_from_aml_uri,
+    )
+
+    job_ops.download("batch", download_path=Path("dest"))
+    assert job_ops._get_batch_job_scoring_output_uri.call_args[0] == ("batch",)
+    assert records == [("score-blob", Path("dest"))]
+
+
+def test_download_logs_when_named_output_missing(monkeypatch):
+    job_ops = _make_job_operations()
+    job = SimpleNamespace(
+        name="job",
+        properties={},
+        status="Completed",
+        tags={},
+        outputs={},
+    )
+    job_ops.get = MagicMock(return_value=job)
+    job_ops._get_named_output_uri = MagicMock(return_value={})
+    records = []
+
+    def _fake_download_artifact_from_aml_uri(*, uri, destination, datastore_operation):
+        records.append(uri)
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_operations.download_artifact_from_aml_uri",
+        _fake_download_artifact_from_aml_uri,
+    )
+
+    job_ops.download("job", download_path=Path("dest"), output_name="missing")
+    job_ops._get_named_output_uri.assert_called_with("job", "missing")
+    assert records == []

--- a/sdk/ml/azure-ai-ml/tests/test_job_ops_helper_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_job_ops_helper_gaps.py
@@ -1,0 +1,1150 @@
+import subprocess
+import io
+from io import StringIO
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+import azure.ai.ml.operations._job_ops_helper as job_ops_helper
+from azure.ai.ml._restclient.v2022_02_01_preview.models import DataType, ModelType
+from azure.ai.ml.constants._common import GitProperties
+from azure.ai.ml.constants._job.job import JobLogPattern, JobType
+from azure.ai.ml.exceptions import JobException, ErrorCategory
+from azure.ai.ml.operations._job_ops_helper import (
+    _get_last_log_primary_instance,
+    _get_sorted_filtered_logs,
+    _wait_before_polling,
+    get_git_properties,
+    get_job_output_uris_from_dataplane,
+    has_pat_token,
+    stream_logs_until_completion,
+    _incremental_print,
+)
+from azure.ai.ml.operations._run_history_constants import JobStatus, RunHistoryConstants
+
+
+def test_get_sorted_filtered_logs_common_runtime_no_fallback(monkeypatch):
+    # Ensure COMMON_RUNTIME_STREAM_LOG_PATTERN matches our test log so fallback is not triggered.
+    monkeypatch.setattr(JobLogPattern, "COMMON_RUNTIME_STREAM_LOG_PATTERN", r"^runtime_log\.txt$")
+
+    logs = ["runtime_log.txt", "other_log.txt"]
+    # processed_logs contains the matching log so the previously_printed_index should point to it.
+    processed_logs = {"runtime_log.txt": 1}
+
+    result = _get_sorted_filtered_logs(logs, job_type="command", processed_logs=processed_logs, only_streamable=True)
+
+    # Since the only matching log is already in processed_logs, the full list of filtered logs is returned
+    # starting from that log.
+    assert result == ["runtime_log.txt"]
+
+
+def test_get_sorted_filtered_logs_legacy_command_pattern(monkeypatch):
+    # Force the initial COMMON_RUNTIME_STREAM_LOG_PATTERN to match nothing so fallback is taken.
+    monkeypatch.setattr(JobLogPattern, "COMMON_RUNTIME_STREAM_LOG_PATTERN", r"^$")
+    monkeypatch.setattr(JobType, "COMMAND", ["command"])
+    monkeypatch.setattr(JobLogPattern, "COMMAND_JOB_LOG_PATTERN", r"^cmd_.*")
+
+    logs = ["cmd_log1.txt", "other_log.txt"]
+
+    result = _get_sorted_filtered_logs(logs, job_type="command", processed_logs=None, only_streamable=True)
+
+    # After falling back, only the command log should match the COMMAND_JOB_LOG_PATTERN.
+    assert result == ["cmd_log1.txt"]
+
+
+def test_get_sorted_filtered_logs_legacy_pipeline_vs_sweep_patterns(monkeypatch):
+    # Ensure no common-runtime logs so legacy patterns are used.
+    monkeypatch.setattr(JobLogPattern, "COMMON_RUNTIME_STREAM_LOG_PATTERN", r"^$")
+    monkeypatch.setattr(JobType, "COMMAND", ["command"])
+    monkeypatch.setattr(JobType, "PIPELINE", ["pipeline"])
+    monkeypatch.setattr(JobType, "SWEEP", ["sweep"])
+    monkeypatch.setattr(JobLogPattern, "PIPELINE_JOB_LOG_PATTERN", r"^pipe_.*")
+    monkeypatch.setattr(JobLogPattern, "SWEEP_JOB_LOG_PATTERN", r"^sweep_.*")
+
+    logs = ["pipe_log.txt", "sweep_log.txt", "other.txt"]
+
+    # Pipeline job_type should pick PIPELINE_JOB_LOG_PATTERN.
+    pipeline_result = _get_sorted_filtered_logs(logs, job_type="pipeline", processed_logs=None, only_streamable=True)
+    assert pipeline_result == ["pipe_log.txt"]
+
+    # Sweep job_type should pick SWEEP_JOB_LOG_PATTERN.
+    sweep_result = _get_sorted_filtered_logs(logs, job_type="sweep", processed_logs=None, only_streamable=True)
+    assert sweep_result == ["sweep_log.txt"]
+
+
+def test_get_sorted_filtered_logs_processed_logs_indexing(monkeypatch):
+    # Make all logs match the pattern so ordering and processed_logs behavior are exercised.
+    monkeypatch.setattr(JobLogPattern, "COMMON_RUNTIME_STREAM_LOG_PATTERN", r"^log_.*")
+
+    logs = ["log_a.txt", "log_b.txt", "log_c.txt"]
+    # processed_logs contains the first two logs, so the function should start from the last processed.
+    processed_logs = {"log_a.txt": 10, "log_b.txt": 20}
+
+    result = _get_sorted_filtered_logs(logs, job_type="command", processed_logs=processed_logs, only_streamable=True)
+
+    # Since log_b is the last processed one, we expect to start from it and include log_c.
+    assert result == ["log_b.txt", "log_c.txt"]
+
+
+def test_get_last_log_primary_instance_no_regex_match():
+    # Last log does not match the expected pattern, so it should be returned as-is.
+    logs = ["some_log.txt", "another.log"]
+
+    result = _get_last_log_primary_instance(logs)
+
+    assert result == "another.log"
+
+
+def test_get_last_log_primary_instance_primary_rank_found():
+    logs = [
+        "task_rank_1.txt",
+        "task_rank_0.txt",  # primary rank according to primary_ranks list
+        "task_worker_1.txt",
+    ]
+
+    result = _get_last_log_primary_instance(logs)
+
+    # The function should prefer the log with the primary rank suffix.
+    assert result == "task_rank_0.txt"
+
+
+def test_get_last_log_primary_instance_no_primary_rank_uses_first_matching_sorted():
+    logs = [
+        "alpha_rank_2.txt",
+        "alpha_rank_3.txt",
+        "alpha_rank_4.txt",
+    ]
+
+    result = _get_last_log_primary_instance(logs)
+
+    # No primary rank is present, so the first of the matching logs in sorted order is returned.
+    assert result == "alpha_rank_2.txt"
+
+
+def test_get_git_properties_not_git_repo_returns_empty_dict(monkeypatch):
+    def _raise_exception(*args, **kwargs):
+        raise Exception("not a git repo")
+
+    monkeypatch.setattr(subprocess, "check_output", _raise_exception)
+
+    monkeypatch.delenv(GitProperties.ENV_REPOSITORY_URI, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_BRANCH, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_COMMIT, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_DIRTY, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_BUILD_ID, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_BUILD_URI, raising=False)
+
+    properties = get_git_properties()
+
+    assert properties == {}
+
+
+def test_get_git_properties_git_repo_and_dirty_true(monkeypatch):
+    outputs = [
+        b"true\n",  # rev-parse --is-inside-work-tree
+        b"https://example.com/repo.git\n",  # ls-remote --get-url
+        b"main\n",  # symbolic-ref --short HEAD
+        b"abcdef123456\n",  # rev-parse HEAD
+        b" M file\n",  # status --porcelain .
+    ]
+
+    def _fake_check_output(args, stderr=None):  # pylint: disable=unused-argument
+        assert args[0] == "git"
+        return outputs.pop(0)
+
+    monkeypatch.setattr(subprocess, "check_output", _fake_check_output)
+
+    monkeypatch.delenv(GitProperties.ENV_REPOSITORY_URI, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_BRANCH, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_COMMIT, raising=False)
+    monkeypatch.delenv(GitProperties.ENV_DIRTY, raising=False)
+    monkeypatch.setenv(GitProperties.ENV_BUILD_ID, "build-123")
+    monkeypatch.setenv(GitProperties.ENV_BUILD_URI, "https://build.example.com/123")
+
+    properties = get_git_properties()
+
+    assert properties[GitProperties.PROP_MLFLOW_GIT_REPO_URL] == "https://example.com/repo.git"
+    assert properties[GitProperties.PROP_MLFLOW_GIT_BRANCH] == "main"
+    assert properties[GitProperties.PROP_MLFLOW_GIT_COMMIT] == "abcdef123456"
+    assert properties[GitProperties.PROP_DIRTY] == "True"
+    assert properties[GitProperties.PROP_BUILD_ID] == "build-123"
+    assert properties[GitProperties.PROP_BUILD_URI] == "https://build.example.com/123"
+
+
+def test_get_git_properties_keyboard_interrupt_propagates(monkeypatch):
+    def _raise_keyboard_interrupt(*args, **kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(subprocess, "check_output", _raise_keyboard_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        get_git_properties()
+
+
+def test_has_pat_token_none_returns_false():
+    assert has_pat_token(None) is False
+
+
+def test_has_pat_token_detects_token_in_both_patterns():
+    url1 = "https://dev.azure.com/mypattoken@organization/project/_git/repo"
+    url2 = "https://mypattoken@dev.azure.com/organization/project/_git/repo"
+
+    assert has_pat_token(url1) is True
+    assert has_pat_token(url2) is True
+
+
+def test_has_pat_token_without_token_returns_false():
+    url = "https://dev.azure.com/organization/project/_git/repo"
+
+    assert has_pat_token(url) is False
+
+
+class DummyService:
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+
+class DummyWarning:
+    def __init__(self, message: str):
+        self.message = message
+
+
+class DummyError:
+    def __init__(self, data):
+        self._data = data
+
+    def as_dict(self):
+        return self._data
+
+
+class DummyRunDetails:
+    def __init__(self, status, log_files=None, warnings=None, error=None):
+        self.status = status
+        self.log_files = log_files or {}
+        self.warnings = warnings
+        self.error = error
+
+
+class DummyOutputsProps:
+    def __init__(self, job_type, services, properties, outputs):
+        self.job_type = job_type
+        self.services = services
+        self.properties = properties
+        self.outputs = outputs
+
+
+class DummyPropsNoOutputs:
+    def __init__(self, job_type, services, properties):
+        self.job_type = job_type
+        self.services = services
+        self.properties = properties
+
+
+class DummyOutput:
+    def __init__(self, job_output_type, uri):
+        self.job_output_type = job_output_type
+        self.uri = uri
+
+
+class DummyJobResource:
+    def __init__(self, name, props):
+        self.name = name
+        self.properties = props
+
+
+class DummyRunOperations:
+    def __init__(self, details_sequence):
+        self._subscription_id = "sub-id"
+        self._resource_group_name = "rg-name"
+        self._details_sequence = list(details_sequence)
+
+    def get_run_details(self, name):  # pylint: disable=unused-argument
+        return self._details_sequence.pop(0)
+
+
+def _common_monkeypatch_streaming(monkeypatch, log_content="some log line"):
+    # Avoid real sleeping
+    monkeypatch.setattr(job_ops_helper.time, "sleep", lambda _: None)
+
+    # Simple stdout capture via replacing sys.stdout in the module
+    fake_stdout = io.StringIO()
+    monkeypatch.setattr(job_ops_helper, "sys", types.SimpleNamespace(stdout=fake_stdout))
+
+    # Simplify log handling
+    monkeypatch.setattr(job_ops_helper, "_get_sorted_filtered_logs", lambda logs, *_, **__: list(logs.keys()))
+
+    # Avoid real HTTP calls
+    monkeypatch.setattr(
+        job_ops_helper,
+        "create_requests_pipeline_with_retry",
+        lambda requests_pipeline: "pipeline-with-retries",
+    )
+    monkeypatch.setattr(
+        job_ops_helper,
+        "download_text_from_url",
+        lambda url, pipeline, timeout: log_content,
+    )
+
+    return fake_stdout
+
+
+def test_stream_logs_feature_store_azureml_with_outputs(monkeypatch):
+    fake_stdout = _common_monkeypatch_streaming(monkeypatch)
+
+    captured_datastore_args = {}
+
+    def fake_get_datastore_info(datastore_operations, datastore_name):  # pylint: disable=unused-argument
+        captured_datastore_args["datastore_name"] = datastore_name
+        return {"name": datastore_name}
+
+    monkeypatch.setattr(job_ops_helper, "get_datastore_info", fake_get_datastore_info)
+    monkeypatch.setattr(
+        job_ops_helper,
+        "list_logs_in_datastore",
+        lambda ds_props, prefix, legacy_log_folder_name: {"log1": "https://log-url"},
+    )
+
+    services = {"Studio": DummyService(endpoint="https://original-studio")}
+    properties = {
+        "azureml.FeatureStoreJobType": True,
+        "azureml.FeatureStoreName": "fs-name",
+        "azureml.FeatureSetName": "fset-name",
+        "azureml.FeatureSetVersion": "1",
+    }
+    outputs = {
+        "default": DummyOutput(
+            job_output_type=DataType.URI_FOLDER,
+            uri="azureml://datastores/mydatastore/paths/some/path",
+        )
+    }
+    props = DummyOutputsProps(job_type="Command", services=services, properties=properties, outputs=outputs)
+    job = DummyJobResource(name="job-123", props=props)
+
+    details_sequence = [
+        DummyRunDetails(status=JobStatus.RUNNING, log_files={"log1": "https://log-url"}, warnings=[DummyWarning("warn-msg")]),
+        DummyRunDetails(status=JobStatus.COMPLETED, log_files={"log1": "https://log-url"}, warnings=[DummyWarning("warn-msg")]),
+    ]
+    run_ops = DummyRunOperations(details_sequence)
+
+    stream_logs_until_completion(
+        run_operations=run_ops,
+        job_resource=job,
+        datastore_operations=object(),
+        raise_exception_on_failed_job=True,
+        requests_pipeline=object(),
+    )
+
+    output = fake_stdout.getvalue()
+    assert "featureStore/fs-name/featureSets/fset-name/1/matJobs/jobs/job-123" in output
+    assert "Warnings:" in output
+    assert "warn-msg" in output
+    assert captured_datastore_args["datastore_name"] == "mydatastore"
+
+
+def test_stream_logs_feature_store_plain_no_outputs(monkeypatch):
+    fake_stdout = _common_monkeypatch_streaming(monkeypatch)
+
+    services = {"Studio": DummyService(endpoint="https://original-studio")}
+    properties = {
+        "FeatureStoreJobType": True,
+        "FeatureStoreName": "plain-fs",
+        "FeatureSetName": "plain-fset",
+        "FeatureSetVersion": "2",
+    }
+    props = DummyPropsNoOutputs(job_type="command", services=services, properties=properties)
+    job = DummyJobResource(name="job-456", props=props)
+
+    details_sequence = [
+        DummyRunDetails(status=JobStatus.RUNNING, log_files={}, warnings=[]),
+        DummyRunDetails(status=JobStatus.COMPLETED, log_files={}, warnings=[]),
+    ]
+    run_ops = DummyRunOperations(details_sequence)
+
+    stream_logs_until_completion(
+        run_operations=run_ops,
+        job_resource=job,
+        datastore_operations=None,
+        raise_exception_on_failed_job=True,
+        requests_pipeline=object(),
+    )
+
+    output = fake_stdout.getvalue()
+    assert "featureStore/plain-fs/featureSets/plain-fset/2/matJobs/jobs/job-456" in output
+    # No warnings section should be printed when warnings list is empty
+    assert "Warnings:" not in output
+
+
+def test_stream_logs_non_feature_store_uses_existing_endpoint(monkeypatch):
+    fake_stdout = _common_monkeypatch_streaming(monkeypatch)
+
+    studio_url = "https://existing-studio-url"
+    services = {"Studio": DummyService(endpoint=studio_url)}
+    properties = {}
+    props = DummyOutputsProps(job_type="Pipeline", services=services, properties=properties, outputs=None)
+    job = DummyJobResource(name="job-789", props=props)
+
+    details_sequence = [
+        DummyRunDetails(status=JobStatus.RUNNING, log_files={}, warnings=None),
+        DummyRunDetails(status=JobStatus.COMPLETED, log_files={}, warnings=None),
+    ]
+    run_ops = DummyRunOperations(details_sequence)
+
+    stream_logs_until_completion(
+        run_operations=run_ops,
+        job_resource=job,
+        datastore_operations=None,
+        raise_exception_on_failed_job=True,
+        requests_pipeline=object(),
+    )
+
+    output = fake_stdout.getvalue()
+    assert f"Web View: {studio_url}" in output
+    # Ensure execution summary is printed
+    assert "Execution Summary" in output
+
+
+class DummyTypedAssetReference:
+    def __init__(self, asset_id, type_value):
+        self.asset_id = asset_id
+        self.type = type_value
+
+
+class DummyRunMetadata:
+    def __init__(self, outputs):
+        self.outputs = outputs
+
+
+class DummyRunData:
+    def __init__(self, run_metadata):
+        self.run_metadata = run_metadata
+
+
+class DummyRunOperationsData:
+    def __init__(self, run_data):
+        self._run_data = run_data
+
+    def get_run_data(self, job_name):
+        return self._run_data
+
+
+class DummyDatasetUri:
+    def __init__(self, uri):
+        self.uri = uri
+
+
+class DummyModelUri:
+    def __init__(self, path):
+        self.path = path
+
+
+class DummyDatasetUrisResponse:
+    def __init__(self, values):
+        self.values = values
+
+
+class DummyModelUrisResponse:
+    def __init__(self, values):
+        self.values = values
+
+
+class DummyDatasetDataplaneOperations:
+    def __init__(self, uri_mapping):
+        self._uri_mapping = uri_mapping
+
+    def get_batch_dataset_uris(self, asset_ids):
+        values = {asset_id: DummyDatasetUri(self._uri_mapping[asset_id]) for asset_id in asset_ids}
+        return DummyDatasetUrisResponse(values)
+
+
+class DummyModelDataplaneOperations:
+    def __init__(self, path_mapping):
+        self._path_mapping = path_mapping
+
+    def get_batch_model_uris(self, asset_ids):
+        values = {asset_id: DummyModelUri(self._path_mapping[asset_id]) for asset_id in asset_ids}
+        return DummyModelUrisResponse(values)
+
+
+def test_get_job_output_uris_all_outputs_dataset_and_model():
+    dataset_type_value = list(DataType)[0].value
+    model_type_value = list(ModelType)[0].value
+
+    outputs = {
+        "data_out": DummyTypedAssetReference("data-asset-id", dataset_type_value),
+        "model_out": DummyTypedAssetReference("model-asset-id", model_type_value),
+    }
+    run_metadata = DummyRunMetadata(outputs)
+    run_data = DummyRunData(run_metadata)
+    run_operations = DummyRunOperationsData(run_data)
+
+    dataset_uri_mapping = {"data-asset-id": "azureml://dataset/uri"}
+    model_path_mapping = {"model-asset-id": "azureml://model/path"}
+
+    dataset_dataplane_operations = DummyDatasetDataplaneOperations(dataset_uri_mapping)
+    model_dataplane_operations = DummyModelDataplaneOperations(model_path_mapping)
+
+    result = get_job_output_uris_from_dataplane(
+        job_name="job-1",
+        run_operations=run_operations,
+        dataset_dataplane_operations=dataset_dataplane_operations,
+        model_dataplane_operations=model_dataplane_operations,
+    )
+
+    assert result == {
+        "data_out": "azureml://dataset/uri",
+        "model_out": "azureml://model/path",
+    }
+
+
+def test_get_job_output_uris_filtered_dataset_only_and_no_model_op():
+    dataset_type_value = list(DataType)[0].value
+
+    outputs = {
+        "dataset1": DummyTypedAssetReference("ds-1", dataset_type_value),
+        "dataset2": DummyTypedAssetReference("ds-2", dataset_type_value),
+    }
+    run_metadata = DummyRunMetadata(outputs)
+    run_data = DummyRunData(run_metadata)
+    run_operations = DummyRunOperationsData(run_data)
+
+    dataset_uri_mapping = {
+        "ds-1": "azureml://dataset/one",
+        "ds-2": "azureml://dataset/two",
+    }
+    dataset_dataplane_operations = DummyDatasetDataplaneOperations(dataset_uri_mapping)
+
+    result = get_job_output_uris_from_dataplane(
+        job_name="job-2",
+        run_operations=run_operations,
+        dataset_dataplane_operations=dataset_dataplane_operations,
+        model_dataplane_operations=None,
+        output_names=["dataset1", "nonexistent"],
+    )
+
+    assert result == {"dataset1": "azureml://dataset/one"}
+
+
+def test_get_job_output_uris_no_outputs_returns_empty_dict():
+    outputs = {}
+    run_metadata = DummyRunMetadata(outputs)
+    run_data = DummyRunData(run_metadata)
+    run_operations = DummyRunOperationsData(run_data)
+
+    dataset_dataplane_operations = DummyDatasetDataplaneOperations({})
+
+    result = get_job_output_uris_from_dataplane(
+        job_name="job-3",
+        run_operations=run_operations,
+        dataset_dataplane_operations=dataset_dataplane_operations,
+        model_dataplane_operations=None,
+    )
+
+    assert result == {}
+
+
+class GenDummyProps:
+    def __init__(self, job_type, services=None, properties=None, outputs=None):
+        self.job_type = job_type
+        self.services = services or {}
+        self.properties = properties or {}
+        if outputs is not None:
+            self.outputs = outputs
+
+
+class GenDummyJobResource:
+    def __init__(self, name, job_type, services=None, properties_extra=None, outputs=None):
+        self.name = name
+        self.properties = GenDummyProps(job_type, services=services, properties=properties_extra, outputs=outputs)
+
+
+class GenDummyRunOperations:
+    def __init__(self, details_sequence):
+        self._details_sequence = list(details_sequence)
+        self._subscription_id = "sub-id"
+        self._resource_group_name = "rg-name"
+
+    def get_run_details(self, job_name):  # pylint: disable=unused-argument
+        if len(self._details_sequence) > 1:
+            return self._details_sequence.pop(0)
+        return self._details_sequence[0]
+
+
+def test_wait_before_polling_negative_raises_job_exception():
+    with pytest.raises(JobException) as ex:
+        _wait_before_polling(-1.0)
+    assert "current_seconds must be positive" in str(ex.value)
+    assert ex.value.error_category == ErrorCategory.USER_ERROR
+
+
+def test_wait_before_polling_positive_respects_min_and_max():
+    small = _wait_before_polling(0.0)
+    large = _wait_before_polling(1000.0)
+    min_interval = int(RunHistoryConstants._WAIT_COMPLETION_POLLING_INTERVAL_MIN)
+    max_interval = int(RunHistoryConstants._WAIT_COMPLETION_POLLING_INTERVAL_MAX)
+    assert small >= min_interval
+    assert large <= max_interval
+
+
+def test_stream_logs_pipeline_finalizing_breaks_after_success(monkeypatch):
+    services = {"Studio": type("S", (), {"endpoint": "https://studio"})()}
+    job = GenDummyJobResource("job-pipeline", "pipeline", services=services)
+
+    in_progress_status = RunHistoryConstants.IN_PROGRESS_STATUSES[0]
+    details_in_progress = DummyRunDetails(status=in_progress_status, log_files={"log1": "http://log"})
+    details_finalizing = DummyRunDetails(status=JobStatus.FINALIZING, log_files={"log1": "http://log"})
+    run_ops = GenDummyRunOperations([details_in_progress, details_finalizing])
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper.create_requests_pipeline_with_retry",
+        lambda requests_pipeline: object(),
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper._get_sorted_filtered_logs",
+        lambda logs, *_, **__: list(logs.keys()),
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper.download_text_from_url",
+        lambda url, pipeline, timeout: "The activity completed successfully. Finalizing run...",
+    )
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    stream_logs_until_completion(run_ops, job, raise_exception_on_failed_job=True, requests_pipeline=object())
+
+    output = stream.getvalue()
+    assert "Execution Summary" in output
+    assert "RunId: job-pipeline" in output
+
+
+def test_stream_logs_non_pipeline_failed_prints_error_after_loop(monkeypatch):
+    job = GenDummyJobResource("job-command", "command")
+
+    in_progress_status = RunHistoryConstants.IN_PROGRESS_STATUSES[0]
+    details_in_progress = DummyRunDetails(status=in_progress_status, log_files={})
+    error = DummyError({"code": "TestError"})
+    details_failed = DummyRunDetails(status=JobStatus.FAILED, log_files={}, error=error)
+    run_ops = GenDummyRunOperations([details_in_progress, details_failed])
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper.create_requests_pipeline_with_retry",
+        lambda requests_pipeline: object(),
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper._get_sorted_filtered_logs",
+        lambda logs, *_, **__: [],
+    )
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    stream_logs_until_completion(run_ops, job, raise_exception_on_failed_job=False, requests_pipeline=object())
+
+    output = stream.getvalue()
+    assert "Error:" in output
+    assert "TestError" in output
+
+
+def test_stream_logs_failed_raises_job_exception_when_configured(monkeypatch):
+    job = GenDummyJobResource("job-failed", "command")
+
+    error = DummyError({"code": "AnotherError"})
+    details_failed = DummyRunDetails(status=JobStatus.FAILED, log_files={}, error=error)
+    run_ops = GenDummyRunOperations([details_failed])
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper.create_requests_pipeline_with_retry",
+        lambda requests_pipeline: object(),
+    )
+
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    with pytest.raises(JobException) as ex:
+        stream_logs_until_completion(run_ops, job, raise_exception_on_failed_job=True, requests_pipeline=object())
+
+    assert ex.value.error_category == ErrorCategory.SYSTEM_ERROR
+    assert "AnotherError" in str(ex.value)
+
+
+def test_stream_logs_keyboard_interrupt_raises_wrapped_job_exception(monkeypatch):
+    job = GenDummyJobResource("job-interrupt", "command")
+
+    in_progress_status = RunHistoryConstants.IN_PROGRESS_STATUSES[0]
+    details_in_progress = DummyRunDetails(status=in_progress_status, log_files={})
+    run_ops = GenDummyRunOperations([details_in_progress])
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper.create_requests_pipeline_with_retry",
+        lambda requests_pipeline: object(),
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._job_ops_helper._get_sorted_filtered_logs",
+        lambda logs, *_, **__: [],
+    )
+
+    def _raise_keyboard_interrupt(_):  # pylint: disable=unused-argument
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("time.sleep", _raise_keyboard_interrupt)
+
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    with pytest.raises(JobException) as ex:
+        stream_logs_until_completion(run_ops, job, raise_exception_on_failed_job=True, requests_pipeline=object())
+
+    assert ex.value.error_category == ErrorCategory.USER_ERROR
+    assert "output streaming for the run interrupted" in str(ex.value)
+
+
+def test_get_sorted_filtered_logs_streaming_pattern(monkeypatch):
+    dummy_patterns = type(
+        "JobLogPattern",
+        (),
+        {
+            "COMMON_RUNTIME_STREAM_LOG_PATTERN": r"^stream/.*",
+            "COMMON_RUNTIME_ALL_USER_LOG_PATTERN": r"^stream/.*",
+            "COMMAND_JOB_LOG_PATTERN": r"^legacy_command.*",
+            "PIPELINE_JOB_LOG_PATTERN": r"^legacy_pipeline.*",
+            "SWEEP_JOB_LOG_PATTERN": r"^legacy_sweep.*",
+        },
+    )
+    dummy_types = type(
+        "JobType",
+        (),
+        {"COMMAND": ["command"], "PIPELINE": ["pipeline"], "SWEEP": ["sweep"]},
+    )
+    monkeypatch.setattr(job_ops_helper, "JobLogPattern", dummy_patterns)
+    monkeypatch.setattr(job_ops_helper, "JobType", dummy_types)
+    logs = ["stream/alpha.log", "stream/beta.log"]
+    result = job_ops_helper._get_sorted_filtered_logs(logs, "other")
+    assert result == ["stream/alpha.log", "stream/beta.log"]
+
+
+@pytest.mark.parametrize(
+    "job_type_value,fallback_attr,log_name",
+    [
+        ("COMMAND", "COMMAND_JOB_LOG_PATTERN", "legacy_command.log"),
+        ("PiPeLiNe", "PIPELINE_JOB_LOG_PATTERN", "legacy_pipeline.log"),
+        ("sWeEp", "SWEEP_JOB_LOG_PATTERN", "legacy_sweep.log"),
+    ],
+)
+
+def test_get_sorted_filtered_logs_fallback_patterns(monkeypatch, job_type_value, fallback_attr, log_name):
+    base_patterns = {
+        "COMMON_RUNTIME_STREAM_LOG_PATTERN": r"^nevermatch$",
+        "COMMON_RUNTIME_ALL_USER_LOG_PATTERN": r"^nevermatch$",
+        "COMMAND_JOB_LOG_PATTERN": r"^nevermatch$",
+        "PIPELINE_JOB_LOG_PATTERN": r"^nevermatch$",
+        "SWEEP_JOB_LOG_PATTERN": r"^nevermatch$",
+    }
+    base_patterns[fallback_attr] = rf"^{log_name}$"
+    dummy_patterns = type("JobLogPattern", (), base_patterns)
+    dummy_types = type("JobType", (), {"COMMAND": ["command"], "PIPELINE": ["pipeline"], "SWEEP": ["sweep"]})
+    monkeypatch.setattr(job_ops_helper, "JobLogPattern", dummy_patterns)
+    monkeypatch.setattr(job_ops_helper, "JobType", dummy_types)
+    result = job_ops_helper._get_sorted_filtered_logs([log_name], job_type_value)
+    assert result == [log_name]
+
+
+def test_get_sorted_filtered_logs_all_user_pattern(monkeypatch):
+    dummy_patterns = type(
+        "JobLogPattern",
+        (),
+        {
+            "COMMON_RUNTIME_STREAM_LOG_PATTERN": r"^stream-only$",
+            "COMMON_RUNTIME_ALL_USER_LOG_PATTERN": r"^user-log$",
+            "COMMAND_JOB_LOG_PATTERN": r"^nevermatch$",
+            "PIPELINE_JOB_LOG_PATTERN": r"^nevermatch$",
+            "SWEEP_JOB_LOG_PATTERN": r"^nevermatch$",
+        },
+    )
+    dummy_types = type(
+        "JobType",
+        (),
+        {"COMMAND": ["command"], "PIPELINE": ["pipeline"], "SWEEP": ["sweep"]},
+    )
+    monkeypatch.setattr(job_ops_helper, "JobLogPattern", dummy_patterns)
+    monkeypatch.setattr(job_ops_helper, "JobType", dummy_types)
+    result = job_ops_helper._get_sorted_filtered_logs(["user-log"], "other", only_streamable=False)
+    assert result == ["user-log"]
+
+
+def test_incremental_print_skips_empty_log():
+    processed_logs = {}
+    fileout = io.StringIO()
+
+    _incremental_print("", processed_logs, "log.txt", fileout)
+
+    assert fileout.getvalue() == ""
+    assert processed_logs == {}
+
+
+def test_incremental_print_writes_header_and_updates_processed():
+    processed_logs = {}
+    fileout = io.StringIO()
+    log_name = "logfile.txt"
+    header_line = "=" * (len(log_name) + 10)
+
+    _incremental_print("first line\nsecond line", processed_logs, log_name, fileout)
+
+    expected_output = (
+        "\n"
+        "Streaming logfile.txt\n"
+        f"{header_line}\n"
+        "\n"
+        "first line\n"
+        "second line\n"
+    )
+    assert fileout.getvalue() == expected_output
+    assert processed_logs["logfile.txt"] == 2
+
+
+def test_incremental_print_appends_only_unprocessed_lines():
+    processed_logs = {"logfile.txt": 1}
+    fileout = io.StringIO()
+
+    _incremental_print("line1\nline2\nline3", processed_logs, "logfile.txt", fileout)
+
+    assert fileout.getvalue() == "line2\nline3\n"
+    assert processed_logs["logfile.txt"] == 3
+
+
+def test_incremental_print_skips_empty_file():
+    processed_logs = {}
+    buffer = StringIO()
+    _incremental_print("", processed_logs, "log.txt", buffer)
+    assert buffer.getvalue() == ""
+    assert processed_logs == {}
+
+
+def test_incremental_print_writes_header_for_first_stream():
+    processed_logs = {}
+    buffer = StringIO()
+    log_content = "line1\nline2"
+    _incremental_print(log_content, processed_logs, "log.txt", buffer)
+    header = "\nStreaming log.txt\n" + "=" * (len("log.txt") + 10) + "\n\n"
+    body = "line1\nline2\n"
+    assert buffer.getvalue() == header + body
+    assert processed_logs["log.txt"] == 2
+
+
+def test_incremental_print_continues_existing_stream_without_header():
+    processed_logs = {"log.txt": 2}
+    buffer = StringIO()
+    _incremental_print("line1\nline2\nline3", processed_logs, "log.txt", buffer)
+    assert buffer.getvalue() == "line3\n"
+    assert processed_logs["log.txt"] == 3
+
+
+def test_get_last_log_primary_instance_returns_last_when_missing_pattern():
+    logs = ["alpha.txt", "beta"]
+    assert _get_last_log_primary_instance(logs) == "beta"
+
+
+def test_get_last_log_primary_instance_prefers_primary_rank():
+    logs = ["prefix_rank_2.txt", "prefix_rank_0.txt", "prefix_rank_3.txt", "prefix_worker_0.txt"]
+    assert _get_last_log_primary_instance(logs) == "prefix_rank_0.txt"
+
+
+def test_get_last_log_primary_instance_returns_highest_sorted_when_no_primary_marker():
+    logs = ["prefix_rank_2.txt", "prefix_rank_3.txt"]
+    assert _get_last_log_primary_instance(logs) == "prefix_rank_2.txt"
+
+
+def test_wait_before_polling_negative_seconds_raises_job_exception():
+    with pytest.raises(JobException) as exc_info:
+        _wait_before_polling(-1.0)
+    assert exc_info.value.message == "current_seconds must be positive"
+
+
+def test_wait_before_polling_returns_at_least_minimum_interval():
+    minimum = int(RunHistoryConstants._WAIT_COMPLETION_POLLING_INTERVAL_MIN)
+    result = _wait_before_polling(0.0)
+    assert result >= minimum
+
+
+def test_stream_logs_feature_store_with_warnings(monkeypatch):
+    job_name = 'job123'
+    run_details = SimpleNamespace(
+        status=JobStatus.COMPLETED,
+        log_files={},
+        warnings=[SimpleNamespace(message='warning text')],
+        error=None,
+    )
+    run_operations = SimpleNamespace(
+        _subscription_id='sub',
+        _resource_group_name='rg',
+        get_run_details=lambda name: run_details,
+    )
+    fs_name = 'myfs'
+    fset_name = 'myfset'
+    fset_version = 'v1'
+    job_properties = SimpleNamespace(
+        job_type='pipeline',
+        services={'Studio': SimpleNamespace(endpoint='https://studio.example')},
+        properties={
+            'azureml.FeatureStoreJobType': True,
+            'azureml.FeatureStoreName': fs_name,
+            'azureml.FeatureSetName': fset_name,
+            'azureml.FeatureSetVersion': fset_version,
+        },
+        outputs={
+            'default': SimpleNamespace(
+                job_output_type=DataType.URI_FOLDER,
+                uri='https://ml.azure.com/datastores/store/prefix',
+            )
+        },
+    )
+    job_resource = SimpleNamespace(name=job_name, properties=job_properties)
+    datastore_operations = SimpleNamespace()
+
+    datastore_called = {}
+
+    def fake_get_datastore_info(operations, name):
+        datastore_called['name'] = name
+        return SimpleNamespace(name=name)
+
+    monkeypatch.setattr(job_ops_helper, 'get_datastore_info', fake_get_datastore_info)
+    monkeypatch.setattr(
+        job_ops_helper,
+        'create_requests_pipeline_with_retry',
+        lambda requests_pipeline: requests_pipeline,
+    )
+    monkeypatch.setattr(job_ops_helper.time, 'time', lambda: 0)
+    monkeypatch.setattr(job_ops_helper.time, 'sleep', lambda _: None)
+    output = io.StringIO()
+    monkeypatch.setattr(job_ops_helper.sys, 'stdout', output)
+
+    job_ops_helper.stream_logs_until_completion(
+        run_operations=run_operations,
+        job_resource=job_resource,
+        datastore_operations=datastore_operations,
+        raise_exception_on_failed_job=True,
+        requests_pipeline='pipeline',
+    )
+
+    value = output.getvalue()
+    expected_endpoint = (
+        'https://ml.azure.com/featureStore/myfs/featureSets/myfset/v1/matJobs/'
+        'jobs/job123?wsid=/subscriptions/sub/resourceGroups/rg/providers/'
+        'Microsoft.MachineLearningServices/workspaces/myfs'
+    )
+    assert expected_endpoint in value
+    assert 'Warnings:' in value
+    assert 'warning text' in value
+    assert datastore_called['name'] == 'store'
+
+
+def test_stream_logs_failed_job_logs_error_when_not_raising(monkeypatch):
+    run_details = SimpleNamespace(
+        status=JobStatus.FAILED,
+        log_files={},
+        warnings=[],
+        error=SimpleNamespace(as_dict=lambda: {'code': 'error', 'message': 'details'}),
+    )
+    run_operations = SimpleNamespace(
+        _subscription_id='sub',
+        _resource_group_name='rg',
+        get_run_details=lambda name: run_details,
+    )
+    job_properties = SimpleNamespace(
+        job_type='command',
+        services={'Studio': SimpleNamespace(endpoint='https://studio')},
+        properties={},
+    )
+    job_resource = SimpleNamespace(name='job123', properties=job_properties)
+
+    monkeypatch.setattr(
+        job_ops_helper,
+        'create_requests_pipeline_with_retry',
+        lambda requests_pipeline: requests_pipeline,
+    )
+    monkeypatch.setattr(job_ops_helper.time, 'time', lambda: 0)
+    monkeypatch.setattr(job_ops_helper.time, 'sleep', lambda _: None)
+    output = io.StringIO()
+    monkeypatch.setattr(job_ops_helper.sys, 'stdout', output)
+
+    job_ops_helper.stream_logs_until_completion(
+        run_operations=run_operations,
+        job_resource=job_resource,
+        datastore_operations=None,
+        raise_exception_on_failed_job=False,
+        requests_pipeline='pipeline',
+    )
+
+    value = output.getvalue()
+    assert 'Error:' in value
+    assert 'code' in value
+    assert 'error' in value
+
+
+def test_stream_logs_failed_job_raises_exception_when_requested(monkeypatch):
+    run_details = SimpleNamespace(
+        status=JobStatus.FAILED,
+        log_files={},
+        warnings=[],
+        error=SimpleNamespace(as_dict=lambda: {'code': 'error', 'message': 'details'}),
+    )
+    run_operations = SimpleNamespace(
+        _subscription_id='sub',
+        _resource_group_name='rg',
+        get_run_details=lambda name: run_details,
+    )
+    job_properties = SimpleNamespace(
+        job_type='command',
+        services={'Studio': SimpleNamespace(endpoint='https://studio')},
+        properties={},
+    )
+    job_resource = SimpleNamespace(name='job123', properties=job_properties)
+
+    monkeypatch.setattr(
+        job_ops_helper,
+        'create_requests_pipeline_with_retry',
+        lambda requests_pipeline: requests_pipeline,
+    )
+    monkeypatch.setattr(job_ops_helper.time, 'time', lambda: 0)
+    monkeypatch.setattr(job_ops_helper.time, 'sleep', lambda _: None)
+    output = io.StringIO()
+    monkeypatch.setattr(job_ops_helper.sys, 'stdout', output)
+
+    with pytest.raises(JobException) as excinfo:
+        job_ops_helper.stream_logs_until_completion(
+            run_operations=run_operations,
+            job_resource=job_resource,
+            datastore_operations=None,
+            requests_pipeline='pipeline',
+        )
+
+    assert 'Exception' in str(excinfo.value)
+
+
+class _FakeWarning:
+    def __init__(self, message):
+        self.message = message
+
+
+class _FakeError:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def as_dict(self):
+        return self._payload
+
+
+class _FakeRunDetails:
+    def __init__(self, status, warnings=None, error=None, log_files=None):
+        self.status = status
+        self.warnings = warnings or []
+        self.error = error
+        self.log_files = log_files or {}
+
+
+class _RunOperationsStub:
+    def __init__(self, details):
+        self._details = details
+        self._subscription_id = "sub"
+        self._resource_group_name = "rg"
+
+    def get_run_details(self, name):
+        return self._details
+
+
+class _KeyboardInterruptRunOperations:
+    def __init__(self):
+        self._subscription_id = "sub"
+        self._resource_group_name = "rg"
+
+    def get_run_details(self, name):
+        raise KeyboardInterrupt()
+
+
+class _FakeJobProperties:
+    def __init__(self, job_type, services=None, properties=None, outputs=None):
+        self.job_type = job_type
+        self.services = services or {}
+        self.properties = properties or {}
+        self.outputs = outputs
+
+
+class _FakeJobResource:
+    def __init__(self, name, properties):
+        self.name = name
+        self.properties = properties
+
+
+def _make_job_resource(job_type):
+    return _FakeJobResource(
+        name="test-job",
+        properties=_FakeJobProperties(job_type=job_type, services={}, properties={}, outputs=None),
+    )
+
+
+def test_stream_logs_until_completion_prints_warnings(monkeypatch, capsys):
+    run_details = _FakeRunDetails(
+        status=job_ops_helper.JobStatus.COMPLETED,
+        warnings=[_FakeWarning("warning line")],
+    )
+    run_operations = _RunOperationsStub(run_details)
+    job_resource = _make_job_resource("command")
+    def _fake_create_requests_pipeline_with_retry(requests_pipeline=None, **kwargs):
+        return requests_pipeline
+    monkeypatch.setattr(job_ops_helper, "create_requests_pipeline_with_retry", _fake_create_requests_pipeline_with_retry)
+    job_ops_helper.stream_logs_until_completion(
+        run_operations, job_resource, requests_pipeline=object()
+    )
+    captured = capsys.readouterr()
+    assert "Execution Summary" in captured.out
+    assert "Warnings:" in captured.out
+    assert "warning line" in captured.out
+    assert "RunId: test-job" in captured.out
+
+
+def test_stream_logs_until_completion_prints_error_without_exception(monkeypatch, capsys):
+    run_details = _FakeRunDetails(status=job_ops_helper.JobStatus.FAILED)
+    run_operations = _RunOperationsStub(run_details)
+    job_resource = _make_job_resource("command")
+    def _fake_create_requests_pipeline_with_retry(requests_pipeline=None, **kwargs):
+        return requests_pipeline
+    monkeypatch.setattr(job_ops_helper, "create_requests_pipeline_with_retry", _fake_create_requests_pipeline_with_retry)
+    job_ops_helper.stream_logs_until_completion(
+        run_operations,
+        job_resource,
+        raise_exception_on_failed_job=False,
+        requests_pipeline=object(),
+    )
+    captured = capsys.readouterr()
+    assert "Error:" in captured.out
+    assert "Detailed error not set on the Run. Please check the logs for details." in captured.out
+
+
+def test_stream_logs_until_completion_raises_when_job_fails(monkeypatch):
+    error_payload = {"code": "bad"}
+    run_details = _FakeRunDetails(status=job_ops_helper.JobStatus.FAILED, error=_FakeError(error_payload))
+    run_operations = _RunOperationsStub(run_details)
+    job_resource = _make_job_resource("command")
+    def _fake_create_requests_pipeline_with_retry(requests_pipeline=None, **kwargs):
+        return requests_pipeline
+    monkeypatch.setattr(job_ops_helper, "create_requests_pipeline_with_retry", _fake_create_requests_pipeline_with_retry)
+    with pytest.raises(job_ops_helper.JobException) as excinfo:
+        job_ops_helper.stream_logs_until_completion(run_operations, job_resource, requests_pipeline=object())
+    message = str(excinfo.value)
+    assert "Exception :" in message
+    assert '"code": "bad"' in message
+
+
+def test_stream_logs_until_completion_keyboard_interrupt(monkeypatch):
+    run_operations = _KeyboardInterruptRunOperations()
+    job_resource = _make_job_resource("command")
+    def _fake_create_requests_pipeline_with_retry(requests_pipeline=None, **kwargs):
+        return requests_pipeline
+    monkeypatch.setattr(job_ops_helper, "create_requests_pipeline_with_retry", _fake_create_requests_pipeline_with_retry)
+    with pytest.raises(job_ops_helper.JobException) as excinfo:
+        job_ops_helper.stream_logs_until_completion(run_operations, job_resource, requests_pipeline=object())
+    message = str(excinfo.value).lower()
+    assert "output streaming for the run interrupted" in message

--- a/sdk/ml/azure-ai-ml/tests/test_local_job_invoker_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_local_job_invoker_gaps.py
@@ -1,0 +1,1080 @@
+import os
+import subprocess
+from pathlib import Path
+import json
+import builtins
+import io
+import base64
+import zipfile
+
+import pytest
+from azure.core.exceptions import AzureError
+
+from azure.ai.ml.exceptions import JobException, MlException
+
+import azure.ai.ml.operations._local_job_invoker as local_job_invoker
+from azure.ai.ml.operations._local_job_invoker import _get_creationflags_and_startupinfo_for_background_process, _log_subprocess, patch_invocation_script_serialization, LOCAL_JOB_FAILURE_MSG, start_run_if_local, AZUREML_RUN_SETUP_DIR, CommonRuntimeHelper
+
+
+def test_get_creationflags_and_startupinfo_for_background_process_windows(monkeypatch):
+    # On non-Windows platforms, subprocess may not expose Windows-specific attributes.
+    # Patch them in so that the Windows-specific code path can be exercised.
+    if not hasattr(local_job_invoker.subprocess, "STARTUPINFO"):
+        class DummyStartupInfo:
+            def __init__(self):
+                self.dwFlags = 0
+                self.wShowWindow = 0
+
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTUPINFO", DummyStartupInfo, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW", 1, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "SW_HIDE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "SW_HIDE", 0, raising=False)
+
+    result = _get_creationflags_and_startupinfo_for_background_process(os_override="nt")
+
+    assert "creationflags" in result
+    assert "startupinfo" in result
+    assert "stdin" not in result
+    assert "stdout" not in result
+    assert "stderr" not in result
+
+
+def test_get_creationflags_and_startupinfo_for_background_process_non_windows():
+    result = _get_creationflags_and_startupinfo_for_background_process(os_override="posix")
+
+    assert result["stdin"] is subprocess.DEVNULL
+    assert result["stdout"] is subprocess.DEVNULL
+    assert result["stderr"] is subprocess.STDOUT
+    # ensure that keys with None values are filtered out
+    assert "creationflags" not in result
+    assert "startupinfo" not in result
+
+
+def test_invoke_command_windows_uses_cmd_and_patches_invocation_script(monkeypatch, tmp_path):
+    # On non-Windows platforms, subprocess may not expose Windows-specific attributes.
+    # Patch them in so that the Windows-specific code path can be exercised when invoke_command
+    # calls _get_creationflags_and_startupinfo_for_background_process without an os_override.
+    if not hasattr(local_job_invoker.subprocess, "STARTUPINFO"):
+        class DummyStartupInfo:
+            def __init__(self):
+                self.dwFlags = 0
+                self.wShowWindow = 0
+
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTUPINFO", DummyStartupInfo, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW", 1, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "SW_HIDE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "SW_HIDE", 0, raising=False)
+
+    original_os_name = local_job_invoker.os.name
+    monkeypatch.setattr(local_job_invoker.os, "name", "nt", raising=False)
+
+    patched_paths = []
+
+    def fake_patch_invocation_script_serialization(invocation_path):
+        patched_paths.append(invocation_path)
+
+    monkeypatch.setattr(
+        local_job_invoker,
+        "patch_invocation_script_serialization",
+        fake_patch_invocation_script_serialization,
+    )
+
+    popen_calls = []
+
+    class DummyPopen:
+        def __init__(self, *args, **kwargs):
+            popen_calls.append((args, kwargs))
+
+    monkeypatch.setattr(local_job_invoker.subprocess, "Popen", DummyPopen)
+
+    invocation_dir = tmp_path / local_job_invoker.AZUREML_RUN_SETUP_DIR
+    invocation_dir.mkdir(parents=True, exist_ok=True)
+
+    invocation_script_path = invocation_dir / local_job_invoker.INVOCATION_BAT_FILE
+    invocation_script_path.write_text("echo test")
+
+    try:
+        local_job_invoker.invoke_command(tmp_path)
+    finally:
+        monkeypatch.setattr(local_job_invoker.os, "name", original_os_name, raising=False)
+
+    assert patched_paths[0] == invocation_script_path
+    assert len(popen_calls) == 1
+    args, kwargs = popen_calls[0]
+    invoked_command = args[0]
+    assert invoked_command[0] == "cmd.exe"
+    assert invoked_command[1] == "/c"
+    assert str(invocation_script_path) in invoked_command[2]
+    assert kwargs["cwd"] == tmp_path
+    assert "env" in kwargs
+
+
+def test_get_creationflags_and_startupinfo_for_background_process_windows_extra(monkeypatch):
+    # Ensure Windows-specific flags and startupinfo structure are set correctly.
+    if not hasattr(local_job_invoker.subprocess, "STARTUPINFO"):
+        class DummyStartupInfo:
+            def __init__(self):
+                self.dwFlags = 0
+                self.wShowWindow = 0
+
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTUPINFO", DummyStartupInfo, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW", 1, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "SW_HIDE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "SW_HIDE", 0, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "CREATE_NEW_CONSOLE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "CREATE_NEW_CONSOLE", 0x00000010, raising=False)
+
+    result = local_job_invoker._get_creationflags_and_startupinfo_for_background_process(os_override="nt")
+
+    assert "creationflags" in result
+    assert isinstance(result["creationflags"], int)
+    assert result["creationflags"] == 0x00000010
+    assert "startupinfo" in result
+    assert hasattr(result["startupinfo"], "dwFlags")
+    assert hasattr(result["startupinfo"], "wShowWindow")
+    assert "stdin" not in result
+    assert "stdout" not in result
+    assert "stderr" not in result
+    assert "shell" not in result
+
+
+def test_get_creationflags_and_startupinfo_for_background_process_non_windows_extra():
+    result = local_job_invoker._get_creationflags_and_startupinfo_for_background_process(os_override="posix")
+
+    assert "stdin" in result
+    assert "stdout" in result
+    assert "stderr" in result
+    assert result["stdin"] is subprocess.DEVNULL
+    assert result["stdout"] is subprocess.DEVNULL
+    assert result["stderr"] is subprocess.STDOUT
+    assert "startupinfo" not in result
+    assert "creationflags" not in result
+    assert "shell" not in result
+
+
+def test_invoke_command_windows_uses_cmd_and_patches_invocation_script_extra(tmp_path, monkeypatch):
+    # Ensure invoke_command uses cmd.exe and patches the invocation script on Windows.
+    if not hasattr(local_job_invoker.subprocess, "STARTUPINFO"):
+        class DummyStartupInfo:
+            def __init__(self):
+                self.dwFlags = 0
+                self.wShowWindow = 0
+
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTUPINFO", DummyStartupInfo, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW", 1, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "SW_HIDE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "SW_HIDE", 0, raising=False)
+
+    original_os_name = local_job_invoker.os.name
+    monkeypatch.setattr(local_job_invoker.os, "name", "nt", raising=False)
+
+    run_setup_dir = tmp_path / local_job_invoker.AZUREML_RUN_SETUP_DIR
+    run_setup_dir.mkdir(parents=True)
+    invocation_script = run_setup_dir / local_job_invoker.INVOCATION_BAT_FILE
+    invocation_script.write_text("echo test")
+
+    patched_paths = []
+
+    def fake_patch_invocation_script_serialization(path: Path) -> None:
+        patched_paths.append(path)
+
+    monkeypatch.setattr(
+        local_job_invoker,
+        "patch_invocation_script_serialization",
+        fake_patch_invocation_script_serialization,
+    )
+
+    popen_args = {}
+
+    class FakePopen:
+        def __init__(self, cmd, cwd=None, env=None, **kwargs):  # pylint: disable=unused-argument
+            popen_args["cmd"] = cmd
+            popen_args["cwd"] = cwd
+            popen_args["env"] = env
+
+    monkeypatch.setattr(local_job_invoker.subprocess, "Popen", FakePopen)
+
+    try:
+        local_job_invoker.invoke_command(tmp_path)
+    finally:
+        monkeypatch.setattr(local_job_invoker.os, "name", original_os_name, raising=False)
+
+    assert patched_paths[0] == invocation_script
+    assert popen_args["cmd"][0] == "cmd.exe"
+    assert popen_args["cmd"][1] == "/c"
+    assert str(invocation_script) in popen_args["cmd"][2]
+    assert popen_args["cwd"] == tmp_path
+    assert "AZUREML_TARGET_TYPE" not in popen_args["env"]
+
+
+def test_invoke_command_non_windows_uses_bash_and_chmod(tmp_path, monkeypatch):
+    original_os_name = local_job_invoker.os.name
+    monkeypatch.setattr(local_job_invoker.os, "name", "posix", raising=False)
+
+    run_setup_dir = tmp_path / local_job_invoker.AZUREML_RUN_SETUP_DIR
+    run_setup_dir.mkdir(parents=True)
+    invocation_script = run_setup_dir / local_job_invoker.INVOCATION_BASH_FILE
+    invocation_script.write_text("echo test")
+
+    chmod_calls = []
+
+    def fake_check_output(cmd, **kwargs):  # pylint: disable=unused-argument
+        chmod_calls.append(cmd)
+
+    monkeypatch.setattr(local_job_invoker.subprocess, "check_output", fake_check_output)
+
+    popen_args = {}
+
+    class FakePopen:
+        def __init__(self, cmd, cwd=None, env=None, **kwargs):  # pylint: disable=unused-argument
+            popen_args["cmd"] = cmd
+            popen_args["cwd"] = cwd
+            popen_args["env"] = env
+
+    monkeypatch.setattr(local_job_invoker.subprocess, "Popen", FakePopen)
+
+    env_backup = os.environ.get("AZUREML_TARGET_TYPE")
+    os.environ["AZUREML_TARGET_TYPE"] = "some_value"
+
+    try:
+        local_job_invoker.invoke_command(tmp_path)
+    finally:
+        if env_backup is None:
+            os.environ.pop("AZUREML_TARGET_TYPE", None)
+        else:
+            os.environ["AZUREML_TARGET_TYPE"] = env_backup
+        monkeypatch.setattr(local_job_invoker.os, "name", original_os_name, raising=False)
+
+    assert chmod_calls[0][0] == "chmod"
+    assert chmod_calls[0][1] == "+x"
+    assert chmod_calls[0][2] == invocation_script
+    assert popen_args["cmd"][0] == "/bin/bash"
+    assert popen_args["cmd"][1] == "-c"
+    assert str(invocation_script) in popen_args["cmd"][2]
+    assert popen_args["cwd"] == tmp_path
+    assert "AZUREML_TARGET_TYPE" not in popen_args["env"]
+
+
+class _FakeLocalService:
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+
+class _FakeProperties:
+    def __init__(self, services):
+        self.services = services
+
+
+class _FakeJobDefinition:
+    def __init__(self, endpoint: str = ""):
+        services = {"Local": _FakeLocalService(endpoint)} if endpoint is not None else None
+        self.properties = _FakeProperties(services)
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes, raise_exc: Exception | None = None):
+        self.content = content
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+
+class _FakePipeline:
+    def __init__(self, response: _FakeResponse | None = None, error: Exception | None = None):
+        self._response = response
+        self._error = error
+
+    def post(self, url, json=None, headers=None):  # pylint: disable=unused-argument
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+def _build_endpoint_with_snapshot(snapshot_id: str) -> str:
+    body = json.dumps({"SnapshotId": snapshot_id})
+    encoded = local_job_invoker.urllib.parse.quote_plus(body)
+    return "https://example.com/path?param=value" + local_job_invoker.EXECUTION_SERVICE_URL_KEY + encoded
+
+
+def test_get_execution_service_response_azure_error_raises_system_exit():
+    endpoint = _build_endpoint_with_snapshot("snap-1")
+    job_def = _FakeJobDefinition(endpoint=endpoint)
+
+    pipeline = _FakePipeline(error=AzureError("network failure"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        local_job_invoker.get_execution_service_response(job_def, "token", pipeline)  # type: ignore[arg-type]
+
+    assert isinstance(exc_info.value, SystemExit)
+
+
+def test_get_execution_service_response_other_error_raises_jobexception():
+    endpoint = _build_endpoint_with_snapshot("snap-2")
+    job_def = _FakeJobDefinition(endpoint=endpoint)
+
+    response = _FakeResponse(b"content", raise_exc=Exception("bad status"))
+    pipeline = _FakePipeline(response=response)
+
+    with pytest.raises(JobException) as exc_info:
+        local_job_invoker.get_execution_service_response(job_def, "token", pipeline)  # type: ignore[arg-type]
+
+    assert "Failed to read in local executable job" in str(exc_info.value)
+
+
+def test_is_local_run_with_no_services_returns_false():
+    job_def = _FakeJobDefinition(endpoint="")
+    job_def.properties.services = None
+
+    assert local_job_invoker.is_local_run(job_def) is False  # type: ignore[arg-type]
+
+
+def test_is_local_run_with_local_endpoint_without_key_returns_false():
+    endpoint = "https://example.com/path"
+    job_def = _FakeJobDefinition(endpoint=endpoint)
+
+    assert local_job_invoker.is_local_run(job_def) is False  # type: ignore[arg-type]
+
+
+def test_is_local_run_with_local_endpoint_with_key_returns_true():
+    endpoint = _build_endpoint_with_snapshot("snap-3")
+    job_def = _FakeJobDefinition(endpoint=endpoint)
+
+    assert local_job_invoker.is_local_run(job_def) is True  # type: ignore[arg-type]
+
+
+class _FakeToken:
+    def __init__(self, token: str):
+        self.token = token
+
+
+class _FakeCredential:
+    def __init__(self, token: str = "test-token"):
+        self._token = token
+
+    def get_token(self, scope: str):  # pylint: disable=unused-argument
+        return _FakeToken(self._token)
+
+
+def test_start_run_if_local_success_returns_snapshot_id(monkeypatch, tmp_path):
+    job_def = _FakeJobDefinition(endpoint=_build_endpoint_with_snapshot("snap-success"))
+    credential = _FakeCredential()
+
+    def fake_get_execution_service_response(job_definition, token, requests_pipeline):  # pylint: disable=unused-argument
+        return b"zip-content", "snapshot-123"
+
+    def fake_unzip_to_temporary_file(job_definition, zip_content):  # pylint: disable=unused-argument
+        return tmp_path
+
+    invoked = {"called": False}
+
+    def fake_invoke_command(project_temp_dir):  # pylint: disable=unused-argument
+        invoked["called"] = True
+
+    monkeypatch.setattr(local_job_invoker, "get_execution_service_response", fake_get_execution_service_response)
+    monkeypatch.setattr(local_job_invoker, "unzip_to_temporary_file", fake_unzip_to_temporary_file)
+    monkeypatch.setattr(local_job_invoker, "invoke_command", fake_invoke_command)
+
+    snapshot_id = local_job_invoker.start_run_if_local(job_def, credential, "https://base", None)  # type: ignore[arg-type]
+
+    assert snapshot_id == "snapshot-123"
+    assert invoked["called"] is True
+
+
+def test_start_run_if_local_failure_wraps_exception_in_mlexception(monkeypatch, tmp_path):
+    job_def = _FakeJobDefinition(endpoint=_build_endpoint_with_snapshot("snap-fail"))
+    credential = _FakeCredential()
+
+    def fake_get_execution_service_response(job_definition, token, requests_pipeline):  # pylint: disable=unused-argument
+        return b"zip-content", "snapshot-err"
+
+    def fake_unzip_to_temporary_file(job_definition, zip_content):  # pylint: disable=unused-argument
+        raise RuntimeError("unzip failed")
+
+    monkeypatch.setattr(local_job_invoker, "get_execution_service_response", fake_get_execution_service_response)
+    monkeypatch.setattr(local_job_invoker, "unzip_to_temporary_file", fake_unzip_to_temporary_file)
+
+    with pytest.raises(MlException) as exc_info:
+        local_job_invoker.start_run_if_local(job_def, credential, "https://base", None)  # type: ignore[arg-type]
+
+    assert "unzip failed" in str(exc_info.value)
+
+
+class _FakeOutput:
+    def __init__(self, lines):
+        self._lines = list(lines)
+        self._index = 0
+
+    def readline(self):
+        if self._index < len(self._lines):
+            line = self._lines[self._index]
+            self._index += 1
+            return line
+        return ""
+
+
+class _FakeFile:
+    def __init__(self):
+        self.written = []
+
+    def write(self, data):
+        self.written.append(data)
+
+
+def test_log_subprocess_writes_to_file_without_console(monkeypatch):
+    created_threads = []
+
+    class _FakeThread:
+        def __init__(self, target):
+            self._target = target
+            self.daemon = False
+            self.started = False
+            created_threads.append(self)
+
+        def start(self):
+            self.started = True
+            self._target()
+
+    monkeypatch.setattr(local_job_invoker, "Thread", _FakeThread)
+
+    output = _FakeOutput(["line1\n", "line2\n"])
+    file_obj = _FakeFile()
+
+    _log_subprocess(output, file_obj, show_in_console=False)
+
+    assert file_obj.written == ["line1\n", "line2\n"]
+    assert len(created_threads) == 1
+    assert created_threads[0].daemon is True
+    assert created_threads[0].started is True
+
+
+def test_log_subprocess_writes_to_file_and_console(monkeypatch):
+    created_threads = []
+
+    class _FakeThread:
+        def __init__(self, target):
+            self._target = target
+            self.daemon = False
+            self.started = False
+            created_threads.append(self)
+
+        def start(self):
+            self.started = True
+            self._target()
+
+    monkeypatch.setattr(local_job_invoker, "Thread", _FakeThread)
+
+    printed = []
+
+    def _fake_print(*args, **kwargs):  # type: ignore[no-untyped-def]
+        printed.append((args, kwargs))
+
+    monkeypatch.setattr(builtins, "print", _fake_print)
+
+    output = _FakeOutput(["lineA\n", "lineB\n"])
+    file_obj = _FakeFile()
+
+    _log_subprocess(output, file_obj, show_in_console=True)
+
+    assert file_obj.written == ["lineA\n", "lineB\n"]
+    assert len(printed) == 2
+    assert printed[0][0][0] == "lineA\n"
+    assert printed[1][0][0] == "lineB\n"
+    assert len(created_threads) == 1
+    assert created_threads[0].daemon is True
+    assert created_threads[0].started is True
+
+
+class TestCopyBootstrapperFromContainer:
+    def test_copy_bootstrapper_from_container_success(self, tmp_path, monkeypatch):
+        original_home = Path.home
+
+        def fake_home():
+            return tmp_path
+
+        monkeypatch.setattr(local_job_invoker.Path, "home", staticmethod(fake_home))
+
+        helper = local_job_invoker.CommonRuntimeHelper("test_job")
+
+        written_chunks = []
+
+        class FakeContainer:
+            def get_archive(self, path):
+                return [b"chunk1", b"chunk2"], None
+
+        class FakeTar:
+            def __init__(self, *args, **kwargs):
+                self._names = [local_job_invoker.CommonRuntimeHelper.VM_BOOTSTRAPPER_FILE_NAME]
+                self.extracted = []
+
+            def getnames(self):
+                return self._names
+
+            def extract(self, name, path):
+                self.extracted.append((name, path))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        def fake_open_tar(path, mode="r"):
+            assert mode == "r"
+            return FakeTar()
+
+        def fake_remove(path):
+            written_chunks.append(path)
+
+        monkeypatch.setattr(local_job_invoker.tarfile, "open", fake_open_tar)
+        monkeypatch.setattr(local_job_invoker.os, "remove", fake_remove)
+
+        container = FakeContainer()
+
+        helper.copy_bootstrapper_from_container(container)
+
+        tar_file_path = helper.vm_bootstrapper_full_path + ".tar"
+        assert tar_file_path in written_chunks
+        assert os.path.dirname(helper.vm_bootstrapper_full_path) == os.path.dirname(tar_file_path)
+
+        Path.home = original_home
+
+    def test_copy_bootstrapper_from_container_docker_api_error(self, tmp_path, monkeypatch):
+        original_home = Path.home
+
+        def fake_home():
+            return tmp_path
+
+        monkeypatch.setattr(local_job_invoker.Path, "home", staticmethod(fake_home))
+
+        helper = local_job_invoker.CommonRuntimeHelper("test_job_error")
+
+        class ErrorContainer:
+            def get_archive(self, path):
+                raise local_job_invoker.docker.errors.APIError("api error", None, "explanation")
+
+        container = ErrorContainer()
+
+        with pytest.raises(MlException) as exc_info:
+            helper.copy_bootstrapper_from_container(container)
+
+        assert "Copying vm-bootstrapper from container has failed." in str(exc_info.value)
+
+        Path.home = original_home
+
+
+class TestCheckBootstrapperProcessStatus:
+    def test_check_bootstrapper_process_status_success_returns_code(self, tmp_path, monkeypatch):
+        def fake_home():
+            return tmp_path
+
+        monkeypatch.setattr(local_job_invoker.Path, "home", staticmethod(fake_home))
+
+        helper = local_job_invoker.CommonRuntimeHelper("job_success")
+
+        class FakeProcess:
+            def poll(self):
+                return 0
+
+        process = FakeProcess()
+        return_code = helper.check_bootstrapper_process_status(process)
+        assert return_code == 0
+
+    def test_check_bootstrapper_process_status_failure_raises_runtime_error(self, tmp_path, monkeypatch):
+        def fake_home():
+            return tmp_path
+
+        monkeypatch.setattr(local_job_invoker.Path, "home", staticmethod(fake_home))
+
+        helper = local_job_invoker.CommonRuntimeHelper("job_failure")
+        helper.stderr = io.StringIO("bootstrapper stderr content")
+
+        class FakeProcess:
+            def poll(self):
+                return 1
+
+        process = FakeProcess()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            helper.check_bootstrapper_process_status(process)
+
+        message = str(exc_info.value)
+        assert "bootstrapper stderr content" in message
+        assert local_job_invoker.CommonRuntimeHelper.BOOTSTRAP_BINARY_FAILURE_MSG.split("{")[0] in message
+
+
+class TestStartRunIfLocal:
+    class _FakeToken:
+        def __init__(self, token):
+            self.token = token
+
+    class _FakeCredential:
+        def get_token(self, scope):
+            return TestStartRunIfLocal._FakeToken("fake_token")
+
+    class _FakePipeline:
+        def __init__(self):
+            self.calls = []
+
+    def test_start_run_if_local_success(self, monkeypatch):
+        fake_credential = TestStartRunIfLocal._FakeCredential()
+        fake_pipeline = TestStartRunIfLocal._FakePipeline()
+
+        def fake_get_execution_service_response(job_definition, token, requests_pipeline):
+            fake_pipeline.calls.append((job_definition, token, requests_pipeline))
+            return b"zipcontent", "snapshot-123"
+
+        captured_args = {}
+
+        def fake_unzip_to_temporary_file(job_definition, zip_content):
+            captured_args["job_definition"] = job_definition
+            captured_args["zip_content"] = zip_content
+            return Path("/tmp/fake_dir")
+
+        invoked = {}
+
+        def fake_invoke_command(project_temp_dir):
+            invoked["dir"] = project_temp_dir
+
+        monkeypatch.setattr(
+            local_job_invoker,
+            "get_execution_service_response",
+            fake_get_execution_service_response,
+        )
+        monkeypatch.setattr(local_job_invoker, "unzip_to_temporary_file", fake_unzip_to_temporary_file)
+        monkeypatch.setattr(local_job_invoker, "invoke_command", fake_invoke_command)
+
+        job_definition = object()
+        snapshot_id = local_job_invoker.start_run_if_local(
+            job_definition,
+            fake_credential,
+            "https://example.com",
+            fake_pipeline,
+        )
+
+        assert snapshot_id == "snapshot-123"
+        assert captured_args["job_definition"] is job_definition
+        assert captured_args["zip_content"] == b"zipcontent"
+        assert invoked["dir"] == Path("/tmp/fake_dir")
+
+    def test_start_run_if_local_failure_wraps_exception(self, monkeypatch):
+        fake_credential = TestStartRunIfLocal._FakeCredential()
+        fake_pipeline = TestStartRunIfLocal._FakePipeline()
+
+        def fake_get_execution_service_response(job_definition, token, requests_pipeline):
+            return b"zipcontent", "snapshot-456"
+
+        def fake_unzip_to_temporary_file(job_definition, zip_content):
+            raise ValueError("unzip failed")
+
+        monkeypatch.setattr(
+            local_job_invoker,
+            "get_execution_service_response",
+            fake_get_execution_service_response,
+        )
+        monkeypatch.setattr(local_job_invoker, "unzip_to_temporary_file", fake_unzip_to_temporary_file)
+
+        job_definition = object()
+
+        with pytest.raises(MlException) as exc_info:
+            local_job_invoker.start_run_if_local(
+                job_definition,
+                fake_credential,
+                "https://example.com",
+                fake_pipeline,
+            )
+
+        expected_msg = local_job_invoker.LOCAL_JOB_FAILURE_MSG.format(ValueError("unzip failed"))
+        assert expected_msg in str(exc_info.value)
+
+
+def test_get_creationflags_windows(monkeypatch):
+    if not hasattr(local_job_invoker.subprocess, "STARTUPINFO"):
+        class DummyStartupInfo:
+            def __init__(self):
+                self.dwFlags = 0
+                self.wShowWindow = 0
+
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTUPINFO", DummyStartupInfo, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "STARTF_USESHOWWINDOW", 1, raising=False)
+
+    if not hasattr(local_job_invoker.subprocess, "SW_HIDE"):
+        monkeypatch.setattr(local_job_invoker.subprocess, "SW_HIDE", 0, raising=False)
+
+    result = local_job_invoker._get_creationflags_and_startupinfo_for_background_process(os_override='nt')
+    assert result['creationflags'] == 0x00000010
+    startupinfo = result['startupinfo']
+    assert (startupinfo.dwFlags & subprocess.STARTF_USESHOWWINDOW) == subprocess.STARTF_USESHOWWINDOW
+    assert startupinfo.wShowWindow == subprocess.SW_HIDE
+    assert 'shell' not in result
+    assert 'stdin' not in result
+    assert 'stdout' not in result
+    assert 'stderr' not in result
+
+
+def test_get_creationflags_unix():
+    result = local_job_invoker._get_creationflags_and_startupinfo_for_background_process(os_override='posix')
+    assert result['stdin'] == subprocess.DEVNULL
+    assert result['stdout'] == subprocess.DEVNULL
+    assert result['stderr'] == subprocess.STDOUT
+    assert 'shell' not in result
+    assert 'creationflags' not in result
+    assert 'startupinfo' not in result
+
+
+def test_patch_invocation_script_serialization_transforms_snapshots(tmp_path):
+    invocation_script = tmp_path / 'invoke.sh'
+    invocation_script.write_text("echo start\n--snapshots '{\"abc\": 123}'\necho end\n")
+    patch_invocation_script_serialization(invocation_script)
+    updated = invocation_script.read_text()
+    assert '--snapshots "{\\"abc\\": 123}"' in updated
+
+
+def test_patch_invocation_script_serialization_no_match(tmp_path):
+    invocation_script = tmp_path / 'invoke.sh'
+    invocation_script.write_text("echo start\nno snapshots flag here\n")
+    patch_invocation_script_serialization(invocation_script)
+    assert invocation_script.read_text() == "echo start\nno snapshots flag here\n"
+
+
+class _DummyToken:
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+
+class _DummyCredential:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def get_token(self, _: str) -> _DummyToken:
+        return _DummyToken(self._token)
+
+
+class _DummyLocalService:
+    def __init__(self) -> None:
+        self.endpoint = "dummy"
+
+
+class _DummyProperties:
+    def __init__(self) -> None:
+        self.services = {"Local": _DummyLocalService()}
+
+
+class _DummyJobDefinition:
+    def __init__(self) -> None:
+        self.name = "test"
+        self.properties = _DummyProperties()
+
+
+def test_start_run_if_local_returns_snapshot(monkeypatch, tmp_path):
+    job_definition = _DummyJobDefinition()
+    credential = _DummyCredential("token")
+    requests_pipeline = object()
+
+    monkeypatch.setattr(
+        local_job_invoker,
+        "get_execution_service_response",
+        lambda jd, token, pipeline: (b"zip", "snapshot-id"),
+    )
+    monkeypatch.setattr(
+        local_job_invoker,
+        "unzip_to_temporary_file",
+        lambda jd, content: tmp_path,
+    )
+    invoked = []
+
+    def dummy_invoke(path):
+        invoked.append(path)
+
+    monkeypatch.setattr(local_job_invoker, "invoke_command", dummy_invoke)
+
+    result = start_run_if_local(job_definition, credential, "ws", requests_pipeline)
+
+    assert result == "snapshot-id"
+    assert invoked == [tmp_path]
+
+
+def test_start_run_if_local_wraps_unzip_errors(monkeypatch):
+    job_definition = _DummyJobDefinition()
+    credential = _DummyCredential("token")
+    requests_pipeline = object()
+
+    monkeypatch.setattr(
+        local_job_invoker,
+        "get_execution_service_response",
+        lambda jd, token, pipeline: (b"zip", "snapshot"),
+    )
+    monkeypatch.setattr(
+        local_job_invoker,
+        "unzip_to_temporary_file",
+        lambda jd, content: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(MlException) as exc_info:
+        start_run_if_local(job_definition, credential, "ws", requests_pipeline)
+
+    expected_message = LOCAL_JOB_FAILURE_MSG.format("boom")
+    assert exc_info.value.message == expected_message
+
+
+def _build_common_runtime_response():
+    bootstrapper_info = {"registry": "https://example.com", "value": 1}
+    job_spec = "{'job': 'spec'}"
+    encoded_bootstrapper_info = base64.b64encode(json.dumps(bootstrapper_info).encode("utf-8"))
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_ref:
+        zip_ref.writestr(
+            f"{AZUREML_RUN_SETUP_DIR}/common_runtime_bootstrapper_info.json",
+            encoded_bootstrapper_info,
+        )
+        zip_ref.writestr(f"{AZUREML_RUN_SETUP_DIR}/common_runtime_job_spec.json", job_spec)
+    return buffer.getvalue(), bootstrapper_info, job_spec
+
+
+def _build_bootstrapper_only_response():
+    bootstrapper_info = {"field": "value"}
+    encoded_bootstrapper_info = base64.b64encode(json.dumps(bootstrapper_info).encode("utf-8"))
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_ref:
+        zip_ref.writestr(
+            f"{AZUREML_RUN_SETUP_DIR}/common_runtime_bootstrapper_info.json",
+            encoded_bootstrapper_info,
+        )
+    return buffer.getvalue()
+
+
+def _prepare_helper(monkeypatch, tmp_path, job_suffix):
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.Path.home",
+        lambda: tmp_path,
+    )
+    return CommonRuntimeHelper(f"job-{job_suffix}")
+
+
+def test_get_common_runtime_info_from_response_success(monkeypatch, tmp_path):
+    helper = _prepare_helper(monkeypatch, tmp_path, "success")
+    try:
+        response, expected_info, expected_spec = _build_common_runtime_response()
+        bootstrapper_info, job_spec = helper.get_common_runtime_info_from_response(response)
+        assert bootstrapper_info == expected_info
+        assert job_spec == expected_spec
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+def test_get_common_runtime_info_from_response_missing_file(monkeypatch, tmp_path):
+    helper = _prepare_helper(monkeypatch, tmp_path, "missing")
+    try:
+        response = _build_bootstrapper_only_response()
+        with pytest.raises(RuntimeError) as error:
+            helper.get_common_runtime_info_from_response(response)
+        assert "common_runtime_bootstrapper_info.json" in str(error.value)
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
+        self.terminate_called = False
+        self.kill_called = False
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        self.terminate_called = True
+
+    def kill(self):
+        self.kill_called = True
+
+
+@pytest.mark.usefixtures("monkeypatch", "tmp_path")
+def test_execute_bootstrapper_returns_process_when_status_truthy(monkeypatch, tmp_path):
+    helper = _prepare_helper(monkeypatch, tmp_path, "success-runner")
+    fake_process = _FakeProcess()
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.subprocess.Popen",
+        lambda *args, **kwargs: fake_process,
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker._log_subprocess",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        CommonRuntimeHelper,
+        "check_bootstrapper_process_status",
+        lambda self, process: 1,
+    )
+    try:
+        result = helper.execute_bootstrapper("bootstrapper", "job-spec")
+        assert result is fake_process
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+@pytest.mark.usefixtures("monkeypatch", "tmp_path")
+def test_execute_bootstrapper_raises_and_disconnects_on_failure(monkeypatch, tmp_path):
+    helper = _prepare_helper(monkeypatch, tmp_path, "failure-runner")
+    fake_process = _FakeProcess()
+    fake_process.stdout.write("")
+    fake_process.stderr.write("")
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.subprocess.Popen",
+        lambda *args, **kwargs: fake_process,
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker._log_subprocess",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        CommonRuntimeHelper,
+        "check_bootstrapper_process_status",
+        lambda self, process: None,
+    )
+    helper.stderr.write("failure details")
+    helper.stderr.flush()
+    helper.stderr.seek(0)
+    try:
+        with pytest.raises(RuntimeError) as error:
+            helper.execute_bootstrapper("bootstrapper", "job-spec")
+        assert str(error.value) == LOCAL_JOB_FAILURE_MSG.format("failure details")
+        assert fake_process.terminate_called is True
+        assert fake_process.kill_called is True
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+# GENERATED ADDITIONAL TESTS
+
+def test_execute_bootstrapper_returns_process_when_check_returns_truthy(monkeypatch, tmp_path):
+    monkeypatch.setattr("azure.ai.ml.operations._local_job_invoker.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker._log_subprocess", lambda *_args, **_kwargs: None
+    )
+    process_metadata = {}
+
+    class FakeProcess:
+        def __init__(self):
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+            self.terminate_called = False
+            self.kill_called = False
+
+        def terminate(self):
+            self.terminate_called = True
+
+        def kill(self):
+            self.kill_called = True
+
+    fake_process = FakeProcess()
+
+    def fake_popen(*args, **kwargs):
+        process_metadata["args"] = args
+        process_metadata["kwargs"] = kwargs
+        return fake_process
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.CommonRuntimeHelper.check_bootstrapper_process_status",
+        lambda _self, _process: 1,
+    )
+
+    helper = CommonRuntimeHelper(job_name="job")
+    try:
+        result = helper.execute_bootstrapper(str(tmp_path / "bootstrapper"), '{"job": "spec"}')
+        assert result is fake_process
+        assert helper.common_runtime_temp_folder == process_metadata["kwargs"]["cwd"]
+        assert process_metadata["kwargs"]["env"] == helper.LOCAL_JOB_ENV_VARS
+        assert not fake_process.terminate_called
+        assert not fake_process.kill_called
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+def test_execute_bootstrapper_raises_when_check_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr("azure.ai.ml.operations._local_job_invoker.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker._log_subprocess", lambda *_args, **_kwargs: None
+    )
+
+    class FakeProcess:
+        def __init__(self):
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+            self.terminate_called = False
+            self.kill_called = False
+
+        def terminate(self):
+            self.terminate_called = True
+
+        def kill(self):
+            self.kill_called = True
+
+    fake_process = FakeProcess()
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.subprocess.Popen", lambda *args, **kwargs: fake_process
+    )
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._local_job_invoker.CommonRuntimeHelper.check_bootstrapper_process_status",
+        lambda _self, _process: None,
+    )
+
+    helper = CommonRuntimeHelper(job_name="job")
+    helper.stderr.write("bootstrapper failure")
+    helper.stderr.seek(0)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            helper.execute_bootstrapper(str(tmp_path / "bootstrapper"), '{"job": "spec"}')
+        assert str(excinfo.value) == LOCAL_JOB_FAILURE_MSG.format("bootstrapper failure")
+        assert fake_process.terminate_called
+        assert fake_process.kill_called
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()
+
+
+def test_check_bootstrapper_process_status_raises_for_non_zero_return_code(monkeypatch, tmp_path):
+    monkeypatch.setattr("azure.ai.ml.operations._local_job_invoker.Path.home", lambda: tmp_path)
+
+    helper = CommonRuntimeHelper(job_name="job")
+    helper.stderr.write("stderr contents")
+    helper.stderr.seek(0)
+
+    class DummyProcess:
+        @staticmethod
+        def poll():
+            return 3
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            helper.check_bootstrapper_process_status(DummyProcess())
+        assert str(excinfo.value) == helper.BOOTSTRAP_BINARY_FAILURE_MSG.format("stderr contents")
+    finally:
+        helper.stdout.close()
+        helper.stderr.close()

--- a/sdk/ml/azure-ai-ml/tests/test_model_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_model_operations_gaps.py
@@ -1,0 +1,489 @@
+import pytest
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+from azure.ai.ml.constants._common import ASSET_ID_FORMAT, AzureMLResourceType
+from azure.ai.ml.entities import Environment
+from azure.ai.ml.entities._assets import ModelPackage
+from azure.ai.ml.entities._assets.workspace_asset_reference import WorkspaceAssetReference
+from azure.ai.ml.exceptions import ValidationException
+from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope, OperationsContainer
+from azure.ai.ml.operations import _model_operations as model_module
+from azure.ai.ml.operations._model_operations import ModelOperations
+
+
+class _DummyModel:
+    def __init__(self, name, properties):
+        self.name = name
+        self.properties = properties
+        self.version = None
+        self._auto_increment_version = False
+        self.path = None
+        self.type = None
+        self._base_path = None
+
+    def _to_rest_object(self):
+        return SimpleNamespace()
+
+
+def _make_model_operations(all_operations=None, registry_name=None):
+    operation_scope = OperationScope('sub', 'rg', 'ws', registry_name=registry_name)
+    operation_scope._workspace_location = None
+    operation_scope._workspace_id = None
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = SimpleNamespace(
+        model_versions=MagicMock(),
+        model_containers=MagicMock(),
+        workspaces=SimpleNamespace(get=MagicMock(return_value=SimpleNamespace(workspace_id='workspace-guid', location='eastus'))),
+        resource_management_asset_reference=SimpleNamespace(begin_import_method=MagicMock()),
+        _config=SimpleNamespace(credential=None),
+    )
+    datastore_operations = MagicMock()
+    return ModelOperations(
+        operation_scope,
+        operation_config,
+        service_client,
+        datastore_operations,
+        all_operations=all_operations,
+        workspace_rg='rg',
+        workspace_sub='sub',
+    )
+
+
+class _DummyPackageRequest:
+    def __init__(self, env_version):
+        self.inferencing_server = SimpleNamespace()
+        self.base_environment_source = None
+        self.target_environment_id = 'base-env'
+        self.environment_version = env_version
+        self._base_path = '.'
+
+    def _to_rest_object(self):
+        return self
+
+
+def PackageResponse(target_environment_id):
+    return type('PackageResponse', (), {'target_environment_id': target_environment_id})()
+
+
+class _DummyWorkspaceOperation:
+    def get(self, name):
+        return SimpleNamespace(location='eastus', _workspace_id='workspace-id')
+
+
+class _DummyEnvironmentOperation:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, name, version):
+        self.calls.append((name, version))
+        return f'env-{name}-{version}'
+
+
+def _make_all_operations():
+    return SimpleNamespace(all_operations={
+        'workspaces': _DummyWorkspaceOperation(),
+        AzureMLResourceType.ENVIRONMENT: _DummyEnvironmentOperation(),
+    })
+
+
+class _DummyOrchestrator:
+    def __init__(self, operation_container, operation_scope, operation_config):
+        self.operation_container = operation_container
+        self.operation_scope = operation_scope
+        self.operation_config = operation_config
+
+
+def test_create_or_update_rejects_evaluator_request(monkeypatch):
+    ops = _make_model_operations()
+    model = _DummyModel('m', {'kind': 'evaluator'})
+    monkeypatch.setattr(model_module, '_is_evaluator', lambda props: True)
+    with pytest.raises(ValidationException) as exc_info:
+        ops.create_or_update(model)
+    assert 'Unable to create the evaluator' in str(exc_info.value)
+
+
+def test_create_or_update_rejects_mismatched_evaluator_flags(monkeypatch):
+    ops = _make_model_operations()
+    model = _DummyModel('mismatch', {'kind': 'regular'})
+    monkeypatch.setattr(model_module, '_is_evaluator', lambda props=None: bool(props and props.get('kind') == 'evaluator'))
+    ops._get_model_properties = MagicMock(return_value={'kind': 'evaluator'})
+    with pytest.raises(ValidationException) as exc_info:
+        ops.create_or_update(model)
+    assert 'Unable to create the model with name mismatch' in str(exc_info.value)
+
+
+def test_get_requires_version_and_label_are_exclusive():
+    ops = _make_model_operations()
+    with pytest.raises(ValidationException) as exc_info:
+        ops.get('name', version='1', label='latest')
+    assert 'Cannot specify both version and label.' in str(exc_info.value)
+
+
+def test_get_requires_version_or_label():
+    ops = _make_model_operations()
+    with pytest.raises(ValidationException) as exc_info:
+        ops.get('name')
+    assert 'Must provide either version or label' in str(exc_info.value)
+
+
+def test_get_resolves_label(monkeypatch):
+    ops = _make_model_operations()
+    resolver = MagicMock(return_value='resolved-model')
+    monkeypatch.setattr(model_module, '_resolve_label_to_asset', resolver)
+    result = ops.get('name', label='latest')
+    assert result == 'resolved-model'
+    resolver.assert_called_once_with(ops, 'name', 'latest')
+
+
+def test_package_returns_package_out_when_skip_to_rest():
+    ops = _make_model_operations()
+    package_request = _DummyPackageRequest('1')
+    package_out = PackageResponse(target_environment_id='env-id')
+    begin_mock = MagicMock()
+    begin_mock.return_value.result.return_value = package_out
+    ops._model_versions_operation.begin_package = begin_mock
+    result = ops.package('model', '1', package_request, skip_to_rest=True)
+    assert result is package_out
+    begin_mock.assert_called_once()
+
+
+def test_package_resolves_environment_with_regex(monkeypatch):
+    monkeypatch.setattr(model_module, 'OperationOrchestrator', _DummyOrchestrator)
+    all_ops = _make_all_operations()
+    ops = _make_model_operations(all_operations=all_ops)
+    package_request = _DummyPackageRequest('5')
+    package_out = PackageResponse(target_environment_id='azureml://locations/e/workspaces/w/environments/env/versions/5')
+    begin_mock = MagicMock()
+    begin_mock.return_value.result.return_value = package_out
+    ops._model_versions_operation.begin_package = begin_mock
+    result = ops.package('model', '1', package_request)
+    assert result == 'env-env-5'
+    env_operation = all_ops.all_operations[AzureMLResourceType.ENVIRONMENT]
+    assert env_operation.calls == [('env', '5')]
+
+
+def test_package_parses_arm_id_when_regex_missing(monkeypatch):
+    monkeypatch.setattr(model_module, 'OperationOrchestrator', _DummyOrchestrator)
+    monkeypatch.setattr(model_module, 'AMLVersionedArmId', lambda arm_id: SimpleNamespace(asset_name='arm-id', asset_version='7'))
+    all_ops = _make_all_operations()
+    ops = _make_model_operations(all_operations=all_ops)
+    package_request = _DummyPackageRequest('5')
+    package_out = PackageResponse(target_environment_id='fallback-id')
+    package_out.additional_properties = {'targetEnvironmentId': 'azureml://locations/e/workspaces/w/environments/arm/versions/not-a-number'}
+    begin_mock = MagicMock()
+    begin_mock.return_value.result.return_value = package_out
+    ops._model_versions_operation.begin_package = begin_mock
+    result = ops.package('model', '1', package_request)
+    assert result == 'env-arm-id-7'
+    env_operation = all_ops.all_operations[AzureMLResourceType.ENVIRONMENT]
+    assert env_operation.calls == [('arm-id', '7')]
+
+
+def test_share_calls_create_or_update_with_workspace_asset_reference():
+    operation_scope = OperationScope(
+        subscription_id="sub",
+        resource_group_name="rg",
+        workspace_name="workspace-name",
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = MagicMock()
+    service_client.model_versions = MagicMock()
+    service_client.model_containers = MagicMock()
+    workspace_details = MagicMock(workspace_id="guid-123", location="eastus")
+    service_client.workspaces.get.return_value = workspace_details
+    datastore_operations = MagicMock()
+    model_ops = ModelOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        datastore_operations=datastore_operations,
+    )
+    expected_model = MagicMock()
+    model_ops.create_or_update = MagicMock(return_value=expected_model)
+
+    @contextmanager
+    def dummy_registry_client(registry_name):
+        yield
+
+    model_ops._set_registry_client = dummy_registry_client
+
+    result = model_ops.share(
+        name="model-name",
+        version="1",
+        share_with_name="shared-name",
+        share_with_version="2",
+        registry_name="dest-registry",
+    )
+
+    assert result == expected_model
+    service_client.workspaces.get.assert_called_once_with(
+        resource_group_name="rg", workspace_name="workspace-name"
+    )
+    created_asset = model_ops.create_or_update.call_args[0][0]
+    assert isinstance(created_asset, WorkspaceAssetReference)
+    assert created_asset.name == "shared-name"
+    assert created_asset.version == "2"
+    expected_asset_id = ASSET_ID_FORMAT.format(
+        workspace_details.location,
+        workspace_details.workspace_id,
+        AzureMLResourceType.MODEL,
+        "model-name",
+        "1",
+    )
+    assert created_asset.asset_id == expected_asset_id
+
+
+def test_package_parses_target_environment_id_pattern_and_resolves_environment():
+    operation_scope = OperationScope(
+        subscription_id="sub",
+        resource_group_name="rg",
+        workspace_name="workspace",
+        workspace_id="workspace-id",
+        workspace_location="location",
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = MagicMock()
+    service_client.model_versions = MagicMock()
+    service_client.model_containers = MagicMock()
+    datastore_operations = MagicMock()
+    environment_operation = MagicMock()
+    expected_environment = MagicMock(spec=Environment)
+    environment_operation.get.return_value = expected_environment
+    operations_container = OperationsContainer()
+    operations_container.add(AzureMLResourceType.ENVIRONMENT, environment_operation)
+    model_ops = ModelOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        datastore_operations=datastore_operations,
+        all_operations=operations_container,
+    )
+    package_request = MagicMock(spec=ModelPackage)
+    package_request.inferencing_server = MagicMock(code_configuration=None)
+    package_request.base_environment_source = None
+    package_request.target_environment_id = "target-environment"
+    package_request.environment_version = "1"
+    package_request._base_path = "base"
+    rest_package_request = MagicMock()
+    rest_package_request.target_environment_id = "azureml://locations/location/workspaces/workspace-id/environments/parsed-env/versions/5"
+    package_request._to_rest_object.return_value = rest_package_request
+    package_out = type("PackageResponse", (), {})()
+    package_out.target_environment_id = rest_package_request.target_environment_id
+    begin_package_result = MagicMock()
+    begin_package_result.result.return_value = package_out
+    model_ops._model_versions_operation.begin_package.return_value = begin_package_result
+
+    result = model_ops.package("mymodel", "v1", package_request)
+
+    assert result == expected_environment
+    environment_operation.get.assert_called_once_with(name="parsed-env", version="5")
+
+
+def test_package_handles_registry_package_response_and_control_plane_fetch(monkeypatch):
+    operation_scope = OperationScope(
+        subscription_id="sub-a",
+        resource_group_name="original-rg",
+        workspace_name="workspace",
+        registry_name="registry-target",
+        workspace_id="workspace-id",
+        workspace_location="location",
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    service_client = MagicMock()
+    service_client.model_versions = MagicMock()
+    service_client.model_containers = MagicMock()
+    datastore_operations = MagicMock()
+    control_plane_client = MagicMock()
+    control_plane_client._config = MagicMock()
+    control_plane_client._config.subscription_id = "original-sub"
+    env_rest = MagicMock()
+    control_plane_client.environment_versions.get.return_value = env_rest
+    expected_environment = MagicMock()
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._model_operations.Environment._from_rest_object",
+        lambda rest: expected_environment,
+    )
+    model_ops = ModelOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        datastore_operations=datastore_operations,
+        control_plane_client=control_plane_client,
+        workspace_rg="fetched-rg",
+        workspace_sub="fetched-sub",
+    )
+    package_request = MagicMock(spec=ModelPackage)
+    package_request.inferencing_server = MagicMock(code_configuration=None)
+    package_request.base_environment_source = None
+    package_request.target_environment_id = "target-env"
+    package_request.environment_version = "2"
+    package_request._base_path = "base"
+    rest_package_request = MagicMock()
+    rest_package_request.target_environment_id = "azureml://locations/location/workspaces/workspace-id/environments/target-env/versions/2"
+    package_request._to_rest_object.return_value = rest_package_request
+    class PackageResponse:
+        pass
+    package_out = PackageResponse()
+    package_out.additional_properties = {"targetEnvironmentId": "fallback-id"}
+    begin_package_result = MagicMock()
+    begin_package_result.result.return_value = package_out
+    model_ops._model_versions_operation.begin_package.return_value = begin_package_result
+
+    class FakeArmId:
+        def __init__(self, arm_id):
+            self.asset_name = "fallback-env"
+            self.asset_version = "42"
+
+    monkeypatch.setattr(
+        "azure.ai.ml.operations._model_operations.AMLVersionedArmId",
+        FakeArmId,
+    )
+
+    result = model_ops.package("mymodel", "v1", package_request)
+
+    assert result == expected_environment
+    control_plane_client.environment_versions.get.assert_called_once_with(
+        name="fallback-env",
+        version="42",
+        workspace_name="workspace",
+        **{
+            "resource_group_name": "fetched-rg",
+        },
+    )
+    assert control_plane_client._config.subscription_id == "fetched-sub"
+    assert model_ops._scope_kwargs["resource_group_name"] == "original-rg"
+
+
+class FakeOperationOrchestrator:
+    def __init__(self, operation_container, operation_scope, operation_config):
+        self.operation_container = operation_container
+        self.operation_scope = operation_scope
+        self.operation_config = operation_config
+
+    def get_asset_arm_id(self, *args, **kwargs):
+        return "asset-id"
+
+
+class FakeModelPackage:
+    def __init__(self, target_environment_id, environment_version):
+        self.inferencing_server = SimpleNamespace(code_configuration=None)
+        self.base_environment_source = None
+        self._base_path = None
+        self.target_environment_id = target_environment_id
+        self.environment_version = environment_version
+
+    def _to_rest_object(self):
+        return self
+
+
+class FakePoller:
+    def __init__(self, result):
+        self._result = result
+
+    def result(self):
+        return self._result
+
+
+class FakeModelVersionsOperation:
+    def __init__(self, package_out):
+        self.package_out = package_out
+
+    def begin_package(self, **kwargs):
+        return FakePoller(self.package_out)
+
+
+class PackageResponse:
+    def __init__(self, target_environment_id):
+        self.target_environment_id = target_environment_id
+
+
+@pytest.fixture(autouse=True)
+def patch_operation_orchestrator(monkeypatch):
+    monkeypatch.setattr("azure.ai.ml.operations._model_operations.OperationOrchestrator", FakeOperationOrchestrator)
+
+
+def test_package_response_registry_branch_retrieves_environment(monkeypatch):
+    monkeypatch.setattr(Environment, "_from_rest_object", lambda rest_obj: "control_plane_environment")
+    package_out = PackageResponse(
+        "azureml://locations/eastus/workspaces/ws-id/environments/pkg-env/versions/2"
+    )
+    fake_model_versions = FakeModelVersionsOperation(package_out)
+    service_client = SimpleNamespace(
+        model_versions=fake_model_versions,
+        model_containers=SimpleNamespace(),
+        _config=SimpleNamespace(credential="credential"),
+    )
+    operation_scope = OperationScope(
+        subscription_id="sub_id",
+        resource_group_name="resource_group",
+        workspace_name="workspace",
+        registry_name="registry",
+        workspace_id="ws-id",
+        workspace_location="eastus",
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    control_plane_client = SimpleNamespace(
+        _config=SimpleNamespace(subscription_id="original"),
+        environment_versions=SimpleNamespace(
+            get=lambda name, version, workspace_name, **kwargs: "control_plane_rest"
+        ),
+    )
+    model_operations = ModelOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        datastore_operations=object(),
+        all_operations=OperationsContainer(),
+        control_plane_client=control_plane_client,
+        workspace_rg="workspace_rg",
+        workspace_sub="workspace_sub",
+    )
+    fake_package = FakeModelPackage(target_environment_id="pkg-env", environment_version="2")
+    result = model_operations.package(
+        name="model",
+        version="1",
+        package_request=fake_package,
+    )
+    assert result == "control_plane_environment"
+    assert model_operations._scope_kwargs["resource_group_name"] == "resource_group"
+    assert control_plane_client._config.subscription_id == "workspace_sub"
+
+
+def test_package_response_workspace_branch_uses_environment_operation():
+    package_out = PackageResponse(
+        "azureml://locations/north/workspaces/ws-id/environments/pkg-env/versions/3"
+    )
+    fake_model_versions = FakeModelVersionsOperation(package_out)
+    service_client = SimpleNamespace(
+        model_versions=fake_model_versions,
+        model_containers=SimpleNamespace(),
+        _config=SimpleNamespace(credential="credential"),
+    )
+    operation_scope = OperationScope(
+        subscription_id="sub_id",
+        resource_group_name="resource_group",
+        workspace_name="workspace",
+        workspace_id="ws-id",
+        workspace_location="north",
+    )
+    operation_config = OperationConfig(show_progress=False, enable_telemetry=False)
+    operations_container = OperationsContainer()
+    fake_environment_operation = SimpleNamespace(get=Mock(return_value="workspace_environment"))
+    operations_container.all_operations[AzureMLResourceType.ENVIRONMENT] = fake_environment_operation
+    model_operations = ModelOperations(
+        operation_scope=operation_scope,
+        operation_config=operation_config,
+        service_client=service_client,
+        datastore_operations=object(),
+        all_operations=operations_container,
+    )
+    fake_package = FakeModelPackage(target_environment_id="pkg-env", environment_version="3")
+    result = model_operations.package(
+        name="model",
+        version="1",
+        package_request=fake_package,
+    )
+    assert result == "workspace_environment"
+    fake_environment_operation.get.assert_called_once_with(name="pkg-env", version="3")

--- a/sdk/ml/azure-ai-ml/tests/test_pipeline_expression_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_pipeline_expression_gaps.py
@@ -1,0 +1,276 @@
+import pytest
+from types import SimpleNamespace
+
+from azure.ai.ml.constants._common import AZUREML_PRIVATE_FEATURES_ENV_VAR
+from azure.ai.ml.constants._component import ComponentParameterTypes
+from azure.ai.ml.entities._job.pipeline._pipeline_expression import (
+    ExpressionInput,
+    PipelineExpression,
+    PipelineExpressionOperator,
+)
+from azure.ai.ml.exceptions import UserErrorException
+
+
+class _DummyBindingValue:
+    def __init__(self, binding):
+        self._binding = binding
+
+    def _data_binding(self):
+        return self._binding
+
+
+def test_string_concatenation_data_binding_generation():
+    expression = PipelineExpression([
+        "'hello'",
+        "'world'",
+        PipelineExpressionOperator.ADD,
+    ], {})
+    assert expression._to_data_binding() == "helloworld"
+
+
+def test_to_data_binding_rejects_non_add_operator():
+    expression = PipelineExpression([
+        "'a'",
+        "'b'",
+        PipelineExpressionOperator.SUB,
+    ], {})
+    with pytest.raises(UserErrorException) as excinfo:
+        expression._to_data_binding()
+    assert "Only string concatenation expression is supported to convert to data binding" in str(
+        excinfo.value
+    )
+    assert "('a' - 'b')" in str(excinfo.value)
+
+
+def test_to_data_binding_rejects_non_string_pipeline_input():
+    binding_value = _DummyBindingValue("${{parent.inputs.bad_input}}")
+    inputs = {
+        "bad_input": ExpressionInput(
+            "bad_input",
+            ComponentParameterTypes.INTEGER,
+            binding_value,
+        ),
+    }
+    expression = PipelineExpression([
+        "bad_input",
+        "'unit'",
+        PipelineExpressionOperator.ADD,
+    ], inputs)
+    with pytest.raises(UserErrorException) as excinfo:
+        expression._to_data_binding()
+    assert "Only string concatenation expression is supported to convert to data binding" in str(
+        excinfo.value
+    )
+
+
+def test_parse_pipeline_inputs_from_data_binding_returns_names():
+    data_binding = "prefix ${{parent.inputs.first}} and ${{parent.inputs.second}} suffix"
+    assert PipelineExpression.parse_pipeline_inputs_from_data_binding(data_binding) == [
+        "first",
+        "second",
+    ]
+
+
+def test_get_operation_result_type_rejects_invalid_operand_type():
+    with pytest.raises(UserErrorException) as excinfo:
+        PipelineExpression._get_operation_result_type(
+            "unsupported",
+            PipelineExpressionOperator.ADD,
+            ComponentParameterTypes.STRING,
+        )
+    assert "Pipeline input type 'unsupported' is not supported in expression" in str(
+        excinfo.value
+    )
+
+
+def test_get_operation_result_type_propagates_invalid_operation():
+    with pytest.raises(UserErrorException) as excinfo:
+        PipelineExpression._get_operation_result_type(
+            ComponentParameterTypes.STRING,
+            PipelineExpressionOperator.SUB,
+            ComponentParameterTypes.STRING,
+        )
+    assert "Operator '-' is not supported between instances of" in str(excinfo.value)
+
+
+def test_parse_pipeline_inputs_from_data_binding_extracts_names():
+    data_binding = "${{parent.inputs.alpha}}-${{parent.inputs.beta}}"
+    assert PipelineExpression.parse_pipeline_inputs_from_data_binding(data_binding) == ["alpha", "beta"]
+
+
+def test_get_operation_result_type_returns_the_result_for_supported_types():
+    result = PipelineExpression._get_operation_result_type(
+        ComponentParameterTypes.INTEGER,
+        PipelineExpressionOperator.ADD,
+        ComponentParameterTypes.INTEGER,
+    )
+    assert result == ComponentParameterTypes.INTEGER
+
+
+def test_get_operation_result_type_rejects_non_supported_operand_type():
+    with pytest.raises(UserErrorException) as excinfo:
+        PipelineExpression._get_operation_result_type(
+            "UnsupportedType",
+            PipelineExpressionOperator.ADD,
+            ComponentParameterTypes.INTEGER,
+        )
+    assert "Pipeline input type 'UnsupportedType' is not supported in expression" in str(
+        excinfo.value
+    )
+
+
+def test_get_operation_result_type_invalid_operation_raises_user_error():
+    with pytest.raises(UserErrorException) as excinfo:
+        PipelineExpression._get_operation_result_type(
+            ComponentParameterTypes.STRING,
+            PipelineExpressionOperator.SUB,
+            ComponentParameterTypes.STRING,
+        )
+    assert "Operator '-' is not supported between instances of 'string' and 'string'." in str(excinfo.value)
+
+
+def test_string_concatenation_rejects_non_add_operator():
+    left = ExpressionInput(
+        'left',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'left_value'),
+    )
+    right = ExpressionInput(
+        'right',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'right_value'),
+    )
+    expression = PipelineExpression(['left', 'right', PipelineExpressionOperator.SUB], {'left': left, 'right': right})
+    assert expression._string_concatenation is False
+
+
+def test_string_concatenation_rejects_non_string_input():
+    expression = PipelineExpression(
+        ['count'],
+        {
+            'count': ExpressionInput('count', ComponentParameterTypes.INTEGER, object()),
+        },
+    )
+    assert expression._string_concatenation is False
+
+
+def test_string_concatenation_rejects_non_string_constant():
+    expression = PipelineExpression(['1', '2', PipelineExpressionOperator.ADD], {})
+    assert expression._string_concatenation is False
+
+
+def test_to_data_binding_raises_when_not_string_concatenation():
+    left = ExpressionInput(
+        'left',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'left_value'),
+    )
+    right = ExpressionInput(
+        'right',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'right_value'),
+    )
+    expression = PipelineExpression(['left', 'right', PipelineExpressionOperator.SUB], {'left': left, 'right': right})
+    with pytest.raises(UserErrorException) as excinfo:
+        expression._to_data_binding()
+    expected_message = (
+        'Only string concatenation expression is supported to convert to data binding, '
+        f"current expression is '{expression.expression}'."
+    )
+    assert excinfo.value.message == expected_message
+
+
+def test_to_data_binding_concatenates_string_inputs():
+    first = ExpressionInput(
+        'first',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'hello'),
+    )
+    second = ExpressionInput(
+        'second',
+        ComponentParameterTypes.STRING,
+        SimpleNamespace(_data_binding=lambda: 'world'),
+    )
+    expression = PipelineExpression(['first', 'second', PipelineExpressionOperator.ADD], {'first': first, 'second': second})
+    assert expression._to_data_binding() == 'helloworld'
+
+
+def test_component_code_reuses_cached_lines():
+    inputs = {
+        "a": ExpressionInput("a", ComponentParameterTypes.STRING, SimpleNamespace()),
+        "b": ExpressionInput("b", ComponentParameterTypes.STRING, SimpleNamespace()),
+    }
+    expression = PipelineExpression(["a", "b", "+", "a", "b", "+", "+"], inputs)
+    code = expression._component_code
+    assert "inter_var_0 = a + b" in code
+    assert code.count("inter_var_0 = a + b") == 1
+    assert "inter_var_1 = inter_var_0 + inter_var_0" in code
+    assert "return inter_var_1" in code
+    assert "@command_component(" in code
+    assert '"string"' in code
+
+
+def test_create_component_sets_environment(monkeypatch):
+    inputs = {
+        "a": ExpressionInput("a", ComponentParameterTypes.STRING, "alpha"),
+        "b": ExpressionInput("b", ComponentParameterTypes.STRING, "beta"),
+    }
+    expression = PipelineExpression(["a", "b", "+"], inputs)
+    captured_kwargs = {}
+
+    def dummy_component(**kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(environment_variables=None)
+
+    def dummy_load_component(path):
+        return dummy_component
+
+    monkeypatch.setattr("azure.ai.ml.load_component", dummy_load_component)
+    component = expression._create_component()
+    assert captured_kwargs == {"a": "alpha", "b": "beta"}
+    assert component.environment_variables == {AZUREML_PRIVATE_FEATURES_ENV_VAR: "true"}
+    assert expression._create_component() is component
+
+
+def test_operation_result_type_valid_and_invalid():
+    assert PipelineExpression._get_operation_result_type(
+        ComponentParameterTypes.STRING,
+        PipelineExpressionOperator.ADD,
+        ComponentParameterTypes.STRING,
+    ) == ComponentParameterTypes.STRING
+
+    with pytest.raises(UserErrorException) as exc_info:
+        PipelineExpression._get_operation_result_type(
+            ComponentParameterTypes.STRING,
+            PipelineExpressionOperator.SUB,
+            ComponentParameterTypes.STRING,
+        )
+    assert "Operator" in str(exc_info.value)
+
+
+def test_operand_type_prefers_expression_inputs_then_primitives():
+    inputs = {
+        "alpha": ExpressionInput("alpha", ComponentParameterTypes.INTEGER, object()),
+    }
+    expression = PipelineExpression([], inputs)
+    assert expression._get_operand_type("alpha") == ComponentParameterTypes.INTEGER
+    assert expression._get_operand_type("True") == ComponentParameterTypes.BOOLEAN
+
+
+def test_component_code_reuses_cached_operations_and_decorator_format():
+    postfix = ["a", "b", "+", "a", "b", "+", "+"]
+    inputs = {
+        "a": ExpressionInput("a", ComponentParameterTypes.NUMBER, object()),
+        "b": ExpressionInput("b", ComponentParameterTypes.NUMBER, object()),
+    }
+    expression = PipelineExpression(postfix, inputs)
+    code = expression._component_code
+
+    assert "    inter_var_0 = a + b" in code
+    assert code.count("    inter_var_0 = a + b") == 1
+    assert "    inter_var_1 = inter_var_0 + inter_var_0" in code
+    assert 'display_name="Expression: ((a + b) + (a + b))",' in code
+    assert 'Output(type="number")' in code
+    assert "    a: float," in code
+    assert "    b: float," in code
+    assert expression._result_type == ComponentParameterTypes.NUMBER

--- a/sdk/ml/azure-ai-ml/tests/test_schedule_operations_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_schedule_operations_gaps.py
@@ -1,0 +1,841 @@
+import types
+from types import SimpleNamespace
+import pytest
+
+from azure.ai.ml.constants._monitoring import (
+    DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY,
+    DEPLOYMENT_MODEL_INPUTS_NAME_KEY,
+    DEPLOYMENT_MODEL_INPUTS_VERSION_KEY,
+    DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY,
+    DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY,
+    DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY,
+    MonitorDatasetContext,
+)
+from azure.ai.ml.entities._inputs_outputs.input import Input
+from azure.ai.ml.entities._monitoring.signals import BaselineDataRange, ReferenceData
+from azure.ai.ml.operations._schedule_operations import (
+    ScheduleOperations,
+    ARM_ID_PREFIX,
+    AZUREML_RESOURCE_PROVIDER,
+    NAMED_RESOURCE_ID_FORMAT_WITH_PARENT,
+    AzureMLResourceType,
+    MonitorSignalType,
+    ScheduleException,
+)
+from azure.ai.ml.operations import _schedule_operations as schedule_module
+from azure.ai.ml.entities import MonitoringTarget
+from azure.ai.ml._scope_dependent_operations import OperationScope, OperationConfig
+
+
+class DummyTarget:
+    def __init__(self, endpoint_deployment_id=None, model_id=None):
+        self.endpoint_deployment_id = endpoint_deployment_id
+        self.model_id = model_id
+
+
+default_monitor_called = False
+
+
+class DummyCreateMonitor:
+    def __init__(self, monitoring_target, monitoring_signals):
+        self.monitoring_target = monitoring_target
+        self.monitoring_signals = monitoring_signals
+
+
+class DummySchedule:
+    def __init__(
+        self,
+        create_monitor=None,
+        base_path='.',
+        signals=None,
+        target=None,
+    ):
+        if create_monitor is not None:
+            self.create_monitor = create_monitor
+            self._base_path = base_path
+        else:
+            if target is None:
+                target = DummyTarget()
+            self.create_monitor = DummyCreateMonitor(target, signals)
+            self._base_path = 'base/path'
+        self.default_monitor_called = False
+        self.default_created = False
+
+    def _create_default_monitor_definition(self):
+        self.default_monitor_called = True
+        self.default_created = True
+
+
+class DummyJobOperations:
+    def __init__(self):
+        self.resolved_inputs = []
+        self.resolved_inputs_multi = []
+
+    def _resolve_job_input(self, input_data, base_path):
+        self.resolved_inputs.append(('single', input_data, base_path))
+
+    def _resolve_job_inputs(self, inputs, base_path):
+        self.resolved_inputs.append(('multiple', inputs, base_path))
+        self.resolved_inputs_multi.append(list(inputs))
+
+
+class DummyDataAsset:
+    def __init__(self, asset_type='dummy_type'):
+        self.type = asset_type
+
+
+class DummyDataOperations:
+    def __init__(self, asset_type='dummy_type'):
+        self.asset_type = asset_type
+        self.assets = {}
+
+    def register(self, name, version, type='uri_folder'):
+        self.assets[(name, version)] = DummyDataAsset(type)
+
+    def get(self, name, version=None):  # pylint:disable=unused-argument
+        if self.assets and (name, version) in self.assets:
+            return self.assets[(name, version)]
+        return DummyDataAsset(asset_type=self.asset_type)
+
+
+class DummyCollectionEntry:
+    def __init__(self, data, enabled):
+        self.data = data
+        self.enabled = enabled
+
+
+class DummyDataCollector:
+    def __init__(self, model_inputs_id=None, model_outputs_id=None, app_traces_id=None, collections=None):
+        # Support both styles: either direct collections dict or individual ids
+        if isinstance(model_inputs_id, dict) and model_outputs_id is None and collections is None:
+            self.collections = model_inputs_id
+            return
+        if collections is not None:
+            self.collections = collections
+            return
+        self.collections = {
+            'model_inputs': DummyCollectionEntry(model_inputs_id, 'true'),
+            'model_outputs': DummyCollectionEntry(model_outputs_id, 'true'),
+        }
+        if app_traces_id is not None:
+            self.collections['app_traces'] = DummyCollectionEntry(app_traces_id, 'true')
+
+
+class DummyOnlineDeployment:
+    def __init__(self, data_collector=None, tags=None):
+        self.data_collector = data_collector
+        self.tags = tags or {}
+
+
+class DummyOnlineDeploymentOperations:
+    def __init__(self, deployment):
+        self._deployment = deployment
+
+    def get(self, deployment_name, endpoint_name):  # pylint:disable=unused-argument
+        return self._deployment
+
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.calls = []
+        self.assets = []
+
+    def get_asset_arm_id(self, asset, azureml_type, register_asset=None):  # pylint:disable=unused-argument
+        self.calls.append((asset, azureml_type, register_asset))
+        self.assets.append(asset)
+        return f'resolved:{asset}' if asset is not None else None
+
+
+class DummyGenSignal:
+    def __init__(self, signal_type, production_data=None, reference_data=None):
+        self.type = signal_type
+        self.production_data = production_data
+        self.reference_data = reference_data
+
+
+class DummyLlmData:
+    def __init__(self, input_data, data_window):
+        self.input_data = input_data
+        self.data_window = data_window
+
+
+class DummyBaselineDataRange:
+    def __init__(self, lookback_window_size=None, lookback_window_offset=None):  # pylint:disable=unused-argument
+        self.lookback_window_size = lookback_window_size
+        self.lookback_window_offset = lookback_window_offset
+
+
+class DummyInput:
+    def __init__(self, path=None, type=None):  # pylint:disable=redefined-builtin
+        self.path = path
+        self.type = type
+
+
+class DummyScheduleOperations(ScheduleOperations):
+    '''Lightweight test subclass that bypasses the real constructor and
+    exposes configurable private properties used by the tested methods.
+    '''
+
+    def __init__(self, subscription_id='sub-id', resource_group_name='rg-name', workspace_name='ws-name'):
+        # Intentionally do not call super().__init__
+        self._test_subscription_id = subscription_id
+        self._test_resource_group_name = resource_group_name
+        self._test_workspace_name = workspace_name
+        self._test_online_deployment_operations = None
+        self._test_job_operations = None
+        self._test_data_operations = None
+        self._orchestrators = None
+
+    @property
+    def _subscription_id(self):  # type: ignore[override]
+        return self._test_subscription_id
+
+    @property
+    def _resource_group_name(self):  # type: ignore[override]
+        return self._test_resource_group_name
+
+    @property
+    def _workspace_name(self):  # type: ignore[override]
+        return self._test_workspace_name
+
+    @property
+    def _online_deployment_operations(self):  # type: ignore[override]
+        return self._test_online_deployment_operations
+
+    @_online_deployment_operations.setter
+    def _online_deployment_operations(self, value):  # type: ignore[override]
+        self._test_online_deployment_operations = value
+
+    @property
+    def _job_operations(self):  # type: ignore[override]
+        return self._test_job_operations
+
+    @_job_operations.setter
+    def _job_operations(self, value):  # type: ignore[override]
+        self._test_job_operations = value
+
+    @property
+    def _data_operations(self):  # type: ignore[override]
+        return self._test_data_operations
+
+    @_data_operations.setter
+    def _data_operations(self, value):  # type: ignore[override]
+        self._test_data_operations = value
+
+
+def _create_schedule_ops_instance():
+    return DummyScheduleOperations()
+
+
+def test_process_and_get_endpoint_deployment_names_from_id_named_and_arm_paths(monkeypatch):
+    ops = _create_schedule_ops_instance()
+
+    # Non-ARM (named) path
+    target_named = DummyTarget(endpoint_deployment_id=f'{ARM_ID_PREFIX}my-endpoint:my-deployment')
+
+    def fake_is_arm(resource_id, parent_type, child_type):  # pylint:disable=unused-argument
+        return False
+
+    monkeypatch.setattr(schedule_module, 'is_ARM_id_for_parented_resource', fake_is_arm)
+
+    endpoint_name, deployment_name = ops._process_and_get_endpoint_deployment_names_from_id(target_named)
+
+    assert endpoint_name == 'my-endpoint'
+    assert deployment_name == 'my-deployment'
+    expected_arm = NAMED_RESOURCE_ID_FORMAT_WITH_PARENT.format(
+        ops._subscription_id,
+        ops._resource_group_name,
+        AZUREML_RESOURCE_PROVIDER,
+        ops._workspace_name,
+        schedule_module.snake_to_camel(AzureMLResourceType.ONLINE_ENDPOINT),
+        'my-endpoint',
+        AzureMLResourceType.DEPLOYMENT,
+        'my-deployment',
+    )
+    assert target_named.endpoint_deployment_id == expected_arm
+
+    # ARM path
+    arm_id_value = expected_arm
+
+    def fake_is_arm_true(resource_id, parent_type, child_type):  # pylint:disable=unused-argument
+        return True
+
+    monkeypatch.setattr(schedule_module, 'is_ARM_id_for_parented_resource', fake_is_arm_true)
+
+    class DummyAMLNamedArmId:
+        def __init__(self, arm_id):  # pylint:disable=unused-argument
+            self.parent_asset_name = 'parent-endpoint'
+            self.asset_name = 'child-deployment'
+
+    monkeypatch.setattr(schedule_module, 'AMLNamedArmId', DummyAMLNamedArmId)
+
+    target_arm = DummyTarget(endpoint_deployment_id=arm_id_value)
+    endpoint_name2, deployment_name2 = ops._process_and_get_endpoint_deployment_names_from_id(target_arm)
+
+    assert endpoint_name2 == 'parent-endpoint'
+    assert deployment_name2 == 'child-deployment'
+    assert target_arm.endpoint_deployment_id == arm_id_value
+
+
+def test_resolve_monitor_schedule_arm_id_generation_token_statistics_default_and_existing(monkeypatch):
+    ops = _create_schedule_ops_instance()
+
+    # Set up fake deployment with data collector and app_traces
+    data_collector = DummyDataCollector(
+        model_inputs_id='inputs-name:1',
+        model_outputs_id='outputs-name:2',
+        app_traces_id='traces-name:3',
+    )
+    deployment = DummyOnlineDeployment(data_collector=data_collector)
+    ops._online_deployment_operations = DummyOnlineDeploymentOperations(deployment)
+    job_ops = DummyJobOperations()
+    ops._job_operations = job_ops
+    data_ops = DummyDataOperations(asset_type='table')
+    ops._data_operations = data_ops
+    ops._orchestrators = DummyOrchestrator()
+
+    # Monkeypatch monitoring-related classes to simple dummies
+    monkeypatch.setattr(schedule_module, 'GenerationTokenStatisticsSignal', DummyGenSignal)
+    monkeypatch.setattr(schedule_module, 'LlmData', DummyLlmData)
+    monkeypatch.setattr(schedule_module, 'BaselineDataRange', DummyBaselineDataRange)
+    monkeypatch.setattr(schedule_module, 'Input', DummyInput)
+
+    # Also simplify AMLVersionedArmId to parse 'name:version'
+    class DummyAMLVersionedArmId:
+        def __init__(self, arm_id):
+            name, version = arm_id.split(':')
+            self.asset_name = name
+            self.asset_version = version
+
+    monkeypatch.setattr(schedule_module, 'AMLVersionedArmId', DummyAMLVersionedArmId)
+
+    target = DummyTarget(endpoint_deployment_id=f'{ARM_ID_PREFIX}endpoint:deployment')
+
+    # First signal: no production_data -> default created
+    signal1 = DummyGenSignal(signal_type=MonitorSignalType.GENERATION_TOKEN_STATISTICS, production_data=None)
+
+    # Second signal: has existing production_data -> path where default not created
+    existing_input = DummyInput(path='existing', type='table')
+    existing_llm_data = DummyLlmData(input_data=existing_input, data_window=None)
+    signal2 = DummyGenSignal(
+        signal_type=MonitorSignalType.GENERATION_TOKEN_STATISTICS,
+        production_data=existing_llm_data,
+    )
+
+    monitoring_signals = {'sig1': signal1, 'sig2': signal2}
+    create_monitor = DummyCreateMonitor(monitoring_target=target, monitoring_signals=monitoring_signals)
+    schedule = DummySchedule(create_monitor=create_monitor)
+
+    ops._resolve_monitor_schedule_arm_id(schedule)
+
+    # signal1 should now have production_data created via DummyLlmData
+    assert isinstance(signal1.production_data, DummyLlmData)
+    assert isinstance(signal1.production_data.input_data, DummyInput)
+    assert signal1.production_data.input_data.path.startswith('traces-name:3')
+
+    # job_ops should have been called for both signals
+    resolved_single_calls = [c for c in job_ops.resolved_inputs if c[0] == 'single']
+    assert len(resolved_single_calls) == 2
+    # Ensure that one of the calls used the default-created production_data from signal1
+    paths = {input_data.path for _, input_data, _ in resolved_single_calls}
+    assert 'traces-name:3' in next(iter(paths)) or any('traces-name:3' in p for p in paths)
+
+
+def test_resolve_monitor_schedule_arm_id_raises_when_no_monitoring_signals_and_no_data_collector():
+    ops = _create_schedule_ops_instance()
+
+    # No endpoint_deployment_id and no model_id -> mdc flags remain False
+    target = DummyTarget(endpoint_deployment_id=None, model_id=None)
+    create_monitor = DummyCreateMonitor(monitoring_target=target, monitoring_signals=None)
+    schedule = DummySchedule(create_monitor=create_monitor)
+    ops._job_operations = DummyJobOperations()
+    ops._data_operations = DummyDataOperations()
+    ops._online_deployment_operations = DummyOnlineDeploymentOperations(DummyOnlineDeployment())
+    ops._orchestrators = DummyOrchestrator()
+
+    with pytest.raises(ScheduleException) as exc_info:
+        ops._resolve_monitor_schedule_arm_id(schedule)
+
+    message = str(exc_info.value)
+    assert 'monitoring_signals is None' in message or 'monitoring_signals' in message
+
+
+class DummyFADProductionData:
+    def __init__(self, input_data=None, data_context=None, data_window=None):  # pylint: disable=unused-argument
+        self.input_data = input_data
+        self.data_context = data_context
+        self.data_window = data_window
+        self.pre_processing_component = 'pre_comp_prod'
+
+
+class DummyRefData:
+    def __init__(self, input_data=None):
+        self.input_data = input_data
+        self.pre_processing_component = 'pre_comp_ref'
+
+
+class DummyAMLVersionedArmId:
+    def __init__(self, arm_id):  # pylint: disable=unused-argument
+        # arm_id format is not important for tests; just set deterministic name/version
+        self.asset_name = 'asset_name'
+        self.asset_version = '1'
+
+
+def _create_schedule_ops(job_ops=None, data_ops=None, online_ops=None, orchestrator=None):
+    ops = DummyScheduleOperations()
+    ops._operation_scope = types.SimpleNamespace(resource_group_name=ops._resource_group_name)
+    ops._job_operations = job_ops or DummyJobOperations()
+    ops._data_operations = data_ops or DummyDataOperations()
+    ops._online_deployment_operations = online_ops
+    ops._orchestrators = orchestrator or DummyOrchestrator()
+
+    # avoid exercising real ARM id logic in these tests
+    def fake_process(self, target):  # pylint: disable=unused-argument
+        return 'endpoint', 'deployment'
+
+    ops._process_and_get_endpoint_deployment_names_from_id = types.MethodType(fake_process, ops)
+    return ops
+
+
+def test_feature_attr_drift_default_production_data_created_and_inputs_resolved(monkeypatch):
+    monkeypatch.setattr(schedule_module, 'AMLVersionedArmId', DummyAMLVersionedArmId)
+    monkeypatch.setattr(schedule_module, 'Input', DummyInput)
+    monkeypatch.setattr(schedule_module, 'BaselineDataRange', DummyBaselineDataRange)
+    monkeypatch.setattr(schedule_module, 'FADProductionData', DummyFADProductionData)
+
+    data_ops = DummyDataOperations()
+    data_ops.register('asset_name', '1', 'uri_folder')
+
+    collections = {
+        'model_inputs': DummyCollectionEntry('/subscriptions/sub/.../model_inputs', enabled='true'),
+        'model_outputs': DummyCollectionEntry('/subscriptions/sub/.../model_outputs', enabled='true'),
+    }
+    data_collector = DummyDataCollector(collections)
+    online_dep = DummyOnlineDeployment(data_collector=data_collector)
+    online_ops = DummyOnlineDeploymentOperations(online_dep)
+
+    job_ops = DummyJobOperations()
+    orchestrator = DummyOrchestrator()
+
+    ops = _create_schedule_ops(job_ops=job_ops, data_ops=data_ops, online_ops=online_ops, orchestrator=orchestrator)
+
+    target = DummyTarget(endpoint_deployment_id='endpoint:deployment')
+
+    signal = types.SimpleNamespace()
+    signal.type = schedule_module.MonitorSignalType.FEATURE_ATTRIBUTION_DRIFT
+    signal.production_data = None
+    signal.reference_data = DummyRefData(input_data=DummyInput(path='ref_path'))
+
+    schedule = DummySchedule(signals={'sig1': signal}, target=target)
+
+    schedule_module.ScheduleOperations._resolve_monitor_schedule_arm_id(ops, schedule)  # type: ignore[arg-type]
+
+    assert isinstance(signal.production_data, list)
+    assert len(signal.production_data) == 2
+    assert len(job_ops.resolved_inputs) == 3
+    assert isinstance(signal.reference_data.pre_processing_component, str)
+    assert signal.reference_data.pre_processing_component.startswith('resolved:')
+    for prod_data in signal.production_data:
+        assert prod_data.pre_processing_component.startswith('resolved:')
+
+
+def test_feature_attr_drift_raises_when_no_data_collector_and_no_production(monkeypatch):
+    monkeypatch.setattr(schedule_module, 'Input', DummyInput)
+    monkeypatch.setattr(schedule_module, 'BaselineDataRange', DummyBaselineDataRange)
+    monkeypatch.setattr(schedule_module, 'FADProductionData', DummyFADProductionData)
+
+    ops = _create_schedule_ops()
+
+    # no endpoint_deployment_id, so mdc flags remain False
+    target = DummyTarget(endpoint_deployment_id=None)
+
+    signal = types.SimpleNamespace()
+    signal.type = schedule_module.MonitorSignalType.FEATURE_ATTRIBUTION_DRIFT
+    signal.production_data = None
+    signal.reference_data = None
+
+    schedule = DummySchedule(signals={'sig_err': signal}, target=target)
+
+    with pytest.raises(schedule_module.ScheduleException) as ex:
+        schedule_module.ScheduleOperations._resolve_monitor_schedule_arm_id(ops, schedule)  # type: ignore[arg-type]
+
+    assert 'production data must be provided' in str(ex.value)
+
+
+def test_non_feature_signal_uses_resolve_job_inputs_and_updates_preprocessing():
+    job_ops = DummyJobOperations()
+    orchestrator = DummyOrchestrator()
+    ops = _create_schedule_ops(job_ops=job_ops, orchestrator=orchestrator)
+
+    target = DummyTarget()
+
+    prod = types.SimpleNamespace()
+    prod.input_data = DummyInput(path='prod_path')
+    prod.pre_processing_component = 'comp_prod'
+
+    ref = types.SimpleNamespace()
+    ref.input_data = DummyInput(path='ref_path')
+    ref.pre_processing_component = 'comp_ref'
+
+    signal = types.SimpleNamespace()
+    signal.type = schedule_module.MonitorSignalType.DATA_QUALITY
+    signal.production_data = prod
+    signal.reference_data = ref
+
+    schedule = DummySchedule(signals={'dq': signal}, target=target)
+
+    schedule_module.ScheduleOperations._resolve_monitor_schedule_arm_id(ops, schedule)  # type: ignore[arg-type]
+
+    assert len(job_ops.resolved_inputs_multi) == 1
+    resolved_inputs = job_ops.resolved_inputs_multi[0]
+    assert resolved_inputs[0] is prod.input_data
+    assert resolved_inputs[1] is ref.input_data
+
+    assert prod.pre_processing_component == 'resolved:comp_prod'
+    assert ref.pre_processing_component == 'resolved:comp_ref'
+
+
+def test_process_and_get_endpoint_deployment_names_uses_arm_id_when_arm_id(monkeypatch):
+    ops = _create_schedule_ops_instance()
+    arm_id_value = '/subscriptions/sub/providers/Microsoft.MachineLearningServices/workspaces/ws/onlineEndpoints/parent-endpoint/deployments/child-deployment'
+
+    def fake_is_arm(resource_id, parent_type, child_type):  # pylint:disable=unused-argument
+        return resource_id == arm_id_value
+
+    monkeypatch.setattr(schedule_module, 'is_ARM_id_for_parented_resource', fake_is_arm)
+
+    class DummyAMLNamedArmId:
+        def __init__(self, arm_id):  # pylint:disable=unused-argument
+            self.parent_asset_name = 'parent-endpoint'
+            self.asset_name = 'child-deployment'
+
+    monkeypatch.setattr(schedule_module, 'AMLNamedArmId', DummyAMLNamedArmId)
+
+    target = MonitoringTarget(endpoint_deployment_id=arm_id_value)
+    endpoint_name, deployment_name = ops._process_and_get_endpoint_deployment_names_from_id(target)
+    assert endpoint_name == 'parent-endpoint'
+    assert deployment_name == 'child-deployment'
+    assert target.endpoint_deployment_id == arm_id_value
+
+
+def test_process_and_get_endpoint_deployment_names_parses_named_id(monkeypatch):
+    ops = DummyScheduleOperations(subscription_id='sub', resource_group_name='rg', workspace_name='ws')
+
+    def fake_is_arm(resource_id, parent_type, child_type):  # pylint:disable=unused-argument
+        return False
+
+    monkeypatch.setattr(schedule_module, 'is_ARM_id_for_parented_resource', fake_is_arm)
+
+    target = MonitoringTarget(endpoint_deployment_id='endpoint:deployment')
+    endpoint_name, deployment_name = ops._process_and_get_endpoint_deployment_names_from_id(target)
+    assert endpoint_name == 'endpoint'
+    assert deployment_name == 'deployment'
+    assert target.endpoint_deployment_id.startswith('/subscriptions/sub/')
+    assert '/workspaces/ws/onlineEndpoints/endpoint/deployments/deployment' in target.endpoint_deployment_id
+
+
+def _make_schedule_ops():
+    schedule_ops = ScheduleOperations.__new__(ScheduleOperations)
+    schedule_ops._operation_scope = types.SimpleNamespace(
+        subscription_id='subs',
+        resource_group_name='rg',
+        workspace_name='ws',
+    )
+    schedule_ops._operation_config = types.SimpleNamespace(show_progress=False, enable_telemetry=False)
+    return schedule_ops
+
+
+def test_process_endpoint_deployment_for_named_resource(monkeypatch):
+    schedule_ops = _make_schedule_ops()
+    target = DummyTarget()
+    target.endpoint_deployment_id = 'endpointX:deploymentY'
+
+    monkeypatch.setattr(
+        'azure.ai.ml.operations._schedule_operations.is_ARM_id_for_parented_resource',
+        lambda *_: False,
+    )
+
+    endpoint_name, deployment_name = schedule_ops._process_and_get_endpoint_deployment_names_from_id(target)
+
+    assert endpoint_name == 'endpointX'
+    assert deployment_name == 'deploymentY'
+    expected_formatted_id = NAMED_RESOURCE_ID_FORMAT_WITH_PARENT.format(
+        schedule_ops._subscription_id,
+        schedule_ops._resource_group_name,
+        AZUREML_RESOURCE_PROVIDER,
+        schedule_ops._workspace_name,
+        schedule_module.snake_to_camel(AzureMLResourceType.ONLINE_ENDPOINT),
+        'endpointX',
+        AzureMLResourceType.DEPLOYMENT,
+        'deploymentY',
+    )
+    assert target.endpoint_deployment_id == expected_formatted_id
+
+
+def test_process_endpoint_deployment_for_arm_id(monkeypatch):
+    schedule_ops = _make_schedule_ops()
+    target = DummyTarget()
+    original_id = (
+        '/subscriptions/foo/resourceGroups/bar/providers/Microsoft.MachineLearningServices'
+        '/workspaces/baz/onlineEndpoints/endpointAlpha/deployments/deployBeta'
+    )
+    target.endpoint_deployment_id = original_id
+
+    monkeypatch.setattr(
+        'azure.ai.ml.operations._schedule_operations.is_ARM_id_for_parented_resource',
+        lambda *_: True,
+    )
+
+    class StubNamedArmId:
+        def __init__(self, arm_id):
+            self.parent_asset_name = 'endpointAlpha'
+            self.asset_name = 'deployBeta'
+
+    monkeypatch.setattr(
+        'azure.ai.ml.operations._schedule_operations.AMLNamedArmId',
+        StubNamedArmId,
+    )
+
+    endpoint_name, deployment_name = schedule_ops._process_and_get_endpoint_deployment_names_from_id(target)
+
+    assert endpoint_name == 'endpointAlpha'
+    assert deployment_name == 'deployBeta'
+    assert target.endpoint_deployment_id == original_id
+
+
+class GeneratedDummyJobOperations:
+    def __init__(self):
+        self.resolved_inputs = []
+        self.resolved_job_inputs = []
+
+    def _resolve_job_input(self, input_obj, base_path):
+        self.resolved_inputs.append((input_obj, base_path))
+
+    def _resolve_job_inputs(self, inputs, base_path):
+        self.resolved_job_inputs.append((inputs, base_path))
+
+
+class GeneratedDummyDataOperations:
+    def get(self, name, version):
+        return SimpleNamespace(type=f'Type({name},{version})')
+
+
+class GeneratedDummyOnlineDeploymentOperations:
+    def __init__(self, deployment):
+        self._deployment = deployment
+
+    def get(self, deployment_name, endpoint_name):
+        return self._deployment
+
+
+def _generated_build_operations_container(job_ops, online_ops, data_ops):
+    class Container:
+        def get_operation(self, resource_type, _type_check):
+            if resource_type == AzureMLResourceType.JOB:
+                return job_ops
+            if resource_type == AzureMLResourceType.ONLINE_DEPLOYMENT:
+                return online_ops
+            if resource_type == AzureMLResourceType.DATA:
+                return data_ops
+            raise KeyError(resource_type)
+
+    return Container()
+
+
+class GeneratedDummyOrchestrator:
+    def get_asset_arm_id(self, asset, azureml_type=None, register_asset=None):
+        if asset:
+            return asset
+        return f'{azureml_type}-arm'
+
+
+class GeneratedDummyMonitorDefinition:
+    def __init__(self, target, monitoring_signals):
+        self.monitoring_target = target
+        self.monitoring_signals = monitoring_signals
+
+
+class GeneratedDummySchedule:
+    def __init__(self, target, monitoring_signals):
+        self.create_monitor = GeneratedDummyMonitorDefinition(target, monitoring_signals)
+        self._base_path = '/base'
+
+    def _create_default_monitor_definition(self):
+        self.default_created = True
+
+
+class GeneratedDummySignal:
+    def __init__(self, signal_type):
+        self.type = signal_type
+        self.production_data = None
+        self.reference_data = None
+
+
+def _generated_build_schedule_operations(online_deployment):
+    schedule_ops = object.__new__(ScheduleOperations)
+    schedule_ops._operation_scope = types.SimpleNamespace(subscription_id='sub', resource_group_name='rg', workspace_name='ws')
+    schedule_ops._kwargs = {}
+    schedule_ops._service_client_kwargs = {}
+    schedule_ops._orchestrators = GeneratedDummyOrchestrator()
+    job_ops = GeneratedDummyJobOperations()
+    data_ops = GeneratedDummyDataOperations()
+    schedule_ops._all_operations = _generated_build_operations_container(
+        job_ops, GeneratedDummyOnlineDeploymentOperations(online_deployment), data_ops
+    )
+    return schedule_ops, job_ops
+
+
+def _generated_build_endpoint_deployment(tags):
+    return SimpleNamespace(tags=tags, data_collector=None)
+
+
+def _generated_build_target():
+    return SimpleNamespace(endpoint_deployment_id='endpoint:deployment', model_id=None)
+
+
+def test_data_drift_without_collector_raises_schedule_exception():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, _ = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.DATA_DRIFT)
+    schedule = GeneratedDummySchedule(target, {'data_drift': signal})
+
+    with pytest.raises(schedule_module.ScheduleException) as exc_info:
+        schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    assert 'A target and baseline dataset must be provided' in str(exc_info.value)
+
+
+def test_data_drift_with_input_collector_populates_defaults():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'true',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, job_ops = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.DATA_DRIFT)
+    schedule = GeneratedDummySchedule(target, {'data_drift': signal})
+
+    schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    expected_input_path = f'{tags[DEPLOYMENT_MODEL_INPUTS_NAME_KEY]}:{tags[DEPLOYMENT_MODEL_INPUTS_VERSION_KEY]}'
+    assert signal.production_data.input_data.path == expected_input_path
+    assert signal.reference_data.input_data.path == expected_input_path
+    inputs, base_path = job_ops.resolved_job_inputs[-1]
+    assert base_path == '/base'
+    assert inputs[0].path == expected_input_path
+    assert inputs[1].path == expected_input_path
+
+
+def test_prediction_drift_with_output_collector_populates_defaults():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'true',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, job_ops = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.PREDICTION_DRIFT)
+    schedule = GeneratedDummySchedule(target, {'prediction_drift': signal})
+
+    schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    expected_output_path = f'{tags[DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY]}:{tags[DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY]}'
+    assert signal.production_data.input_data.path == expected_output_path
+    assert signal.reference_data.input_data.path == expected_output_path
+    inputs, base_path = job_ops.resolved_job_inputs[-1]
+    assert base_path == '/base'
+    assert inputs[0].path == expected_output_path
+    assert inputs[1].path == expected_output_path
+
+
+def test_prediction_drift_without_output_collector_raises_schedule_exception():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, _ = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.PREDICTION_DRIFT)
+    schedule = GeneratedDummySchedule(target, {'prediction_drift': signal})
+
+    with pytest.raises(schedule_module.ScheduleException) as exc_info:
+        schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    assert 'A target and baseline dataset must be provided' in str(exc_info.value)
+
+
+def test_feature_attribution_with_input_collector_populates_production_list():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'true',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'true',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, job_ops = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.FEATURE_ATTRIBUTION_DRIFT)
+    signal.reference_data = ReferenceData(
+        input_data=Input(path='ref_target:1', type='ref-type'),
+        data_context=MonitorDatasetContext.MODEL_OUTPUTS,
+        data_window=BaselineDataRange(lookback_window_size='default', lookback_window_offset='default'),
+    )
+    schedule = GeneratedDummySchedule(target, {'feature_attr': signal})
+
+    schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    assert isinstance(signal.production_data, list)
+    assert len(signal.production_data) == 2
+    paths = [prod.input_data.path for prod in signal.production_data]
+    assert paths == [
+        f'{tags[DEPLOYMENT_MODEL_INPUTS_NAME_KEY]}:{tags[DEPLOYMENT_MODEL_INPUTS_VERSION_KEY]}',
+        f'{tags[DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY]}:{tags[DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY]}',
+    ]
+    assert len(job_ops.resolved_inputs) == 3
+    assert job_ops.resolved_inputs[-1][0].path == 'ref_target:1'
+
+
+def test_feature_attribution_without_output_collector_raises_schedule_exception():
+    tags = {
+        DEPLOYMENT_MODEL_INPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_OUTPUTS_COLLECTION_KEY: 'false',
+        DEPLOYMENT_MODEL_INPUTS_NAME_KEY: 'model_in',
+        DEPLOYMENT_MODEL_INPUTS_VERSION_KEY: 'v1',
+        DEPLOYMENT_MODEL_OUTPUTS_NAME_KEY: 'model_out',
+        DEPLOYMENT_MODEL_OUTPUTS_VERSION_KEY: 'v2',
+    }
+    deployment = _generated_build_endpoint_deployment(tags)
+    schedule_ops, _ = _generated_build_schedule_operations(deployment)
+    target = _generated_build_target()
+    signal = GeneratedDummySignal(schedule_module.MonitorSignalType.FEATURE_ATTRIBUTION_DRIFT)
+    schedule = GeneratedDummySchedule(target, {'feature_attr': signal})
+
+    with pytest.raises(schedule_module.ScheduleException) as exc_info:
+        schedule_ops._resolve_monitor_schedule_arm_id(schedule)
+
+    assert 'A production data must be provided' in str(exc_info.value)

--- a/sdk/ml/azure-ai-ml/tests/test_thresholds_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_thresholds_gaps.py
@@ -1,0 +1,942 @@
+import pytest
+import types
+from types import SimpleNamespace
+
+from azure.ai.ml._restclient.v2023_06_01_preview.models import (
+    MonitoringThreshold,
+    FeatureAttributionMetricThreshold,
+    ClassificationModelPerformanceMetricThreshold,
+    GenerationSafetyQualityMetricThreshold,
+    GenerationTokenStatisticsMetricThreshold,
+    CustomMetricThreshold,
+)
+from azure.ai.ml.constants._monitoring import MonitorMetricName
+from azure.ai.ml.entities._monitoring.thresholds import (
+    NumericalDriftMetrics,
+    CategoricalDriftMetrics,
+    DataDriftMetricThreshold,
+    PredictionDriftMetricThreshold,
+    DataQualityMetricThreshold,
+    FeatureAttributionDriftMetricThreshold,
+    ModelPerformanceClassificationThresholds,
+    ModelPerformanceRegressionThresholds,
+    ModelPerformanceMetricThreshold,
+    CustomMonitoringMetricThreshold,
+    GenerationSafetyQualityMonitoringMetricThreshold,
+    GenerationTokenStatisticsMonitorMetricThreshold,
+)
+
+GenerationTokenStatisticsMonitoringMetricThreshold = GenerationTokenStatisticsMonitorMetricThreshold
+
+
+class _DummyThreshold:
+    def __init__(self, metric: str, value: float):
+        class _Value:
+            pass
+
+        self.metric = metric
+        self.threshold = _Value()
+        self.threshold.value = value
+
+
+def test_numerical_drift_metrics_from_rest_jensen_shannon_distance():
+    metric = NumericalDriftMetrics._from_rest_object("JensenShannonDistance", 0.5)
+
+    assert metric.jensen_shannon_distance == 0.5
+    assert metric.normalized_wasserstein_distance is None
+    assert metric.population_stability_index is None
+    assert metric.two_sample_kolmogorov_smirnov_test is None
+
+
+def test_numerical_drift_metrics_from_rest_normalized_wasserstein_distance():
+    metric = NumericalDriftMetrics._from_rest_object("NormalizedWassersteinDistance", 0.3)
+
+    assert metric.jensen_shannon_distance is None
+    assert metric.normalized_wasserstein_distance == 0.3
+    assert metric.population_stability_index is None
+    assert metric.two_sample_kolmogorov_smirnov_test is None
+
+
+def test_numerical_drift_metrics_from_rest_population_stability_index():
+    metric = NumericalDriftMetrics._from_rest_object("PopulationStabilityIndex", 0.2)
+
+    assert metric.jensen_shannon_distance is None
+    assert metric.normalized_wasserstein_distance is None
+    assert metric.population_stability_index == 0.2
+    assert metric.two_sample_kolmogorov_smirnov_test is None
+
+
+def test_numerical_drift_metrics_from_rest_two_sample_ks_test():
+    metric = NumericalDriftMetrics._from_rest_object("TwoSampleKolmogorovSmirnovTest", 0.1)
+
+    assert metric.jensen_shannon_distance is None
+    assert metric.normalized_wasserstein_distance is None
+    assert metric.population_stability_index is None
+    assert metric.two_sample_kolmogorov_smirnov_test == 0.1
+
+
+def test_numerical_drift_metrics_from_rest_unknown_metric_returns_empty():
+    metric = NumericalDriftMetrics._from_rest_object("UnknownMetric", 1.0)
+
+    assert metric.jensen_shannon_distance is None
+    assert metric.normalized_wasserstein_distance is None
+    assert metric.population_stability_index is None
+    assert metric.two_sample_kolmogorov_smirnov_test is None
+
+
+def test_numerical_drift_metrics_get_default_thresholds():
+    metric = NumericalDriftMetrics._get_default_thresholds()
+
+    assert metric.normalized_wasserstein_distance == 0.1
+    assert metric.jensen_shannon_distance is None
+    assert metric.population_stability_index is None
+    assert metric.two_sample_kolmogorov_smirnov_test is None
+
+
+def test_categorical_drift_metrics_find_name_and_threshold_priority_order():
+    metrics = CategoricalDriftMetrics(
+        jensen_shannon_distance=0.2,
+        population_stability_index=0.4,
+        pearsons_chi_squared_test=0.6,
+    )
+
+    metric_name, threshold = metrics._find_name_and_threshold()
+
+    assert metric_name == MonitorMetricName.JENSEN_SHANNON_DISTANCE
+    assert isinstance(threshold, MonitoringThreshold)
+    assert threshold.value == 0.2
+
+
+def test_categorical_drift_metrics_find_name_and_threshold_population_only():
+    metrics = CategoricalDriftMetrics(
+        population_stability_index=0.4,
+    )
+
+    metric_name, threshold = metrics._find_name_and_threshold()
+
+    assert metric_name == MonitorMetricName.POPULATION_STABILITY_INDEX
+    assert isinstance(threshold, MonitoringThreshold)
+    assert threshold.value == 0.4
+
+
+def test_categorical_drift_metrics_find_name_and_threshold_pearsons_only():
+    metrics = CategoricalDriftMetrics(
+        pearsons_chi_squared_test=0.6,
+    )
+
+    metric_name, threshold = metrics._find_name_and_threshold()
+
+    assert metric_name == MonitorMetricName.PEARSONS_CHI_SQUARED_TEST
+    assert isinstance(threshold, MonitoringThreshold)
+    assert threshold.value == 0.6
+
+
+def test_categorical_drift_metrics_get_default_thresholds():
+    metric = CategoricalDriftMetrics._get_default_thresholds()
+
+    assert metric.jensen_shannon_distance == 0.1
+    assert metric.population_stability_index is None
+    assert metric.pearsons_chi_squared_test is None
+
+
+def test_data_drift_metric_threshold_eq_not_implemented_for_other_type():
+    threshold = DataDriftMetricThreshold()
+
+    result = DataDriftMetricThreshold.__eq__(threshold, 5)  # type: ignore[arg-type]
+
+    assert result is NotImplemented
+
+
+def test_prediction_drift_metric_threshold_eq_not_implemented_for_other_type():
+    threshold = PredictionDriftMetricThreshold()
+
+    result = PredictionDriftMetricThreshold.__eq__(threshold, "other")  # type: ignore[arg-type]
+
+    assert result is NotImplemented
+
+
+def test_data_quality_metric_threshold_eq_not_implemented_for_other_type():
+    threshold = DataQualityMetricThreshold()
+
+    result = DataQualityMetricThreshold.__eq__(threshold, object())  # type: ignore[arg-type]
+
+    assert result is NotImplemented
+
+
+def test_feature_attribution_drift_metric_threshold_to_rest_with_and_without_value():
+    fat_with_value = FeatureAttributionDriftMetricThreshold(normalized_discounted_cumulative_gain=2.5)
+    rest_with_value = fat_with_value._to_rest_object()
+    assert isinstance(rest_with_value, FeatureAttributionMetricThreshold)
+    assert rest_with_value.threshold.value == 2.5
+
+    fat_without_value = FeatureAttributionDriftMetricThreshold()
+    rest_without_value = fat_without_value._to_rest_object()
+    assert rest_without_value.threshold is None
+
+
+def test_feature_attribution_drift_metric_threshold_from_rest():
+    rest_obj = FeatureAttributionMetricThreshold(
+        metric="NormalizedDiscountedCumulativeGain",
+        threshold=MonitoringThreshold(value=1.2),
+    )
+    fat = FeatureAttributionDriftMetricThreshold._from_rest_object(rest_obj)
+    assert isinstance(fat, FeatureAttributionDriftMetricThreshold)
+    assert fat.normalized_discounted_cumulative_gain == 1.2
+
+
+def test_model_performance_classification_thresholds_to_str_and_from_rest():
+    thresholds = ModelPerformanceClassificationThresholds(accuracy=0.8, precision=0.7, recall=0.6)
+    result = thresholds._to_str_object()
+    assert '"metric":"Accuracy"' in result
+    assert '"threshold":{"value":0.8}' in result
+    assert '"metric":"Precision"' in result
+    assert '"threshold":{"value":0.7}' in result
+    assert '"metric":"Recall"' in result
+    assert '"threshold":{"value":0.6}' in result
+
+    empty_thresholds = ModelPerformanceClassificationThresholds()
+    assert empty_thresholds._to_str_object() is None
+
+    rest_obj = ClassificationModelPerformanceMetricThreshold(
+        metric="Accuracy", threshold=MonitoringThreshold(value=0.9)
+    )
+    from_rest = ModelPerformanceClassificationThresholds._from_rest_object(rest_obj)
+    assert isinstance(from_rest, ModelPerformanceClassificationThresholds)
+    assert from_rest.accuracy == 0.9
+    assert from_rest.precision is None
+    assert from_rest.recall is None
+
+
+def test_model_performance_regression_thresholds_to_str_object_branches():
+    thresholds = ModelPerformanceRegressionThresholds(
+        mean_absolute_error=1.0,
+        mean_squared_error=2.0,
+        root_mean_squared_error=3.0,
+    )
+    result = thresholds._to_str_object()
+    assert '"metric":"MeanAbsoluteError"' in result
+    assert '"threshold":{"value":1.0}' in result
+    assert '"metric":"MeanSquaredError"' in result
+    assert '"threshold":{"value":2.0}' in result
+    assert '"metric":"RootMeanSquaredError"' in result
+    assert '"threshold":{"value":3.0}' in result
+
+    empty_thresholds = ModelPerformanceRegressionThresholds()
+    assert empty_thresholds._to_str_object() is None
+
+
+def test_model_performance_metric_threshold_to_str_object_combinations():
+    classification = ModelPerformanceClassificationThresholds(accuracy=0.75)
+    regression = ModelPerformanceRegressionThresholds(mean_absolute_error=1.1)
+
+    both = ModelPerformanceMetricThreshold(classification=classification, regression=regression)
+    both_str = both._to_str_object()
+    assert both_str.startswith("[") and both_str.endswith("]")
+    assert '"metric":"Accuracy"' in both_str
+    assert '"metric":"MeanAbsoluteError"' in both_str
+    assert "," in both_str.strip("[]")
+
+    only_classification = ModelPerformanceMetricThreshold(classification=classification)
+    only_class_str = only_classification._to_str_object()
+    assert only_class_str.startswith("[") and only_class_str.endswith("]")
+    assert '"metric":"Accuracy"' in only_class_str
+    assert "MeanAbsoluteError" not in only_class_str
+
+    only_regression = ModelPerformanceMetricThreshold(regression=regression)
+    only_reg_str = only_regression._to_str_object()
+    assert only_reg_str.startswith("[") and only_reg_str.endswith("]")
+    assert '"metric":"MeanAbsoluteError"' in only_reg_str
+    assert "Accuracy" not in only_reg_str
+
+    empty = ModelPerformanceMetricThreshold()
+    assert empty._to_str_object() is None
+
+
+def test_custom_monitoring_metric_threshold_to_and_from_rest():
+    custom_with_threshold = CustomMonitoringMetricThreshold(metric_name="myMetric", threshold=1.5)
+    rest_with_threshold = custom_with_threshold._to_rest_object()
+    assert rest_with_threshold.metric == "myMetric"
+    assert isinstance(rest_with_threshold.threshold, MonitoringThreshold)
+    assert rest_with_threshold.threshold.value == 1.5
+
+    custom_without_threshold = CustomMonitoringMetricThreshold(metric_name="myMetric", threshold=None)
+    rest_without_threshold = custom_without_threshold._to_rest_object()
+    assert rest_without_threshold.metric == "myMetric"
+    assert rest_without_threshold.threshold is None
+
+    from_rest = CustomMonitoringMetricThreshold._from_rest_object(rest_with_threshold)
+    assert from_rest.metric_name == "myMetric"
+    assert from_rest.threshold == 1.5
+
+
+def test_generation_safety_quality_monitoring_metric_threshold_to_and_from_rest_with_defaults():
+    safety = GenerationSafetyQualityMonitoringMetricThreshold(
+        groundedness={"aggregated_groundedness_pass_rate": 0.9},
+        relevance={
+            "acceptable_relevance_score_per_instance": 4,
+            "aggregated_relevance_pass_rate": 0.8,
+        },
+    )
+    rest_list = safety._to_rest_object()
+    grounded_accept = [m for m in rest_list if m.metric == "AcceptableGroundednessScorePerInstance"][0]
+    grounded_agg = [m for m in rest_list if m.metric == "AggregatedGroundednessPassRate"][0]
+    relevance_accept = [m for m in rest_list if m.metric == "AcceptableRelevanceScorePerInstance"][0]
+    relevance_agg = [m for m in rest_list if m.metric == "AggregatedRelevancePassRate"][0]
+
+    assert grounded_accept.threshold.value == 3
+    assert grounded_agg.threshold.value == 0.9
+    assert relevance_accept.threshold.value == 4
+    assert relevance_agg.threshold.value == 0.8
+
+    round_tripped = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(rest_list)
+    assert round_tripped.groundedness["aggregated_groundedness_pass_rate"] == 0.9
+    assert "acceptable_groundedness_score_per_instance" in round_tripped.groundedness
+    assert round_tripped.relevance["acceptable_relevance_score_per_instance"] == 4
+    assert round_tripped.relevance["aggregated_relevance_pass_rate"] == 0.8
+
+
+def test_generation_token_statistics_monitor_metric_threshold_to_rest_with_and_without_total_token():
+    token_thresholds = GenerationTokenStatisticsMonitoringMetricThreshold(
+        totaltoken={"total_token_count": 5, "total_token_count_per_group": 2}
+    )
+    rest_list = token_thresholds._to_rest_object()
+    assert len(rest_list) == 2
+
+    total_count = [m for m in rest_list if m.metric == "TotalTokenCount"][0]
+    total_count_per_group = [m for m in rest_list if m.metric == "TotalTokenCountPerGroup"][0]
+
+    assert isinstance(total_count, GenerationTokenStatisticsMetricThreshold)
+    assert total_count.threshold.value == 5
+    assert isinstance(total_count_per_group, GenerationSafetyQualityMetricThreshold)
+    assert total_count_per_group.threshold.value == 2
+
+    token_thresholds_default = GenerationTokenStatisticsMonitoringMetricThreshold(
+        totaltoken={"total_token_count_per_group": 4}
+    )
+    rest_list_default = token_thresholds_default._to_rest_object()
+    total_count_default = [m for m in rest_list_default if m.metric == "TotalTokenCount"][0]
+    assert total_count_default.threshold.value == 3
+
+
+def test_generation_token_statistics_monitor_metric_threshold_from_rest_and_defaults():
+    rest_list = [
+        GenerationTokenStatisticsMetricThreshold(
+            metric="TotalTokenCount", threshold=MonitoringThreshold(value=7)
+        ),
+        GenerationTokenStatisticsMetricThreshold(
+            metric="TotalTokenCountPerGroup", threshold=MonitoringThreshold(value=11)
+        ),
+    ]
+    from_rest = GenerationTokenStatisticsMonitoringMetricThreshold._from_rest_object(rest_list)
+    assert from_rest.totaltoken["total_token_count"] == 7
+    assert from_rest.totaltoken["total_token_count_per_group"] == 11
+
+    default_obj = GenerationTokenStatisticsMonitoringMetricThreshold._get_default_thresholds()
+    assert default_obj.totaltoken["total_token_count"] == 0
+    assert default_obj.totaltoken["total_token_count_per_group"] == 0
+
+
+def test_model_performance_classification_accuracy_true_and_false_branches():
+    cls_with_accuracy = ModelPerformanceClassificationThresholds(accuracy=0.8, precision=None, recall=None)
+    result_with_accuracy = cls_with_accuracy._to_str_object()
+    assert '"Accuracy"' in result_with_accuracy
+
+    cls_without_accuracy = ModelPerformanceClassificationThresholds(accuracy=None, precision=0.5, recall=None)
+    result_without_accuracy = cls_without_accuracy._to_str_object()
+    assert '"Precision"' in result_without_accuracy
+    assert '"Accuracy"' not in result_without_accuracy
+
+
+def test_model_performance_metric_threshold_str_object_len_branches_and_nonempty():
+    classification_thresholds = ModelPerformanceClassificationThresholds(accuracy=0.9, precision=None, recall=None)
+    regression_thresholds = ModelPerformanceRegressionThresholds(
+        mean_absolute_error=0.1,
+        mean_squared_error=None,
+        root_mean_squared_error=None,
+    )
+
+    metric_two = ModelPerformanceMetricThreshold(
+        classification=classification_thresholds,
+        regression=regression_thresholds,
+    )
+    result_two = metric_two._to_str_object()
+    assert result_two.startswith("[")
+    assert '"Accuracy"' in result_two
+    assert '"MeanAbsoluteError"' in result_two
+
+    metric_one = ModelPerformanceMetricThreshold(
+        classification=classification_thresholds,
+        regression=None,
+    )
+    result_one = metric_one._to_str_object()
+    assert result_one.startswith("[")
+    assert '"Accuracy"' in result_one
+    assert '"MeanAbsoluteError"' not in result_one
+
+
+def test_custom_monitoring_metric_threshold_to_rest_object_threshold_branches():
+    metric_with_threshold = CustomMonitoringMetricThreshold(metric_name="my_metric", threshold=1.5)
+    rest_with_threshold = metric_with_threshold._to_rest_object()
+    assert isinstance(rest_with_threshold, CustomMetricThreshold)
+    assert rest_with_threshold.threshold.value == 1.5
+
+    metric_without_threshold = CustomMonitoringMetricThreshold(metric_name="my_metric", threshold=None)
+    rest_without_threshold = metric_without_threshold._to_rest_object()
+    assert isinstance(rest_without_threshold, CustomMetricThreshold)
+    assert rest_without_threshold.threshold is None
+
+
+def test_generation_safety_quality_monitoring_metric_threshold_empty_returns_empty_list():
+    metric = GenerationSafetyQualityMonitoringMetricThreshold()
+    rest_list = metric._to_rest_object()
+    assert isinstance(rest_list, list)
+    assert rest_list == []
+
+
+def test_generation_token_statistics_monitor_metric_threshold_default_total_token_count_branch():
+    metric = GenerationTokenStatisticsMonitoringMetricThreshold(
+        totaltoken={"total_token_count_per_group": 7}
+    )
+    rest_list = metric._to_rest_object()
+    assert len(rest_list) == 2
+
+    total_token_rest = next(x for x in rest_list if x.metric == "TotalTokenCount")
+    assert isinstance(total_token_rest, GenerationTokenStatisticsMetricThreshold)
+    assert total_token_rest.threshold.value == 3
+
+    per_group_rest = next(x for x in rest_list if x.metric == "TotalTokenCountPerGroup")
+    assert isinstance(per_group_rest, GenerationSafetyQualityMetricThreshold)
+    assert per_group_rest.threshold.value == 7
+
+
+def test_generation_safety_quality_from_rest_object_relevance_only_and_others_none():
+    thresholds = [
+        _DummyThreshold("AcceptableRelevanceScorePerInstance", 4.0),
+        _DummyThreshold("AggregatedRelevancePassRate", 0.9),
+    ]
+
+    result = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.groundedness is None
+    assert result.coherence is None
+    assert result.fluency is None
+    assert result.similarity is None
+    assert result.relevance == {
+        "acceptable_relevance_score_per_instance": 4.0,
+        "aggregated_relevance_pass_rate": 0.9,
+    }
+
+
+def test_generation_safety_quality_from_rest_object_with_no_thresholds_returns_all_none():
+    thresholds = []
+
+    result = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.groundedness is None
+    assert result.relevance is None
+    assert result.coherence is None
+    assert result.fluency is None
+    assert result.similarity is None
+
+
+def test_generation_token_statistics_from_rest_object_with_both_metrics():
+    thresholds = [
+        _DummyThreshold("TotalTokenCount", 5.0),
+        _DummyThreshold("TotalTokenCountPerGroup", 7.0),
+    ]
+
+    result = GenerationTokenStatisticsMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.totaltoken == {
+        "total_token_count": 5.0,
+        "total_token_count_per_group": 7.0,
+    }
+
+
+def test_generation_token_statistics_from_rest_object_with_no_metrics_results_in_none():
+    thresholds = []
+
+    result = GenerationTokenStatisticsMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.totaltoken is None
+
+
+def test_generation_token_statistics_get_default_thresholds_values():
+    result = GenerationTokenStatisticsMonitoringMetricThreshold._get_default_thresholds()
+
+    assert result.totaltoken == {
+        "total_token_count": 0,
+        "total_token_count_per_group": 0,
+    }
+
+
+def test_generation_safety_quality_from_rest_object_all_metrics():
+    thresholds = [
+        _DummyThreshold("AcceptableGroundednessScorePerInstance", 1.1),
+        _DummyThreshold("AggregatedGroundednessPassRate", 2.2),
+        _DummyThreshold("AcceptableRelevanceScorePerInstance", 3.3),
+        _DummyThreshold("AggregatedRelevancePassRate", 4.4),
+        _DummyThreshold("AcceptableCoherenceScorePerInstance", 5.5),
+        _DummyThreshold("AggregatedCoherencePassRate", 6.6),
+        _DummyThreshold("AcceptableFluencyScorePerInstance", 7.7),
+        _DummyThreshold("AggregatedFluencyPassRate", 8.8),
+        _DummyThreshold("AcceptableSimilarityScorePerInstance", 9.9),
+        _DummyThreshold("AggregatedSimilarityPassRate", 10.1),
+    ]
+
+    result = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.groundedness == {
+        "acceptable_groundedness_score_per_instance": 1.1,
+        "aggregated_groundedness_pass_rate": 2.2,
+    }
+    assert result.relevance == {
+        "acceptable_relevance_score_per_instance": 3.3,
+        "aggregated_relevance_pass_rate": 4.4,
+    }
+    assert result.coherence == {
+        "acceptable_coherence_score_per_instance": 5.5,
+        "aggregated_coherence_pass_rate": 6.6,
+    }
+    assert result.fluency == {
+        "acceptable_fluency_score_per_instance": 7.7,
+        "aggregated_fluency_pass_rate": 8.8,
+    }
+    assert result.similarity == {
+        "acceptable_similarity_score_per_instance": 9.9,
+        "aggregated_similarity_pass_rate": 10.1,
+    }
+
+
+def test_generation_token_statistics_from_rest_object_only_total_token_count():
+    thresholds = [
+        _DummyThreshold("TotalTokenCount", 5.0),
+    ]
+
+    result = GenerationTokenStatisticsMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.totaltoken == {"total_token_count": 5.0}
+
+
+def test_generation_token_statistics_from_rest_object_only_total_token_count_per_group():
+    thresholds = [
+        _DummyThreshold("TotalTokenCountPerGroup", 4.0),
+    ]
+
+    result = GenerationTokenStatisticsMonitoringMetricThreshold._from_rest_object(thresholds)
+
+    assert result.totaltoken == {"total_token_count_per_group": 4.0}
+
+@pytest.mark.parametrize(
+    'field_kwargs, expected_metric, expected_value',
+    [
+        ({'jensen_shannon_distance': 0.12}, MonitorMetricName.JENSEN_SHANNON_DISTANCE, 0.12),
+        ({'normalized_wasserstein_distance': 0.34}, MonitorMetricName.NORMALIZED_WASSERSTEIN_DISTANCE, 0.34),
+        ({'population_stability_index': 0.56}, MonitorMetricName.POPULATION_STABILITY_INDEX, 0.56),
+        ({'two_sample_kolmogorov_smirnov_test': 0.78}, MonitorMetricName.TWO_SAMPLE_KOLMOGOROV_SMIRNOV_TEST, 0.78),
+    ],
+)
+def test_numerical_drift_metrics_selects_first_available_metric(field_kwargs, expected_metric, expected_value):
+    metrics = NumericalDriftMetrics(**field_kwargs)
+    metric_name, threshold = metrics._find_name_and_threshold()
+    assert metric_name == expected_metric
+    assert threshold.value == expected_value
+
+@pytest.mark.parametrize(
+    'field_kwargs, expected_metric, expected_value',
+    [
+        ({'jensen_shannon_distance': 0.11}, MonitorMetricName.JENSEN_SHANNON_DISTANCE, 0.11),
+        ({'population_stability_index': 0.22}, MonitorMetricName.POPULATION_STABILITY_INDEX, 0.22),
+        ({'pearsons_chi_squared_test': 0.33}, MonitorMetricName.PEARSONS_CHI_SQUARED_TEST, 0.33),
+    ],
+)
+def test_categorical_drift_metrics_selects_next_metric_when_prior_absent(field_kwargs, expected_metric, expected_value):
+    metrics = CategoricalDriftMetrics(**field_kwargs)
+    metric_name, threshold = metrics._find_name_and_threshold()
+    assert metric_name == expected_metric
+    assert threshold.value == expected_value
+
+@pytest.mark.parametrize(
+    'rest_metric, attribute_name, value',
+    [
+        ('JensenShannonDistance', 'jensen_shannon_distance', 0.13),
+        ('PopulationStabilityIndex', 'population_stability_index', 0.24),
+        ('PearsonsChiSquaredTest', 'pearsons_chi_squared_test', 0.35),
+    ],
+)
+def test_categorical_drift_metrics_from_rest_sets_attribute(rest_metric, attribute_name, value):
+    metrics = CategoricalDriftMetrics()._from_rest_object(rest_metric, value)
+    assert getattr(metrics, attribute_name) == value
+
+
+def test_categorical_drift_metrics_from_rest_returns_empty_for_unknown_metric():
+    metrics = CategoricalDriftMetrics()._from_rest_object('UnknownMetric', 0.5)
+    assert metrics.jensen_shannon_distance is None
+    assert metrics.population_stability_index is None
+    assert metrics.pearsons_chi_squared_test is None
+
+
+def test_data_drift_metric_threshold_from_rest_groups_numerical_and_categorical_thresholds():
+    obj = [
+        SimpleNamespace(
+            data_type='Numerical',
+            metric='JensenShannonDistance',
+            threshold=SimpleNamespace(value=0.45),
+        ),
+        SimpleNamespace(
+            data_type='Categorical',
+            metric='PearsonsChiSquaredTest',
+            threshold=SimpleNamespace(value=0.67),
+        ),
+    ]
+    result = DataDriftMetricThreshold._from_rest_object(obj)
+    assert result.numerical.jensen_shannon_distance == 0.45
+    assert result.categorical.pearsons_chi_squared_test == 0.67
+
+
+def test_feature_attribution_drift_metric_threshold_serialization():
+    metric = FeatureAttributionDriftMetricThreshold(normalized_discounted_cumulative_gain=0.7)
+    rest_obj = metric._to_rest_object()
+    assert rest_obj.metric == "normalizedDiscountedCumulativeGain"
+    assert rest_obj.threshold.value == 0.7
+
+    no_value_rest = FeatureAttributionDriftMetricThreshold()._to_rest_object()
+    assert no_value_rest.metric == "normalizedDiscountedCumulativeGain"
+    assert no_value_rest.threshold is None
+
+    restored = FeatureAttributionDriftMetricThreshold._from_rest_object(rest_obj)
+    assert restored.normalized_discounted_cumulative_gain == 0.7
+
+    none_rest = FeatureAttributionDriftMetricThreshold._from_rest_object(
+        FeatureAttributionMetricThreshold(metric="NormalizedDiscountedCumulativeGain", threshold=None)
+    )
+    assert none_rest.normalized_discounted_cumulative_gain is None
+
+
+def test_model_performance_classification_and_regression_to_str_object_variations():
+    classification = ModelPerformanceClassificationThresholds(accuracy=0.8, recall=0.4)
+    classification_str = classification._to_str_object()
+    assert classification_str == (
+        "{\"modelType\":\"classification\",\"metric\":\"Accuracy\",\"threshold\":{\"value\":0.8}}, "
+        "{\"modelType\":\"classification\",\"metric\":\"Recall\",\"threshold\":{\"value\":0.4}}"
+    )
+    assert ModelPerformanceClassificationThresholds()._to_str_object() is None
+
+    regression = ModelPerformanceRegressionThresholds(mean_absolute_error=1.1, mean_squared_error=2.2)
+    regression_str = regression._to_str_object()
+    assert regression_str == (
+        "{\"modelType\":\"regression\",\"metric\":\"MeanAbsoluteError\",\"threshold\":{\"value\":1.1}}, "
+        "{\"modelType\":\"regression\",\"metric\":\"MeanSquaredError\",\"threshold\":{\"value\":2.2}}"
+    )
+    assert ModelPerformanceRegressionThresholds()._to_str_object() is None
+
+
+def test_model_performance_metric_threshold_to_str_object_variants():
+    classification = ModelPerformanceClassificationThresholds(accuracy=0.6)
+    regression = ModelPerformanceRegressionThresholds(mean_absolute_error=1.0)
+    combined = ModelPerformanceMetricThreshold(classification=classification, regression=regression)
+    assert combined._to_str_object() == "[" + classification._to_str_object() + ", " + regression._to_str_object() + "]"
+
+    single = ModelPerformanceMetricThreshold(classification=classification)
+    assert single._to_str_object() == "[" + classification._to_str_object() + "]"
+
+
+def test_model_performance_metric_threshold_from_rest_object():
+    rest_obj = ClassificationModelPerformanceMetricThreshold(
+        metric="Accuracy",
+        threshold=MonitoringThreshold(value=0.333),
+    )
+    result = ModelPerformanceMetricThreshold._from_rest_object(rest_obj)
+    assert result.classification.accuracy == 0.333
+    assert result.regression is None
+
+
+def test_custom_monitoring_metric_threshold_serialization():
+    custom = CustomMonitoringMetricThreshold(metric_name="myMetric", threshold=0.12)
+    rest_obj = custom._to_rest_object()
+    assert rest_obj.metric == "myMetric"
+    assert rest_obj.threshold.value == 0.12
+
+    other = CustomMonitoringMetricThreshold(metric_name="otherMetric")
+    other_rest = other._to_rest_object()
+    assert other_rest.metric == "otherMetric"
+    assert other_rest.threshold is None
+
+    round_trip = CustomMonitoringMetricThreshold._from_rest_object(
+        CustomMetricThreshold(metric="roundTrip", threshold=MonitoringThreshold(value=0.9))
+    )
+    assert round_trip.metric_name == "roundTrip"
+    assert round_trip.threshold == 0.9
+
+
+def test_generation_safety_quality_monitoring_metric_threshold_variants():
+    groundedness = {
+        "acceptable_groundedness_score_per_instance": 5.5,
+        "aggregated_groundedness_pass_rate": 0.92,
+    }
+    fluency = {"aggregated_fluency_pass_rate": 0.77}
+    subject = GenerationSafetyQualityMonitoringMetricThreshold(groundedness=groundedness, fluency=fluency)
+    rest_list = subject._to_rest_object()
+    metrics = {threshold.metric: threshold for threshold in rest_list}
+    assert metrics["AcceptableGroundednessScorePerInstance"].threshold.value == 5.5
+    assert metrics["AggregatedGroundednessPassRate"].threshold.value == 0.92
+    assert metrics["AcceptableFluencyScorePerInstance"].threshold.value == 3
+    assert metrics["AggregatedFluencyPassRate"].threshold.value == 0.77
+
+    restored = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(
+        [
+            GenerationSafetyQualityMetricThreshold(
+                metric="AcceptableGroundednessScorePerInstance", threshold=MonitoringThreshold(value=2.2)
+            ),
+            GenerationSafetyQualityMetricThreshold(
+                metric="AggregatedGroundednessPassRate", threshold=MonitoringThreshold(value=0.55)
+            ),
+            GenerationSafetyQualityMetricThreshold(
+                metric="AcceptableSimilarityScorePerInstance", threshold=MonitoringThreshold(value=1.8)
+            ),
+            GenerationSafetyQualityMetricThreshold(
+                metric="AggregatedSimilarityPassRate", threshold=MonitoringThreshold(value=0.85)
+            ),
+        ]
+    )
+    assert restored.groundedness["acceptable_groundedness_score_per_instance"] == 2.2
+    assert restored.groundedness["aggregated_groundedness_pass_rate"] == 0.55
+    assert restored.similarity["acceptable_similarity_score_per_instance"] == 1.8
+    assert restored.similarity["aggregated_similarity_pass_rate"] == 0.85
+
+
+def test_generation_token_statistics_monitor_metric_threshold_variations():
+    subject = GenerationTokenStatisticsMonitorMetricThreshold(
+        totaltoken={"total_token_count": 10, "total_token_count_per_group": 4}
+    )
+    rest_list = subject._to_rest_object()
+    metrics = {threshold.metric: threshold for threshold in rest_list}
+    assert metrics["TotalTokenCount"].threshold.value == 10
+    assert metrics["TotalTokenCountPerGroup"].threshold.value == 4
+
+    fallback = GenerationTokenStatisticsMonitorMetricThreshold(totaltoken={"total_token_count_per_group": 7})
+    fallback_list = fallback._to_rest_object()
+    fallback_metrics = {threshold.metric: threshold for threshold in fallback_list}
+    assert fallback_metrics["TotalTokenCount"].threshold.value == 3
+    assert fallback_metrics["TotalTokenCountPerGroup"].threshold.value == 7
+
+    restored = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object(
+        [
+            GenerationTokenStatisticsMetricThreshold(metric="TotalTokenCount", threshold=MonitoringThreshold(value=11)),
+            GenerationTokenStatisticsMetricThreshold(
+                metric="TotalTokenCountPerGroup", threshold=MonitoringThreshold(value=5)
+            ),
+        ]
+    )
+    assert restored.totaltoken["total_token_count"] == 11
+    assert restored.totaltoken["total_token_count_per_group"] == 5
+
+
+def test_generation_safety_to_rest_object_defaults_and_from_rest_reconstruction():
+    threshold = GenerationSafetyQualityMonitoringMetricThreshold(
+        groundedness={"aggregated_groundedness_pass_rate": 0.65},
+        fluency={
+            "acceptable_fluency_score_per_instance": 0.75,
+            "aggregated_fluency_pass_rate": 0.9,
+        },
+    )
+    rest = threshold._to_rest_object()
+    assert len(rest) == 4
+    assert rest[0].metric == "AcceptableGroundednessScorePerInstance"
+    assert rest[0].threshold.value == 3
+    assert rest[1].metric == "AggregatedGroundednessPassRate"
+    assert rest[1].threshold.value == 0.65
+    assert rest[2].metric == "AcceptableFluencyScorePerInstance"
+    assert rest[2].threshold.value == 0.75
+    assert rest[3].metric == "AggregatedFluencyPassRate"
+    assert rest[3].threshold.value == 0.9
+
+    rest_items = [
+        types.SimpleNamespace(metric="AcceptableRelevanceScorePerInstance", threshold=types.SimpleNamespace(value=0.12)),
+        types.SimpleNamespace(metric="AggregatedRelevancePassRate", threshold=types.SimpleNamespace(value=0.4)),
+        types.SimpleNamespace(metric="AcceptableCoherenceScorePerInstance", threshold=types.SimpleNamespace(value=0.22)),
+        types.SimpleNamespace(metric="AggregatedCoherencePassRate", threshold=types.SimpleNamespace(value=0.55)),
+    ]
+    reconstructed = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(rest_items)
+    assert reconstructed.relevance == {
+        "acceptable_relevance_score_per_instance": 0.12,
+        "aggregated_relevance_pass_rate": 0.4,
+    }
+    assert reconstructed.coherence == {
+        "acceptable_coherence_score_per_instance": 0.22,
+        "aggregated_coherence_pass_rate": 0.55,
+    }
+
+
+def test_generation_token_statistics_to_rest_from_rest_and_defaults():
+    threshold = GenerationTokenStatisticsMonitorMetricThreshold(
+        totaltoken={"total_token_count_per_group": 8},
+    )
+    rest = threshold._to_rest_object()
+    assert len(rest) == 2
+    assert rest[0].metric == "TotalTokenCount"
+    assert rest[0].threshold.value == 3
+    assert rest[1].metric == "TotalTokenCountPerGroup"
+    assert rest[1].threshold.value == 8
+
+    rest_items = [
+        types.SimpleNamespace(metric="TotalTokenCount", threshold=types.SimpleNamespace(value=5)),
+        types.SimpleNamespace(metric="TotalTokenCountPerGroup", threshold=types.SimpleNamespace(value=6)),
+    ]
+    reconstructed = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object(rest_items)
+    assert reconstructed.totaltoken == {"total_token_count": 5, "total_token_count_per_group": 6}
+
+    defaults = GenerationTokenStatisticsMonitorMetricThreshold._get_default_thresholds()
+    assert defaults.totaltoken == {"total_token_count": 0, "total_token_count_per_group": 0}
+
+
+def test_generation_token_statistics_to_rest_object_default_total_token_count():
+    metric = GenerationTokenStatisticsMonitorMetricThreshold(
+        totaltoken={"total_token_count_per_group": 5.75}
+    )
+    rest = metric._to_rest_object()
+    assert len(rest) == 2
+    total_count, per_group = rest
+    assert total_count.metric == "TotalTokenCount"
+    assert total_count.threshold.value == 3
+    assert per_group.metric == "TotalTokenCountPerGroup"
+    assert per_group.threshold.value == 5.75
+
+
+def test_generation_token_statistics_to_rest_object_respects_total_token_count():
+    metric = GenerationTokenStatisticsMonitorMetricThreshold(
+        totaltoken={"total_token_count": 8, "total_token_count_per_group": 2}
+    )
+    rest = metric._to_rest_object()
+    assert rest[0].metric == "TotalTokenCount"
+    assert rest[0].threshold.value == 8
+    assert rest[1].metric == "TotalTokenCountPerGroup"
+    assert rest[1].threshold.value == 2
+
+
+def test_generation_token_statistics_from_rest_object_populates_totaltoken():
+    rest = [
+        GenerationTokenStatisticsMetricThreshold(
+            metric="TotalTokenCount",
+            threshold=MonitoringThreshold(value=4),
+        ),
+        GenerationSafetyQualityMetricThreshold(
+            metric="TotalTokenCountPerGroup",
+            threshold=MonitoringThreshold(value=9),
+        ),
+    ]
+    result = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object(rest)
+    assert result.totaltoken == {"total_token_count": 4, "total_token_count_per_group": 9}
+
+
+def test_generation_token_statistics_from_rest_object_returns_none_for_empty_list():
+    result = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object([])
+    assert result.totaltoken is None
+
+
+def test_generation_token_statistics_get_default_thresholds():
+    result = GenerationTokenStatisticsMonitorMetricThreshold._get_default_thresholds()
+    assert result.totaltoken == {"total_token_count": 0, "total_token_count_per_group": 0}
+
+
+def test_generation_safety_quality_to_rest_groundedness_default_acceptance():
+    threshold = GenerationSafetyQualityMonitoringMetricThreshold(
+        groundedness={"aggregated_groundedness_pass_rate": 0.7}
+    )
+    rest = threshold._to_rest_object()
+    assert len(rest) == 2
+    assert rest[0].metric == "AcceptableGroundednessScorePerInstance"
+    assert rest[0].threshold.value == 3
+    assert rest[1].metric == "AggregatedGroundednessPassRate"
+    assert rest[1].threshold.value == 0.7
+
+
+def test_generation_safety_quality_to_rest_relevance_with_custom_acceptance():
+    threshold = GenerationSafetyQualityMonitoringMetricThreshold(
+        relevance={
+            "acceptable_relevance_score_per_instance": 4.2,
+            "aggregated_relevance_pass_rate": 0.88,
+        }
+    )
+    rest = threshold._to_rest_object()
+    assert len(rest) == 2
+    assert rest[0].metric == "AcceptableRelevanceScorePerInstance"
+    assert rest[0].threshold.value == 4.2
+    assert rest[1].metric == "AggregatedRelevancePassRate"
+    assert rest[1].threshold.value == 0.88
+
+
+def test_generation_safety_quality_from_rest_populates_dicts():
+    thresholds = [
+        GenerationSafetyQualityMetricThreshold(
+            metric="AcceptableGroundednessScorePerInstance", threshold=MonitoringThreshold(value=0.4)
+        ),
+        GenerationSafetyQualityMetricThreshold(
+            metric="AggregatedGroundednessPassRate", threshold=MonitoringThreshold(value=0.8)
+        ),
+        GenerationSafetyQualityMetricThreshold(
+            metric="AcceptableSimilarityScorePerInstance", threshold=MonitoringThreshold(value=0.2)
+        ),
+        GenerationSafetyQualityMetricThreshold(
+            metric="AggregatedSimilarityPassRate", threshold=MonitoringThreshold(value=0.9)
+        ),
+    ]
+    result = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object(thresholds)
+    assert result.groundedness == {
+        "acceptable_groundedness_score_per_instance": 0.4,
+        "aggregated_groundedness_pass_rate": 0.8,
+    }
+    assert result.similarity == {
+        "acceptable_similarity_score_per_instance": 0.2,
+        "aggregated_similarity_pass_rate": 0.9,
+    }
+    assert result.relevance is None
+    assert result.coherence is None
+    assert result.fluency is None
+
+
+def test_generation_safety_quality_from_rest_empty_returns_none():
+    result = GenerationSafetyQualityMonitoringMetricThreshold._from_rest_object([])
+    assert result.groundedness is None
+    assert result.relevance is None
+    assert result.coherence is None
+    assert result.fluency is None
+    assert result.similarity is None
+
+
+def test_generation_token_statistics_to_rest_total_token_count_default():
+    threshold = GenerationTokenStatisticsMonitorMetricThreshold(totaltoken={"total_token_count_per_group": 2})
+    rest = threshold._to_rest_object()
+    assert len(rest) == 2
+    assert rest[0].metric == "TotalTokenCount"
+    assert rest[0].threshold.value == 3
+    assert rest[1].metric == "TotalTokenCountPerGroup"
+    assert rest[1].threshold.value == 2
+
+
+def test_generation_token_statistics_to_rest_total_token_count_custom():
+    threshold = GenerationTokenStatisticsMonitorMetricThreshold(
+        totaltoken={"total_token_count": 5, "total_token_count_per_group": 1.5}
+    )
+    rest = threshold._to_rest_object()
+    assert len(rest) == 2
+    assert rest[0].metric == "TotalTokenCount"
+    assert rest[0].threshold.value == 5
+    assert rest[1].metric == "TotalTokenCountPerGroup"
+    assert rest[1].threshold.value == 1.5
+
+
+def test_generation_token_statistics_from_rest_returns_totaltoken_dict():
+    thresholds = [
+        GenerationTokenStatisticsMetricThreshold(metric="TotalTokenCount", threshold=MonitoringThreshold(value=6)),
+        GenerationTokenStatisticsMetricThreshold(
+            metric="TotalTokenCountPerGroup", threshold=MonitoringThreshold(value=1.5)
+        ),
+    ]
+    result = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object(thresholds)
+    assert result.totaltoken == {"total_token_count": 6, "total_token_count_per_group": 1.5}
+
+
+def test_generation_token_statistics_from_rest_empty_returns_none():
+    result = GenerationTokenStatisticsMonitorMetricThreshold._from_rest_object([])
+    assert result.totaltoken is None

--- a/sdk/ml/azure-ai-ml/tests/test_utils_gaps.py
+++ b/sdk/ml/azure-ai-ml/tests/test_utils_gaps.py
@@ -1,0 +1,356 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from azure.ai.ml._restclient.v2022_05_01.models import ManagedServiceIdentity
+from azure.ai.ml.constants._common import WorkspaceDiscoveryUrlKey
+from azure.ai.ml._utils import utils
+from azure.ai.ml._utils.utils import (
+    ListViewType,
+    MlException,
+    MFE_PATH_PREFIX,
+    _get_base_urls_from_discovery_service,
+    _get_mfe_base_url_from_batch_endpoint,
+    _get_mfe_base_url_from_discovery_service,
+    _get_mfe_base_url_from_registry_discovery_service,
+    _get_workspace_base_url,
+    append_double_curly,
+    camel_to_snake,
+    convert_identity_dict,
+    download_text_from_url,
+    float_to_str,
+    from_iso_duration_format_min_sec,
+    hash_dict,
+    map_single_brackets_and_warn,
+    module_logger,
+    modified_operation_client,
+    snake_to_camel,
+    snake_to_kebab,
+    snake_to_pascal,
+    strip_double_curly,
+)
+
+
+class _StubResponse:
+    def __init__(self, status_code, text_value):
+        self.status_code = status_code
+        self._text_value = text_value
+
+    def text(self):
+        return self._text_value
+
+
+class _StubPipeline:
+    def __init__(self, response):
+        self._response = response
+        self.last_kwargs = {}
+
+    def get(self, uri, **kwargs):
+        self.last_kwargs = kwargs
+        return self._response
+
+
+class _FakePipeline:
+    def __init__(self):
+        self.policies = None
+
+    def with_policies(self, **kwargs):
+        self.policies = kwargs
+        return self
+
+
+class _FakeClient:
+    def __init__(self):
+        self._base_url = "https://original"
+
+
+class _FakeOperation:
+    def __init__(self):
+        self._client = _FakeClient()
+
+
+def test_snake_to_pascal_handles_none_simple_and_multiple():
+    assert snake_to_pascal(None) is None
+    assert snake_to_pascal("foo_bar") == "FooBar"
+    assert snake_to_pascal("foo_bar,baz_qux") == "FooBar,BazQux"
+
+
+def test_snake_to_kebab_handles_values_and_none():
+    assert snake_to_kebab("a_b_c") == "a-b-c"
+    assert snake_to_kebab(None) is None
+
+
+def test_camel_to_snake_converts_and_handles_none():
+    assert camel_to_snake("HTTPRequest") == "http_request"
+    assert camel_to_snake(None) is None
+
+
+def test_snake_to_camel_handles_values_and_none():
+    assert snake_to_camel("foo_bar") == "fooBar"
+    assert snake_to_camel(None) is None
+
+
+def test_float_to_str_preserves_precision():
+    assert float_to_str(1.23e-5) == "0.0000123"
+
+
+def test_download_text_from_url_returns_empty_for_404():
+    pipeline = _StubPipeline(_StubResponse(404, "not found"))
+    assert download_text_from_url("https://example.com", pipeline) == ""
+
+
+def test_download_text_from_url_respects_timeout_tuple():
+    pipeline = _StubPipeline(_StubResponse(200, "payload"))
+    result = download_text_from_url("https://example.com", pipeline, timeout=(1.5, 3.5))
+    assert result == "payload"
+    assert pipeline.last_kwargs == {"read_timeout": 3.5, "connection_timeout": 1.5}
+
+
+def test_discovery_service_urls_and_mfe_paths(monkeypatch):
+    base_urls = {WorkspaceDiscoveryUrlKey.API: "https://api.azure.com"}
+    discovery_url = "https://discovery"
+    workspace_operations = SimpleNamespace(
+        get=lambda name: SimpleNamespace(discovery_url=discovery_url)
+    )
+    pipeline = _FakePipeline()
+
+    def fake_download(source_uri, pipeline_arg, **kwargs):
+        assert source_uri == discovery_url
+        assert pipeline_arg is pipeline
+        return json.dumps(base_urls)
+
+    monkeypatch.setattr(utils, "download_text_from_url", fake_download)
+
+    result = _get_base_urls_from_discovery_service(workspace_operations, "workspace", pipeline)
+    assert result == base_urls
+
+    monkeypatch.setattr(
+        utils, "_get_base_urls_from_discovery_service", lambda *_args, **_kwargs: base_urls
+    )
+    assert (
+        _get_mfe_base_url_from_discovery_service(None, "workspace", pipeline)
+        == f"{base_urls[WorkspaceDiscoveryUrlKey.API]}{MFE_PATH_PREFIX}"
+    )
+    assert (
+        _get_mfe_base_url_from_registry_discovery_service(None, "workspace", pipeline)
+        == base_urls[WorkspaceDiscoveryUrlKey.API]
+    )
+    assert _get_workspace_base_url(None, "workspace", pipeline) == base_urls[WorkspaceDiscoveryUrlKey.API]
+
+
+def test_batch_endpoint_mfe_url_and_modified_client():
+    endpoint = SimpleNamespace(scoring_uri="https://example.azure.com/subscriptions/123/resource")
+    assert _get_mfe_base_url_from_batch_endpoint(endpoint) == "https://example.azure.com"
+
+    class _Client:
+        def __init__(self, base_url):
+            self._base_url = base_url
+
+    class _Operation:
+        def __init__(self, base_url):
+            self._client = _Client(base_url)
+
+    operation = _Operation("https://original.azure.com")
+    with modified_operation_client(operation, "https://override.azure.com"):
+        assert operation._client._base_url == "https://override.azure.com"
+    assert operation._client._base_url == "https://original.azure.com"
+
+    with modified_operation_client(operation, None):
+        assert operation._client._base_url == "https://original.azure.com"
+    assert operation._client._base_url == "https://original.azure.com"
+
+
+def test_hash_dict_omits_keys_and_is_deterministic():
+    sample = {"b": 2, "a": 1, "c": {"nested": 3}}
+    full_hash = hash_dict(sample)
+    assert full_hash == hash_dict({"a": 1, "b": 2, "c": {"nested": 3}})
+    omitted_hash = hash_dict(sample, keys_to_omit=["b"])
+    assert omitted_hash == hash_dict({"a": 1, "c": {"nested": 3}})
+    assert full_hash != omitted_hash
+
+
+def test_convert_identity_dict_variants_and_curly_helpers():
+    default_identity = convert_identity_dict(None)
+    assert default_identity.type == "SystemAssigned"
+
+    none_identity = ManagedServiceIdentity(type="none")
+    normalized = convert_identity_dict(none_identity)
+    assert normalized.type == "SystemAssigned"
+
+    list_identity = ManagedServiceIdentity(
+        type="user_assigned",
+        user_assigned_identities=[{"resource_id": "/subscriptions/id"}],
+    )
+    converted = convert_identity_dict(list_identity)
+    assert converted.user_assigned_identities == {"/subscriptions/id": {}}
+    assert converted.type == snake_to_camel("user_assigned")
+
+    dict_identity = ManagedServiceIdentity(
+        type="user_assigned",
+        user_assigned_identities={"/subscriptions/another": {}},
+    )
+    assert convert_identity_dict(dict_identity) is dict_identity
+
+    assert strip_double_curly("${{value}}") == "value"
+    assert append_double_curly("value") == "${{value}}"
+
+
+def test_discovery_service_url_helpers(monkeypatch):
+    base_url = "https://example.com"
+    monkeypatch.setattr(
+        utils,
+        "_get_base_urls_from_discovery_service",
+        lambda *_args, **_kwargs: {WorkspaceDiscoveryUrlKey.API: base_url},
+    )
+    endpoint = type("BatchEndpoint", (), {"scoring_uri": f"{base_url}/subscriptions/abc"})()
+
+    assert _get_mfe_base_url_from_discovery_service(None, "ws", None) == f"{base_url}{MFE_PATH_PREFIX}"
+    assert _get_mfe_base_url_from_registry_discovery_service(None, "ws", None) == base_url
+    assert _get_workspace_base_url(None, "ws", None) == base_url
+    assert _get_mfe_base_url_from_batch_endpoint(endpoint) == base_url
+
+
+def test_modified_operation_client_restores_url():
+    operation = _FakeOperation()
+    with modified_operation_client(operation, "https://custom"):
+        assert operation._client._base_url == "https://custom"
+    assert operation._client._base_url == "https://original"
+
+
+def test_modified_operation_client_ignores_empty_url():
+    operation = _FakeOperation()
+    with modified_operation_client(operation, ""):
+        assert operation._client._base_url == "https://original"
+    assert operation._client._base_url == "https://original"
+
+
+def test_from_iso_duration_format_min_sec():
+    assert from_iso_duration_format_min_sec("PT3M4.567S") == "3m 4s"
+
+
+def test_hash_dict_omit_keys_and_ordering():
+    payload = {"b": 2, "a": 1}
+    default_hash = hash_dict(payload)
+    reordered_hash = hash_dict({"a": 1, "b": 2})
+    assert default_hash == reordered_hash
+    omitted_hash = hash_dict(payload, keys_to_omit=["b"])
+    assert omitted_hash != default_hash
+
+
+def test_convert_identity_dict_variants():
+    assert convert_identity_dict(None).type == "SystemAssigned"
+
+    system_assigned = convert_identity_dict(ManagedServiceIdentity(type="system_assigned"))
+    assert system_assigned.type == "SystemAssigned"
+
+    list_identity = ManagedServiceIdentity(
+        type="user_assigned",
+        user_assigned_identities=[{"resource_id": "/subscriptions/123"}],
+    )
+    list_converted = convert_identity_dict(list_identity)
+    assert "/subscriptions/123" in list_converted.user_assigned_identities
+    assert list_converted.type == snake_to_camel("user_assigned")
+
+    dict_identity = ManagedServiceIdentity(
+        type="user_assigned",
+        user_assigned_identities={"/subscriptions/123": {"foo": "bar"}},
+    )
+    dict_converted = convert_identity_dict(dict_identity)
+    assert dict_converted.user_assigned_identities == dict_identity.user_assigned_identities
+
+
+def test_strip_and_append_double_curly():
+    assert strip_double_curly("${{payload}}") == "payload"
+    assert append_double_curly("payload") == "${{payload}}"
+
+
+def test_map_single_brackets_and_warn(monkeypatch):
+    warnings = []
+    monkeypatch.setattr(module_logger, "warning", lambda msg: warnings.append(msg))
+    command = "{inputs.value} {outputs.artifacts} {search_space.choice}"
+    result = map_single_brackets_and_warn(command)
+
+    assert "${{inputs.value}}" in result
+    assert "${{outputs.artifacts}}" in result
+    assert "${{search_space.choice}}" in result
+    assert warnings == ["Use of {} for parameters is deprecated, instead use ${{}}."]
+
+
+class DummyLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, message):
+        self.infos.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+def test_transform_dict_keys_recurses():
+    data = {"outer_key": {"inner_key": 42}}
+    transformed = utils.transform_dict_keys(data, lambda key: key.replace("_", "-"))
+    assert "outer-key" in transformed
+    assert transformed["outer-key"]["inner-key"] == 42
+    assert "inner_key" in data["outer_key"]
+
+
+def test_merge_dict_merges_nested_dicts():
+    origin = {"nested": {"value": 1}}
+    delta = {"nested": {"value": 2}, "extra": {"leaf": "x"}}
+    merged = utils.merge_dict(origin, delta)
+    assert merged["nested"]["value"] == 2
+    assert merged["extra"]["leaf"] == "x"
+    assert origin["nested"]["value"] == 2
+
+
+def test_merge_dict_overwrites_non_dict_values():
+    origin = {"nested": {"value": 1}}
+    delta = {"nested": 10}
+    merged = utils.merge_dict(origin, delta)
+    assert merged["nested"] == 10
+    assert isinstance(origin["nested"], dict)
+
+
+def test_retry_retries_until_success(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda _: None)
+    logger = DummyLogger()
+    attempts = {"count": 0}
+
+    def flaky():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise ValueError("boom")
+        return "ok"
+
+    decorated = utils.retry(ValueError, "fail", logger, max_attempts=2, delay_multiplier=0)(flaky)
+    assert decorated() == "ok"
+    assert logger.infos
+    assert any("Operation failed. Retrying" in info for info in logger.infos)
+
+
+def test_retry_warns_and_rethrows_when_exhausted(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda _: None)
+    logger = DummyLogger()
+
+    def always_fail():
+        raise RuntimeError("boom")
+
+    decorated = utils.retry(RuntimeError, "cannot recover", logger, max_attempts=1, delay_multiplier=0)(always_fail)
+    with pytest.raises(RuntimeError):
+        decorated()
+    assert logger.warnings == ["cannot recover"]
+
+
+def test_get_list_view_type_conflict_raises():
+    with pytest.raises(MlException) as excinfo:
+        utils.get_list_view_type(True, True)
+    assert "Cannot provide both archived-only and include-archived." in str(excinfo.value)
+
+
+def test_get_list_view_type_returns_expected_values():
+    assert utils.get_list_view_type(True, False) == ListViewType.ALL
+    assert utils.get_list_view_type(False, True) == ListViewType.ARCHIVED_ONLY
+    assert utils.get_list_view_type(False, False) == ListViewType.ACTIVE_ONLY


### PR DESCRIPTION
## Summary

Adds 20 new unit test files with **495 passing tests** targeting previously uncovered branches in the azure-ai-ml SDK.

## Coverage Impact (excluding vendor/generated code)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Branch coverage** | 58.3% | **85.1%** | **+26.8%** |
| **Line coverage** | 76.0% | 76.1% | +0.1% |

## Details

- **495 tests pass, 0 failures** — all tests verified locally
- All tests use mocking/monkeypatching with **no external service dependencies**
- Tests generated using coverage-driven test generation tooling with gpt-5-mini

### Modules covered:
- **Operations**: job, schedule, model, component, data, batch endpoint
- **Storage helpers**: blob, fileshare, gen2
- **Utilities**: asset utils, artifact utils/utilities, exception helper, general utils
- **Other**: local job invoker, deployment templates, pipeline expressions, thresholds

## Test Files Added (20)

| File | Tests | Lines |
|------|-------|-------|
| test_job_ops_helper_gaps.py | ~55 | 1,150 |
| test_local_job_invoker_gaps.py | ~50 | 1,080 |
| test_job_operations_gaps.py | ~45 | 1,050 |
| test_thresholds_gaps.py | ~40 | 947 |
| test_deployment_template_gaps.py | ~35 | 881 |
| test_artifact_utils_gaps.py | ~30 | 879 |
| test_schedule_operations_gaps.py | ~30 | 845 |
| test_artifact_utilities_gaps.py | ~25 | 747 |
| test_data_index_func_gaps.py | ~25 | 661 |
| test_blob_storage_helper_gaps.py | ~20 | 506 |
| test_asset_utils_gaps.py | ~20 | 497 |
| test_batch_endpoint_operations_gaps.py | ~20 | 494 |
| test_model_operations_gaps.py | ~20 | 489 |
| test_exception_helper_gaps.py | ~15 | 392 |
| test_utils_gaps.py | ~15 | 356 |
| test_fileshare_storage_helper_gaps.py | ~15 | 344 |
| test_gen2_storage_helper_gaps.py | ~10 | 284 |
| test_pipeline_expression_gaps.py | ~10 | 276 |
| test_data_operations_gaps.py | ~10 | 192 |
| test_component_operations_gaps.py | ~5 | 152 |
