### PR TITLE
fix(monitor): centralize OTel log SDK imports to prevent silent failures

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_log_imports.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_log_imports.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Centralized imports for OpenTelemetry log SDK types.
+
+The OpenTelemetry log SDK (``opentelemetry.sdk._logs``) is an internal module
+whose public surface has changed across releases.  This module provides a
+single place to handle version-aware fallback imports so that individual
+modules don't each need their own try/except blocks.
+
+When an import fails a warning is emitted instead of failing silently.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+# The canonical (>=1.39) names live in opentelemetry.sdk._logs.
+try:
+    from opentelemetry.sdk._logs import (  # noqa: F401
+        LogRecordProcessor,
+        ReadWriteLogRecord,
+        ReadableLogRecord,
+        LoggerProvider,
+    )
+    from opentelemetry.sdk._logs.export import (  # noqa: F401
+        BatchLogRecordProcessor,
+        LogRecordExporter,
+        LogRecordExportResult,
+    )
+except ImportError:
+    _logger.warning(
+        "Failed to import from opentelemetry.sdk._logs. "
+        "Ensure opentelemetry-sdk>=1.39 is installed.",
+        exc_info=True,
+    )
+    raise

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_performance_counters/_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_performance_counters/_manager.py
@@ -9,7 +9,7 @@ import psutil
 
 from opentelemetry import metrics
 from opentelemetry.metrics import CallbackOptions, Observation
-from opentelemetry.sdk._logs import ReadWriteLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import ReadWriteLogRecord
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_MESSAGE,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_performance_counters/_processor.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_performance_counters/_processor.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from opentelemetry.sdk._logs import LogRecordProcessor, ReadWriteLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import LogRecordProcessor, ReadWriteLogRecord
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
 from azure.monitor.opentelemetry.exporter._performance_counters._manager import _PerformanceCountersManager

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_manager.py
@@ -9,7 +9,7 @@ import threading
 
 import psutil
 
-from opentelemetry.sdk._logs import ReadWriteLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import ReadWriteLogRecord
 from opentelemetry.sdk.metrics import MeterProvider, Meter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_processor.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_processor.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from opentelemetry.sdk._logs import LogRecordProcessor, ReadWriteLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import LogRecordProcessor, ReadWriteLogRecord
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
 from azure.monitor.opentelemetry.exporter._quickpulse._state import get_quickpulse_manager

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -5,8 +5,8 @@ import logging
 from typing import Optional, Sequence, Any
 
 from opentelemetry._logs.severity import SeverityNumber
-from opentelemetry.sdk._logs import ReadableLogRecord
-from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+from azure.monitor.opentelemetry.exporter._log_imports import ReadableLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import LogRecordExporter, LogRecordExportResult
 from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_ESCAPED,
     EXCEPTION_MESSAGE,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_processor.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_processor.py
@@ -3,8 +3,8 @@
 
 from typing import Optional, Dict, Any
 
-from opentelemetry.sdk._logs import ReadWriteLogRecord
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogRecordExporter
+from azure.monitor.opentelemetry.exporter._log_imports import ReadWriteLogRecord
+from azure.monitor.opentelemetry.exporter._log_imports import BatchLogRecordProcessor, LogRecordExporter
 from opentelemetry.trace import get_current_span
 
 


### PR DESCRIPTION
## Summary

The azure-monitor-opentelemetry-exporter imports types (`ReadableLogRecord`, `ReadWriteLogRecord`, `LogRecordExporter`, etc.) from `opentelemetry.sdk._logs`, which is an internal module whose public surface changed between OTel SDK releases. Currently these imports are scattered across 6 source files — if any import fails due to a version mismatch, the `ImportError` is silently swallowed by upstream `try/except` blocks, producing no diagnostic output and causing zero telemetry to be exported.

This PR introduces `_log_imports.py` as a single import point for all OTel log SDK types, and adds a warning-level log message when the imports fail, making version-mismatch issues visible instead of silent.

## Changes

- New `_log_imports.py`: consolidates all `opentelemetry.sdk._logs` imports with a warning on `ImportError`
- Updated 6 modules to import from `_log_imports` instead of directly from `opentelemetry.sdk._logs`

## Testing

Verified that all types resolve correctly with `opentelemetry-sdk==1.40` and `1.41`.

Fixes #46269