### PR TITLE
Support responses API and always-on model discovery

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-githubcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
+++ b/sdk/agentserver/azure-ai-agentserver-githubcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
@@ -151,7 +151,7 @@ def _build_session_config() -> Dict[str, Any]:
         if api_key:
             logger.info(f"BYOK mode (API key): {base_url}")
             return {
-                "model": model or "gpt-4.1",
+                "model": model,
                 "provider": ProviderConfig(
                     type="openai",
                     base_url=base_url,
@@ -163,7 +163,7 @@ def _build_session_config() -> Dict[str, Any]:
 
         logger.info(f"BYOK mode (Managed Identity): {base_url}")
         return {
-            "model": model or "gpt-4.1",
+            "model": model,
             "provider": ProviderConfig(
                 type="openai",
                 base_url=base_url,
@@ -326,8 +326,8 @@ class CopilotAdapter(FoundryCBAgent):
                 "Creating new Copilot session"
                 + (f" for conversation {conversation_id!r}" if conversation_id else "")
             )
-            # Filter out internal flags (starting with _) before passing to SDK
-            sdk_config = {k: v for k, v in config.items() if not k.startswith("_")}
+            # Filter out internal flags (starting with _) and None values before passing to SDK
+            sdk_config = {k: v for k, v in config.items() if not k.startswith("_") and v is not None}
             # Always enable streaming — the SDK only emits
             # ASSISTANT_MESSAGE_DELTA when streaming=True.
             session = await client.create_session(
@@ -778,61 +778,150 @@ class GitHubCopilotAdapter(CopilotAdapter):
         return cls(project_root=str(root), **kwargs)
 
     async def initialize(self):
-        """Discover and cache the best model at startup (if not already configured).
+        """Discover deployments and configure the model and wire API at startup.
 
-        Call after construction and before ``run()``.  If ``AZURE_AI_FOUNDRY_MODEL``
-        is set or a model is already in the session config, discovery is skipped.
+        Call after construction and before ``run()``.  Discovery always runs
+        to validate the configured model against available deployments and to
+        set ``wire_api`` (``responses`` or ``completions``) based on model
+        capabilities.  If ``AZURE_AI_FOUNDRY_MODEL`` is set, the configured
+        model is matched against discovered deployments; if not found, the
+        best available model is auto-selected.
         """
         resource_url = self._session_config.get("_foundry_resource_url")
         if not resource_url:
             return  # Not using Foundry models — nothing to discover
-        if self._session_config.get("model"):
-            logger.info(f"Model already configured: {self._session_config['model']}")
-            return
+
+        configured_model = self._session_config.get("model")
+        logger.info(
+            "Starting model discovery for %s (configured model: %s)",
+            resource_url, configured_model or "<none>",
+        )
 
         try:
-            from ._foundry_model_discovery import discover_foundry_deployments, get_default_model
+            from ._foundry_model_discovery import FoundryDeployment, discover_foundry_deployments, get_default_model
             from ._model_cache import ModelCache
 
             cache = ModelCache()
+            deployments = None
+
+            # Try cache first to avoid ARM traffic
             cached = cache.get_cache_info(resource_url)
-            if cached and cached.get("selected_model"):
-                self._session_config["model"] = cached["selected_model"]
-                logger.info(f"Using cached model: {cached['selected_model']} (age: {cached['age_hours']:.1f}h)")
+            if cached and cached.get("deployments"):
+                cached_deps = cached["deployments"]
+                deployments = [
+                    FoundryDeployment(
+                        name=d["name"],
+                        model_name=d.get("model_name", d["name"]),
+                        model_version=d.get("model_version", ""),
+                        model_format=d.get("model_format", "OpenAI"),
+                        token_rate_limit=d.get("token_rate_limit", 0),
+                        capabilities=d.get("capabilities"),
+                    )
+                    for d in cached_deps
+                ]
+                # If a wire_api was cached but capabilities weren't, restore it
+                for dep, raw in zip(deployments, cached_deps):
+                    if not dep.capabilities and "wire_api" in raw:
+                        dep._cached_wire_api = raw["wire_api"]
+                logger.info(
+                    "Using cached deployments (%d, age: %.1fh)",
+                    len(deployments), cached["age_hours"],
+                )
+            elif cached and cached.get("selected_model"):
+                # Older cache format: selected_model without deployments list
+                cached_model = cached["selected_model"]
+                if not configured_model:
+                    self._session_config["model"] = cached_model
+                logger.info(
+                    "Using cached model (no deployments): %s (age: %.1fh)",
+                    cached_model, cached["age_hours"],
+                )
                 return
 
-            # Need a token for discovery
-            if self._credential is not None:
-                token = self._credential.get_token("https://management.azure.com/.default").token
-                deployments = await discover_foundry_deployments(
-                    resource_url=resource_url,
-                    access_token=token,
-                    management_token=token,
-                )
-                if deployments:
-                    selected = get_default_model(deployments)
-                    if selected:
-                        self._session_config["model"] = selected
-                        cache.set_selected_model(
-                            resource_url=resource_url,
-                            model_name=selected,
-                            deployments=[{
-                                "name": d.name,
-                                "model_name": d.model_name,
-                                "model_version": d.model_version,
-                                "model_format": d.model_format,
-                                "token_rate_limit": d.token_rate_limit,
-                            } for d in deployments],
-                        )
-                        logger.info(f"Auto-selected model: {selected}")
-                    else:
-                        logger.warning("No suitable model found during discovery")
+            # Cache miss or expired — do full ARM discovery
+            if not deployments:
+                if self._credential is not None:
+                    management_token = self._credential.get_token("https://management.azure.com/.default").token
+                    cognitive_token = self._credential.get_token(_COGNITIVE_SERVICES_SCOPE).token
+                    deployments = await discover_foundry_deployments(
+                        resource_url=resource_url,
+                        access_token=cognitive_token,
+                        management_token=management_token,
+                    )
                 else:
-                    logger.warning("No deployments found during discovery")
-            else:
-                logger.info("No credential available for model discovery — set AZURE_AI_FOUNDRY_MODEL manually")
+                    logger.info("No credential available for model discovery — set AZURE_AI_FOUNDRY_MODEL manually")
+
+            if not deployments:
+                logger.warning("No deployments found during discovery")
+                if not configured_model:
+                    self._session_config["model"] = "gpt-4.1"
+                    logger.warning("No model discovered — falling back to gpt-4.1")
+                return
+
+            logger.info("Model discovery found %d deployment(s):", len(deployments))
+            for d in deployments:
+                caps = {k: v for k, v in d.capabilities.items() if not k.startswith("_")} if d.capabilities else {}
+                logger.info(
+                    "  - %s (model=%s, version=%s, format=%s, TPM=%s, wire_api=%s, capabilities=%s)",
+                    d.name, d.model_name, d.model_version,
+                    d.model_format, d.token_rate_limit, d.wire_api, caps,
+                )
+
+            # Match configured model against discovered deployments
+            matched_deployment = None
+            if configured_model:
+                for d in deployments:
+                    if d.name == configured_model:
+                        matched_deployment = d
+                        break
+                if matched_deployment:
+                    logger.info("Configured model '%s' found in deployments (wire_api=%s)",
+                                configured_model, matched_deployment.wire_api)
+                else:
+                    logger.warning("Configured model '%s' NOT found in deployments — "
+                                   "available: %s", configured_model,
+                                   ", ".join(d.name for d in deployments))
+
+            # Auto-select if no model configured or configured model not found
+            if not matched_deployment:
+                selected = get_default_model(deployments)
+                if selected:
+                    self._session_config["model"] = selected
+                    matched_deployment = next(d for d in deployments if d.name == selected)
+                    logger.info(f"Auto-selected model: {selected} (wire_api={matched_deployment.wire_api})")
+                else:
+                    logger.warning("No suitable model found during discovery")
+                    if not configured_model:
+                        self._session_config["model"] = "gpt-4.1"
+                        logger.warning("Falling back to gpt-4.1")
+                    return
+
+            # Set wire_api based on matched deployment capabilities
+            if matched_deployment and "provider" in self._session_config:
+                self._session_config["provider"]["wire_api"] = matched_deployment.wire_api
+                logger.info("Set wire_api=%s for model %s",
+                            matched_deployment.wire_api, matched_deployment.name)
+
+            # Update cache
+            cache.set_selected_model(
+                resource_url=resource_url,
+                model_name=self._session_config.get("model", configured_model),
+                deployments=[{
+                    "name": d.name,
+                    "model_name": d.model_name,
+                    "model_version": d.model_version,
+                    "model_format": d.model_format,
+                    "token_rate_limit": d.token_rate_limit,
+                    "wire_api": d.wire_api,
+                    "capabilities": d.capabilities,
+                } for d in deployments],
+            )
+
         except Exception:
             logger.warning("Model discovery failed — set AZURE_AI_FOUNDRY_MODEL manually", exc_info=True)
+            if not configured_model:
+                self._session_config["model"] = "gpt-4.1"
+                logger.warning("No model discovered — falling back to gpt-4.1")
 
     async def _load_conversation_history(self, conversation_id: str) -> Optional[str]:
         """Load prior conversation turns from Foundry for cold-start bootstrap.
@@ -915,7 +1004,7 @@ class GitHubCopilotAdapter(CopilotAdapter):
                     logger.warning(f"ACL denied tool request during history bootstrap: kind={kind}")
                     return _perm_result_boot(kind="denied-by-rules", rules=[])
 
-                sdk_config = {k: v for k, v in config.items() if not k.startswith("_")}
+                sdk_config = {k: v for k, v in config.items() if not k.startswith("_") and v is not None}
                 session = await client.create_session(
                     **sdk_config,
                     on_permission_request=_on_permission_boot,

--- a/sdk/agentserver/azure-ai-agentserver-githubcopilot/azure/ai/agentserver/githubcopilot/_foundry_model_discovery.py
+++ b/sdk/agentserver/azure-ai-agentserver-githubcopilot/azure/ai/agentserver/githubcopilot/_foundry_model_discovery.py
@@ -6,7 +6,7 @@ Fetches available model deployments from Azure AI Foundry and allows users to se
 import json
 import logging
 import re
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,7 @@ class FoundryDeployment:
     def __init__(
         self, name: str, model_name: str, model_version: str,
         model_format: str = "", status: str = "Succeeded", token_rate_limit: int = 0,
+        capabilities: Optional[Dict[str, Any]] = None,
     ):
         self.name = name
         self.model_name = model_name
@@ -24,11 +25,34 @@ class FoundryDeployment:
         self.model_format = model_format or "OpenAI"  # Default to OpenAI/Azure format
         self.status = status
         self.token_rate_limit = token_rate_limit  # Tokens per minute
+        self.capabilities = capabilities or {}
+
+    @property
+    def supports_responses(self) -> bool:
+        return self.capabilities.get("responses") in ("true", True)
+
+    @property
+    def supports_chat(self) -> bool:
+        return (
+            self.capabilities.get("chatCompletion") in ("true", True)
+            or self.capabilities.get("chat_completion") in ("true", True)
+        )
+
+    @property
+    def wire_api(self) -> str:
+        """Return the appropriate wire API based on model capabilities."""
+        if self.supports_responses:
+            return "responses"
+        # Fall back to cached wire_api if capabilities weren't available
+        cached = getattr(self, "_cached_wire_api", None)
+        if cached:
+            return cached
+        return "completions"
 
     def __repr__(self):
         return (
             f"{self.name} ({self.model_name} {self.model_version}"
-            f" - {self.model_format}, {self.token_rate_limit} TPM)"
+            f" - {self.model_format}, {self.token_rate_limit} TPM, wire_api={self.wire_api})"
         )
 
 
@@ -176,23 +200,20 @@ async def _discover_via_management_api(resource_name: str, management_token: str
                         model_version = model.get("version", "")
                         model_format = model.get("format", "")
 
-                        # Filter: chat-capable models only - check capabilities field ONLY
+                        # Filter: chat-capable or responses-capable models
                         capabilities = properties.get("capabilities", {})
 
-                        # Check for chat completion capability
                         is_chat = (
                             capabilities.get("chatCompletion") in ("true", True)
                             or capabilities.get("chat_completion") in ("true", True)
                         )
+                        is_responses = capabilities.get("responses") in ("true", True)
 
-                        if not is_chat:
-                            logger.debug(f"Skipping non-chat model: {name} (capabilities: {capabilities})")
+                        if not is_chat and not is_responses:
+                            logger.debug(f"Skipping model without chat/responses: {name} (capabilities: {capabilities})")
                             continue
 
-                        # Filter: Only supported model formats (OpenAI, Meta, Anthropic)
-                        if model_format not in ["OpenAI", "Meta", "Anthropic"]:
-                            logger.debug(f"Skipping unsupported model format: {name} (format: {model_format})")
-                            continue
+                        # Note: no model_format filter — capability check above is sufficient
 
                         # Extract rate limits (tokens per minute)
                         rate_limits = properties.get("rateLimits", [])
@@ -202,14 +223,15 @@ async def _discover_via_management_api(resource_name: str, management_token: str
                                 token_rate_limit = limit.get("count", 0)
                                 break
 
-                        # Include this chat-capable model
+                        # Include this model
                         deployment = FoundryDeployment(
                             name=name,
                             model_name=model_name,
                             model_version=model_version,
                             model_format=model_format,
                             status=properties.get("provisioningState", "Unknown"),
-                            token_rate_limit=token_rate_limit
+                            token_rate_limit=token_rate_limit,
+                            capabilities=capabilities,
                         )
                         deployments.append(deployment)
 
@@ -322,22 +344,20 @@ async def _discover_via_openai_api(resource_url: str, access_token: str) -> List
 
                                 logger.info(f"Found deployment: {name} (model: {model_name}, format: {model_format})")
 
-                                # Filter: Only chat-capable models - check capabilities field ONLY
+                                # Filter: chat-capable or responses-capable models
                                 capabilities = item.get("capabilities", {})
 
                                 is_chat = (
                                     capabilities.get("chatCompletion") in ("true", True)
                                     or capabilities.get("chat_completion") in ("true", True)
                                 )
+                                is_responses = capabilities.get("responses") in ("true", True)
 
-                                if not is_chat:
-                                    logger.debug(f"Skipping non-chat model: {name} (capabilities: {capabilities})")
+                                if not is_chat and not is_responses:
+                                    logger.debug(f"Skipping model without chat/responses: {name} (capabilities: {capabilities})")
                                     continue
 
-                                # Filter: Only supported model formats (OpenAI, Meta, Anthropic)
-                                if model_format not in ["OpenAI", "Meta", "Anthropic"]:
-                                    logger.debug(f"Skipping unsupported model format: {name} (format: {model_format})")
-                                    continue
+                                # Note: no model_format filter — capability check above is sufficient
 
                                 # Extract rate limits (tokens per minute)
                                 rate_limits = item.get("rateLimits", [])
@@ -353,7 +373,8 @@ async def _discover_via_openai_api(resource_url: str, access_token: str) -> List
                                     model_version="",
                                     model_format=model_format,
                                     status="Succeeded",
-                                    token_rate_limit=token_rate_limit
+                                    token_rate_limit=token_rate_limit,
+                                    capabilities=capabilities,
                                 )
                                 deployments.append(deployment)
 

--- a/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/unit_tests/test_copilot_adapter.py
+++ b/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/unit_tests/test_copilot_adapter.py
@@ -210,3 +210,265 @@ class TestClearAndReinitialize:
         assert adapter.get_model() == "gpt-4-turbo"
         mock_discover.assert_called_once()  # Discovery should be invoked
         mock_get_default.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# wire_api selection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWireApiSelection:
+    """Tests for dynamic wire_api selection based on model capabilities."""
+
+    @pytest.mark.asyncio
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.get_default_model')
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.discover_foundry_deployments')
+    @patch('azure.ai.agentserver.githubcopilot._model_cache.ModelCache')
+    async def test_responses_capable_model_sets_responses_wire_api(
+        self, mock_cache_class, mock_discover, mock_get_default
+    ):
+        """Model with responses=true should set wire_api to 'responses'."""
+        from azure.ai.agentserver.githubcopilot._foundry_model_discovery import FoundryDeployment
+
+        mock_cache_instance = MagicMock()
+        mock_cache_class.return_value = mock_cache_instance
+        mock_cache_instance.get_cache_info.return_value = None
+
+        deployment = FoundryDeployment(
+            name="gpt-5.3-codex",
+            model_name="gpt-5.3-codex",
+            model_version="2026-02-24",
+            model_format="OpenAI",
+            token_rate_limit=5000000,
+            capabilities={"chatCompletion": "false", "responses": "true"},
+        )
+        mock_discover.return_value = [deployment]
+        mock_get_default.return_value = "gpt-5.3-codex"
+
+        from azure.ai.agentserver.githubcopilot._copilot_adapter import ProviderConfig
+        adapter = GitHubCopilotAdapter(session_config={
+            "_foundry_resource_url": "https://test.openai.azure.com",
+            "provider": ProviderConfig(
+                type="openai",
+                base_url="https://test.openai.azure.com/openai/v1/",
+                bearer_token="placeholder",
+                wire_api="completions",
+            ),
+        })
+        adapter._session_config.pop("model", None)
+
+        mock_credential = MagicMock()
+        mock_token = MagicMock()
+        mock_token.token = "test_token"
+        mock_credential.get_token.return_value = mock_token
+        adapter._credential = mock_credential
+
+        await adapter.initialize()
+
+        assert adapter.get_model() == "gpt-5.3-codex"
+        assert adapter._session_config["provider"]["wire_api"] == "responses"
+
+    @pytest.mark.asyncio
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.get_default_model')
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.discover_foundry_deployments')
+    @patch('azure.ai.agentserver.githubcopilot._model_cache.ModelCache')
+    async def test_chat_only_model_sets_completions_wire_api(
+        self, mock_cache_class, mock_discover, mock_get_default
+    ):
+        """Model with only chatCompletion=true should set wire_api to 'completions'."""
+        from azure.ai.agentserver.githubcopilot._foundry_model_discovery import FoundryDeployment
+
+        mock_cache_instance = MagicMock()
+        mock_cache_class.return_value = mock_cache_instance
+        mock_cache_instance.get_cache_info.return_value = None
+
+        deployment = FoundryDeployment(
+            name="gpt-4.1",
+            model_name="gpt-4.1",
+            model_version="2025-04-14",
+            model_format="OpenAI",
+            token_rate_limit=100000,
+            capabilities={"chatCompletion": "true", "responses": "false"},
+        )
+        mock_discover.return_value = [deployment]
+        mock_get_default.return_value = "gpt-4.1"
+
+        from azure.ai.agentserver.githubcopilot._copilot_adapter import ProviderConfig
+        adapter = GitHubCopilotAdapter(session_config={
+            "_foundry_resource_url": "https://test.openai.azure.com",
+            "provider": ProviderConfig(
+                type="openai",
+                base_url="https://test.openai.azure.com/openai/v1/",
+                bearer_token="placeholder",
+                wire_api="completions",
+            ),
+        })
+        adapter._session_config.pop("model", None)
+
+        mock_credential = MagicMock()
+        mock_token = MagicMock()
+        mock_token.token = "test_token"
+        mock_credential.get_token.return_value = mock_token
+        adapter._credential = mock_credential
+
+        await adapter.initialize()
+
+        assert adapter.get_model() == "gpt-4.1"
+        assert adapter._session_config["provider"]["wire_api"] == "completions"
+
+    @pytest.mark.asyncio
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.get_default_model')
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.discover_foundry_deployments')
+    @patch('azure.ai.agentserver.githubcopilot._model_cache.ModelCache')
+    async def test_both_capabilities_prefers_responses(
+        self, mock_cache_class, mock_discover, mock_get_default
+    ):
+        """Model with both chatCompletion=true and responses=true should prefer responses."""
+        from azure.ai.agentserver.githubcopilot._foundry_model_discovery import FoundryDeployment
+
+        mock_cache_instance = MagicMock()
+        mock_cache_class.return_value = mock_cache_instance
+        mock_cache_instance.get_cache_info.return_value = None
+
+        deployment = FoundryDeployment(
+            name="gpt-4o",
+            model_name="gpt-4o",
+            model_version="2024-11-20",
+            model_format="OpenAI",
+            token_rate_limit=40000,
+            capabilities={"chatCompletion": "true", "responses": "true"},
+        )
+        mock_discover.return_value = [deployment]
+        mock_get_default.return_value = "gpt-4o"
+
+        from azure.ai.agentserver.githubcopilot._copilot_adapter import ProviderConfig
+        adapter = GitHubCopilotAdapter(session_config={
+            "_foundry_resource_url": "https://test.openai.azure.com",
+            "provider": ProviderConfig(
+                type="openai",
+                base_url="https://test.openai.azure.com/openai/v1/",
+                bearer_token="placeholder",
+                wire_api="completions",
+            ),
+        })
+        adapter._session_config.pop("model", None)
+
+        mock_credential = MagicMock()
+        mock_token = MagicMock()
+        mock_token.token = "test_token"
+        mock_credential.get_token.return_value = mock_token
+        adapter._credential = mock_credential
+
+        await adapter.initialize()
+
+        assert adapter.get_model() == "gpt-4o"
+        assert adapter._session_config["provider"]["wire_api"] == "responses"
+
+
+# ---------------------------------------------------------------------------
+# Configured model matching tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConfiguredModelMatching:
+    """Tests for validating configured model against discovered deployments."""
+
+    @pytest.mark.asyncio
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.get_default_model')
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.discover_foundry_deployments')
+    @patch('azure.ai.agentserver.githubcopilot._model_cache.ModelCache')
+    async def test_configured_model_matched(
+        self, mock_cache_class, mock_discover, mock_get_default
+    ):
+        """Configured model found in deployments keeps that model."""
+        from azure.ai.agentserver.githubcopilot._foundry_model_discovery import FoundryDeployment
+
+        mock_cache_instance = MagicMock()
+        mock_cache_class.return_value = mock_cache_instance
+        mock_cache_instance.get_cache_info.return_value = None
+
+        deployments = [
+            FoundryDeployment(
+                name="gpt-5.3-codex", model_name="gpt-5.3-codex",
+                model_version="2026-02-24", token_rate_limit=5000000,
+                capabilities={"responses": "true"},
+            ),
+            FoundryDeployment(
+                name="gpt-4o", model_name="gpt-4o",
+                model_version="2024-11-20", token_rate_limit=40000,
+                capabilities={"chatCompletion": "true", "responses": "true"},
+            ),
+        ]
+        mock_discover.return_value = deployments
+
+        from azure.ai.agentserver.githubcopilot._copilot_adapter import ProviderConfig
+        adapter = GitHubCopilotAdapter(session_config={
+            "model": "gpt-4o",
+            "_foundry_resource_url": "https://test.openai.azure.com",
+            "provider": ProviderConfig(
+                type="openai",
+                base_url="https://test.openai.azure.com/openai/v1/",
+                bearer_token="placeholder",
+                wire_api="completions",
+            ),
+        })
+
+        mock_credential = MagicMock()
+        mock_token = MagicMock()
+        mock_token.token = "test_token"
+        mock_credential.get_token.return_value = mock_token
+        adapter._credential = mock_credential
+
+        await adapter.initialize()
+
+        assert adapter.get_model() == "gpt-4o"
+        assert adapter._session_config["provider"]["wire_api"] == "responses"
+        mock_get_default.assert_not_called()  # Should not auto-select
+
+    @pytest.mark.asyncio
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.get_default_model')
+    @patch('azure.ai.agentserver.githubcopilot._foundry_model_discovery.discover_foundry_deployments')
+    @patch('azure.ai.agentserver.githubcopilot._model_cache.ModelCache')
+    async def test_configured_model_not_found_auto_selects(
+        self, mock_cache_class, mock_discover, mock_get_default
+    ):
+        """Configured model not in deployments triggers auto-selection."""
+        from azure.ai.agentserver.githubcopilot._foundry_model_discovery import FoundryDeployment
+
+        mock_cache_instance = MagicMock()
+        mock_cache_class.return_value = mock_cache_instance
+        mock_cache_instance.get_cache_info.return_value = None
+
+        deployment = FoundryDeployment(
+            name="gpt-5.3-codex", model_name="gpt-5.3-codex",
+            model_version="2026-02-24", token_rate_limit=5000000,
+            capabilities={"responses": "true"},
+        )
+        mock_discover.return_value = [deployment]
+        mock_get_default.return_value = "gpt-5.3-codex"
+
+        from azure.ai.agentserver.githubcopilot._copilot_adapter import ProviderConfig
+        adapter = GitHubCopilotAdapter(session_config={
+            "model": "nonexistent-model",
+            "_foundry_resource_url": "https://test.openai.azure.com",
+            "provider": ProviderConfig(
+                type="openai",
+                base_url="https://test.openai.azure.com/openai/v1/",
+                bearer_token="placeholder",
+                wire_api="completions",
+            ),
+        })
+
+        mock_credential = MagicMock()
+        mock_token = MagicMock()
+        mock_token.token = "test_token"
+        mock_credential.get_token.return_value = mock_token
+        adapter._credential = mock_credential
+
+        await adapter.initialize()
+
+        assert adapter.get_model() == "gpt-5.3-codex"
+        assert adapter._session_config["provider"]["wire_api"] == "responses"
+        mock_get_default.assert_called_once()


### PR DESCRIPTION
## Changes (azure-ai-agentserver-githubcopilot)

### Model Discovery
- Always run model discovery even when a model is configured via env var (\AZURE_AI_FOUNDRY_MODEL\)
- Validate the configured model against discovered deployments
- Log all discovered deployments with capabilities and wire_api

### Responses API Support
- Accept models with \esponses=true\ capability (not just \chatCompletion=true\)
- Dynamically set \wire_api\ to \esponses\ or \completions\ based on the matched model's capabilities
- Add \capabilities\ dict, \supports_responses\, \supports_chat\, and \wire_api\ properties to \FoundryDeployment\

### Config Builder
- Remove hardcoded \gpt-4.1\ default from config builder so discovery can run when no model is specified
- Fallback to \gpt-4.1\ only if discovery fails