### PR TITLE
[Identity] Add RequestIdPolicy to default pipeline policies

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added `RequestIdPolicy` to the default pipeline policies to ensure a unique `x-ms-client-request-id` header is sent with each request. ([#46070](https://github.com/Azure/azure-sdk-for-python/pull/46070))
+
 ## 1.25.3 (2026-03-12)
 
 ### Bugs Fixed

--- a/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
@@ -11,6 +11,7 @@ from azure.core.pipeline.policies import (
     HeadersPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
+    RequestIdPolicy,
     RetryPolicy,
     UserAgentPolicy,
     HttpLoggingPolicy,
@@ -38,6 +39,7 @@ def _get_config(**kwargs) -> Configuration:
 
 def _get_policies(config, _per_retry_policies=None, **kwargs):
     policies = [
+        RequestIdPolicy(**kwargs),
         config.headers_policy,
         config.user_agent_policy,
         config.proxy_policy,

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -120,6 +120,7 @@ def test_request_url(authority):
         assert actual.scheme == "https"
         assert actual.netloc == expected_netloc
         assert actual.path.startswith("/" + tenant_id)
+        assert "x-ms-client-request-id" in request.headers
         return mock_response(json_payload={"token_type": "Bearer", "expires_in": 42, "access_token": "***"})
 
     client = AadClient(tenant_id, "client id", transport=Mock(send=send), authority=authority)

--- a/sdk/identity/azure-identity/tests/test_aad_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client_async.py
@@ -172,6 +172,7 @@ async def test_request_url(authority):
         assert actual.scheme == "https"
         assert actual.netloc == expected_netloc
         assert actual.path.startswith("/" + tenant_id)
+        assert "x-ms-client-request-id" in request.headers
         return mock_response(json_payload={"token_type": "Bearer", "expires_in": 42, "access_token": "***"})
 
     client = AadClient(tenant_id, "client id", transport=Mock(send=send), authority=authority)


### PR DESCRIPTION
This aids debugging requests.

Other language SDKs appear to include this header by default.