### PR TITLE
fix(core): add flush_spans() to drain BatchSpanProcessor before sandbox suspend

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/__init__.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/__init__.py
@@ -13,6 +13,7 @@ Public API::
         AgentServerHost,
         create_error_response,
         end_span,
+        flush_spans,
         record_error,
         trace_stream,
     )
@@ -22,7 +23,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 from ._base import AgentServerHost
 from ._config import AgentConfig
 from ._errors import create_error_response
-from ._tracing import end_span, record_error, trace_stream
+from ._tracing import end_span, flush_spans, record_error, trace_stream
 from ._version import VERSION
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "AgentServerHost",
     "create_error_response",
     "end_span",
+    "flush_spans",
     "record_error",
     "trace_stream",
 ]

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -189,6 +189,34 @@ def end_span(span: Any, exc: Optional[BaseException] = None) -> None:
     span.end()
 
 
+def flush_spans(timeout_millis: int = 5000) -> None:
+    """Flush all pending spans from the TracerProvider.
+
+    The ``BatchSpanProcessor`` buffers spans and exports them on a timer
+    (default 5 seconds).  In hosted sandbox environments the platform may
+    suspend the process immediately after an HTTP response is sent, before
+    the batch timer fires.  Calling this function after ending the request
+    span ensures that all child spans — including short-lived ones created
+    by third-party tracers (e.g. LangChain/LangGraph per-node spans) — are
+    exported before the sandbox is frozen.
+
+    No-op when the OTel SDK is not installed or the provider does not
+    support ``force_flush``.
+
+    :param timeout_millis: Maximum time to wait for the flush, in
+        milliseconds.  Defaults to 5000 (5 seconds).
+    """
+    if not _HAS_OTEL:
+        return
+    provider = trace.get_tracer_provider()
+    flush = getattr(provider, "force_flush", None)
+    if flush is not None:
+        try:
+            flush(timeout_millis)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("TracerProvider.force_flush() failed", exc_info=True)
+
+
 def record_error(span: Any, exc: BaseException) -> None:
     """Record an exception and ERROR status on a span.
 
@@ -225,6 +253,7 @@ async def trace_stream(
         raise
     finally:
         end_span(span, exc=error)
+        flush_spans()
 
 
 # ======================================================================


### PR DESCRIPTION
## Problem

`BatchSpanProcessor` exports spans on a background timer (default 5 seconds). In hosted sandbox environments (Azure AI Foundry vNext), the platform may suspend the process immediately after an HTTP response is sent, before the batch timer fires. This causes short-lived spans to be lost.

**Split from [#46154](https://github.com/Azure/azure-sdk-for-python/pull/46154)** per review feedback — this PR contains only the **core** package changes. The responses package changes (`_endpoint_handler.py`) remain in #46154.

## Changes (core package only)

| File | Change |
|------|--------|
| `core/_tracing.py` | Add `flush_spans()` function + call from `trace_stream` finally block |
| `core/__init__.py` | Export `flush_spans` in public API |

## `flush_spans()` behavior

- Calls `TracerProvider.force_flush(timeout_millis=5000)` to synchronously drain the batch buffer
- No-op when OTel SDK is not installed or provider does not support `force_flush`
- Catches and logs (debug level) any flush errors to avoid disrupting the response path

## Before vs After

### Before — 11 spans (per-node spans lost)
```
invoke_agent root → invoke_agent agent → chat × 4 + tool × 4 + retriever
```

### After — 19+ spans (full node hierarchy) ✅
```
invoke_agent root → invoke_agent agent
  ├─ invoke_agent user_proxy
  ├─ invoke_agent orchestrator
  ├─ invoke_agent retrieve_context → gen_ai.retriever
  ├─ invoke_agent research_destination
  ├─ invoke_agent draft_plan → chat gpt-4o
  ├─ invoke_agent run_tools → chat + 4× execute_tool + chat
  ├─ invoke_agent evaluate_constraints
  └─ invoke_agent finalize → chat gpt-4o
```

Verified on hosted sandbox with 5 invokes producing 19-31 spans each.
