### PR TITLE
Confirm pr builds still operating

### DIFF
--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -13,3 +13,4 @@ opentelemetry-sdk~=1.26
 opentelemetry-instrumentation-requests>=0.50b0
 ../../identity/azure-identity
 packaging # for version parsing in test_basic_transport_async.py
+ruff


### PR DESCRIPTION
I made a config change in our public feed, and wanted to ensure that builds still work without the CFS migration. If this fails I'll immediately revert.