### PR TITLE
Fix multi-turn/crescendo results showing single-turn baseline content

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed multi-turn and crescendo red team strategies producing output items identical to their baseline counterparts. The Foundry execution path was writing all strategies' conversations to a single shared JSONL file, causing each strategy to read all conversations and mislabel them. Now writes per-strategy JSONL files using PyRIT's scenario result grouping.
+
 ### Other Changes
 
 ## 1.16.4 (2026-04-03)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_execution_manager.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_execution_manager.py
@@ -208,9 +208,16 @@ class FoundryExecutionManager:
                 )
                 self._result_processors[risk_value] = result_processor
 
-                # Generate JSONL output
-                output_path = os.path.join(self.output_dir, f"{risk_value}_results.jsonl")
-                result_processor.to_jsonl(output_path)
+                # Generate per-strategy JSONL files directly from the scenario's
+                # strategy grouping.  ScenarioResult.attack_results is keyed by
+                # atomic_attack_name (the FoundryStrategy value, e.g. "baseline",
+                # "crescendo"), so each strategy gets its own file — matching the
+                # legacy orchestrator path where each (strategy, risk) pair had a
+                # separate UUID-based JSONL file.
+                strategy_files = result_processor.to_jsonl_per_strategy(
+                    output_dir=self.output_dir,
+                    risk_value=risk_value,
+                )
 
                 # Get summary stats
                 stats = result_processor.get_summary_stats()
@@ -220,7 +227,7 @@ class FoundryExecutionManager:
                 strategy_results = self._group_results_by_strategy(
                     orchestrator=orchestrator,
                     risk_value=risk_value,
-                    output_path=output_path,
+                    strategy_files=strategy_files,
                     attack_strategies=attack_strategies,
                     include_baseline=include_baseline,
                 )
@@ -354,23 +361,24 @@ class FoundryExecutionManager:
         self,
         orchestrator: ScenarioOrchestrator,
         risk_value: str,
