### PR TITLE
agentserver: use FOUNDRY_HOSTING_ENVIRONMENT for hosted detection

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
@@ -23,6 +23,7 @@ from typing_extensions import Self
 
 _ENV_FOUNDRY_AGENT_NAME = "FOUNDRY_AGENT_NAME"
 _ENV_FOUNDRY_AGENT_VERSION = "FOUNDRY_AGENT_VERSION"
+_ENV_FOUNDRY_HOSTING_ENVIRONMENT = "FOUNDRY_HOSTING_ENVIRONMENT"
 _ENV_FOUNDRY_PROJECT_ENDPOINT = "FOUNDRY_PROJECT_ENDPOINT"
 _ENV_FOUNDRY_PROJECT_ARM_ID = "FOUNDRY_PROJECT_ARM_ID"
 _ENV_FOUNDRY_AGENT_SESSION_ID = "FOUNDRY_AGENT_SESSION_ID"
@@ -86,6 +87,18 @@ class AgentConfig:
         self.appinsights_connection_string = appinsights_connection_string
         self.otlp_endpoint = otlp_endpoint
         self.sse_keepalive_interval = sse_keepalive_interval
+
+    @property
+    def is_hosted(self) -> bool:
+        """Whether the agent is running in a Foundry-hosted container environment.
+
+        Returns ``True`` when the platform-injected ``FOUNDRY_HOSTING_ENVIRONMENT``
+        environment variable exists and is non-empty. This variable is set
+        exclusively by the Foundry platform at container startup.
+
+        :rtype: bool
+        """
+        return bool(os.environ.get(_ENV_FOUNDRY_HOSTING_ENVIRONMENT))
 
     @classmethod
     def from_env(cls) -> Self:

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
@@ -54,6 +54,8 @@ class AgentConfig:
     :param agent_name: Agent name from ``FOUNDRY_AGENT_NAME``.
     :param agent_version: Agent version from ``FOUNDRY_AGENT_VERSION``.
     :param agent_id: Combined identifier (``"name:version"`` or ``"name"`` or ``""``).
+    :param is_hosted: Whether the agent is running in a Foundry-hosted container environment,
+        derived from ``FOUNDRY_HOSTING_ENVIRONMENT``.
     :param project_endpoint: Foundry project endpoint from ``FOUNDRY_PROJECT_ENDPOINT``.
     :param project_id: Foundry project ARM resource ID from ``FOUNDRY_PROJECT_ARM_ID``.
     :param session_id: Default session ID from ``FOUNDRY_AGENT_SESSION_ID``.
@@ -69,6 +71,7 @@ class AgentConfig:
         agent_name: str,
         agent_version: str,
         agent_id: str,
+        is_hosted: bool,
         project_endpoint: str,
         project_id: str,
         session_id: str,
@@ -80,6 +83,7 @@ class AgentConfig:
         self.agent_name = agent_name
         self.agent_version = agent_version
         self.agent_id = agent_id
+        self.is_hosted = is_hosted
         self.project_endpoint = project_endpoint
         self.project_id = project_id
         self.session_id = session_id
@@ -87,18 +91,6 @@ class AgentConfig:
         self.appinsights_connection_string = appinsights_connection_string
         self.otlp_endpoint = otlp_endpoint
         self.sse_keepalive_interval = sse_keepalive_interval
-
-    @property
-    def is_hosted(self) -> bool:
-        """Whether the agent is running in a Foundry-hosted container environment.
-
-        Returns ``True`` when the platform-injected ``FOUNDRY_HOSTING_ENVIRONMENT``
-        environment variable exists and is non-empty. This variable is set
-        exclusively by the Foundry platform at container startup.
-
-        :rtype: bool
-        """
-        return bool(os.environ.get(_ENV_FOUNDRY_HOSTING_ENVIRONMENT))
 
     @classmethod
     def from_env(cls) -> Self:
@@ -121,6 +113,7 @@ class AgentConfig:
             agent_name=agent_name,
             agent_version=agent_version,
             agent_id=agent_id,
