### PR TITLE
single write account exclude region bug

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Bugs Fixed
 
+* Fixed write routing for single-write-style requests to consistently honor `excluded_locations` during endpoint selection, including the single-write write branch, PPAF failover candidate selection, and SessionRetryPolicy PPAF pinning. PPAF now prefers non-excluded regions and only falls back to excluded regions as last resort for availability.
+
 #### Other Changes
 
 ### 4.16.0b2 (2026-04-04)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 
-* Fixed write routing for single-write-style requests to consistently honor `excluded_locations` during endpoint selection, including the single-write write branch, PPAF failover candidate selection, and SessionRetryPolicy PPAF pinning. PPAF now prefers non-excluded regions and only falls back to excluded regions as last resort for availability.
+* Fixed write routing for single-write-style requests to consistently honor `excluded_locations` during endpoint selection. See [PR 46265](https://github.com/Azure/azure-sdk-for-python/pull/46265)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_endpoint_discovery_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_endpoint_discovery_retry_policy.py
@@ -75,7 +75,7 @@ class EndpointDiscoveryRetryPolicy(object):
             location = self.global_endpoint_manager.location_cache.get_location_from_endpoint(
                 str(self.request.location_endpoint_to_route))
             regional_endpoint = (self.global_endpoint_manager.location_cache.
-                                account_read_regional_routing_contexts_by_location.get(location))
+                                 account_read_regional_routing_contexts_by_location.get(location).primary_endpoint)
             partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
             self.global_endpoint_manager.resolve_service_endpoint_for_partition(self.request, self.pk_range_wrapper)
             return True

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_endpoint_discovery_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_endpoint_discovery_retry_policy.py
@@ -23,6 +23,8 @@
 Azure Cosmos database service.
 """
 
+
+
 # cspell:ignore PPAF
 
 from azure.cosmos.documents import _OperationType
@@ -74,9 +76,10 @@ class EndpointDiscoveryRetryPolicy(object):
             partition_level_info = self.global_endpoint_manager.partition_range_to_failover_info[self.pk_range_wrapper]
             location = self.global_endpoint_manager.location_cache.get_location_from_endpoint(
                 str(self.request.location_endpoint_to_route))
-            regional_endpoint = (self.global_endpoint_manager.location_cache.
-                                 account_read_regional_routing_contexts_by_location.get(location).primary_endpoint)
-            partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
+            routing_context = (self.global_endpoint_manager.location_cache.
+                               account_read_regional_routing_contexts_by_location.get(location))
+            if routing_context is not None:
+                partition_level_info.unavailable_regional_endpoints[location] = routing_context.primary_endpoint
             self.global_endpoint_manager.resolve_service_endpoint_for_partition(self.request, self.pk_range_wrapper)
             return True
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_per_partition_automatic_failover.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_per_partition_automatic_failover.py
@@ -18,6 +18,7 @@ from azure.cosmos._partition_health_tracker import _PPAFPartitionThresholdsTrack
 from azure.cosmos.documents import _OperationType
 from azure.cosmos._request_object import RequestObject
 from azure.cosmos._routing.routing_range import PartitionKeyRangeWrapper
+from azure.cosmos._ppaf_location_selector import select_next_ppaf_region
 
 if TYPE_CHECKING:
     from azure.cosmos._cosmos_client_connection import CosmosClientConnection
@@ -34,7 +35,7 @@ class PartitionLevelFailoverInfo:
     Used to track the partition key range and the regions where it is available.
     """
     def __init__(self) -> None:
-        self.unavailable_regional_endpoints: dict[str, "RegionalRoutingContext"] = {}
+        self.unavailable_regional_endpoints: dict[str, str] = {}
         self._lock = threading.Lock()
         self.current_region: Optional[str] = None
 
@@ -42,7 +43,8 @@ class PartitionLevelFailoverInfo:
             self,
             available_account_regional_endpoints: dict[str, "RegionalRoutingContext"],
             endpoint_region: str,
-            request: RequestObject) -> bool:
+            request: RequestObject,
+            excluded_locations: Optional[list[str]] = None) -> bool:
         """
         Tries to move to the next available regional endpoint for the partition key range.
         :param dict[str, RegionalRoutingContext] available_account_regional_endpoints: The available regional endpoints
@@ -51,26 +53,31 @@ class PartitionLevelFailoverInfo:
         :return: True if the move was successful, False otherwise.
         :rtype: bool
         """
+        excluded_locations = set(excluded_locations or [])
         with self._lock:
-            if endpoint_region != self.current_region and self.current_region is not None:
-                regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
-                request.route_to_location(regional_endpoint)
-                return True
+            previous_current_region = self.current_region
+            selected_region = select_next_ppaf_region(
+                available_account_regional_endpoints,
+                endpoint_region,
+                self.current_region,
+                self.unavailable_regional_endpoints,
+                excluded_locations)
+            if selected_region is None:
+                return False
 
-            for regional_endpoint in available_account_regional_endpoints:
-                if regional_endpoint == self.current_region:
-                    continue
-
-                if regional_endpoint in self.unavailable_regional_endpoints:
-                    continue
-
-                self.current_region = regional_endpoint
+            self.current_region = selected_region
+            if selected_region in excluded_locations:
+                if previous_current_region is not None and selected_region == previous_current_region:
+                    logger.warning("PPAF - Falling back to excluded current regional endpoint: %s", self.current_region)
+                else:
+                    logger.warning("PPAF - Falling back to excluded regional endpoint: %s", self.current_region)
+            else:
                 logger.warning("PPAF - Moving to next available regional endpoint: %s", self.current_region)
-                regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
-                request.route_to_location(regional_endpoint)
-                return True
 
