### PR TITLE
[Storage] Marked all immutability policy and legal hold tests to be playback only

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -1526,6 +1526,7 @@ class TestStorageAppendBlob(StorageRecordedTestCase):
         assert prop.is_append_blob_sealed is None
         copied_blob3.append_block("abc")
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_create_append_blob_with_immutability_policy(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -1519,6 +1519,7 @@ class TestStorageAppendBlobAsync(AsyncStorageRecordedTestCase):
         assert prop.is_append_blob_sealed is None
         await copied_blob3.append_block("abc")
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_create_append_blob_with_immutability_policy(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -730,6 +730,7 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
         assert content.properties.etag == put_block_list_resp.get('etag')
         assert content.properties.last_modified == put_block_list_resp.get('last_modified')
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_put_block_with_immutability_policy(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -806,6 +806,7 @@ class TestStorageBlockBlobAsync(AsyncStorageRecordedTestCase):
         assert content.properties.etag == put_block_list_resp.get('etag')
         assert content.properties.last_modified == put_block_list_resp.get('last_modified')
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_put_block_with_immutability_policy(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1473,6 +1473,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         copy_content = copyblob.download_blob().readall()
         assert copy_content == self.byte_data
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_copy_blob_with_immutability_policy(self, **kwargs):
@@ -2091,6 +2092,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         assert container_props is not None
         assert blob_props is not None
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_blob_service_sas(self, **kwargs):
@@ -2160,7 +2162,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         # Assert
         assert 'ss=bf' in token
 
-    @pytest.mark.live_test_only
+    @pytest.mark.skip(reason="Temporarily skipping immutability test due to service bug")
     @BlobPreparer()
     def test_set_immutability_policy_using_sas(self, **kwargs):
         versioned_storage_account_name = kwargs.pop("versioned_storage_account_name")
@@ -2714,7 +2716,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         assert info.get('sku_name') is not None
         assert info.get('account_kind') is not None
 
-    @pytest.mark.live_test_only
+    @pytest.mark.skip(reason="Temporarily skipping immutability test due to service bug")
     @BlobPreparer()
     def test_get_account_information_with_container_sas(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -3109,6 +3111,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         # Assert that the token attempts to refresh 4 times (i.e, get_token called 4 times)
         assert token_credential.get_token_count == 4
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_blob_immutability_policy(self, **kwargs):
@@ -3161,6 +3164,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_blob_legal_hold(self, **kwargs):
@@ -3204,6 +3208,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
             blob.delete_blob()
             mgmt_client.blob_containers.delete(storage_resource_group_name, versioned_storage_account_name, container_name)
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_download_blob_with_immutability_policy(self, **kwargs):
@@ -3253,6 +3258,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_list_blobs_with_immutability_policy(self, **kwargs):
@@ -3298,6 +3304,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_snapshot_immutability_policy_and_legal_hold(self, **kwargs):
@@ -3347,6 +3354,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_versioning_immutability_policy_and_legal_hold(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -1821,6 +1821,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         copy_content = await (await copyblob.download_blob()).readall()
         assert copy_content == self.byte_data
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_copy_blob_with_immutability_policy(self, **kwargs):
@@ -2693,7 +2694,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         assert info.get('sku_name') is not None
         assert info.get('account_kind') is not None
 
-    @pytest.mark.live_test_only
+    @pytest.mark.skip(reason="Temporarily skipping immutability test due to service bug")
     @BlobPreparer()
     async def test_get_account_information_with_container_sas(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -3033,6 +3034,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
             await bsc.get_service_properties()
             assert transport.session is not None
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_blob_immutability_policy(self, **kwargs):
@@ -3086,6 +3088,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_blob_legal_hold(self, **kwargs):
@@ -3129,6 +3132,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
             await blob.delete_blob()
             await mgmt_client.blob_containers.delete(storage_resource_group_name, versioned_storage_account_name, container_name)
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_download_blob_with_immutability_policy(self, **kwargs):
@@ -3181,6 +3185,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_list_blobs_with_immutability_policy(self, **kwargs):
@@ -3229,6 +3234,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_snapshot_immutability_policy_and_legal_hold(self, **kwargs):
@@ -3280,6 +3286,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         return variables
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_versioning_immutability_policy_and_legal_hold(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -131,6 +131,7 @@ class TestStoragePageBlob(StorageRecordedTestCase):
         assert resp.get('last_modified') is not None
         assert blob.get_blob_properties()
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_create_blob_with_immutability_policy(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -160,6 +160,7 @@ class TestStoragePageBlobAsync(AsyncStorageRecordedTestCase):
         assert resp.get('last_modified') is not None
         assert await blob.get_blob_properties()
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_create_blob_with_immutability_policy(self, **kwargs):


### PR DESCRIPTION
For any live immutability or legal hold tests, I've marked as skip with a reason as we don't want to run those live right now.