### PR TITLE
[ContentUnderstanding] Bump version to 1.1.0 — expose usage property on pollers

### DIFF
--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 1.0.2 (2026-04-20)
+## 1.1.0 (2026-04-20)
 
-### Bugs Fixed
-- Exposed `usage` property on `AnalyzeLROPoller` and `AnalyzeAsyncLROPoller` to surface billing and token consumption details (`UsageDetails`) returned by the REST API. Previously the `usage` field in the LRO response envelope was discarded by the generated deserialization callback.
+### Features Added
+- Added `usage` property on `AnalyzeLROPoller` and `AnalyzeAsyncLROPoller` to surface billing and token consumption details (`UsageDetails`) returned by the REST API.
 
 ## 1.0.1 (2026-03-06)
 

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
@@ -31,7 +31,7 @@ This table shows the relationship between SDK versions and supported API service
 
 | SDK version | Supported API service version |
 | ----------- | ----------------------------- |
-| 1.0.2       | 2025-11-01                    |
+| 1.1.0       | 2025-11-01                    |
 | 1.0.1       | 2025-11-01                    |
 | 1.0.0       | 2025-11-01                    |
 

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/azure/ai/contentunderstanding/_version.py
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/azure/ai/contentunderstanding/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.2"
+VERSION = "1.1.0"


### PR DESCRIPTION
## Description

Bumps `azure-ai-contentunderstanding` from 1.0.2 to **1.1.0** and recategorizes the changelog entry as **Features Added** (was incorrectly listed as Bugs Fixed in PR #46278).

Adding a new `usage` property to `AnalyzeLROPoller` / `AnalyzeAsyncLROPoller` is a new feature, not a bug fix, so it warrants a minor version bump.

### Changes

- `_version.py`: `1.0.2` → `1.1.0`
- `CHANGELOG.md`: Version header updated to `1.1.0`; entry moved from "Bugs Fixed" to "Features Added"
- `README.md`: SDK version table updated to `1.1.0`

Follows up on #46278 which introduced the `usage` property.

## All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
  - Version bump only; no new code paths — existing tests from #46278 cover the `usage` property.