-            return False
+            regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
+            request.route_to_location(regional_endpoint)
+            return True
+
 
 class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPartitionEndpointManagerForCircuitBreaker):
     """
@@ -145,10 +152,10 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
                             str(request.location_endpoint_to_route))
                         logger.warning("PPAF - Failover threshold reached for partition key range: %s for region: %s", #pylint: disable=line-too-long
                                        pk_range_wrapper, location)
-                        regional_context = (self.location_cache.
-                                            account_read_regional_routing_contexts_by_location.
-                                            get(location).primary_endpoint)
-                        partition_level_info.unavailable_regional_endpoints[location] = regional_context
+                        regional_endpoint = (self.location_cache.
+                                             account_read_regional_routing_contexts_by_location.
+                                             get(location).primary_endpoint)
+                        partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
 
     def resolve_service_endpoint_for_partition(
             self,
@@ -174,12 +181,20 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
                     endpoint_region = self.location_cache.get_location_from_endpoint(request.location_endpoint_to_route)
                     if endpoint_region in partition_failover_info.unavailable_regional_endpoints:
                         available_account_regional_endpoints = self.location_cache.account_read_regional_routing_contexts_by_location #pylint: disable=line-too-long
+                        excluded_locations = self.location_cache._get_configured_excluded_locations(request)
                         if (partition_failover_info.current_region is not None and
                                 endpoint_region != partition_failover_info.current_region):
                             # this request has not yet seen there's an available region being used for this partition
-                            regional_endpoint = available_account_regional_endpoints[
-                                partition_failover_info.current_region].primary_endpoint
-                            request.route_to_location(regional_endpoint)
+                            if partition_failover_info.current_region not in excluded_locations:
+                                regional_endpoint = available_account_regional_endpoints[
+                                    partition_failover_info.current_region].primary_endpoint
+                                request.route_to_location(regional_endpoint)
+                            else:
+                                partition_failover_info.try_move_to_next_location(
+                                    self.location_cache.account_read_regional_routing_contexts_by_location,
+                                    endpoint_region,
+                                    request,
+                                    excluded_locations)
                         else:
                             if (len(self.location_cache.account_read_regional_routing_contexts_by_location)
                                     == len(partition_failover_info.unavailable_regional_endpoints)):
@@ -194,7 +209,8 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
                                 partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
-                                    request)
+                                    request,
+                                    excluded_locations)
                     else:
                         # Update the current regional endpoint to whatever the request is routing to
                         partition_failover_info.current_region = endpoint_region

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_per_partition_automatic_failover.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_partition_endpoint_manager_per_partition_automatic_failover.py
@@ -50,10 +50,11 @@ class PartitionLevelFailoverInfo:
         :param dict[str, RegionalRoutingContext] available_account_regional_endpoints: The available regional endpoints
         :param str endpoint_region: The current regional endpoint
         :param RequestObject request: The request object containing the routing context.
+        :param Optional[list[str]] excluded_locations: The regions excluded by request/client policy.
         :return: True if the move was successful, False otherwise.
         :rtype: bool
         """
-        excluded_locations = set(excluded_locations or [])
+        excluded_location_set = set(excluded_locations or [])
         with self._lock:
             previous_current_region = self.current_region
             selected_region = select_next_ppaf_region(
@@ -61,12 +62,12 @@ class PartitionLevelFailoverInfo:
                 endpoint_region,
                 self.current_region,
                 self.unavailable_regional_endpoints,
-                excluded_locations)
+                excluded_location_set)
             if selected_region is None:
                 return False
 
             self.current_region = selected_region
-            if selected_region in excluded_locations:
+            if selected_region in excluded_location_set:
                 if previous_current_region is not None and selected_region == previous_current_region:
                     logger.warning("PPAF - Falling back to excluded current regional endpoint: %s", self.current_region)
                 else:
@@ -132,14 +133,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
         :param RequestObject request: The request object containing the routing context.
         :returns: None
         """
-        # If PPAF is enabled, we track consecutive failures for certain exceptions, and only fail over at a partition
+        # If PPAF is enabled, we track consecutive failures for certain exceptions,
+        # and only fail over at a partition
         # level after the threshold is reached
         if request and self.is_per_partition_automatic_failover_applicable(request):
             if (self.ppaf_thresholds_tracker.get_pk_failures(pk_range_wrapper)
                     >= int(os.environ.get(Constants.TIMEOUT_ERROR_THRESHOLD_PPAF,
                                           Constants.TIMEOUT_ERROR_THRESHOLD_PPAF_DEFAULT))):
                 # If the PPAF threshold is reached, we reset the count and mark the endpoint unavailable
-                # Once we mark the endpoint unavailable, the PPAF endpoint manager will try to move to the next
+                # Once we mark the endpoint unavailable, the PPAF endpoint manager
+                # will try to move to the next
                 # available region for the partition key range
                 with self._threshold_lock:
                     # Check for count again, since a previous request may have now reset the count
@@ -162,7 +165,8 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
             request: RequestObject,
             pk_range_wrapper: Optional[PartitionKeyRangeWrapper]
     ) -> str:
-        """Resolves the endpoint to be used for the request. In a PPAF-enabled account, this method checks whether
+        """Resolves the endpoint to be used for the request. In a PPAF-enabled account,
+        this method checks whether
         the partition key range has any unavailable regions, and if so, it tries to move to the next available region.
         If all regions are unavailable, it invalidates the cache and starts once again from the main write region in the
         account configurations.
@@ -190,11 +194,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
                                     partition_failover_info.current_region].primary_endpoint
                                 request.route_to_location(regional_endpoint)
                             else:
-                                partition_failover_info.try_move_to_next_location(
+                                moved = partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
                                     request,
                                     excluded_locations)
+                                if not moved:
+                                    logger.warning("PPAF - No alternate regional endpoint available for partition %s. "
+                                                   "Refreshing cache.", pk_range_wrapper)
+                                    self.partition_range_to_failover_info[pk_range_wrapper] = PartitionLevelFailoverInfo()
+                                    request.clear_route_to_location()
                         else:
                             if (len(self.location_cache.account_read_regional_routing_contexts_by_location)
                                     == len(partition_failover_info.unavailable_regional_endpoints)):
@@ -206,11 +215,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(_GlobalPar
                                 request.clear_route_to_location()
                             else:
                                 # If the current region is unavailable, we try to move to the next available region
-                                partition_failover_info.try_move_to_next_location(
+                                moved = partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
                                     request,
                                     excluded_locations)
+                                if not moved:
+                                    logger.warning("PPAF - No alternate regional endpoint available for partition %s. "
+                                                   "Refreshing cache.", pk_range_wrapper)
+                                    self.partition_range_to_failover_info[pk_range_wrapper] = PartitionLevelFailoverInfo()
+                                    request.clear_route_to_location()
                     else:
                         # Update the current regional endpoint to whatever the request is routing to
                         partition_failover_info.current_region = endpoint_region

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
@@ -297,12 +297,30 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         if not self.connection_policy.EnableEndpointDiscovery or not ordered_locations:
             return self.default_regional_routing_context.get_primary()
 
-        # For single-write-region accounts, failover between the first two available write regions.
+        # For single-write-style requests, prefer non-excluded locations and only use excluded regions as last resort.
         if is_write and not self.can_use_multiple_write_locations_for_request(request):
-            effective_index = min(location_index % 2, len(ordered_locations) - 1)
-            write_location = ordered_locations[effective_index]
-            if write_location in all_contexts_by_loc:
-                return all_contexts_by_loc[write_location].get_primary()
+            excluded_locations = self._get_configured_excluded_locations(request)
+            circuit_breaker_excluded_locations = request.excluded_locations_circuit_breaker or []
+
+            preferred_locations = []
+            circuit_breaker_locations = []
+            fallback_excluded_locations = []
+            for loc_name in ordered_locations:
+                if loc_name not in all_contexts_by_loc:
+                    continue
+                context = all_contexts_by_loc[loc_name]
+                if loc_name in excluded_locations:
+                    fallback_excluded_locations.append(context)
+                    continue
+                if loc_name in circuit_breaker_excluded_locations:
+                    circuit_breaker_locations.append(context)
+                else:
+                    preferred_locations.append(context)
+
+            applicable_contexts = preferred_locations or circuit_breaker_locations or fallback_excluded_locations
+            if applicable_contexts:
+                effective_index = min(location_index % 2, len(applicable_contexts) - 1)
+                return applicable_contexts[effective_index].get_primary()
             return self.default_regional_routing_context.get_primary()  # Fallback if location not found
 
         # For reads or multi-write, filter locations by user and circuit-breaker exclusions.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
@@ -1,0 +1,52 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 Microsoft Corporation
+
+from typing import Iterable, Mapping, Optional, Any
+
+
+def select_next_ppaf_region(
+        available_account_regional_endpoints: Mapping[str, Any],
+        endpoint_region: str,
+        current_region: Optional[str],
+        unavailable_regional_endpoints: Mapping[str, str],
+        excluded_locations: Optional[Iterable[str]] = None) -> Optional[str]:
+    """Select the next region for PPAF using a deterministic preference order.
+
+    Preference order:
+      1. Non-excluded available regions.
+      2. Excluded available regions.
+      3. Excluded current_region (if different from endpoint_region and still available).
+    """
+    excluded = set(excluded_locations or [])
+
+    current_region_fallback = None
+    if endpoint_region != current_region and current_region is not None:
+        if (current_region in available_account_regional_endpoints
+                and current_region not in unavailable_regional_endpoints):
+            if current_region not in excluded:
+                return current_region
+            current_region_fallback = current_region
+
+    fallback_excluded_region = None
+    for regional_endpoint in available_account_regional_endpoints:
+        if regional_endpoint == current_region:
+            continue
+
+        if regional_endpoint in unavailable_regional_endpoints:
+            continue
+
+        if regional_endpoint in excluded:
+            if fallback_excluded_region is None:
+                fallback_excluded_region = regional_endpoint
+            continue
+
+        return regional_endpoint
+
+    if fallback_excluded_region is not None:
+        return fallback_excluded_region
+
+    if current_region_fallback is not None:
+        return current_region_fallback
+
+    return None
+

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
@@ -3,6 +3,8 @@
 
 from typing import Iterable, Mapping, Optional, Any, Collection
 
+# cspell:ignore ppaf PPAF
+
 
 def select_next_ppaf_region(
         available_account_regional_endpoints: Mapping[str, Any],
@@ -12,10 +14,19 @@ def select_next_ppaf_region(
         excluded_locations: Optional[Iterable[str]] = None) -> Optional[str]:
     """Select the next region for PPAF using a deterministic preference order.
 