-        output_path: str,
+        strategy_files: Dict[str, str],
         attack_strategies: List[Union[AttackStrategy, List[AttackStrategy]]],
         include_baseline: bool,
     ) -> Dict[str, Dict[str, Any]]:
         """Group attack results by strategy for red_team_info format.
 
-        Uses the requested attack strategies as keys (via get_strategy_name) rather than
-        extracting from PyRIT attack identifiers, since PyRIT's PromptSendingAttack
-        is used for all single-turn attacks regardless of converter. The overall ASR is
-        used for each strategy because Foundry batches all strategies per risk category.
+        Each strategy is assigned its own JSONL data file, written via
+        ``FoundryResultProcessor.to_jsonl_per_strategy()``, so that downstream
+        result processing reads only the conversations that belong to that
+        strategy — matching the legacy orchestrator path where each
+        ``(strategy, risk)`` pair had its own file.
 
         :param orchestrator: Completed scenario orchestrator
         :type orchestrator: ScenarioOrchestrator
         :param risk_value: Risk category value
         :type risk_value: str
-        :param output_path: Path to JSONL output file
-        :type output_path: str
+        :param strategy_files: Dictionary mapping strategy key to per-strategy JSONL path
+        :type strategy_files: Dict[str, str]
         :param attack_strategies: Original list of requested attack strategies
         :type attack_strategies: List[Union[AttackStrategy, List[AttackStrategy]]]
         :param include_baseline: Whether baseline was included in execution
@@ -388,39 +396,53 @@ class FoundryExecutionManager:
         foundry_strategies, special_strategies = StrategyMapper.filter_for_foundry(attack_strategies)
 
         # Create an entry per requested Foundry strategy using get_strategy_name() as key
-        # so it matches ATTACK_STRATEGY_COMPLEXITY_MAP and _red_team.py eval matching
         for strategy in foundry_strategies:
             strategy_key = get_strategy_name(strategy)
+            data_file = strategy_files.get(strategy_key, "")
+            if not data_file:
+                self.logger.warning(
+                    f"No JSONL file found for strategy '{strategy_key}' in {risk_value}. "
+                    f"Available keys: {list(strategy_files.keys())}"
+                )
             results[strategy_key] = {
-                "data_file": output_path,
+                "data_file": data_file,
                 "status": "completed",
                 "asr": overall_asr,
             }
 
         # Add entries for special strategies that were executed (e.g., IndirectJailbreak via XPIA)
-        # Baseline is handled separately below
+        # Baseline is handled separately below.
+        # Special strategies like IndirectJailbreak run through PromptSendingAttack
+        # so their results appear under "baseline" in strategy_files.
         for strategy in special_strategies:
             flat = strategy if not isinstance(strategy, list) else strategy[0]
             if flat != AttackStrategy.Baseline:
                 strategy_key = get_strategy_name(strategy)
+                # XPIA/IndirectJailbreak uses baseline's PromptSendingAttack,
+                # so its data lives in the "baseline" file.
+                data_file = strategy_files.get(strategy_key, "") or strategy_files.get("baseline", "")
                 results[strategy_key] = {
-                    "data_file": output_path,
+                    "data_file": data_file,
                     "status": "completed",
                     "asr": overall_asr,
                 }
 
         # Add baseline entry if it was included
         if include_baseline:
-            results[get_strategy_name(AttackStrategy.Baseline)] = {
-                "data_file": output_path,
+            baseline_key = get_strategy_name(AttackStrategy.Baseline)
+            data_file = strategy_files.get(baseline_key, "")
+            results[baseline_key] = {
+                "data_file": data_file,
                 "status": "completed",
                 "asr": overall_asr,
             }
 
         # Fallback if no strategies produced results
         if not results:
+            # Use the first available file or empty string
+            fallback_file = next(iter(strategy_files.values()), "")
             results["Foundry"] = {
-                "data_file": output_path,
+                "data_file": fallback_file,
                 "status": "completed",
                 "asr": overall_asr,
             }

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_foundry_result_processor.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_foundry_result_processor.py
@@ -184,6 +184,42 @@ class FoundryResultProcessor:
 
         return jsonl_content
 
+    def to_jsonl_per_strategy(self, output_dir: str, risk_value: str) -> Dict[str, str]:
+        """Write per-strategy JSONL files using the scenario's strategy grouping.
+
+        Uses ``ScenarioOrchestrator.get_attack_results_by_strategy()`` which
+        returns results keyed by ``atomic_attack_name`` — the FoundryStrategy
+        value (e.g. ``"baseline"``, ``"crescendo"``, ``"base64"``).  This
+        avoids any heuristic mapping from PyRIT class names to strategy names.
+
+        :param output_dir: Directory to write per-strategy JSONL files
+        :type output_dir: str
+        :param risk_value: Risk category value (used for file naming)
+        :type risk_value: str
+        :return: Dictionary mapping strategy name to JSONL file path
+        :rtype: Dict[str, str]
+        """
+        results_by_strategy = self.scenario.get_attack_results_by_strategy()
+        memory = self.scenario.get_memory()
+
+        strategy_files: Dict[str, str] = {}
+
+        for strategy_name, attack_results in results_by_strategy.items():
+            jsonl_lines = []
+            for attack_result in attack_results:
+                entry = self._process_attack_result(attack_result, memory)
+                if entry:
+                    jsonl_lines.append(json.dumps(entry, ensure_ascii=False))
+
+            strategy_path = os.path.join(output_dir, f"{risk_value}_{strategy_name}_results.jsonl")
+            Path(strategy_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(strategy_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(jsonl_lines))
+
+            strategy_files[strategy_name] = strategy_path
+
+        return strategy_files
+
     def _process_attack_result(
         self,
         attack_result: AttackResult,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_scenario_orchestrator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_scenario_orchestrator.py
@@ -183,12 +183,29 @@ class ScenarioOrchestrator:
             return []
 
         # ScenarioResult.attack_results is a dict[str, List[AttackResult]]
-        # Flatten all results into a single list
+        # keyed by atomic_attack_name (strategy name, e.g. "baseline", "crescendo")
         all_results: List[AttackResult] = []
-        for objective_id, results_list in self._scenario_result.attack_results.items():
+        for strategy_name, results_list in self._scenario_result.attack_results.items():
             all_results.extend(results_list)
 
         return all_results
+
+    def get_attack_results_by_strategy(self) -> Dict[str, List[AttackResult]]:
+        """Get attack results grouped by strategy name.
+
+        Returns a shallow copy of the ScenarioResult.attack_results dict.
+        Keys are ``atomic_attack_name`` values which correspond to
+        FoundryStrategy values (e.g. ``"baseline"``, ``"crescendo"``,
+        ``"multi_turn"``, ``"base64"``).
+
+        :return: Dictionary mapping strategy name to list of AttackResult
+        :rtype: Dict[str, List[AttackResult]]
+        """
+        if not self._scenario_result:
+            self.logger.debug(f"No scenario results for {self.risk_category}")
+            return {}
+
+        return dict(self._scenario_result.attack_results)
 
     def get_memory(self) -> Any:
         """Get the memory instance for querying conversations.

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_redteam/test_foundry.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_redteam/test_foundry.py
@@ -925,6 +925,50 @@ class TestScenarioOrchestrator:
         results = orchestrator.get_attack_results()
         assert results == []
 
