### PR TITLE
Exporter release 1.0.0b50

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b50 (2026-04-02)
+## 1.0.0b50 (2026-04-03)
 
 ### Bugs Fixed
 - Fix duplicate authentication policy in live metrics exporter causing Unauthorized errors


### PR DESCRIPTION
## 1.0.0b50 (2026-04-03)

### Bugs Fixed
- Fix duplicate authentication policy in live metrics exporter causing Unauthorized errors
  for authenticated Application Insights resources
  ([#46024](https://github.com/Azure/azure-sdk-for-python/pull/46024))
- Suppress internal sdkstats HTTP pipeline logs from appearing in user's logs
  ([#45966](https://github.com/Azure/azure-sdk-for-python/pull/45966))
- Kubernetes pod name takes precedence when populating `cloud_RoleInstance`
  ([#45884](https://github.com/Azure/azure-sdk-for-python/pull/45884))

### Other Changes
- Revert custom properties limit to 8kb
  ([#46066](https://github.com/Azure/azure-sdk-for-python/pull/46066))