### PR TITLE
Fix name reservation pipeline failing to detect unregistered packages

### DIFF
--- a/eng/scripts/discover_unpublished_packages.py
+++ b/eng/scripts/discover_unpublished_packages.py
@@ -16,8 +16,8 @@ INITIAL_VERSION = "1.0.0b1"
 
 def _is_on_pypi(client, name):
     try:
-        client.project(name)
-        return True
+        result = client.project(name)
+        return "info" in result
     except Exception:
         return False
 


### PR DESCRIPTION
## Issue

The daily name reservation pipeline (`publish-namereserve-package.yml`) fails to register new packages like `azure-mgmt-appnetwork` on PyPI because `_is_on_pypi()` in `discover_unpublished_packages.py` incorrectly treats all packages as already registered.

## Root Cause

`PyPIClient.project()` does not raise an exception when a package doesn't exist on PyPI. Instead, the PyPI API returns HTTP 404 with a JSON body `{"message": "Not Found"}`, which is silently decoded. The `_is_on_pypi()` function only checked for exceptions, so it always returned `True` — even for packages that don't exist.

## Fix

Check the response content: a valid PyPI project response contains an `"info"` key, while a 404 response contains `{"message": "Not Found"}`. Changed `_is_on_pypi()` to verify `"info" in result` instead of assuming success when no exception is raised.

## Validation

Tested locally:
- `azure-core` (exists on PyPI) → correctly returns `True`
- `azure-mgmt-appnetwork` (not on PyPI) → now correctly returns `False`
- Full discovery run confirms `azure-mgmt-appnetwork` is now included in the registration list

Test for azure-mgmt-appnetwork and now it could be found: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6066615&view=results