### PR TITLE
[Agentserver] Update base image for test agent

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-github/tests/integration/test_agent/Dockerfile
+++ b/sdk/agentserver/azure-ai-agentserver-github/tests/integration/test_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM mcr.microsoft.com/mirror/docker/library/python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates to use an approved registry.

Using 3.11-slim as 3.12-slim isn't available on the mirror.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/46058
