### PR TITLE
[Key Vault] Add default value for `inner_error`

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -97,7 +97,7 @@ class CertificateOperationError(object):
     :type inner_error: ~azure.keyvault.certificates.CertificateOperationError or None
     """
 
-    def __init__(self, code: str, message: str, inner_error: "Optional[CertificateOperationError]") -> None:
+    def __init__(self, code: str, message: str, inner_error: "Optional[CertificateOperationError]" = None) -> None:
         self._code = code
         self._message = message
         self._inner_error = inner_error


### PR DESCRIPTION
# Description

https://github.com/Azure/azure-sdk-for-python/pull/41965 handled the edge case where `inner_error` is `None`, but didn't introduce a default value for the parameter; the model shouldn't be created by users, so the `_from_error_bundle` method should be the only place where a `CertificateOperationError` is constructed. However, for consistency with the type hint and to prevent unnecessary errors, this adds a default `None` value for the argument.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
