### PR TITLE
Bump azure-ai-agentserver-responses to 1.0.0b3

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0b3 (2026-04-19)
+
+### Bugs Fixed
+
+- Background non-stream finalization now passes isolation keys to `update_response` — previously the `isolation=` kwarg was missing, causing Foundry storage to return 404 when isolation headers were present (the response was created in a scoped partition but the update targeted the unscoped partition). This left responses permanently stuck at `in_progress`.
+
 ## 1.0.0b2 (2026-04-17)
 
 ### Features Added
@@ -16,7 +22,6 @@
 
 ### Bugs Fixed
 
-- Background non-stream finalization now passes isolation keys to `update_response` — previously the `isolation=` kwarg was missing, causing Foundry storage to return 404 when isolation headers were present (the response was created in a scoped partition but the update targeted the unscoped partition). This left responses permanently stuck at `in_progress`.
 - SSE stream replay now works when the response provider does not implement `ResponseStreamProviderProtocol` (e.g. `FoundryStorageProvider`). Previously, `GET /responses/{id}?stream=true` returned HTTP 400 after eager eviction because no stream provider was configured. The host now auto-provisions an in-memory stream provider as a fallback.
 - `item_reference` inputs are now resolved at persistence time — when a `POST /responses` request includes `item_reference` entries in its input, they are batch-resolved via the provider before being stored. Previously, `item_reference` entries were silently dropped during input expansion, so `GET /responses/{id}/input_items` would only return inline items. This matches the .NET SDK behavior (`GetInputItemsForPersistenceAsync`).
 - Post-eviction chat isolation — after eager eviction, GET, DELETE, Cancel, and InputItems requests with missing or mismatched `x-agent-chat-isolation-key` headers now correctly fall through to Foundry storage (which returns HTTP 400) instead of being blocked locally with HTTP 404. In-flight isolation enforcement is unchanged.

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"


### PR DESCRIPTION
## Why

1.0.0b2 was published before PR #46395 (isolation fix for bg non-stream finalization) merged. This bumps the version so the fix can ship.

## Changes

- **`_version.py`**: `1.0.0b2` → `1.0.0b3`
- **`CHANGELOG.md`**: New `1.0.0b3` section with the isolation bug fix entry; removed duplicate from the `1.0.0b2` section
