### PR TITLE
Fix a few issues with bootstrapping builds due to limitations of network isolation

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -25,7 +25,6 @@ json-delta==2.0.2
 python-dotenv==1.0.1
 pyyaml==6.0.2
 urllib3==2.2.3
-six==1.17.0
 
 # local dev packages
 ./eng/tools/azure-sdk-tools[ghtools]

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -22,7 +22,6 @@ coverage==7.6.1
 # locking packages defined as deps from azure-sdk-tools
 Jinja2==3.1.6
 json-delta==2.0.2
-readme_renderer==43.0
 python-dotenv==1.0.1
 pyyaml==6.0.2
 urllib3==2.2.3

--- a/eng/pipelines/templates/steps/use-python-version.yml
+++ b/eng/pipelines/templates/steps/use-python-version.yml
@@ -2,18 +2,10 @@ parameters:
   versionSpec: ''
 
 steps:
-  # as of macos-14, pypy of all stripes is no longer available on the predefined MAC agents
-  # this script installs the newest version of pypy39 from the official pypy site into the hosted tool cache
-  - script: |
-      TOOL_LOCATION=$(AGENT_TOOLSDIRECTORY)/PyPy/3.9.4/x64
-      curl -L -o pypy3.9-v7.3.16-macos_x86_64.tar.bz2 https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2
-      mkdir -p $TOOL_LOCATION
-      tar -xvjf pypy3.9-v7.3.16-macos_x86_64.tar.bz2 -C $TOOL_LOCATION --strip-components=1
-      chmod -R 0755 $TOOL_LOCATION/bin
-      $TOOL_LOCATION/bin/python -m ensurepip
-      touch $TOOL_LOCATION/../x64.complete
-    displayName: Install pypy39 to hosted tool cache
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+    displayName: 'Activate PIP_INDEX URL so that python 3.9 is able to find the correct version of pip.'
+    condition: eq('${{ parameters.versionSpec }}', '3.9')
 
   - task: UsePythonVersion@0
     displayName: "Use Python ${{ parameters.versionSpec }}"

--- a/eng/pipelines/templates/steps/use-python-version.yml
+++ b/eng/pipelines/templates/steps/use-python-version.yml
@@ -3,9 +3,13 @@ parameters:
 
 steps:
   # Using built-in Azure DevOps tasks can result in auto-retrieval of packages like pip from pypi.
-  # Override the PIP_INDEX_URL ASAP so that these auto-restores do not fail in isolated networks.
+  # Set a default PIP_INDEX_URL ASAP so that these auto-restores do not fail in isolated networks.
   - pwsh: |
-      Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+      if (-not $env:PIP_INDEX_URL) {
+        Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+      } else {
+        Write-Host "PIP_INDEX_URL is already set; preserving existing value."
+      }
     displayName: 'Use Public Feed'
 
   - task: UsePythonVersion@0

--- a/eng/pipelines/templates/steps/use-python-version.yml
+++ b/eng/pipelines/templates/steps/use-python-version.yml
@@ -2,10 +2,11 @@ parameters:
   versionSpec: ''
 
 steps:
+  # Using built-in Azure DevOps tasks can result in auto-retrieval of packages like pip from pypi.
+  # Override the PIP_INDEX_URL ASAP so that these auto-restores do not fail in isolated networks.
   - pwsh: |
       Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
-    displayName: 'Activate PIP_INDEX URL so that python 3.9 is able to find the correct version of pip.'
-    condition: eq('${{ parameters.versionSpec }}', '3.9')
+    displayName: 'Use Public Feed'
 
   - task: UsePythonVersion@0
     displayName: "Use Python ${{ parameters.versionSpec }}"

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -13,8 +13,6 @@ build==1.2.2.post1
 
 Jinja2==3.1.6
 json-delta==2.0.2
-readme_renderer==43.0
 python-dotenv==1.0.1
 pyyaml==6.0.2
 urllib3==2.2.3
-six==1.17.0

--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -24,7 +24,7 @@
         "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
       }
     },
-    "PythonVersion": ["pypy3.9", "3.10", "3.11"],
+    "PythonVersion": ["pypy3.11", "3.10", "3.11"],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },


### PR DESCRIPTION
- [x] Two dependencies that are not necessary and breaking `Prep Environment` in [some situations](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6182667&view=logs&j=d049a9a1-4a4a-5c37-2173-6c4a695afdc9&t=66ccb18b-679a-5648-fe09-daa15d79d726)
- [x] We no longer use pypy39 anywhere, we can remove the mac installation that was bypassing known issues.
- [x] Set `PIP_INDEX_URL` with a default, so that when the `ADO task` runs `ensurepip` it doesn't hit CFS issues when activating an older version [as seen here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6182667&view=logs&j=e38a44e6-0f54-58d1-2ed6-3dd6c3f1b1bd&t=e9052853-299d-5330-7898-0434c8d32fbf).

Both `transcription` issues are resolved, proof here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6183487&view=results

 