+            is_hosted=bool(os.environ.get(_ENV_FOUNDRY_HOSTING_ENVIRONMENT)),
             project_endpoint=os.environ.get(_ENV_FOUNDRY_PROJECT_ENDPOINT, ""),
             project_id=os.environ.get(_ENV_FOUNDRY_PROJECT_ARM_ID, ""),
             session_id=os.environ.get(_ENV_FOUNDRY_AGENT_SESSION_ID, ""),

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_config.py
@@ -113,7 +113,7 @@ class AgentConfig:
             agent_name=agent_name,
             agent_version=agent_version,
             agent_id=agent_id,
-            is_hosted=bool(os.environ.get(_ENV_FOUNDRY_HOSTING_ENVIRONMENT)),
+            is_hosted=bool(os.environ.get(_ENV_FOUNDRY_HOSTING_ENVIRONMENT, "")),
             project_endpoint=os.environ.get(_ENV_FOUNDRY_PROJECT_ENDPOINT, ""),
             project_id=os.environ.get(_ENV_FOUNDRY_PROJECT_ARM_ID, ""),
             session_id=os.environ.get(_ENV_FOUNDRY_AGENT_SESSION_ID, ""),

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/test_config.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/test_config.py
@@ -1,0 +1,39 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+"""Unit tests for AgentConfig."""
+import pytest
+
+from azure.ai.agentserver.core._config import AgentConfig
+
+
+class TestAgentConfigIsHosted:
+    """Tests for AgentConfig.is_hosted snapshotting behavior."""
+
+    def test_is_hosted_false_when_env_var_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """is_hosted is False when FOUNDRY_HOSTING_ENVIRONMENT is not set."""
+        monkeypatch.delenv("FOUNDRY_HOSTING_ENVIRONMENT", raising=False)
+        config = AgentConfig.from_env()
+        assert config.is_hosted is False
+
+    def test_is_hosted_false_when_env_var_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """is_hosted is False when FOUNDRY_HOSTING_ENVIRONMENT is set to an empty string."""
+        monkeypatch.setenv("FOUNDRY_HOSTING_ENVIRONMENT", "")
+        config = AgentConfig.from_env()
+        assert config.is_hosted is False
+
+    def test_is_hosted_true_when_env_var_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """is_hosted is True when FOUNDRY_HOSTING_ENVIRONMENT is set to a non-empty value."""
+        monkeypatch.setenv("FOUNDRY_HOSTING_ENVIRONMENT", "production")
+        config = AgentConfig.from_env()
+        assert config.is_hosted is True
+
+    def test_is_hosted_snapshotted_at_creation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """is_hosted reflects the env var value at creation time, not at access time."""
+        monkeypatch.setenv("FOUNDRY_HOSTING_ENVIRONMENT", "production")
+        config = AgentConfig.from_env()
+        assert config.is_hosted is True
+
+        # Changing the env var after creation must not affect the already-created config.
+        monkeypatch.delenv("FOUNDRY_HOSTING_ENVIRONMENT")
+        assert config.is_hosted is True

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_routing.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_routing.py
@@ -141,7 +141,7 @@ class ResponsesAgentServerHost(AgentServerHost):
         }
 
         if store is None:
-            if config.project_endpoint:
+            if config.is_hosted:
                 from ..store._foundry_provider import FoundryStorageProvider
                 from ..store._foundry_settings import FoundryStorageSettings
 


### PR DESCRIPTION
Add `is_hosted` property to `AgentConfig` that returns `True` when the platform-injected `FOUNDRY_HOSTING_ENVIRONMENT` environment variable exists and is non-empty. This variable is set exclusively by the Foundry platform at container startup.

Use `config.is_hosted` instead of `config.project_endpoint` in `_routing.py` for Foundry storage auto-activation. This prevents false-positive auto-activation when developers set `FOUNDRY_PROJECT_ENDPOINT` or other `FOUNDRY_*` vars locally (e.g. to use agent_framework features) without intending to run in a hosted environment.

### Changes
- **`_config.py`**: Add `FOUNDRY_HOSTING_ENVIRONMENT` env var constant and `is_hosted` property on `AgentConfig`
- **`_routing.py`**: Use `config.is_hosted` instead of `config.project_endpoint` for Foundry storage auto-activation