+    def test_get_attack_results_by_strategy_before_execution_returns_empty(self, mock_logger):
+        """Test that get_attack_results_by_strategy returns empty dict before execute()."""
+        mock_target = MagicMock()
+        mock_scorer = MagicMock()
+
+        orchestrator = ScenarioOrchestrator(
+            risk_category="violence",
+            objective_target=mock_target,
+            rai_scorer=mock_scorer,
+            logger=mock_logger,
+        )
+
+        results = orchestrator.get_attack_results_by_strategy()
+        assert results == {}
+
+    def test_get_attack_results_by_strategy_returns_shallow_copy(self, mock_logger):
+        """Test that get_attack_results_by_strategy returns a copy, not a reference."""
+        from pyrit.models import AttackResult, AttackOutcome
+
+        mock_target = MagicMock()
+        mock_scorer = MagicMock()
+
+        orchestrator = ScenarioOrchestrator(
+            risk_category="violence",
+            objective_target=mock_target,
+            rai_scorer=mock_scorer,
+            logger=mock_logger,
+        )
+
+        mock_result = MagicMock(spec=AttackResult)
+        mock_result.outcome = AttackOutcome.SUCCESS
+
+        mock_scenario_result = MagicMock()
+        mock_scenario_result.attack_results = {"baseline": [mock_result], "crescendo": []}
+        orchestrator._scenario_result = mock_scenario_result
+
+        results = orchestrator.get_attack_results_by_strategy()
+        assert "baseline" in results
+        assert len(results["baseline"]) == 1
+
+        # Mutating the returned dict should NOT affect the internal state
+        results["new_key"] = []
+        assert "new_key" not in orchestrator.get_attack_results_by_strategy()
+
     @patch("pyrit.memory.CentralMemory")
     def test_get_memory_returns_memory_instance(self, mock_central_memory, mock_logger):
         """Test that get_memory returns memory instance."""
@@ -1625,7 +1669,10 @@ class TestFoundryExecutionManager:
         results = manager._group_results_by_strategy(
             orchestrator=mock_orchestrator,
             risk_value="violence",
-            output_path="/test/output.jsonl",
+            strategy_files={
+                "base64": "/test/violence_base64_results.jsonl",
+                "rot13": "/test/violence_rot13_results.jsonl",
+            },
             attack_strategies=[AttackStrategy.Base64, AttackStrategy.ROT13],
             include_baseline=False,
         )
@@ -1634,9 +1681,11 @@ class TestFoundryExecutionManager:
         assert "base64" in results
         assert results["base64"]["asr"] == 0.75
         assert results["base64"]["status"] == "completed"
+        assert results["base64"]["data_file"] == "/test/violence_base64_results.jsonl"
 
         assert "rot13" in results
         assert results["rot13"]["asr"] == 0.75
+        assert results["rot13"]["data_file"] == "/test/violence_rot13_results.jsonl"
 
     def test_group_results_by_strategy_with_baseline(self, mock_credential, mock_azure_ai_project, mock_logger):
         """Test grouping results includes baseline when requested."""
@@ -1653,15 +1702,20 @@ class TestFoundryExecutionManager:
         results = manager._group_results_by_strategy(
             orchestrator=mock_orchestrator,
             risk_value="violence",
-            output_path="/test/output.jsonl",
+            strategy_files={
+                "base64": "/test/violence_base64_results.jsonl",
+                "baseline": "/test/violence_baseline_results.jsonl",
+            },
             attack_strategies=[AttackStrategy.Base64, AttackStrategy.Baseline],
             include_baseline=True,
         )
 
-        # Should have base64 + baseline entries
+        # Should have base64 + baseline entries with separate files
         assert "base64" in results
         assert "baseline" in results
         assert results["baseline"]["asr"] == 0.6
