### PR TITLE
Fix: Use AsyncRetryPolicy in FoundryStorageProvider async pipeline

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
@@ -91,7 +91,7 @@ class FoundryStorageProvider:
                 policies.UserAgentPolicy(
                     sdk_moniker="ai-agentserver-responses",
                 ),
-                policies.RetryPolicy(),
+                policies.AsyncRetryPolicy(),
                 policies.AsyncBearerTokenCredentialPolicy(
                     credential,
                     _FOUNDRY_TOKEN_SCOPE,


### PR DESCRIPTION
## Problem
`FoundryStorageProvider` uses `AsyncPipelineClient` but was configured with the synchronous `RetryPolicy`. 

`RetryPolicy` extends `HTTPPolicy` (sync), which cannot properly `await` downstream async policies like `AsyncBearerTokenCredentialPolicy` during retries.

## Fix
Replaced `policies.RetryPolicy()` with `policies.AsyncRetryPolicy()`, which extends `AsyncHTTPPolicy` and correctly awaits the async pipeline chain.