### PR TITLE
Fix UnboundLocalError in create_finetuning_job when validation_data is None

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed default deployment template check to verify `asset_id` is not None before logging template information.
 - Skip _list_secrets for identity-based datastores to prevent noisy telemetry traces.
+- Fixed `UnboundLocalError` in `create_finetuning_job()` when `validation_data` is omitted or `None`.
 
 ### Other Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/finetuning/_create_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/finetuning/_create_job.py
@@ -2,15 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
+
+from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml.constants._common import AssetTypes
 from azure.ai.ml.entities._inputs_outputs import Input, Output
-from azure.ai.ml.entities._job.finetuning.custom_model_finetuning_job import (
-    CustomModelFineTuningJob,
-)
+from azure.ai.ml.entities._job.finetuning.custom_model_finetuning_job import CustomModelFineTuningJob
 from azure.ai.ml.entities._job.job_resources import JobResources
 from azure.ai.ml.entities._job.queue_settings import QueueSettings
-from azure.ai.ml._utils._experimental import experimental
 
 
 @experimental
@@ -68,7 +67,7 @@ def create_finetuning_job(
         task=task,
         model=model_input,
         training_data=training_data_input,
-        validation_data=validation_data_input,  # pylint: disable=(possibly-used-before-assignment
+        validation_data=validation_data_input if validation_data else None,
         hyperparameters=hyperparameters,
         compute=compute,
         resources=job_resources,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/finetuning/_create_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/finetuning/_create_job.py
@@ -49,6 +49,7 @@ def create_finetuning_job(
         path=training_data,
     )
 
+    validation_data_input = None
     if validation_data:
         validation_data_input = Input(
             type=AssetTypes.URI_FILE,
@@ -67,7 +68,7 @@ def create_finetuning_job(
         task=task,
         model=model_input,
         training_data=training_data_input,
-        validation_data=validation_data_input if validation_data else None,
+        validation_data=validation_data_input,
         hyperparameters=hyperparameters,
         compute=compute,
         resources=job_resources,

--- a/sdk/ml/azure-ai-ml/tests/finetuning_job/unittests/test_finetuning_job_convesion.py
+++ b/sdk/ml/azure-ai-ml/tests/finetuning_job/unittests/test_finetuning_job_convesion.py
@@ -1,21 +1,15 @@
-from azure.ai.ml.constants._common import AssetTypes
-from azure.ai.ml.entities._inputs_outputs import Input, Output
-from typing import Optional, Dict
-from azure.ai.ml._restclient.v2024_10_01_preview.models import (
-    UriFileJobInput,
-    MLFlowModelJobInput,
-)
-from azure.ai.ml.constants._job.finetuning import FineTuningTaskTypes
-from azure.ai.ml.entities._job.finetuning.custom_model_finetuning_job import (
-    CustomModelFineTuningJob,
-)
-from azure.ai.ml.entities._job.finetuning.azure_openai_finetuning_job import (
-    AzureOpenAIFineTuningJob,
-)
-from azure.ai.ml.entities._job.finetuning.azure_openai_hyperparameters import (
-    AzureOpenAIHyperparameters,
-)
+from typing import Dict, Optional
+
 import pytest
+
+from azure.ai.ml._restclient.v2024_10_01_preview.models import MLFlowModelJobInput, UriFileJobInput
+from azure.ai.ml.constants._common import AssetTypes
+from azure.ai.ml.constants._job.finetuning import FineTuningTaskTypes
+from azure.ai.ml.entities._inputs_outputs import Input, Output
+from azure.ai.ml.entities._job.finetuning.azure_openai_finetuning_job import AzureOpenAIFineTuningJob
+from azure.ai.ml.entities._job.finetuning.azure_openai_hyperparameters import AzureOpenAIHyperparameters
+from azure.ai.ml.entities._job.finetuning.custom_model_finetuning_job import CustomModelFineTuningJob
+from azure.ai.ml.finetuning import FineTuningTaskType, create_finetuning_job
 
 
 @pytest.mark.finetuning_test
@@ -255,3 +249,36 @@ class TestCustomModelFineTuningJob:
             **kwargs,
         )
         return custom_model_finetuning_job
+
+
+@pytest.mark.finetuning_test
+@pytest.mark.unittest
+class TestCreateFineTuningJobValidationDataNone:
+    def test_create_finetuning_job_without_validation_data(self):
+        """Test that create_finetuning_job works when validation_data is omitted (None)."""
+        job = create_finetuning_job(
+            task=FineTuningTaskType.TEXT_COMPLETION,
+            training_data="tests/test_configs/finetuning_job/test_datasets/text_completion/train.jsonl",
+            model="azureml://registries/azureml-meta/models/Meta-Llama-3-8B/versions/8",
+            output_model_name_prefix="llama-finetune-registered-1234",
+            hyperparameters={
+                "per_device_train_batch_size": "1",
+                "learning_rate": "0.00002",
+                "num_train_epochs": "1",
+            },
+            display_name="llama-3-8B-display-name",
+            name="llama-3-8B",
+            experiment_name="llama-3-8B-finetuning-experiment",
+            tags={"foo_tag": "bar"},
+            properties={"my_property": "my_value"},
+        )
+        assert isinstance(job, CustomModelFineTuningJob)
+        assert job.validation_data is None
+        assert job.training_data is not None
+        assert job.training_data.type == AssetTypes.URI_FILE
+        assert job.model.type == AssetTypes.MLFLOW_MODEL
+        assert job.hyperparameters == {
+            "per_device_train_batch_size": "1",
+            "learning_rate": "0.00002",
+            "num_train_epochs": "1",
+        }


### PR DESCRIPTION
### Notes

- Fix UnboundLocalError in create_finetuning_job when validation_data is None: https://github.com/Azure/azure-sdk-for-python/issues/45770
- Added the missing UT

### Testing

1. Via repro script
  - Before changes
<img width="1714" height="453" alt="image" src="https://github.com/user-attachments/assets/110b04d8-f4ec-4653-844c-8b9e49988d00" />
  - After changes
<img width="1695" height="426" alt="image" src="https://github.com/user-attachments/assets/55ba4b29-2340-4aa1-b714-e33ce6cdf3ff" />

2. Samples testing - [https://github.com/Azure/azureml-examples/pull/3840](https://github.com/Azure/azureml-examples/pull/3840)
  - Compared with samples run against main: https://github.com/Azure/azureml-examples/pull/3841

4. Unit tests ~ Successful

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
