### PR TITLE
Fix Verifytypes

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/verifytypes.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/verifytypes.py
@@ -176,6 +176,13 @@ class verifytypes(Check):
 
                 command = get_pip_command(python_executable) + ["install", ".", "--force-reinstall"]
 
+                # When using uv, add --no-sources to ignore [tool.uv.sources] relative paths
+                # that can't resolve in a sparse checkout, and --python to target the correct venv.
+                if command[0] == "uv":
+                    command += ["--no-sources"]
+                    if python_executable:
+                        command += ["--python", python_executable]
+
                 subprocess.check_call(command, stdout=subprocess.DEVNULL)
             finally:
                 os.chdir(cwd)  # allow temp dir to be deleted


### PR DESCRIPTION
[Resolve this issue](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6171682&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=23d29da4-00cb-5783-b17c-96bda25d9c52&l=1071)

`Verifytypes` prevents regression by first running against your PR version of the package, then checking out the package from main, installing that, and running `verifytypes` again. We error if there is a more than 5% regression.

Well, the keyvault packages have `[tool.uv.sources]` attribute:

```
   [tool.uv.sources]
   azure-core = { path = "../../core/azure-core" }
   azure-identity = { path = "../../identity/azure-identity" }
   azure-keyvault-nspkg = { path = "../../nspkg/azure-keyvault-nspkg" }
   azure-sdk-tools = { path = "../../../eng/tools/azure-sdk-tools" }
```

`uv` attempts to follow these even during package assembly. The issue is, when the `verifytypes` check grabs the main version of the package, it's JUST getting the package code. Due to that, those tool paths aren't present, and `uv` fails to install.

By passing `--no-sources` and `--python` we are  A) ensuring we don't hit the installation error and B) making certain verifytypes is installing on the proper venv.

