### PR TITLE
Add allowedDeploymentTemplates to MFE swagger

### DIFF
--- a/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/machineLearningServices.json
+++ b/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/machineLearningServices.json
@@ -4922,6 +4922,26 @@
         }
       }
     },
+    "ModelDeploymentTemplateDetails": {
+      "description": "Details of a default deployment template reference.",
+      "type": "object",
+      "properties": {
+        "assetId": {
+          "description": "The asset ID of the deployment template.",
+          "type": "string"
+        }
+      }
+    },
+    "ModelDeploymentTemplateReferenceDetails": {
+      "description": "Reference details for an allowed deployment template.",
+      "type": "object",
+      "properties": {
+        "assetId": {
+          "description": "The asset reference ID of the deployment template.",
+          "type": "string"
+        }
+      }
+    },
     "ModelDataCollection": {
       "description": "The Model data collection properties.",
       "type": "object",
@@ -5083,6 +5103,17 @@
         "resourceRequirements": {
           "description": "Resource requirements for the model",
           "$ref": "#/definitions/ContainerResourceRequirements"
+        },
+        "defaultDeploymentTemplate": {
+          "description": "Default deployment template for the model.",
+          "$ref": "#/definitions/ModelDeploymentTemplateDetails"
+        },
+        "allowedDeploymentTemplates": {
+          "description": "List of allowed deployment templates for the model.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ModelDeploymentTemplateReferenceDetails"
+          }
         }
       }
     },

--- a/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/machineLearningServices.json
+++ b/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/machineLearningServices.json
@@ -4922,26 +4922,6 @@
         }
       }
     },
-    "ModelDeploymentTemplateDetails": {
-      "description": "Details of a default deployment template reference.",
-      "type": "object",
-      "properties": {
-        "assetId": {
-          "description": "The asset ID of the deployment template.",
-          "type": "string"
-        }
-      }
-    },
-    "ModelDeploymentTemplateReferenceDetails": {
-      "description": "Reference details for an allowed deployment template.",
-      "type": "object",
-      "properties": {
-        "assetId": {
-          "description": "The asset reference ID of the deployment template.",
-          "type": "string"
-        }
-      }
-    },
     "ModelDataCollection": {
       "description": "The Model data collection properties.",
       "type": "object",
@@ -5103,17 +5083,6 @@
         "resourceRequirements": {
           "description": "Resource requirements for the model",
           "$ref": "#/definitions/ContainerResourceRequirements"
-        },
-        "defaultDeploymentTemplate": {
-          "description": "Default deployment template for the model.",
-          "$ref": "#/definitions/ModelDeploymentTemplateDetails"
-        },
-        "allowedDeploymentTemplates": {
-          "description": "List of allowed deployment templates for the model.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ModelDeploymentTemplateReferenceDetails"
-          }
         }
       }
     },

--- a/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/mfe.json
+++ b/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2021-10-01-dataplanepreview/mfe.json
@@ -5742,6 +5742,19 @@
               "x-nullable": true
             }
           }
+        },
+        "allowedDeploymentTemplates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "assetId": {
+                "type": "string",
+                "x-nullable": true
+              }
+            }
+          },
+          "x-nullable": true
         }
       },
       "x-ms-client-name": "ModelVersionDetails",


### PR DESCRIPTION
Adds defaultDeploymentTemplate and llowedDeploymentTemplates properties to the Model definition in the 2021-10-01-dataplanepreview swagger, along with the new ModelDeploymentTemplateDetails and ModelDeploymentTemplateReferenceDetails definitions.