### PR TITLE
[Key Vault] Fix MyPy error in KeyProperties.tags return type annotation

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -252,11 +252,11 @@ class KeyProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def tags(self) -> Dict[str, str]:
+    def tags(self) -> Optional[Dict[str, str]]:
         """Application specific metadata in the form of key-value pairs.
 
         :returns: A dictionary of tags attached to the key.
-        :rtype: dict[str, str]
+        :rtype: dict[str, str] or None
         """
         return self._tags
 


### PR DESCRIPTION
## Description

Fix a pre-existing MyPy type error in `azure-keyvault-keys` that was blocking the shared keyvault release pipeline.

### Root Cause

`KeyProperties.tags` was annotated with return type `Dict[str, str]`, but `self._tags` is initialized as `kwargs.get("tags", None)`, which can return `None`. MyPy correctly flagged this mismatch:
