### PR TITLE
Shorten CG timeout, though it's been disabled

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -58,6 +58,7 @@ extends:
       componentgovernance:
         enabled: false
         justificationForDisabling: "To reduce redundant CG runs across all our pipeline jobs we are disabling and only running in our main build job."
+        timeout: 180
       credscan:
         suppressionsFile: '$(Build.SourcesDirectory)/eng/CredScanSuppression.json'
       psscriptanalyzer:


### PR DESCRIPTION
Looks like it's getting included even though we disable it here.