### PR TITLE
perf(cosmos): share partition key range cache across clients per endpoint

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -3557,8 +3557,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         return partitionKey
 
     def refresh_routing_map_provider(self) -> None:
-        # re-initializes the routing map provider, effectively refreshing the current partition key range cache
-        self._routing_map_provider = routing_map_provider.SmartRoutingMapProvider(self)
+        # Clear the shared partition key range cache for this endpoint and re-initialize
+        self._routing_map_provider.clear_cache()
 
     def _refresh_container_properties_cache(self, container_link: str):
         # If container properties cache is stale, refresh it by reading the container.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -23,6 +23,7 @@
 Cosmos database service.
 """
 import logging
+import threading
 from typing import Any, Optional
 
 from ... import _base
@@ -30,6 +31,11 @@ from ..collection_routing_map import CollectionRoutingMap
 from .. import routing_range
 
 _LOGGER = logging.getLogger(__name__)
+
+# Shared routing map cache across all clients targeting the same endpoint.
+# Key: account endpoint URL, Value: dict of collection_id -> CollectionRoutingMap
+_shared_routing_map_cache: dict[str, dict[str, CollectionRoutingMap]] = {}
+_shared_cache_lock = threading.Lock()
 
 # pylint: disable=protected-access
 
@@ -49,9 +55,20 @@ class PartitionKeyRangeCache(object):
         """
 
         self._documentClient = client
+        self._endpoint = getattr(client, 'url_connection', '')
 
-        # keeps the cached collection routing map by collection id
-        self._collection_routing_map_by_item = {}
+        # Share routing map cache across clients with the same endpoint
+        with _shared_cache_lock:
+            if self._endpoint not in _shared_routing_map_cache:
+                _shared_routing_map_cache[self._endpoint] = {}
+            self._collection_routing_map_by_item = _shared_routing_map_cache[self._endpoint]
+
+    def clear_cache(self):
+        """Clear the shared routing map cache for this endpoint."""
+        with _shared_cache_lock:
+            if self._endpoint in _shared_routing_map_cache:
+                _shared_routing_map_cache[self._endpoint] = {}
+            self._collection_routing_map_by_item = _shared_routing_map_cache.get(self._endpoint, {})
 
     async def get_overlapping_ranges(self, collection_link, partition_key_ranges, feed_options, **kwargs):
         """Given a partition key range and a collection, return the list of

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -23,6 +23,7 @@
 Cosmos database service.
 """
 import logging
+import threading
 from typing import Any, Optional
 
 from .. import _base
@@ -31,6 +32,11 @@ from . import routing_range
 from .routing_range import PartitionKeyRange
 
 _LOGGER = logging.getLogger(__name__)
+
+# Shared routing map cache across all clients targeting the same endpoint.
+# Key: account endpoint URL, Value: dict of collection_id -> CollectionRoutingMap
+_shared_routing_map_cache: dict[str, dict[str, CollectionRoutingMap]] = {}
+_shared_cache_lock = threading.Lock()
 
 
 # pylint: disable=protected-access