+        assert results["base64"]["data_file"] == "/test/violence_base64_results.jsonl"
+        assert results["baseline"]["data_file"] == "/test/violence_baseline_results.jsonl"
 
     def test_group_results_by_strategy_keys_match_complexity_map(
         self, mock_credential, mock_azure_ai_project, mock_logger
@@ -1682,10 +1736,15 @@ class TestFoundryExecutionManager:
         mock_orchestrator.calculate_asr.return_value = 0.5
 
         strategies = [AttackStrategy.Base64, AttackStrategy.ROT13, AttackStrategy.Morse]
+        strategy_files = {
+            "base64": "/test/violence_base64_results.jsonl",
+            "rot13": "/test/violence_rot13_results.jsonl",
+            "morse": "/test/violence_morse_results.jsonl",
+        }
         results = manager._group_results_by_strategy(
             orchestrator=mock_orchestrator,
             risk_value="violence",
-            output_path="/test/output.jsonl",
+            strategy_files=strategy_files,
             attack_strategies=strategies,
             include_baseline=False,
         )
@@ -1711,7 +1770,7 @@ class TestFoundryExecutionManager:
         results = manager._group_results_by_strategy(
             orchestrator=mock_orchestrator,
             risk_value="violence",
-            output_path="/test/output.jsonl",
+            strategy_files={},
             attack_strategies=[],
             include_baseline=False,
         )
@@ -1737,7 +1796,7 @@ class TestFoundryExecutionManager:
         results = manager._group_results_by_strategy(
             orchestrator=mock_orchestrator,
             risk_value="violence",
-            output_path="/test/output.jsonl",
+            strategy_files={"indirect_jailbreak": "/test/violence_indirect_jailbreak_results.jsonl"},
             attack_strategies=[AttackStrategy.IndirectJailbreak],
             include_baseline=False,
         )
@@ -1746,6 +1805,114 @@ class TestFoundryExecutionManager:
         assert "indirect_jailbreak" in results
         assert results["indirect_jailbreak"]["asr"] == 0.3
         assert "Foundry" not in results  # Should NOT fall back
+
+    def test_to_jsonl_per_strategy_baseline_and_crescendo(
+        self, mock_credential, mock_azure_ai_project, mock_logger, tmp_path
+    ):
+        """Test that to_jsonl_per_strategy produces separate files per strategy.
+
+        Reproduces the root cause of multi-turn results showing single-turn content:
+        baseline and multi-turn conversations were in the same JSONL, and both strategies
+        read ALL entries. After the fix, each strategy gets its own file.
+        """
+        from pyrit.models import AttackResult, AttackOutcome
+
+        # Create mock scenario with results grouped by strategy
+        mock_orchestrator = MagicMock()
+
+        baseline_result = MagicMock(spec=AttackResult)
+        baseline_result.conversation_id = "conv-baseline-1"
+        baseline_result.outcome = AttackOutcome.FAILURE
+        baseline_result.attack_identifier = {"__type__": "PromptSendingAttack"}
+        baseline_result.last_score = None
+
+        crescendo_result = MagicMock(spec=AttackResult)
+        crescendo_result.conversation_id = "conv-crescendo-1"
+        crescendo_result.outcome = AttackOutcome.SUCCESS
+        crescendo_result.attack_identifier = {"__type__": "CrescendoAttack"}
+        crescendo_result.last_score = None
+
+        mock_orchestrator.get_attack_results_by_strategy.return_value = {
+            "baseline": [baseline_result],
+            "crescendo": [crescendo_result],
+        }
+        mock_orchestrator.get_attack_results.return_value = [baseline_result, crescendo_result]
+
+        # Mock memory to return conversation pieces
+        mock_memory = MagicMock()
+        mock_piece_baseline = MagicMock()
+        mock_piece_baseline.api_role = "user"
+        mock_piece_baseline.original_value = "baseline prompt"
+        mock_piece_baseline.converted_value = "baseline prompt"
+        mock_piece_baseline.sequence = 0
+        mock_piece_baseline.labels = {}
+        mock_piece_baseline.prompt_metadata = {}
+
+        mock_piece_baseline_resp = MagicMock()
+        mock_piece_baseline_resp.api_role = "assistant"
+        mock_piece_baseline_resp.original_value = "baseline response"
+        mock_piece_baseline_resp.converted_value = "baseline response"
+        mock_piece_baseline_resp.sequence = 1
+        mock_piece_baseline_resp.labels = {}
+        mock_piece_baseline_resp.prompt_metadata = {}
+
+        mock_piece_mt1 = MagicMock()
+        mock_piece_mt1.api_role = "user"
+        mock_piece_mt1.original_value = "turn 1"
+        mock_piece_mt1.converted_value = "turn 1"
+        mock_piece_mt1.sequence = 0
+        mock_piece_mt1.labels = {}
+        mock_piece_mt1.prompt_metadata = {}
+
+        mock_piece_mt2 = MagicMock()
+        mock_piece_mt2.api_role = "assistant"
+        mock_piece_mt2.original_value = "response 1"
+        mock_piece_mt2.converted_value = "response 1"
+        mock_piece_mt2.sequence = 1
+        mock_piece_mt2.labels = {}
+        mock_piece_mt2.prompt_metadata = {}
+
+        def get_pieces(conversation_id):
+            if conversation_id == "conv-baseline-1":
+                return [mock_piece_baseline, mock_piece_baseline_resp]
+            else:
+                return [mock_piece_mt1, mock_piece_mt2]
+
+        mock_memory.get_message_pieces = get_pieces
+        mock_orchestrator.get_memory.return_value = mock_memory
+
+        mock_dataset = MagicMock()
+        mock_dataset.get_all_seed_groups.return_value = []
+
+        processor = FoundryResultProcessor(
+            scenario=mock_orchestrator,
+            dataset_config=mock_dataset,
+            risk_category="violence",
+        )
+
+        strategy_files = processor.to_jsonl_per_strategy(
+            output_dir=str(tmp_path),
+            risk_value="violence",
+        )
+
+        # Should produce separate files keyed by strategy name
+        assert "baseline" in strategy_files
+        assert "crescendo" in strategy_files
+        assert strategy_files["baseline"] != strategy_files["crescendo"]
+
+        # Baseline file should contain ONLY baseline conversations
+        with open(strategy_files["baseline"], "r") as f:
+            baseline_lines = [l for l in f.read().strip().split("\n") if l]
+        assert len(baseline_lines) == 1
+        baseline_data = json.loads(baseline_lines[0])
+        assert baseline_data["conversation"]["messages"][0]["content"] == "baseline prompt"
+
+        # Crescendo file should contain ONLY multi-turn conversations
+        with open(strategy_files["crescendo"], "r") as f:
+            crescendo_lines = [l for l in f.read().strip().split("\n") if l]
+        assert len(crescendo_lines) == 1
+        crescendo_data = json.loads(crescendo_lines[0])
+        assert crescendo_data["conversation"]["messages"][0]["content"] == "turn 1"
 
     @pytest.mark.asyncio
     async def test_execute_attacks_empty_objectives(self, mock_credential, mock_azure_ai_project, mock_logger):
@@ -3556,7 +3723,7 @@ class TestReviewFixRegressions:
         ), patch.object(RAIServiceScorer, "__init__", return_value=None), patch.object(
             FoundryResultProcessor, "__init__", return_value=None
         ), patch.object(
-            FoundryResultProcessor, "to_jsonl", return_value=None
+            FoundryResultProcessor, "to_jsonl_per_strategy", return_value={"baseline": str(tmp_path / "out.jsonl")}
         ), patch.object(
             FoundryResultProcessor,
             "get_summary_stats",


### PR DESCRIPTION
The Foundry execution path generated a single JSONL file per risk category and assigned the same file to ALL strategies in red_team_info. When ResultProcessor read this file for each strategy, every conversation was duplicated and incorrectly labeled - baseline conversations appeared as multi-turn and vice versa.

Root cause: FoundryScenario batches all strategies into one execution, but the result pipeline wrote one combined JSONL and pointed every strategy at it. The legacy orchestrator path (<=1.14.0) avoided this by generating a separate file per (strategy, risk_category) pair.

Fix: Use PyRIT's ScenarioResult.attack_results dict which is keyed by atomic_attack_name (the FoundryStrategy value: 'baseline', 'crescendo', 'base64', etc.). This is the authoritative source for which strategy produced each AttackResult — no heuristic mapping needed.

Changes:
- ScenarioOrchestrator: add get_attack_results_by_strategy() exposing the strategy-keyed dict from ScenarioResult
- FoundryResultProcessor: add to_jsonl_per_strategy() that writes one JSONL file per strategy using the strategy-keyed results
- FoundryExecutionManager: call to_jsonl_per_strategy() and pass per-strategy file paths to _group_results_by_strategy()
- Tests: update 6 existing tests, add 1 new integration test

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