+    :param Mapping[str, Any] available_account_regional_endpoints: Available regional endpoints keyed by region name.
+    :param str endpoint_region: The endpoint region currently being used for the request.
+    :param Optional[str] current_region: The partition's current failover region, if any.
+    :param Collection[str] unavailable_regional_endpoints: Region names currently marked unavailable for the partition.
+    :param Optional[Iterable[str]] excluded_locations: Region names excluded by request/client policy.
+
     Preference order:
       1. Non-excluded available regions.
       2. Excluded available regions.
       3. Excluded current_region (if different from endpoint_region and still available).
+
+    :returns: The next region name to route to, or None when no candidate region exists.
+    :rtype: Optional[str]
     """
     excluded = set(excluded_locations or [])
 
@@ -49,4 +60,3 @@ def select_next_ppaf_region(
         return current_region_fallback
 
     return None
-

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_ppaf_location_selector.py
@@ -1,14 +1,14 @@
 # The MIT License (MIT)
 # Copyright (c) 2025 Microsoft Corporation
 
-from typing import Iterable, Mapping, Optional, Any
+from typing import Iterable, Mapping, Optional, Any, Collection
 
 
 def select_next_ppaf_region(
         available_account_regional_endpoints: Mapping[str, Any],
         endpoint_region: str,
         current_region: Optional[str],
-        unavailable_regional_endpoints: Mapping[str, str],
+        unavailable_regional_endpoints: Collection[str],
         excluded_locations: Optional[Iterable[str]] = None) -> Optional[str]:
     """Select the next region for PPAF using a deterministic preference order.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_service_unavailable_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_service_unavailable_retry_policy.py
@@ -56,9 +56,10 @@ class _ServiceUnavailableRetryPolicy(object):
                     self.pk_range_wrapper]
                 location = self.global_endpoint_manager.location_cache.get_location_from_endpoint(
                     str(self.request.location_endpoint_to_route))
-                regional_endpoint = (self.global_endpoint_manager.location_cache.
-                                     account_read_regional_routing_contexts_by_location.get(location).primary_endpoint)
-                partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
+                routing_context = (self.global_endpoint_manager.location_cache.
+                                   account_read_regional_routing_contexts_by_location.get(location))
+                if routing_context is not None:
+                    partition_level_info.unavailable_regional_endpoints[location] = routing_context.primary_endpoint
                 self.global_endpoint_manager.resolve_service_endpoint_for_partition(self.request, self.pk_range_wrapper)
                 return True
             location_endpoint = self.resolve_next_region_service_endpoint()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_service_unavailable_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_service_unavailable_retry_policy.py
@@ -56,9 +56,9 @@ class _ServiceUnavailableRetryPolicy(object):
                     self.pk_range_wrapper]
                 location = self.global_endpoint_manager.location_cache.get_location_from_endpoint(
                     str(self.request.location_endpoint_to_route))
-                regional_context = (self.global_endpoint_manager.location_cache.
-                                    account_read_regional_routing_contexts_by_location.get(location))
-                partition_level_info.unavailable_regional_endpoints[location] = regional_context
+                regional_endpoint = (self.global_endpoint_manager.location_cache.
+                                     account_read_regional_routing_contexts_by_location.get(location).primary_endpoint)
+                partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
                 self.global_endpoint_manager.resolve_service_endpoint_for_partition(self.request, self.pk_range_wrapper)
                 return True
             location_endpoint = self.resolve_next_region_service_endpoint()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_session_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_session_retry_policy.py
@@ -111,14 +111,19 @@ class _SessionRetryPolicy(object):
                     # If the request endpoint is unavailable, we need to resolve the endpoint for the request using the
                     # partition-level failover info
                     if pk_failover_info.current_region is not None:
-                        excluded_locations = self.global_endpoint_manager.location_cache._get_configured_excluded_locations(
-                            self.request)
+                        # pylint: disable=protected-access
+                        excluded_locations = (
+                            self.global_endpoint_manager.location_cache
+                            ._get_configured_excluded_locations(self.request)
+                        )
+                        # pylint: enable=protected-access
                         if pk_failover_info.current_region not in excluded_locations:
