### PR TITLE
[Storage] Fix potential memory leak caused by exception handling

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -190,11 +190,15 @@ def process_storage_error(storage_error) -> NoReturn:  # type: ignore [misc] # p
     error.additional_info = additional_data
     # error.args is what's surfaced on the traceback - show error message in all cases
     error.args = (error.message,)
+
     try:
-        # `from None` prevents us from double printing the exception (suppresses generated layer error context)
-        exec("raise error from None")  # pylint: disable=exec-used # nosec
-    except SyntaxError as exc:
-        raise error from exc
+        # `from None` suppresses exception chaining to prevent double printing the exception.
+        raise error from None
+    finally:
+        # Explicitly clears exception references to break circular references
+        # and allow immediate garbage collection.
+        error = None
+        storage_error = None
 
 
 def parse_to_internal_user_delegation_key(service_user_delegation_key):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -190,11 +190,15 @@ def process_storage_error(storage_error) -> NoReturn:  # type: ignore [misc] # p
     error.additional_info = additional_data
     # error.args is what's surfaced on the traceback - show error message in all cases
     error.args = (error.message,)
+
     try:
-        # `from None` prevents us from double printing the exception (suppresses generated layer error context)
-        exec("raise error from None")  # pylint: disable=exec-used # nosec
-    except SyntaxError as exc:
-        raise error from exc
+        # `from None` suppresses exception chaining to prevent double printing the exception.
+        raise error from None
+    finally:
+        # Explicitly clears exception references to break circular references
+        # and allow immediate garbage collection.
+        error = None
+        storage_error = None
 
 
 def parse_to_internal_user_delegation_key(service_user_delegation_key):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -190,11 +190,15 @@ def process_storage_error(storage_error) -> NoReturn:  # type: ignore [misc] # p
     error.additional_info = additional_data
     # error.args is what's surfaced on the traceback - show error message in all cases
     error.args = (error.message,)
+
     try:
-        # `from None` prevents us from double printing the exception (suppresses generated layer error context)
-        exec("raise error from None")  # pylint: disable=exec-used # nosec
-    except SyntaxError as exc:
-        raise error from exc
+        # `from None` suppresses exception chaining to prevent double printing the exception.
+        raise error from None
+    finally:
+        # Explicitly clears exception references to break circular references
+        # and allow immediate garbage collection.
+        error = None
+        storage_error = None
 
 
 def parse_to_internal_user_delegation_key(service_user_delegation_key):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -207,11 +207,15 @@ def process_storage_error(storage_error) -> NoReturn:  # type: ignore [misc] # p
     error.additional_info = additional_data
     # error.args is what's surfaced on the traceback - show error message in all cases
     error.args = (error.message,)
+
     try:
-        # `from None` prevents us from double printing the exception (suppresses generated layer error context)
-        exec("raise error from None")  # pylint: disable=exec-used # nosec
-    except SyntaxError as exc:
-        raise error from exc
+        # `from None` suppresses exception chaining to prevent double printing the exception.
+        raise error from None
+    finally:
+        # Explicitly clears exception references to break circular references
+        # and allow immediate garbage collection.
+        error = None
+        storage_error = None
 
 
 def parse_to_internal_user_delegation_key(service_user_delegation_key):


### PR DESCRIPTION
The exception handling logic caused a circular reference that prevented proper garbage collection of certain memory in the application. This change addresses that issue by setting the errors to `None` in a finally block to remove the circular reference. This change also removed the `exec` that was previously added for a Python 2 workaround.