### PR TITLE
[Identity] Update docstring in DefaultAzureCredential

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -110,8 +110,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
         environment variable AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.
     :keyword str managed_identity_client_id: The client ID of a user-assigned managed identity. Defaults to the value
         of the environment variable AZURE_CLIENT_ID, if any. If not specified, a system-assigned identity will be used.
-    :keyword str workload_identity_client_id: The client ID of an identity assigned to the pod. Defaults to the value
-        of the environment variable AZURE_CLIENT_ID, if any. If not specified, the pod's default identity will be used.
+        Explicitly passing `None` overrides the AZURE_CLIENT_ID environment variable and forces use of a
+        system-assigned identity.
+    :keyword str workload_identity_client_id: The client ID of an identity assigned to the pod. Defaults to the
+        value of `managed_identity_client_id` if specified, otherwise the value of the environment variable
+        AZURE_CLIENT_ID, if any. If not specified, the pod's default identity will be used.
     :keyword str workload_identity_tenant_id: Preferred tenant for :class:`~azure.identity.WorkloadIdentityCredential`.
         Defaults to the value of environment variable AZURE_TENANT_ID, if any.
     :keyword str interactive_browser_client_id: The client ID to be used in interactive browser credential. If not

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -96,8 +96,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
         **False**.
     :keyword str managed_identity_client_id: The client ID of a user-assigned managed identity. Defaults to the value
         of the environment variable AZURE_CLIENT_ID, if any. If not specified, a system-assigned identity will be used.
-    :keyword str workload_identity_client_id: The client ID of an identity assigned to the pod. Defaults to the value
-        of the environment variable AZURE_CLIENT_ID, if any. If not specified, the pod's default identity will be used.
+        Explicitly passing `None` overrides the AZURE_CLIENT_ID environment variable and forces use of a
+        system-assigned identity.
+    :keyword str workload_identity_client_id: The client ID of an identity assigned to the pod. Defaults to the
+        value of `managed_identity_client_id` if specified, otherwise the value of the environment variable
+        AZURE_CLIENT_ID, if any. If not specified, the pod's default identity will be used.
     :keyword str workload_identity_tenant_id: Preferred tenant for :class:`~azure.identity.WorkloadIdentityCredential`.
         Defaults to the value of environment variable AZURE_TENANT_ID, if any.
     :keyword str shared_cache_username: Preferred username for :class:`~azure.identity.aio.SharedTokenCacheCredential`.


### PR DESCRIPTION
- Elaborate on behavior for when `managed_identity_client_id=None`. We want to keep `None` behavior as "using system-assigned identity" for cases where a AZURE_CLIENT_ID may be set, but the user still wants to force system-assigned identity.
- The docstring for `workload_identity_client__id` in DAC is updated to mention its coupling with `managed_identity_client_id`. We can revisit removing the coupling at a later time, but for now, let's just document the behavior.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/45900
Closes: https://github.com/Azure/azure-sdk-for-python/issues/45897