-                            location_endpoint = (self.global_endpoint_manager.location_cache.
-                                                 account_read_regional_routing_contexts_by_location.
-                                                 get(pk_failover_info.current_region).primary_endpoint)
-                            self.request.route_to_location(location_endpoint)
-                            return True
+                            regional_context = (self.global_endpoint_manager.location_cache.
+                                                account_read_regional_routing_contexts_by_location.
+                                                get(pk_failover_info.current_region))
+                            if regional_context is not None:
+                                self.request.route_to_location(regional_context.primary_endpoint)
+                                return True
 
         # Resolve the endpoint for the request and pin the resolution to the resolved endpoint
         # This enables marking the endpoint unavailability on endpoint failover/unreachability

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_session_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_session_retry_policy.py
@@ -111,11 +111,14 @@ class _SessionRetryPolicy(object):
                     # If the request endpoint is unavailable, we need to resolve the endpoint for the request using the
                     # partition-level failover info
                     if pk_failover_info.current_region is not None:
-                        location_endpoint = (self.global_endpoint_manager.location_cache.
-                                             account_read_regional_routing_contexts_by_location.
-                                             get(pk_failover_info.current_region).primary_endpoint)
-                        self.request.route_to_location(location_endpoint)
-                        return True
+                        excluded_locations = self.global_endpoint_manager.location_cache._get_configured_excluded_locations(
+                            self.request)
+                        if pk_failover_info.current_region not in excluded_locations:
+                            location_endpoint = (self.global_endpoint_manager.location_cache.
+                                                 account_read_regional_routing_contexts_by_location.
+                                                 get(pk_failover_info.current_region).primary_endpoint)
+                            self.request.route_to_location(location_endpoint)
+                            return True
 
         # Resolve the endpoint for the request and pin the resolution to the resolved endpoint
         # This enables marking the endpoint unavailability on endpoint failover/unreachability

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
@@ -18,6 +18,7 @@ from azure.cosmos.documents import _OperationType
 from azure.cosmos._partition_health_tracker import _PPAFPartitionThresholdsTracker
 from azure.cosmos._request_object import RequestObject
 from azure.cosmos._routing.routing_range import PartitionKeyRangeWrapper
+from azure.cosmos._ppaf_location_selector import select_next_ppaf_region
 
 if TYPE_CHECKING:
     from azure.cosmos.aio._cosmos_client_connection_async import CosmosClientConnection
@@ -42,7 +43,8 @@ class PartitionLevelFailoverInfo:
             self,
             available_account_regional_endpoints: dict[str, "RegionalRoutingContext"],
             endpoint_region: str,
-            request: RequestObject) -> bool:
+            request: RequestObject,
+            excluded_locations: Optional[list[str]] = None) -> bool:
         """
         Tries to move to the next available regional endpoint for the partition key range.
         :param Dict[str, RegionalRoutingContext] available_account_regional_endpoints: The available regional endpoints
@@ -51,26 +53,31 @@ class PartitionLevelFailoverInfo:
         :return: True if the move was successful, False otherwise.
         :rtype: bool
         """
+        excluded_locations = set(excluded_locations or [])
         with self._lock:
-            if endpoint_region != self.current_region and self.current_region is not None:
-                regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
-                request.route_to_location(regional_endpoint)
-                return True
+            previous_current_region = self.current_region
+            selected_region = select_next_ppaf_region(
+                available_account_regional_endpoints,
+                endpoint_region,
+                self.current_region,
+                self.unavailable_regional_endpoints,
+                excluded_locations)
+            if selected_region is None:
+                return False
 
-            for regional_endpoint in available_account_regional_endpoints:
-                if regional_endpoint == self.current_region:
-                    continue
-
-                if regional_endpoint in self.unavailable_regional_endpoints:
-                    continue
-
-                self.current_region = regional_endpoint
+            self.current_region = selected_region
+            if selected_region in excluded_locations:
+                if previous_current_region is not None and selected_region == previous_current_region:
+                    logger.warning("PPAF - Falling back to excluded current regional endpoint: %s", self.current_region)
+                else:
+                    logger.warning("PPAF - Falling back to excluded regional endpoint: %s", self.current_region)
+            else:
                 logger.warning("PPAF - Moving to next available regional endpoint: %s", self.current_region)
-                regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
-                request.route_to_location(regional_endpoint)
-                return True
 
-            return False
+            regional_endpoint = available_account_regional_endpoints[self.current_region].primary_endpoint
+            request.route_to_location(regional_endpoint)
+            return True
+
 
 class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
     _GlobalPartitionEndpointManagerForCircuitBreakerAsync):
@@ -175,12 +182,20 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
                     endpoint_region = self.location_cache.get_location_from_endpoint(request.location_endpoint_to_route)
                     if endpoint_region in partition_failover_info.unavailable_regional_endpoints:
                         available_account_regional_endpoints = self.location_cache.account_read_regional_routing_contexts_by_location #pylint: disable=line-too-long
+                        excluded_locations = self.location_cache._get_configured_excluded_locations(request)
                         if (partition_failover_info.current_region is not None and
                                 endpoint_region != partition_failover_info.current_region):
                             # this request has not yet seen there's an available region being used for this partition
-                            regional_endpoint = available_account_regional_endpoints[
-                                partition_failover_info.current_region].primary_endpoint
-                            request.route_to_location(regional_endpoint)
+                            if partition_failover_info.current_region not in excluded_locations:
+                                regional_endpoint = available_account_regional_endpoints[
+                                    partition_failover_info.current_region].primary_endpoint
+                                request.route_to_location(regional_endpoint)
+                            else:
+                                partition_failover_info.try_move_to_next_location(
+                                    self.location_cache.account_read_regional_routing_contexts_by_location,
+                                    endpoint_region,
+                                    request,
+                                    excluded_locations)
                         else:
                             if (len(self.location_cache.account_read_regional_routing_contexts_by_location) ==
                                     len(partition_failover_info.unavailable_regional_endpoints)):
@@ -195,7 +210,8 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
                                 partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
-                                    request)
+                                    request,
+                                    excluded_locations)
                     else:
                         # Update the current regional endpoint to whatever the request is routing to
                         partition_failover_info.current_region = endpoint_region

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
@@ -50,10 +50,11 @@ class PartitionLevelFailoverInfo:
         :param Dict[str, RegionalRoutingContext] available_account_regional_endpoints: The available regional endpoints
         :param str endpoint_region: The current regional endpoint
         :param RequestObject request: The request object containing the routing context.
+        :param Optional[list[str]] excluded_locations: The regions excluded by request/client policy.
         :return: True if the move was successful, False otherwise.
         :rtype: bool
         """
-        excluded_locations = set(excluded_locations or [])
+        excluded_location_set = set(excluded_locations or [])
         with self._lock:
             previous_current_region = self.current_region
             selected_region = select_next_ppaf_region(
@@ -61,12 +62,12 @@ class PartitionLevelFailoverInfo:
                 endpoint_region,
                 self.current_region,
                 self.unavailable_regional_endpoints,
-                excluded_locations)
+                excluded_location_set)
             if selected_region is None:
                 return False
 
             self.current_region = selected_region
-            if selected_region in excluded_locations:
+            if selected_region in excluded_location_set:
                 if previous_current_region is not None and selected_region == previous_current_region:
                     logger.warning("PPAF - Falling back to excluded current regional endpoint: %s", self.current_region)
                 else:
@@ -133,14 +134,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
         :param RequestObject request: The request object containing the routing context.
         :returns: None
         """
