### PR TITLE
Fix Jinja2 SSTI vulnerability by using SandboxedEnvironment

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_legacy/prompty/_utils.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_legacy/prompty/_utils.py
@@ -242,9 +242,15 @@ FILE_EXT_TO_MIME: Final[Mapping[str, str]] = {
 """Mapping of file extensions to mime types"""
 
 
+_SANDBOXED_ENV = SandboxedEnvironment(trim_blocks=True, keep_trailing_newline=True)
+
+
 def render_jinja_template(template_str: str, *, trim_blocks=True, keep_trailing_newline=True, **kwargs) -> str:
     try:
-        env = SandboxedEnvironment(trim_blocks=trim_blocks, keep_trailing_newline=keep_trailing_newline)
+        if trim_blocks is True and keep_trailing_newline is True:
+            env = _SANDBOXED_ENV
+        else:
+            env = SandboxedEnvironment(trim_blocks=trim_blocks, keep_trailing_newline=keep_trailing_newline)
         template = env.from_string(template_str)
         return template.render(**kwargs)
     except Exception as e:  # pylint: disable=broad-except

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_conversation/__init__.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/simulator/_conversation/__init__.py
@@ -134,8 +134,7 @@ class ConversationBot:
                     self.conversation_starter = conversation_starter_content
                 else:
                     try:
-                        _starter_env = SandboxedEnvironment(undefined=jinja2.StrictUndefined)
-                        self.conversation_starter = _starter_env.from_string(conversation_starter_content)
+                        self.conversation_starter = _sandbox_env.from_string(conversation_starter_content)
                     except jinja2.exceptions.TemplateSyntaxError as e:  # noqa: F841
                         self.conversation_starter = conversation_starter_content
             else:

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_jinja_sandbox.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_jinja_sandbox.py
@@ -1,0 +1,29 @@
+import pytest
+from jinja2.exceptions import SecurityError
+
+from azure.ai.evaluation._legacy.prompty._exceptions import PromptyException
+from azure.ai.evaluation._legacy.prompty._utils import render_jinja_template
+
+
+@pytest.mark.unittest
+class TestJinjaSandbox:
+    """Regression tests: SandboxedEnvironment must block SSTI payloads (CWE-1336)."""
+
+    def test_render_normal_template(self):
+        result = render_jinja_template("Hello, {{ name }}!", name="world")
+        assert result == "Hello, world!"
+
+    def test_render_blocks_mro_traversal(self):
+        with pytest.raises(PromptyException, match="SecurityError") as exc_info:
+            render_jinja_template("{{ ''.__class__.__mro__ }}")
+        assert isinstance(exc_info.value.__cause__, SecurityError)
+
+    def test_render_blocks_subclass_enumeration(self):
+        with pytest.raises(PromptyException, match="SecurityError") as exc_info:
+            render_jinja_template("{{ ''.__class__.__mro__[1].__subclasses__() }}")
+        assert isinstance(exc_info.value.__cause__, SecurityError)
+
+    def test_render_blocks_init_globals_access(self):
+        with pytest.raises(PromptyException, match="SecurityError") as exc_info:
+            render_jinja_template("{{ cycler.__init__.__globals__ }}")
+        assert isinstance(exc_info.value.__cause__, SecurityError)

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_synthetic_conversation_bot.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_synthetic_conversation_bot.py
@@ -102,6 +102,17 @@ class TestConversationBot:
         assert isinstance(bot.conversation_template, jinja2.Template)
 
     @pytest.mark.asyncio
+    async def test_conversation_bot_blocks_unsafe_template(self, bot_user_params):
+        """Regression test: sandbox must block SSTI payloads at render time (CWE-1336)."""
+        malicious_template = "{{ ''.__class__.__mro__ }}"
+        params = {**bot_user_params, "conversation_template": malicious_template}
+        from jinja2.exceptions import SecurityError
+
+        bot = ConversationBot(**params)
+        with pytest.raises(SecurityError):
+            bot.conversation_template.render()
+
+    @pytest.mark.asyncio
     async def test_generate_response_first_turn_with_starter(self, bot_user_params):
         bot = ConversationBot(**bot_user_params)
         session = AsyncMock()


### PR DESCRIPTION
Replace unsandboxed jinja2.Template with jinja2.sandbox.SandboxedEnvironment across all template rendering paths in azure-ai-evaluation to prevent Server-Side Template Injection (CWE-1336).

Fixes: MSRC Case 111609 (VULN-179916)

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