@@ -51,9 +57,20 @@ class PartitionKeyRangeCache(object):
         """
 
         self._documentClient = client
+        self._endpoint = getattr(client, 'url_connection', '')
 
-        # keeps the cached collection routing map by collection id
-        self._collection_routing_map_by_item = {}
+        # Share routing map cache across clients with the same endpoint
+        with _shared_cache_lock:
+            if self._endpoint not in _shared_routing_map_cache:
+                _shared_routing_map_cache[self._endpoint] = {}
+            self._collection_routing_map_by_item = _shared_routing_map_cache[self._endpoint]
+
+    def clear_cache(self):
+        """Clear the shared routing map cache for this endpoint."""
+        with _shared_cache_lock:
+            if self._endpoint in _shared_routing_map_cache:
+                _shared_routing_map_cache[self._endpoint] = {}
+            self._collection_routing_map_by_item = _shared_routing_map_cache.get(self._endpoint, {})
 
     def init_collection_routing_map_if_needed(
             self,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -3424,8 +3424,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         return partitionKey
 
     def refresh_routing_map_provider(self) -> None:
-        # re-initializes the routing map provider, effectively refreshing the current partition key range cache
-        self._routing_map_provider = SmartRoutingMapProvider(self)
+        # Clear the shared partition key range cache for this endpoint and re-initialize
+        self._routing_map_provider.clear_cache()
 
     async def _refresh_container_properties_cache(self, container_link: str):
         # If container properties cache is stale, refresh it by reading the container.

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
@@ -1,0 +1,102 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+import unittest
+import pytest
+
+from azure.cosmos._routing.routing_range import Range
+from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
+from azure.cosmos._routing.routing_map_provider import (
+    PartitionKeyRangeCache,
+    _shared_routing_map_cache,
+    _shared_cache_lock,
+)
+
+
+class MockClient:
+    """Minimal mock client for PartitionKeyRangeCache tests."""
+    def __init__(self, url_connection):
+        self.url_connection = url_connection
+
+
+@pytest.mark.cosmosEmulator
+class TestSharedPartitionKeyRangeCache(unittest.TestCase):
+
+    def tearDown(self):
+        # Clean up shared cache between tests
+        with _shared_cache_lock:
+            _shared_routing_map_cache.clear()
+
+    def test_same_endpoint_shares_cache(self):
+        """Two clients with the same endpoint share the same routing map dict."""
+        client1 = MockClient("https://account1.documents.azure.com:443/")
+        client2 = MockClient("https://account1.documents.azure.com:443/")
+
+        cache1 = PartitionKeyRangeCache(client1)
+        cache2 = PartitionKeyRangeCache(client2)
+
+        self.assertIs(cache1._collection_routing_map_by_item,
+                      cache2._collection_routing_map_by_item)
+
+    def test_different_endpoints_isolated(self):
+        """Two clients with different endpoints have separate caches."""
+        client1 = MockClient("https://account1.documents.azure.com:443/")
+        client2 = MockClient("https://account2.documents.azure.com:443/")
+
+        cache1 = PartitionKeyRangeCache(client1)
+        cache2 = PartitionKeyRangeCache(client2)
+
+        self.assertIsNot(cache1._collection_routing_map_by_item,
+                         cache2._collection_routing_map_by_item)
+
+    def test_shared_cache_populated_by_first_client(self):
+        """When first client populates the cache, second client sees it."""
+        client1 = MockClient("https://account1.documents.azure.com:443/")
+        client2 = MockClient("https://account1.documents.azure.com:443/")
+
+        cache1 = PartitionKeyRangeCache(client1)
+        cache2 = PartitionKeyRangeCache(client2)
+
+        # Simulate first client populating the routing map
+        pk_ranges = [
+            {"id": "0", "minInclusive": "", "maxExclusive": "FF"},
+        ]
+        crm = CollectionRoutingMap.CompleteRoutingMap(
+            [(r, True) for r in pk_ranges], "test-collection"
+        )
+        cache1._collection_routing_map_by_item["test-collection"] = crm
+
+        # Second client should see it
+        self.assertIn("test-collection", cache2._collection_routing_map_by_item)
+        self.assertIs(cache2._collection_routing_map_by_item["test-collection"], crm)
+
+    def test_clear_cache_resets_for_endpoint(self):
+        """clear_cache resets the shared entry for the endpoint."""
+        client1 = MockClient("https://account1.documents.azure.com:443/")
+        cache1 = PartitionKeyRangeCache(client1)
+
+        cache1._collection_routing_map_by_item["coll1"] = "dummy"
+        self.assertIn("coll1", cache1._collection_routing_map_by_item)
+
+        cache1.clear_cache()
+        self.assertNotIn("coll1", cache1._collection_routing_map_by_item)
+
+    def test_clear_cache_does_not_affect_other_endpoints(self):
+        """Clearing cache for one endpoint leaves other endpoints intact."""
+        client1 = MockClient("https://account1.documents.azure.com:443/")
+        client2 = MockClient("https://account2.documents.azure.com:443/")
+
+        cache1 = PartitionKeyRangeCache(client1)
+        cache2 = PartitionKeyRangeCache(client2)
+
+        cache1._collection_routing_map_by_item["coll1"] = "data1"
+        cache2._collection_routing_map_by_item["coll2"] = "data2"
+
+        cache1.clear_cache()
+
+        self.assertNotIn("coll1", cache1._collection_routing_map_by_item)
+        self.assertIn("coll2", cache2._collection_routing_map_by_item)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Clients targeting the same Cosmos DB endpoint now share a single CollectionRoutingMap cache instead of each maintaining an independent copy. This eliminates N-1 redundant copies of partition key range data when N clients connect to the same account.

## Problem

When PPCB is enabled, each CosmosClient eagerly loads the full partition key range routing map via create_pk_range_wrapper(). Each client creates its own SmartRoutingMapProvider with its own _collection_routing_map_by_item dict, resulting in N identical copies for N clients targeting the same endpoint.

## Changes

- **_routing/aio/routing_map_provider.py** + **_routing/routing_map_provider.py**: Module-level _shared_routing_map_cache dict keyed by endpoint URL. PartitionKeyRangeCache.__init__ points _collection_routing_map_by_item to the shared entry. Added clear_cache() method.
- **aio/_cosmos_client_connection_async.py** + **_cosmos_client_connection.py**: refresh_routing_map_provider() calls clear_cache() instead of creating a new SmartRoutingMapProvider.

## Memory Profiling Results

Test setup: tracemalloc, ~100 partitions, 2 regions, PPCB=True, 1 read + 1 upsert per client.

### Current Memory (MB)

| Clients | Original PPCB=True | Shared PPCB=True | Original PPCB=false | Shared PPCB=false |
|---------|-------------------|-----------------|-------------------|------------------|
| 1 | 14.3 | 14.3 | 14.0 | 14.0 |
| 25 | 23.0 | 18.1 | 17.9 | 17.8 |
| 50 | 31.9 | 21.9 | 21.7 | 21.7 |
| 100 | 44.9 | 27.8 | 29.4 | 29.4 |
| 150 | 63.8 | 37.7 | 36.4 | 37.7 |

### PPCB Overhead Reduction

| Clients | Original | Shared Cache | Reduction |
|---------|----------|-------------|-----------|
| 25 | 5.1 MB | 0.3 MB | **-93%** |
| 50 | 10.3 MB | 0.3 MB | **-97%** |
| 100 | 15.4 MB | -1.6 MB | **-110%** |
| 150 | 27.4 MB | -0.0 MB | **-100%** |

### Scaling Estimate

At customer scale (200K partitions x 152 clients): **~2.1 GB -> ~14 MB** (single shared copy).

## Tests

5 unit tests in test_shared_pk_range_cache.py:
- Same endpoint shares cache (identity check)
- Different endpoints are isolated
- First client populates, second sees it
- clear_cache() resets the shared entry
- clear_cache() does not affect other endpoints