-        # If PPAF is enabled, we track consecutive failures for certain exceptions, and only fail over at a partition
+        # If PPAF is enabled, we track consecutive failures for certain exceptions,
+        # and only fail over at a partition
         # level after the threshold is reached
         if request and self.is_per_partition_automatic_failover_applicable(request):
             if (self.ppaf_thresholds_tracker.get_pk_failures(pk_range_wrapper)
                     >= int(os.environ.get(Constants.TIMEOUT_ERROR_THRESHOLD_PPAF,
                                           Constants.TIMEOUT_ERROR_THRESHOLD_PPAF_DEFAULT))):
                 # If the PPAF threshold is reached, we reset the count and mark the endpoint unavailable
-                # Once we mark the endpoint unavailable, the PPAF endpoint manager will try to move to the next
+                # Once we mark the endpoint unavailable, the PPAF endpoint manager
+                # will try to move to the next
                 # available region for the partition key range
                 with self._threshold_lock:
                     # Check for count again, since a previous request may have now reset the count
@@ -163,7 +166,8 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
             request: RequestObject,
             pk_range_wrapper: Optional[PartitionKeyRangeWrapper]
     ) -> str:
-        """Resolves the endpoint to be used for the request. In a PPAF-enabled account, this method checks whether
+        """Resolves the endpoint to be used for the request. In a PPAF-enabled account,
+        this method checks whether
         the partition key range has any unavailable regions, and if so, it tries to move to the next available region.
         If all regions are unavailable, it invalidates the cache and starts once again from the main write region in the
         account configurations.
@@ -191,11 +195,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
                                     partition_failover_info.current_region].primary_endpoint
                                 request.route_to_location(regional_endpoint)
                             else:
-                                partition_failover_info.try_move_to_next_location(
+                                moved = partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
                                     request,
                                     excluded_locations)
+                                if not moved:
+                                    logger.warning("PPAF - No alternate regional endpoint available for partition %s. "
+                                                   "Refreshing cache.", pk_range_wrapper)
+                                    self.partition_range_to_failover_info[pk_range_wrapper] = PartitionLevelFailoverInfo()
+                                    request.clear_route_to_location()
                         else:
                             if (len(self.location_cache.account_read_regional_routing_contexts_by_location) ==
                                     len(partition_failover_info.unavailable_regional_endpoints)):
@@ -207,11 +216,16 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
                                 request.clear_route_to_location()
                             else:
                                 # If the current region is unavailable, we try to move to the next available region
