### PR TITLE
Update Rule 12 in breaking changes guide to include all conflicting property names

### DIFF
--- a/doc/dev/mgmt/sdk-breaking-changes-guide.md
+++ b/doc/dev/mgmt/sdk-breaking-changes-guide.md
@@ -312,19 +312,19 @@ Removal of multiple parameters and addition of parameters `properties` entries f
 
 **Resolution**: Accept these breaking changes.
 
-## 12. Renaming of `values`/`keys` Properties
+## 12. Renaming of Properties That Conflict with Base Model Methods
 
 **Changelog Pattern**:
 
-Removal of a property named `values` or `keys` and addition of a corresponding `values_property` or `keys_property`:
+Removal of a property and addition of a corresponding property with `_property` suffix:
 
 ```md
 - Model `ExceptionEntry` deleted or renamed its instance variable `values`
 - Model `ExceptionEntry` added property `values_property`
 ```
 
-**Reason**: In the base model class of TypeSpec-based SDKs, `keys` and `values` are native method names. To avoid name conflicts, properties named `keys` or `values` are automatically renamed to `keys_property` or `values_property`.
+**Reason**: In the base model class of TypeSpec-based SDKs, the following names are native method names: `keys`, `items`, `values`, `popitem`, `clear`, `update`, `setdefault`, `pop`, `get`, `copy`. To avoid name conflicts, properties using any of these names are automatically renamed with a `_property` suffix (e.g., `values` becomes `values_property`, `items` becomes `items_property`).
 
-**Impact**: Users need to update property access from `.values` to `.values_property` (or `.keys` to `.keys_property`).
+**Impact**: Users need to update property access to use the `_property` suffix (e.g., `.values` to `.values_property`, `.keys` to `.keys_property`, `.items` to `.items_property`).
 
 **Resolution**: Accept these breaking changes.


### PR DESCRIPTION
Updated Rule 12 in `doc/dev/mgmt/sdk-breaking-changes-guide.md` to include the full list of property names that conflict with base model methods in TypeSpec-based SDKs.

Previously, Rule 12 only mentioned `keys` and `values`. This update expands it to cover all 10 conflicting names: `keys`, `items`, `values`, `popitem`, `clear`, `update`, `setdefault`, `pop`, `get`, `copy`.

Changes:
- Renamed section from "Renaming of `values`/`keys` Properties" to "Renaming of Properties That Conflict with Base Model Methods"
- Updated Reason, Impact, and descriptions to reflect the full list of conflicting property names