### PR TITLE
Fix success field on HTTP request telemetry resolving to an integer instead of a boolean when no status code is present

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fix `success` field on HTTP request telemetry resolving to an integer instead of a boolean when no status code is present
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Fix `success` field on HTTP request telemetry resolving to an integer instead of a boolean when no status code is present
+  ([#46311](https://github.com/Azure/azure-sdk-for-python/pull/46311))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -337,6 +337,18 @@ def _is_synthetic_load(properties: Optional[Any]) -> bool:
     return False
 
 
+def _is_status_code_success(status_code: Optional[int], is_trace: bool = False) -> bool:
+    if status_code is None or status_code == 0:
+        return False
+    try:
+        code = int(status_code)
+        if is_trace:
+            return code not in range(400, 500)
+        return code < 400
+    except ValueError:
+        return False
+
+
 def _is_any_synthetic_source(properties: Optional[Any]) -> bool:
     """
     Check if the telemetry should be marked as synthetic from any source.

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -304,7 +304,7 @@ def _handle_std_metric_envelope(
         properties["_MS.MetricId"] = "dependencies/duration"
         properties["_MS.IsAutocollected"] = "True"
         properties["Dependency.Type"] = "http"
-        properties["Dependency.Success"] = str(_is_status_code_success(status_code))  # type: ignore
+        properties["Dependency.Success"] = str(_utils._is_status_code_success(status_code))  # type: ignore
         target, _ = trace_utils._get_target_and_path_for_http_dependency(attributes)
         properties["dependency/target"] = target  # type: ignore
         properties["dependency/resultCode"] = str(status_code)
@@ -319,7 +319,7 @@ def _handle_std_metric_envelope(
             properties["operation/synthetic"] = "True"
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"]  # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"]  # type: ignore
-        properties["Request.Success"] = str(_is_status_code_success(status_code))  # type: ignore
+        properties["Request.Success"] = str(_utils._is_status_code_success(status_code))  # type: ignore
     else:
         # Any other autocollected metrics are not supported yet for standard metrics
         # We ignore these envelopes in these cases
@@ -330,17 +330,6 @@ def _handle_std_metric_envelope(
     envelope.data.base_data.properties = properties  # type: ignore
 
     return envelope
-
-
-def _is_status_code_success(status_code: Optional[str]) -> bool:
-    if status_code is None or status_code == 0:
-        return False
-    try:
-        # Success criteria based solely off status code is True only if status_code < 400
-        # for both client and server spans
-        return int(status_code) < 400
-    except ValueError:
-        return False
 
 
 def _is_metric_namespace_opted_in() -> bool:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -325,7 +325,7 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
                 status_code = 0
             data.response_code = str(status_code)
             # Success criteria for server spans depends on span.success and the actual status code
-            data.success = span.status.is_ok and status_code and status_code not in range(400, 500)
+            data.success = span.status.is_ok and bool(status_code) and status_code not in range(400, 500)
         elif SpanAttributes.MESSAGING_SYSTEM in span.attributes:  # Messaging
             if span.attributes.get(SpanAttributes.MESSAGING_DESTINATION):
                 if span.attributes.get(CLIENT_ADDRESS) or span.attributes.get(SpanAttributes.NET_PEER_NAME):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -324,8 +324,7 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
             else:
                 status_code = 0
             data.response_code = str(status_code)
-            # Success criteria for server spans depends on span.success and the actual status code
-            data.success = span.status.is_ok and bool(status_code) and status_code not in range(400, 500)
+            data.success = span.status.is_ok and _utils._is_status_code_success(status_code, is_trace=True)
         elif SpanAttributes.MESSAGING_SYSTEM in span.attributes:  # Messaging
             if span.attributes.get(SpanAttributes.MESSAGING_DESTINATION):
                 if span.attributes.get(CLIENT_ADDRESS) or span.attributes.get(SpanAttributes.NET_PEER_NAME):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -834,3 +834,47 @@ class TestUtils(unittest.TestCase):
     def test_is_any_synthetic_source_none(self):
         properties = {"http.user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
         self.assertFalse(_utils._is_any_synthetic_source(properties))
+
+    # _is_status_code_success tests
+
+    def test_is_status_code_success_none(self):
+        self.assertFalse(_utils._is_status_code_success(None))
+        self.assertIsInstance(_utils._is_status_code_success(None), bool)
+
+    def test_is_status_code_success_zero(self):
+        self.assertFalse(_utils._is_status_code_success(0))
+        self.assertIsInstance(_utils._is_status_code_success(0), bool)
+
+    def test_is_status_code_success_200(self):
+        self.assertTrue(_utils._is_status_code_success(200))
+        self.assertTrue(_utils._is_status_code_success(200, is_trace=True))
+
+    def test_is_status_code_success_4xx_metrics(self):
+        self.assertFalse(_utils._is_status_code_success(400))
+        self.assertFalse(_utils._is_status_code_success(404))
+        self.assertFalse(_utils._is_status_code_success(499))
+
+    def test_is_status_code_success_4xx_trace(self):
+        self.assertFalse(_utils._is_status_code_success(400, is_trace=True))
+        self.assertFalse(_utils._is_status_code_success(404, is_trace=True))
+        self.assertFalse(_utils._is_status_code_success(499, is_trace=True))
+
+    def test_is_status_code_success_5xx_metrics(self):
+        # Metrics: 5xx is failure (code >= 400)
+        self.assertFalse(_utils._is_status_code_success(500))
+        self.assertFalse(_utils._is_status_code_success(503))
+
+    def test_is_status_code_success_5xx_trace(self):
+        # Trace: 5xx is NOT failure (only 4xx range is failure)
+        self.assertTrue(_utils._is_status_code_success(500, is_trace=True))
+        self.assertTrue(_utils._is_status_code_success(503, is_trace=True))
+
+    def test_is_status_code_success_3xx(self):
+        self.assertTrue(_utils._is_status_code_success(301))
+        self.assertTrue(_utils._is_status_code_success(301, is_trace=True))
+
+    def test_is_status_code_success_returns_bool(self):
+        self.assertIsInstance(_utils._is_status_code_success(200), bool)
+        self.assertIsInstance(_utils._is_status_code_success(0), bool)
+        self.assertIsInstance(_utils._is_status_code_success(None), bool)
+        self.assertIsInstance(_utils._is_status_code_success(500, is_trace=True), bool)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1219,7 +1219,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "net.peer.ip": "peer_ip",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1229,7 +1228,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.status_code": "",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1238,7 +1236,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.request.method": "GET",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1187,6 +1187,16 @@ class TestAzureTraceExporter(unittest.TestCase):
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "400")
 
+        # 5xx - trace treats 5xx as success (only 4xx is failure)
+        span._attributes = {
+            "http.method": "GET",
+            "net.peer.ip": "peer_ip",
+            "http.status_code": 500,
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertTrue(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "500")
+
         ## Stable http semconv
         span._attributes = {
             "http.request.method": "GET",
@@ -1209,7 +1219,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "net.peer.ip": "peer_ip",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1219,7 +1228,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.status_code": "",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1228,7 +1236,6 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.request.method": "GET",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1219,6 +1219,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             "net.peer.ip": "peer_ip",
         }
         envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1228,6 +1229,16 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.status_code": "",
         }
         envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
+        self.assertFalse(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "0")
+
+        # Stable semconv - no status code
+        span._attributes = {
+            "http.request.method": "GET",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1209,6 +1209,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             "net.peer.ip": "peer_ip",
         }
         envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 
@@ -1218,6 +1219,16 @@ class TestAzureTraceExporter(unittest.TestCase):
             "http.status_code": "",
         }
         envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
+        self.assertFalse(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "0")
+
+        # Stable semconv - no status code
+        span._attributes = {
+            "http.request.method": "GET",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertIsInstance(envelope.data.base_data.success, bool)
         self.assertFalse(envelope.data.base_data.success)
         self.assertEqual(envelope.data.base_data.response_code, "0")
 


### PR DESCRIPTION
# Description

Fixes - https://github.com/Azure/azure-sdk-for-python/issues/46118

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
