### PR TITLE
Add @vmpham1012 (Valerie Pham) to githubcopilot CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -281,7 +281,7 @@
 # PRLabel: %Hosted Agents
 /sdk/agentserver/    @JC-386 @lusu-msft
 # PRLabel: %Hosted Agents
-/sdk/agentserver/azure-ai-agentserver-githubcopilot/    @jodeklotzms @pradeepkintali @tendau @ganeshyb @code-vicar
+/sdk/agentserver/azure-ai-agentserver-githubcopilot/    @jodeklotzms @pradeepkintali @tendau @ganeshyb @code-vicar @vmpham1012
 
 # ServiceLabel: %Hosted Agents
 # ServiceOwners: @JC-386 @lusu-msft


### PR DESCRIPTION
Adds Valerie Pham (@vmpham1012) as a code owner for the `azure-ai-agentserver-githubcopilot` package. She is contributing model discovery and auth work to the adapter.