### PR TITLE
bump typespec-python 0.61.2

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -10,9 +10,9 @@
       },
       "devDependencies": {
         "@azure-tools/openai-typespec": "1.11.0",
-        "@azure-tools/typespec-autorest": "~0.66.1",
+        "@azure-tools/typespec-autorest": "~0.66.2",
         "@azure-tools/typespec-azure-core": "~0.66.1",
-        "@azure-tools/typespec-azure-resource-manager": "~0.66.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.66.1",
         "@azure-tools/typespec-azure-rulesets": "~0.66.0",
         "@azure-tools/typespec-client-generator-core": "~0.66.4",
         "@azure-tools/typespec-liftr-base": "0.13.0",
@@ -40,16 +40,16 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.66.1.tgz",
-      "integrity": "sha512-9R2S9hr1nie5lvJQnubvywPajOhdUApTED5MIef5KlF1zZL+DKMFDDOKwnSvFvW7ROmL+Ph8FQagw/6+PStlOg==",
+      "version": "0.66.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.66.2.tgz",
+      "integrity": "sha512-KPloSDZvY7c2PkDCGeWPoWJ3NL+0n5GPQKiospILLE5pCof6g5a20NM8mJLqTE+NMgzbNzgoYE5wXEFFpe3A+A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.66.1",
-        "@azure-tools/typespec-azure-resource-manager": "^0.66.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.66.1",
         "@azure-tools/typespec-client-generator-core": "^0.66.4",
         "@typespec/compiler": "^1.10.0",
         "@typespec/http": "^1.10.0",
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.66.0.tgz",
-      "integrity": "sha512-UbgYUaYTt7prsv+RYxd2kiOWjeEeoH56QOqgXnSOFhYzq/h9fyDaQAm6+CY7cklziED+MYy3uMQd1BG9mNwlfQ==",
+      "version": "0.66.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.66.1.tgz",
+      "integrity": "sha512-LExgmD3oK7iaX0bIdQsoxBYLCMKwPPBHYmLMhNW/GseMF1Dqi1Ne/VP7rmMP0dhrZNFh22LaZI2lTyCKm08DFQ==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -91,7 +91,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.66.0",
+        "@azure-tools/typespec-azure-core": "^0.66.1",
         "@typespec/compiler": "^1.10.0",
         "@typespec/http": "^1.10.0",
         "@typespec/openapi": "^1.10.0",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -15,9 +15,9 @@
     "@typespec/xml": "~0.80.0",
     "@typespec/openapi3": "1.10.0",
     "@azure-tools/openai-typespec": "1.11.0",
-    "@azure-tools/typespec-autorest": "~0.66.1",
+    "@azure-tools/typespec-autorest": "~0.66.2",
     "@azure-tools/typespec-azure-core": "~0.66.1",
-    "@azure-tools/typespec-azure-resource-manager": "~0.66.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.66.1",
     "@azure-tools/typespec-azure-rulesets": "~0.66.0",
     "@azure-tools/typespec-client-generator-core": "~0.66.4",
     "@azure-tools/typespec-liftr-base": "0.13.0"


### PR DESCRIPTION
Bump dependencies in emitter-package.json

Updated:
- @azure-tools/typespec-autorest: ~0.66.1 -> ~0.66.2
- @azure-tools/typespec-azure-resource-manager: ~0.66.0 -> ~0.66.1