-                                partition_failover_info.try_move_to_next_location(
+                                moved = partition_failover_info.try_move_to_next_location(
                                     self.location_cache.account_read_regional_routing_contexts_by_location,
                                     endpoint_region,
                                     request,
                                     excluded_locations)
+                                if not moved:
+                                    logger.warning("PPAF - No alternate regional endpoint available for partition %s. "
+                                                   "Refreshing cache.", pk_range_wrapper)
+                                    self.partition_range_to_failover_info[pk_range_wrapper] = PartitionLevelFailoverInfo()
+                                    request.clear_route_to_location()
                     else:
                         # Update the current regional endpoint to whatever the request is routing to
                         partition_failover_info.current_region = endpoint_region

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_partition_endpoint_manager_per_partition_automatic_failover_async.py
@@ -35,7 +35,7 @@ class PartitionLevelFailoverInfo:
     Used to track the partition key range and the regions where it is available.
     """
     def __init__(self) -> None:
-        self.unavailable_regional_endpoints: dict[str, "RegionalRoutingContext"] = {}
+        self.unavailable_regional_endpoints: dict[str, str] = {}
         self._lock = threading.Lock()
         self.current_region: Optional[str] = None
 
@@ -153,10 +153,10 @@ class _GlobalPartitionEndpointManagerForPerPartitionAutomaticFailoverAsync(
                             str(request.location_endpoint_to_route))
                         logger.warning("PPAF - Failover threshold reached for partition key range: %s for region: %s", #pylint: disable=line-too-long
                                        pk_range_wrapper, location)
-                        regional_context = (self.location_cache.
-                                            account_read_regional_routing_contexts_by_location.
-                                            get(location).primary_endpoint)
-                        partition_level_info.unavailable_regional_endpoints[location] = regional_context
+                        regional_endpoint = (self.location_cache.
+                                             account_read_regional_routing_contexts_by_location.
+                                             get(location).primary_endpoint)
+                        partition_level_info.unavailable_regional_endpoints[location] = regional_endpoint
 
     def resolve_service_endpoint_for_partition(
             self,

--- a/sdk/cosmos/azure-cosmos/tests/test_excluded_locations_emulator.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_excluded_locations_emulator.py
@@ -68,6 +68,18 @@ def get_location(
             break
     return location
 
+
+def _expected_single_write_location(preferred_locations: List[str],
+                                    client_excluded_locations: List[str],
+                                    request_excluded_locations: List[str]) -> str:
+    # Request-level excluded locations override client-level excluded locations.
+    effective_excluded_locations = client_excluded_locations if request_excluded_locations is None else request_excluded_locations
+    for location in preferred_locations:
+        if location not in effective_excluded_locations:
+            return location
+    # If all preferred locations are excluded, fall back to the primary write region.
+    return L1
+
 @pytest.mark.unittest
 @pytest.mark.cosmosEmulator
 class TestExcludedLocationsEmulator:
@@ -123,7 +135,11 @@ class TestExcludedLocationsEmulator:
             if multiple_write_locations:
                 assert actual_location == expected_location[0]
             else:
-                assert actual_location == L1
+                expected_single_write_location = _expected_single_write_location(
+                    preferred_locations,
+                    client_excluded_locations,
+                    request_excluded_locations)
+                assert actual_location == expected_single_write_location
 
     @pytest.mark.parametrize('test_data', metadata_read_with_excluded_locations_test_data())
     def test_metadata_read_with_excluded_locations(self: "TestExcludedLocationsEmulator", test_data: List[List[str]]):

--- a/sdk/cosmos/azure-cosmos/tests/test_excluded_locations_emulator_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_excluded_locations_emulator_async.py
@@ -19,6 +19,7 @@ from test_excluded_locations import (L1, L2, read_item_test_data,
                                      TestDataType, set_test_data_type)
 from test_excluded_locations_emulator import (L1_URL, L2_URL,
                                               get_location,
+                                              _expected_single_write_location,
                                               metadata_read_with_excluded_locations_test_data)
 from test_fault_injection_transport_async import TestFaultInjectionTransportAsync
 from azure.cosmos.exceptions import CosmosHttpResponseError
@@ -93,7 +94,11 @@ class TestExcludedLocationsEmulatorAsync:
             if multiple_write_locations:
                 assert actual_location == expected_location[0]
             else:
-                assert actual_location == L1
+                expected_single_write_location = _expected_single_write_location(
+                    preferred_locations,
+                    client_excluded_locations,
+                    request_excluded_locations)
+                assert actual_location == expected_single_write_location
 
     @pytest.mark.parametrize('test_data', metadata_read_with_excluded_locations_test_data())
     async def test_metadata_read_with_excluded_locations(self: "TestExcludedLocationsEmulatorAsync", test_data: List[List[str]]):

--- a/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
@@ -390,6 +390,28 @@ class TestLocationCache:
         # Assert the correct behavior.
         assert resolved_endpoint == location2_endpoint
 
+    def test_single_write_resolve_endpoint_respects_excluded_regions(self):
+        lc = refresh_location_cache(preferred_locations=[], use_multiple_write_locations=False)
+        db_acc = create_database_account(enable_multiple_writable_locations=False)
+        lc.perform_on_database_account_read(db_acc)
+
+        write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)
+        write_request.excluded_locations = [location1_name]
+
+        resolved_endpoint = lc.resolve_service_endpoint(write_request)
+        assert resolved_endpoint == location2_endpoint
+
+    def test_single_write_falls_back_to_excluded_region_when_no_other_region_available(self):
+        lc = refresh_location_cache(preferred_locations=[], use_multiple_write_locations=False)
+        db_acc = create_database_account(enable_multiple_writable_locations=False)
+        lc.perform_on_database_account_read(db_acc)
+
+        write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)
+        write_request.excluded_locations = [location1_name, location2_name, location3_name]
+
+        resolved_endpoint = lc.resolve_service_endpoint(write_request)
+        assert resolved_endpoint == location1_endpoint
+
     def test_regional_fallback_when_primary_is_excluded(self):
         # This test simulates a scenario where the primary preferred region is excluded
         # by the user, and the secondary is excluded by the circuit breaker.

--- a/sdk/cosmos/azure-cosmos/tests/test_per_partition_automatic_failover.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_per_partition_automatic_failover.py
@@ -104,8 +104,8 @@ class TestPerPartitionAutomaticFailover:
     def test_ppaf_partition_info_cache_and_routing(self, write_operation, error, exclude_regions):
         # This test validates that the partition info cache is updated correctly upon failures, and that the
         # per-partition automatic failover logic routes requests to the next available regional endpoint on 403.3 errors.
-        # We also verify that this logic is unaffected by user excluded regions, since write-region routing is entirely
-        # taken care of on the service.
+        # Excluded regions now affect client-side PPAF candidate selection: non-excluded regions are preferred,
+        # while excluded regions are still available as last-resort fallback.
         error_lambda = lambda r: FaultInjectionTransport.error_after_delay(0, error)
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = self.setup_info(error_lambda, 1,
                                                                                                         write_operation == BATCH, exclude_client_regions=exclude_regions)
@@ -127,10 +127,20 @@ class TestPerPartitionAutomaticFailover:
             doc_fail_id,
             PK_VALUE)
         partition_info = global_endpoint_manager.partition_range_to_failover_info[pk_range_wrapper]
-        # Verify that the partition is marked as unavailable, and that the current regional endpoint is not the same
-        assert len(partition_info.unavailable_regional_endpoints) == 1
-        assert initial_region in partition_info.unavailable_regional_endpoints
-        assert initial_region != partition_info.current_region # west us 3 != west us
+        if exclude_regions:
+            # With excluded fallback enabled, state can either be retained (1 unavailable) or reset (0 unavailable)
+            # depending on whether all candidates for this partition are exhausted within the same failover cycle.
+            assert len(partition_info.unavailable_regional_endpoints) in (0, 1)
+            if len(partition_info.unavailable_regional_endpoints) == 1:
+                assert initial_region in partition_info.unavailable_regional_endpoints
+                assert initial_region != partition_info.current_region
+            else:
+                assert partition_info.current_region is None
+        else:
+            # Verify that the partition is marked as unavailable, and that the current regional endpoint is not the same
+            assert len(partition_info.unavailable_regional_endpoints) == 1
+            assert initial_region in partition_info.unavailable_regional_endpoints
+            assert initial_region != partition_info.current_region # west us 3 != west us
 
         # Now we run another request to see how the cache gets updated
         perform_write_operation(
@@ -140,19 +150,26 @@ class TestPerPartitionAutomaticFailover:
             str(uuid.uuid4()),
             PK_VALUE)
         partition_info = global_endpoint_manager.partition_range_to_failover_info[pk_range_wrapper]
-        # Verify that the cache is empty, since the request going to the second regional endpoint failed
-        # Once we reach the point of all available regions being marked as unavailable, the cache is cleared
-        assert len(partition_info.unavailable_regional_endpoints) == 0
-        assert initial_region not in partition_info.unavailable_regional_endpoints
-        assert partition_info.current_region is None
+        if exclude_regions:
+            # Excluded fallback can keep unavailable state or clear state after candidate exhaustion.
+            assert len(partition_info.unavailable_regional_endpoints) in (0, 1)
+            if len(partition_info.unavailable_regional_endpoints) == 1:
+                assert initial_region in partition_info.unavailable_regional_endpoints
+                assert partition_info.current_region != initial_region
+            else:
+                assert partition_info.current_region is None
+        else:
+            # Once all available regions for the partition are exhausted, PPAF clears partition state.
+            assert len(partition_info.unavailable_regional_endpoints) == 0
+            assert initial_region not in partition_info.unavailable_regional_endpoints
+            assert partition_info.current_region is None
 
 
     @pytest.mark.parametrize("write_operation, error, exclude_regions", write_operations_errors_and_boolean(create_threshold_errors()))
     def test_ppaf_partition_thresholds_and_routing(self, write_operation, error, exclude_regions):
         # This test validates the consecutive failures logic is properly handled for per-partition automatic failover,
         # and that the per-partition automatic failover logic routes requests to the next available regional endpoint
-        # after enough consecutive failures have occurred. We also verify that this logic is unaffected by user excluded
-        # regions, since write-region routing is entirely taken care of on the service.
+        # after enough consecutive failures have occurred while honoring excluded-region preference.
         error_lambda = lambda r: FaultInjectionTransport.error_after_delay(0, error)
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = self.setup_info(error=error_lambda,
                                                                                                         exclude_client_regions=exclude_regions)
@@ -217,8 +234,7 @@ class TestPerPartitionAutomaticFailover:
         # Account config has 2 regions: West US 3 (A) and West US (B). This test validates that after marking the write
         # region (A) as unavailable, the next request is retried to the read region (B) and succeeds. The next read request
         # should see that the write region (A) is unavailable for the partition, and should retry to the read region (B) as well.
-        # We also verify that this logic is unaffected by user excluded regions, since write-region routing is entirely
-        # taken care of on the service.
+        # We also verify retry behavior when excluded regions are configured.
         error_lambda = lambda r: FaultInjectionTransport.error_after_delay(0, error)
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = self.setup_info(error_lambda, max_count=1,
                                                                                                         is_batch=write_operation==BATCH,

--- a/sdk/cosmos/azure-cosmos/tests/test_per_partition_automatic_failover_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_per_partition_automatic_failover_async.py
@@ -6,6 +6,7 @@ import uuid
 import asyncio
 
 import pytest
+import pytest_asyncio
 from typing import Dict, Any, Optional
 
 import test_config
@@ -31,6 +32,14 @@ class TestPerPartitionAutomaticFailoverAsync:
     TEST_DATABASE_ID = test_config.TestConfig.TEST_DATABASE_ID
     TEST_CONTAINER_MULTI_PARTITION_ID = test_config.TestConfig.TEST_MULTI_PARTITION_CONTAINER_ID
 
+    @pytest_asyncio.fixture(autouse=True)
+    async def _cleanup_open_clients(self):
+        self._opened_clients = []
+        yield
+        while self._opened_clients:
+            client = self._opened_clients.pop()
+            await client.close()
+
     async def setup_method_with_custom_transport(self, custom_transport: Optional[AioHttpTransport],
                                                  default_endpoint=host, read_first=False, **kwargs):
         regions = [REGION_2, REGION_1] if read_first else [REGION_1, REGION_2]
@@ -48,6 +57,7 @@ class TestPerPartitionAutomaticFailoverAsync:
         db = client.get_database_client(self.TEST_DATABASE_ID)
         container = db.get_container_client(container_id)
         await client.__aenter__()
+        self._opened_clients.append(client)
         return {"client": client, "db": db, "col": container}
     
     @staticmethod
@@ -99,8 +109,8 @@ class TestPerPartitionAutomaticFailoverAsync:
     async def test_ppaf_partition_info_cache_and_routing_async(self, write_operation, error, exclude_regions):
         # This test validates that the partition info cache is updated correctly upon failures, and that the
         # per-partition automatic failover logic routes requests to the next available regional endpoint.
-        # We also verify that this logic is unaffected by user excluded regions, since write-region routing is
-        # entirely taken care of on the service.
+        # Excluded regions now affect client-side PPAF candidate selection: non-excluded regions are preferred,
+        # while excluded regions are still available as last-resort fallback.
         error_lambda = lambda r: asyncio.create_task(FaultInjectionTransportAsync.error_after_delay(0, error))
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = await self.setup_info(error_lambda, 1,
                                                                                                               write_operation == BATCH, exclude_client_regions=exclude_regions)
@@ -122,10 +132,20 @@ class TestPerPartitionAutomaticFailoverAsync:
             doc_fail_id,
             PK_VALUE)
         partition_info = global_endpoint_manager.partition_range_to_failover_info[pk_range_wrapper]
-        # Verify that the partition is marked as unavailable, and that the current regional endpoint is not the same
-        assert len(partition_info.unavailable_regional_endpoints) == 1
-        assert initial_region in partition_info.unavailable_regional_endpoints
-        assert initial_region != partition_info.current_region # west us 3 != west us
+        if exclude_regions:
+            # With excluded fallback enabled, state can either be retained (1 unavailable) or reset (0 unavailable)
+            # depending on whether all candidates for this partition are exhausted within the same failover cycle.
+            assert len(partition_info.unavailable_regional_endpoints) in (0, 1)
+            if len(partition_info.unavailable_regional_endpoints) == 1:
+                assert initial_region in partition_info.unavailable_regional_endpoints
+                assert initial_region != partition_info.current_region
+            else:
+                assert partition_info.current_region is None
+        else:
+            # Verify that the partition is marked as unavailable, and that the current regional endpoint is not the same
+            assert len(partition_info.unavailable_regional_endpoints) == 1
+            assert initial_region in partition_info.unavailable_regional_endpoints
+            assert initial_region != partition_info.current_region # west us 3 != west us
 
         # Now we run another request to see how the cache gets updated
         await perform_write_operation(
@@ -135,18 +155,25 @@ class TestPerPartitionAutomaticFailoverAsync:
             doc_fail_id,
             PK_VALUE)
         partition_info = global_endpoint_manager.partition_range_to_failover_info[pk_range_wrapper]
-        # Verify that the cache is empty, since the request going to the second regional endpoint failed
-        # Once we reach the point of all available regions being marked as unavailable, the cache is cleared
-        assert len(partition_info.unavailable_regional_endpoints) == 0
-        assert initial_region not in partition_info.unavailable_regional_endpoints
-        assert partition_info.current_region is None
+        if exclude_regions:
+            # Excluded fallback can keep unavailable state or clear state after candidate exhaustion.
+            assert len(partition_info.unavailable_regional_endpoints) in (0, 1)
+            if len(partition_info.unavailable_regional_endpoints) == 1:
+                assert initial_region in partition_info.unavailable_regional_endpoints
+                assert partition_info.current_region != initial_region
+            else:
+                assert partition_info.current_region is None
+        else:
+            # Once all available regions for the partition are exhausted, PPAF clears partition state.
+            assert len(partition_info.unavailable_regional_endpoints) == 0
+            assert initial_region not in partition_info.unavailable_regional_endpoints
+            assert partition_info.current_region is None
 
     @pytest.mark.parametrize("write_operation, error, exclude_regions", write_operations_errors_and_boolean(create_threshold_errors()))
     async def test_ppaf_partition_thresholds_and_routing_async(self, write_operation, error, exclude_regions):
         # This test validates that the partition info cache is updated correctly upon failures, and that the
         # per-partition automatic failover logic routes requests to the next available regional endpoint.
-        # We also verify that this logic is unaffected by user excluded regions, since write-region routing is
-        # entirely taken care of on the service.
+        # We also verify that threshold-triggered failover honors excluded-region preference.
         error_lambda = lambda r: asyncio.create_task(FaultInjectionTransportAsync.error_after_delay(0, error))
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = await self.setup_info(error_lambda,
                                                                                                               exclude_client_regions=exclude_regions,)
@@ -212,8 +239,7 @@ class TestPerPartitionAutomaticFailoverAsync:
         # Account config has 2 regions: West US 3 (A) and West US (B). This test validates that after marking the write
         # region (A) as unavailable, the next request is retried to the read region (B) and succeeds. The next read request
         # should see that the write region (A) is unavailable for the partition, and should retry to the read region (B) as well.
-        # We also verify that this logic is unaffected by user excluded regions, since write-region routing is
-        # entirely taken care of on the service.
+        # We also verify retry behavior when excluded regions are configured.
         error_lambda = lambda r: asyncio.create_task(FaultInjectionTransportAsync.error_after_delay(0, error))
         setup, doc_fail_id, doc_success_id, custom_setup, custom_transport, predicate = await self.setup_info(error_lambda, max_count=1,
                                                                                                         is_batch=write_operation==BATCH,
@@ -249,7 +275,7 @@ class TestPerPartitionAutomaticFailoverAsync:
 
         # Now we run a read request that runs into a 404.1002 error, which should retry to the read region
         # We verify that the read request was going to the correct region by using the raw_response_hook
-        fault_injection_container.read_item(doc_fail_id, PK_VALUE, raw_response_hook=session_retry_hook)
+        await fault_injection_container.read_item(doc_fail_id, PK_VALUE, raw_response_hook=session_retry_hook)
 
     async def test_ppaf_user_agent_feature_flag_async(self):
         # Simple test to verify the user agent suffix is being updated with the relevant feature flags

--- a/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
@@ -98,7 +98,7 @@ def test_session_retry_policy_ppaf_path_does_not_pin_excluded_current_region():
 
     location_cache = unittest.mock.Mock()
     location_cache.get_location_from_endpoint.side_effect = lambda endpoint: {
-        "None": "West US 3",
+        "https://westus3.documents.azure.com": "West US 3",
         "https://eastus2.documents.azure.com": "East US 2",
     }.get(endpoint)
     location_cache._get_configured_excluded_locations.return_value = ["East US 2"]

--- a/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
@@ -1,0 +1,129 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+from types import SimpleNamespace
+import unittest.mock
+
+from azure.cosmos._global_partition_endpoint_manager_per_partition_automatic_failover import (
+    PartitionLevelFailoverInfo,
+)
+from azure.cosmos._request_object import RequestObject
+from azure.cosmos._session_retry_policy import _SessionRetryPolicy
+from azure.cosmos.documents import _OperationType
+from azure.cosmos.http_constants import ResourceType
+
+
+def _request_object():
+    return RequestObject(ResourceType.Document, _OperationType.Create, {})
+
+
+def _context(endpoint: str):
+    context = unittest.mock.Mock()
+    context.primary_endpoint = endpoint
+    return context
+
+
+def test_ppaf_try_move_to_next_location_skips_excluded_region_when_other_region_exists():
+    failover_info = PartitionLevelFailoverInfo()
+    failover_info.current_region = "West US 3"
+    failover_info.unavailable_regional_endpoints["West US 3"] = "https://westus3.documents.azure.com"
+
+    available_regions = {
+        "West US 3": _context("https://westus3.documents.azure.com"),
+        "East US 2": _context("https://eastus2.documents.azure.com"),
+        "Central US": _context("https://centralus.documents.azure.com"),
+    }
+
+    request = _request_object()
+    moved = failover_info.try_move_to_next_location(
+        available_regions,
+        "West US 3",
+        request,
+        excluded_locations=["East US 2"],
+    )
+
+    assert moved is True
+    assert failover_info.current_region == "Central US"
+    assert request.location_endpoint_to_route == "https://centralus.documents.azure.com"
+
+
+def test_ppaf_try_move_to_next_location_falls_back_to_excluded_region_when_only_option():
+    failover_info = PartitionLevelFailoverInfo()
+    failover_info.current_region = "West US 3"
+    failover_info.unavailable_regional_endpoints["West US 3"] = "https://westus3.documents.azure.com"
+
+    available_regions = {
+        "West US 3": _context("https://westus3.documents.azure.com"),
+        "East US 2": _context("https://eastus2.documents.azure.com"),
+    }
+
+    request = _request_object()
+    moved = failover_info.try_move_to_next_location(
+        available_regions,
+        "West US 3",
+        request,
+        excluded_locations=["East US 2"],
+    )
+
+    assert moved is True
+    assert failover_info.current_region == "East US 2"
+    assert request.location_endpoint_to_route == "https://eastus2.documents.azure.com"
+
+
+def test_ppaf_try_move_to_next_location_reuses_excluded_current_region_as_last_resort():
+    failover_info = PartitionLevelFailoverInfo()
+    failover_info.current_region = "East US 2"
+    failover_info.unavailable_regional_endpoints["West US 3"] = "https://westus3.documents.azure.com"
+
+    available_regions = {
+        "West US 3": _context("https://westus3.documents.azure.com"),
+        "East US 2": _context("https://eastus2.documents.azure.com"),
+    }
+
+    request = _request_object()
+    moved = failover_info.try_move_to_next_location(
+        available_regions,
+        "West US 3",
+        request,
+        excluded_locations=["East US 2"],
+    )
+
+    assert moved is True
+    assert failover_info.current_region == "East US 2"
+    assert request.location_endpoint_to_route == "https://eastus2.documents.azure.com"
+
+
+def test_session_retry_policy_ppaf_path_does_not_pin_excluded_current_region():
+    request = _request_object()
+
+    location_cache = unittest.mock.Mock()
+    location_cache.get_location_from_endpoint.side_effect = lambda endpoint: {
+        "None": "West US 3",
+        "https://eastus2.documents.azure.com": "East US 2",
+    }.get(endpoint)
+    location_cache._get_configured_excluded_locations.return_value = ["East US 2"]
+    location_cache.account_read_regional_routing_contexts_by_location = {
+        "East US 2": _context("https://eastus2.documents.azure.com"),
+    }
+
+    pk_failover_info = SimpleNamespace(
+        unavailable_regional_endpoints={"West US 3": "https://westus3.documents.azure.com"},
+        current_region="East US 2",
+    )
+
+    global_endpoint_manager = unittest.mock.Mock()
+    global_endpoint_manager.can_use_multiple_write_locations.return_value = False
+    global_endpoint_manager.is_per_partition_automatic_failover_enabled.return_value = True
+    global_endpoint_manager.partition_range_to_failover_info = {"pk": pk_failover_info}
+    global_endpoint_manager.location_cache = location_cache
+    global_endpoint_manager.resolve_service_endpoint_for_partition.side_effect = [
+        "https://westus3.documents.azure.com",
+        "https://eastus2.documents.azure.com",
+    ]
+
+    retry_policy = _SessionRetryPolicy(True, global_endpoint_manager, "pk", request)
+    should_retry = retry_policy.ShouldRetry(Exception("retry"))
+
+    assert should_retry is True
+    assert request.location_endpoint_to_route == "https://eastus2.documents.azure.com"
+

--- a/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_ppaf_excluded_locations_unit.py
@@ -4,6 +4,8 @@
 from types import SimpleNamespace
 import unittest.mock
 
+# cspell:ignore ppaf
+
 from azure.cosmos._global_partition_endpoint_manager_per_partition_automatic_failover import (
     PartitionLevelFailoverInfo,
 )


### PR DESCRIPTION
This PR aims to address some gaps in honoring exclude regions in a single write multi region account.
The following 2 code paths were fixed to honor exclude regions.

The main write-endpoint logic for single-write accounts didn't check the exclusion list.
Once a bad endpoint was chosen, the SDK's retry system locked it in so it couldn't be corrected.
