### PR TITLE
Text translation v2 ga

### DIFF
--- a/sdk/translation/azure-ai-translation-text/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-text/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2026-6-06)
+## 2.0.0 (2026-06-06)
 
 ### Features Added
 

--- a/sdk/translation/azure-ai-translation-text/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-text/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+## 2.0.0 (2026-6-06)
+
+### Features Added
+
+- GA release of Azure AI Translator Text Translation SDK version 2.0.0.
+- Updated to stable API version 2026-06-06.
+- Added `TranslationTone` and `TranslationGender` enums for type-safe tone and gender options.
+
+### Breaking Changes
+
+- Removed `grade` parameter from translation options.
+
+### Other Changes
+
+- Simplified client constructor and internal authentication handling.
+
 ## 2.0.0b1 (2026-01-08)
 
 ### Features Added

--- a/sdk/translation/azure-ai-translation-text/_metadata.json
+++ b/sdk/translation/azure-ai-translation-text/_metadata.json
@@ -1,3 +1,6 @@
 {
-  "apiVersion": "2025-10-01-preview"
+  "apiVersion": "2026-06-06",
+  "apiVersions": {
+    "TextTranslation": "2026-06-06"
+  }
 }

--- a/sdk/translation/azure-ai-translation-text/apiview-properties.json
+++ b/sdk/translation/azure-ai-translation-text/apiview-properties.json
@@ -24,6 +24,8 @@
         "azure.ai.translation.text.models.TextType": "TextTranslation.TextType",
         "azure.ai.translation.text.models.ProfanityAction": "TextTranslation.ProfanityAction",
         "azure.ai.translation.text.models.ProfanityMarker": "TextTranslation.ProfanityMarker",
+        "azure.ai.translation.text.models.TranslationTone": "TextTranslation.TranslationTone",
+        "azure.ai.translation.text.models.TranslationGender": "TextTranslation.TranslationGender",
         "azure.ai.translation.text.TextTranslationClient.get_supported_languages": "TextTranslation.getSupportedLanguages",
         "azure.ai.translation.text.aio.TextTranslationClient.get_supported_languages": "TextTranslation.getSupportedLanguages",
         "azure.ai.translation.text.TextTranslationClient.translate": "TextTranslation.translate",

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_client.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_client.py
@@ -7,10 +7,11 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING, Union
 from typing_extensions import Self
 
 from azure.core import PipelineClient
+from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline import policies
 from azure.core.rest import HttpRequest, HttpResponse
 
@@ -18,40 +19,34 @@ from ._configuration import TextTranslationClientConfiguration
 from ._operations import _TextTranslationClientOperationsMixin
 from ._utils.serialization import Deserializer, Serializer
 
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
+
 
 class TextTranslationClient(_TextTranslationClientOperationsMixin):
-    """Text translation is a cloud-based REST API feature of the Translator service that uses neural
-    machine translation technology to enable quick and accurate source-to-target text translation
-    in real time across all supported languages.
-
-    The following methods are supported by the Text Translation feature:
-
-    Languages. Returns a list of languages supported by Translate, Transliterate, and Dictionary
-    Lookup operations.
-
-    Translate. Renders single source-language text to multiple target-language texts with a single
-    request.
-
-    Transliterate. Converts characters or letters of a source language to the corresponding
-    characters or letters of a target language.
-
-    Detect. Returns the source code language code and a boolean variable denoting whether the
-    detected language is supported for text translation and transliteration.
+    """Azure Translator is a cloud-based, multilingual, neural machine translation service. The Text
+    Translation API enables robust and scalable translation capabilities suitable for diverse
+    applications.
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-         `https://api.cognitive.microsofttranslator.com
+     `https://api.cognitive.microsofttranslator.com
      <https://api.cognitive.microsofttranslator.com>`_). Required.
     :type endpoint: str
-    :keyword api_version: Mandatory API version parameter. Default value is "2025-10-01-preview".
-     Note that overriding this default value may result in unsupported behavior.
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Default value is None.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials.TokenCredential
+    :keyword api_version: Mandatory API version parameter. Known values are "2026-06-06". Default
+     value is "2026-06-06". Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
-    def __init__(  # pylint: disable=missing-client-constructor-parameter-credential
-        self, endpoint: str, **kwargs: Any
+    def __init__(
+        self, endpoint: str, credential: Optional[Union[AzureKeyCredential, "TokenCredential"]] = None, **kwargs: Any
     ) -> None:
         _endpoint = "{Endpoint}"
-        self._config = TextTranslationClientConfiguration(endpoint=endpoint, **kwargs)
+        self._config = TextTranslationClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
 
         _policies = kwargs.pop("policies", None)
         if _policies is None:

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_configuration.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_configuration.py
@@ -6,11 +6,15 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING, Union
 
+from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline import policies
 
 from ._version import VERSION
+
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
 
 
 class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-attributes
@@ -20,25 +24,41 @@ class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-a
     attributes.
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-         `https://api.cognitive.microsofttranslator.com
+     `https://api.cognitive.microsofttranslator.com
      <https://api.cognitive.microsofttranslator.com>`_). Required.
     :type endpoint: str
-    :keyword api_version: Mandatory API version parameter. Default value is "2025-10-01-preview".
-     Note that overriding this default value may result in unsupported behavior.
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Default value is None.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials.TokenCredential
+    :keyword api_version: Mandatory API version parameter. Known values are "2026-06-06". Default
+     value is "2026-06-06". Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
-    def __init__(self, endpoint: str, **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-10-01-preview")
+    def __init__(
+        self, endpoint: str, credential: Optional[Union[AzureKeyCredential, "TokenCredential"]] = None, **kwargs: Any
+    ) -> None:
+        api_version: str = kwargs.pop("api_version", "2026-06-06")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
 
         self.endpoint = endpoint
+        self.credential = credential
         self.api_version = api_version
+        self.credential_scopes = kwargs.pop("credential_scopes", ["https://cognitiveservices.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "ai-translation-text/{}".format(VERSION))
         self.polling_interval = kwargs.get("polling_interval", 30)
         self._configure(**kwargs)
+
+    def _infer_policy(self, **kwargs):
+        if isinstance(self.credential, AzureKeyCredential):
+            return policies.AzureKeyCredentialPolicy(self.credential, "Ocp-Apim-Subscription-Key", **kwargs)
+        if hasattr(self.credential, "get_token"):
+            return policies.BearerTokenCredentialPolicy(self.credential, *self.credential_scopes, **kwargs)
+        raise TypeError(f"Unsupported credential: {self.credential}")
 
     def _configure(self, **kwargs: Any) -> None:
         self.user_agent_policy = kwargs.get("user_agent_policy") or policies.UserAgentPolicy(**kwargs)
@@ -50,3 +70,5 @@ class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-a
         self.redirect_policy = kwargs.get("redirect_policy") or policies.RedirectPolicy(**kwargs)
         self.retry_policy = kwargs.get("retry_policy") or policies.RetryPolicy(**kwargs)
         self.authentication_policy = kwargs.get("authentication_policy")
+        if self.credential and not self.authentication_policy:
+            self.authentication_policy = self._infer_policy(**kwargs)

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_model_base.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_model_base.py
@@ -687,6 +687,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it optional?
     try:
+        # pylint: disable=unidiomatic-typecheck
         if any(a for a in annotation.__args__ if a == type(None)):  # pyright: ignore
             if len(annotation.__args__) <= 2:  # pyright: ignore
                 if_obj_deserializer = _get_deserialize_callable_from_annotation(
@@ -697,6 +698,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
             # the type is Optional[Union[...]], we need to remove the None type from the Union
             annotation_copy = copy.copy(annotation)
             annotation_copy.__args__ = [a for a in annotation_copy.__args__ if a != type(None)]  # pyright: ignore
+            # pylint: enable=unidiomatic-typecheck
             return _get_deserialize_callable_from_annotation(annotation_copy, module, rf)
     except AttributeError:
         pass

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_operations.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_operations.py
@@ -54,7 +54,7 @@ def build_text_translation_get_supported_languages_request(  # pylint: disable=n
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-10-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-06-06"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -86,7 +86,7 @@ def build_text_translation_translate_request(*, client_trace_id: Optional[str] =
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-10-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-06-06"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -112,7 +112,7 @@ def build_text_translation_transliterate_request(  # pylint: disable=name-too-lo
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-10-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-06-06"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -218,6 +218,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -243,7 +244,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["ETag"] = self._deserialize("str", response.headers.get("ETag"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.GetSupportedLanguagesResult, response.json())
 
@@ -334,7 +335,7 @@ class _TextTranslationClientOperationsMixin(
     @api_version_validation(
         method_added_on="2025-10-01-preview",
         params_added_on={"2025-10-01-preview": ["client_trace_id", "api_version", "content_type", "accept"]},
-        api_versions_list=["2025-10-01-preview"],
+        api_versions_list=["2025-10-01-preview", "2026-06-06"],
     )
     def translate(
         self,
@@ -391,6 +392,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -417,7 +419,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["x-metered-usage"] = self._deserialize("int", response.headers.get("x-metered-usage"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.TranslationResult, response.json())
 
@@ -563,7 +565,7 @@ class _TextTranslationClientOperationsMixin(
                 "accept",
             ]
         },
-        api_versions_list=["2025-10-01-preview"],
+        api_versions_list=["2025-10-01-preview", "2026-06-06"],
     )
     def transliterate(
         self,
@@ -638,6 +640,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -662,7 +665,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["X-RequestId"] = self._deserialize("str", response.headers.get("X-RequestId"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.TransliterateResult, response.json())
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_patch.py
@@ -193,6 +193,32 @@ class _TextTranslationClientOperationsMixin(
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
+    @overload  # type: ignore[override]
+    def translate(
+        self,
+        body: IO[bytes],
+        *,
+        client_trace_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> List[_models.TranslatedTextItem]:
+        """Translate text.
+
+        Translates text using a raw bytes stream as the request body.
+
+        :param body: The request body as a file-like stream of bytes. Required.
+        :type body: IO[bytes]
+        :keyword client_trace_id: A client-generated GUID to uniquely identify the request. Default
+         value is None.
+        :paramtype client_trace_id: str
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: list of TranslatedTextItem
+        :rtype: list[~azure.ai.translation.text.models.TranslatedTextItem]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
     def translate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         body: Union[List[str], List[_models.TranslateInputItem], JSON, IO[bytes]],
@@ -331,6 +357,47 @@ class _TextTranslationClientOperationsMixin(
 
         :param body: JSON body containing transliteration request. Required.
         :type body: JSON
+        :keyword language: Specifies the language of the text to convert from one script to another.
+         Possible languages are listed in the transliteration scope obtained by querying the service
+         for its supported languages. Required.
+        :paramtype language: str
+        :keyword from_script: Specifies the script used by the input text. Look up supported languages
+         using the transliteration scope,
+         to find input scripts available for the selected language. Required.
+        :paramtype from_script: str
+        :keyword to_script: Specifies the output script. Look up supported languages using the
+         transliteration scope, to find output
+         scripts available for the selected combination of input language and input script. Required.
+        :paramtype to_script: str
+        :keyword client_trace_id: A client-generated GUID to uniquely identify the request. Default
+         value is None.
+        :paramtype client_trace_id: str
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: list of TransliteratedText
+        :rtype: list[~azure.ai.translation.text.models.TransliteratedText]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload  # type: ignore[override]
+    def transliterate(
+        self,
+        body: IO[bytes],
+        *,
+        language: str,
+        from_script: str,
+        to_script: str,
+        client_trace_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> List[_models.TransliteratedText]:
+        """Transliterate Text.
+
+        Transliterates text using a raw bytes stream as the request body.
+
+        :param body: The request body as a file-like stream of bytes. Required.
+        :type body: IO[bytes]
         :keyword language: Specifies the language of the text to convert from one script to another.
          Possible languages are listed in the transliteration scope obtained by querying the service
          for its supported languages. Required.

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_operations/_patch.py
@@ -28,7 +28,9 @@ class _TextTranslationClientOperationsMixin(
 ):
     """Mixin class that delegates to the generated operations class while providing custom method signatures."""
 
-    def _get_generated_operations(self) -> _TextTranslationClientOperationsMixinGenerated:  # pylint: disable=protected-access
+    def _get_generated_operations(
+        self,
+    ) -> _TextTranslationClientOperationsMixinGenerated:  # pylint: disable=protected-access
         """Get an instance of the generated operations mixin.
 
         This creates a wrapper object that shares the same _client, _config, _serialize, and _deserialize

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -55,13 +55,14 @@ class TextTranslationClient(ServiceClientGenerated):
 
     Combinations of endpoint and credential values:
 
-    - endpoint + AzureKeyCredential - custom domain translator endpoint
-    - endpoint + AzureKeyCredential + region - global translator endpoint with regional resource
-    - endpoint + TokenCredential - regional endpoint with token authentication
-    - endpoint + None - on-prem container (no authentication)
-    - AzureKeyCredential only - global translator endpoint with global Translator resource (uses default endpoint)
-    - TokenCredential only - global translator endpoint with token authentication (uses default endpoint)
-    - TokenCredential + region + resource_id - global translator endpoint with regional Translator resource
+    - (no args) - global endpoint, no auth (get_languages only)
+    - endpoint only - custom endpoint or container, no auth
+    - AzureKeyCredential + region - global endpoint with subscription key
+    - TokenCredential + audience - global endpoint with Cognitive Services token
+    - TokenCredential + resource_id - global endpoint with Entra ID (global resource)
+    - TokenCredential + region + resource_id - global endpoint with Entra ID (regional resource)
+    - endpoint + AzureKeyCredential - custom endpoint with subscription key
+    - endpoint + TokenCredential - custom endpoint with Entra ID
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
      https://api.cognitive.microsofttranslator.com). Defaults to the global translator endpoint.
@@ -69,9 +70,9 @@ class TextTranslationClient(ServiceClientGenerated):
     :param credential: Credential used to authenticate with the Translator service. Optional for
      unauthenticated operations like get_languages.
     :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials.TokenCredential or None
-    :param region: Azure region of the Translator resource, required when using global endpoint with regional resource.
+    :param region: Azure region of the Translator resource. Required for AzureKeyCredential, optional for Entra ID regional resources.
     :type region: str or None
-    :param resource_id: Azure resource ID, required with TokenCredential when using global endpoint with regional resource.
+    :param resource_id: Azure resource ID for Entra ID authentication. Required when using TokenCredential with global endpoint.
     :type resource_id: str or None
     :param audience: Scopes of the credentials.
     :type audience: str or None
@@ -91,8 +92,9 @@ class TextTranslationClient(ServiceClientGenerated):
         api_version: str = "2026-06-06",
         **kwargs: Any,
     ) -> None:
-        if resource_id and not region:
-            raise ValueError("'region' must be provided when 'resource_id' is specified.")
+        # Validate credential + region/resource_id combinations
+        if region and credential is not None and not isinstance(credential, AzureKeyCredential) and not resource_id:
+            raise ValueError("'resource_id' must be provided when using TokenCredential with 'region'.")
 
         translation_endpoint = get_translation_endpoint(endpoint, api_version)
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -42,7 +42,15 @@ class TranslatorHeaderPolicy(SansIOHTTPPolicy):
 
 
 def get_translation_endpoint(endpoint: str, api_version: str) -> str:
-    """Transform cognitive services endpoint to translator-specific path if needed."""
+    """Transform cognitive services endpoint to translator-specific path if needed.
+
+    :param endpoint: The base endpoint URL.
+    :type endpoint: str
+    :param api_version: The API version string.
+    :type api_version: str
+    :return: The transformed endpoint URL.
+    :rtype: str
+    """
     if "cognitiveservices" in endpoint:
         return endpoint + "/translator/text/v" + api_version
     return endpoint
@@ -69,10 +77,13 @@ class TextTranslationClient(ServiceClientGenerated):
     :type endpoint: str
     :param credential: Credential used to authenticate with the Translator service. Optional for
      unauthenticated operations like get_languages.
-    :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials.TokenCredential or None
-    :param region: Azure region of the Translator resource. Required for AzureKeyCredential, optional for Entra ID regional resources.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials.TokenCredential or None
+    :param region: Azure region of the Translator resource. Required for AzureKeyCredential,
+     optional for Entra ID regional resources.
     :type region: str or None
-    :param resource_id: Azure resource ID for Entra ID authentication. Required when using TokenCredential with global endpoint.
+    :param resource_id: Azure resource ID for Entra ID authentication. Required when using
+     TokenCredential with global endpoint.
     :type resource_id: str or None
     :param audience: Scopes of the credentials.
     :type audience: str or None

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -4,15 +4,12 @@
 # ------------------------------------
 # pylint: disable=C4717, C4722, C4748
 
-from typing import Optional, Any, overload
+from typing import Optional, Any, Union, List
 from azure.core.pipeline import PipelineRequest
-from azure.core.pipeline.policies import SansIOHTTPPolicy, BearerTokenCredentialPolicy, AzureKeyCredentialPolicy
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.credentials import TokenCredential, AzureKeyCredential
 
 from ._client import TextTranslationClient as ServiceClientGenerated
-
-DEFAULT_ENTRA_ID_SCOPE = "https://cognitiveservices.azure.com"
-DEFAULT_SCOPE = "/.default"
 
 
 def patch_sdk():
@@ -24,178 +21,96 @@ def patch_sdk():
     """
 
 
-class TranslatorAuthenticationPolicy(SansIOHTTPPolicy):
-    """Translator Authentication Policy. Adds both authentication headers that are required.
-    Ocp-Apim-Subscription-Region header contains region of the Translator resource.
-    Ocp-Apim-Subscription-Key header contains API key of the Translator resource.
+class TranslatorHeaderPolicy(SansIOHTTPPolicy):
+    """Adds Translator-specific headers for regional resources.
+
+    :param region: Azure region of the Translator resource.
+    :type region: str or None
+    :param resource_id: Azure resource ID of the Translator resource.
+    :type resource_id: str or None
     """
 
-    def __init__(self, credential: AzureKeyCredential, region: str):
-        self.credential = credential
+    def __init__(self, region: Optional[str] = None, resource_id: Optional[str] = None):
         self.region = region
-
-    def on_request(self, request: PipelineRequest) -> None:
-        request.http_request.headers["Ocp-Apim-Subscription-Key"] = self.credential.key
-        request.http_request.headers["Ocp-Apim-Subscription-Region"] = self.region
-
-
-class TranslatorEntraIdAuthenticationPolicy(BearerTokenCredentialPolicy):
-    """Translator EntraId Authentication Policy. Adds headers that are required by Translator Service
-    when global endpoint is used with Entra Id policy.
-    Ocp-Apim-Subscription-Region header contains region of the Translator resource.
-    Ocp-Apim-ResourceId header contains Azure resource Id - Translator resource.
-
-    :param credential: Translator Entra Id Credentials used to access Translator Resource for global endpoint.
-    :type credential: ~azure.core.credentials.TokenCredential
-    :keyword str region: Used for National Clouds.
-    :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audience: Scopes of the credentials.
-    """
-
-    def __init__(
-        self, credential: TokenCredential, resource_id: str, region: str, audience: str, **kwargs: Any
-    ) -> None:
-        super(TranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audience, **kwargs)
         self.resource_id = resource_id
-        self.region = region
-        self.translator_credential = credential
 
     def on_request(self, request: PipelineRequest) -> None:
-        request.http_request.headers["Ocp-Apim-ResourceId"] = self.resource_id
-        request.http_request.headers["Ocp-Apim-Subscription-Region"] = self.region
-        super().on_request(request)
+        if self.region:
+            request.http_request.headers["Ocp-Apim-Subscription-Region"] = self.region
+        if self.resource_id:
+            request.http_request.headers["Ocp-Apim-ResourceId"] = self.resource_id
 
 
-def get_translation_endpoint(endpoint, api_version):
-    if not endpoint:
-        endpoint = "https://api.cognitive.microsofttranslator.com"
-
-    translator_endpoint: str = ""
+def get_translation_endpoint(endpoint: str, api_version: str) -> str:
+    """Transform cognitive services endpoint to translator-specific path if needed."""
     if "cognitiveservices" in endpoint:
-        translator_endpoint = endpoint + "/translator/text/v" + api_version
-    else:
-        translator_endpoint = endpoint
-
-    return translator_endpoint
-
-
-def is_cognitive_services_scope(audience: str) -> bool:
-    if "microsofttranslator" in audience:
-        return True
-
-    return False
-
-
-def set_authentication_policy(credential, kwargs):
-    if isinstance(credential, AzureKeyCredential):
-        if not kwargs.get("authentication_policy"):
-            if kwargs.get("region"):
-                kwargs["authentication_policy"] = TranslatorAuthenticationPolicy(credential, kwargs["region"])
-            else:
-                kwargs["authentication_policy"] = AzureKeyCredentialPolicy(
-                    name="Ocp-Apim-Subscription-Key", credential=credential
-                )
-    elif hasattr(credential, "get_token"):
-        if not kwargs.get("authentication_policy"):
-            if kwargs.get("region") and kwargs.get("resource_id"):
-                scope = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE).rstrip("/").rstrip(DEFAULT_SCOPE) + DEFAULT_SCOPE
-                kwargs["authentication_policy"] = TranslatorEntraIdAuthenticationPolicy(
-                    credential,
-                    kwargs["resource_id"],
-                    kwargs["region"],
-                    scope,
-                )
-            else:
-                if kwargs.get("resource_id") or kwargs.get("region"):
-                    raise ValueError(
-                        """Both 'resource_id' and 'region' must be provided with a TokenCredential for
-                         regional resource authentication."""
-                    )
-                scope: str = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE)
-                if not is_cognitive_services_scope(scope):
-                    scope = scope.rstrip("/").rstrip(DEFAULT_SCOPE) + DEFAULT_SCOPE
-
-                kwargs["authentication_policy"] = BearerTokenCredentialPolicy(credential, scope)
+        return endpoint + "/translator/text/v" + api_version
+    return endpoint
 
 
 class TextTranslationClient(ServiceClientGenerated):
-    """Text translation is a cloud-based REST API feature of the Translator service that uses neural
-    machine translation technology to enable quick and accurate source-to-target text translation
-    in real time across all supported languages.
-
-    The following methods are supported by the Text Translation feature:
-
-    Languages. Returns a list of languages supported by Translate, Transliterate, and Dictionary
-    Lookup operations.
-
-    Translate. Renders single source-language text to multiple target-language texts with a single
-    request.
-
-    Transliterate. Converts characters or letters of a source language to the corresponding
-    characters or letters of a target language.
-
-    Detect. Returns the source code language code and a boolean variable denoting whether the
-    detected language is supported for text translation and transliteration.
-
-    Dictionary lookup. Returns equivalent words for the source term in the target language.
-
-    Dictionary example Returns grammatical structure and context examples for the source term and
-    target term pair.
+    """Azure Translator is a cloud-based, multilingual, neural machine translation service. The Text
+    Translation API enables robust and scalable translation capabilities suitable for diverse
+    applications.
 
     Combinations of endpoint and credential values:
-    str + AzureKeyCredential - used custom domain translator endpoint
-    str + AzureKeyCredential + Region - used for global translator endpoint
-    str + TokenCredential - used for regional endpoint with token authentication
-    str + None - used with text translation on-prem container
-    None + AzureKeyCredential - used for global translator endpoint with global Translator resource
-    None + TokenCredential - general translator endpoint with token authentication
-    None + TokenCredential + Region - general translator endpoint with regional Translator resource
 
-    :keyword str endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-     https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
-    :keyword credential: Credential used to authenticate with the Translator service
-    :paramtype credential: Union[AzureKeyCredential, TokenCredential]
-    :keyword str region: Used for National Clouds.
-    :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audience: Scopes of the credentials.
-    :keyword  str api_version: Default value is "2025-10-01-preview". Note that overriding this default value may
+    - endpoint + AzureKeyCredential - custom domain translator endpoint
+    - endpoint + AzureKeyCredential + region - global translator endpoint with regional resource
+    - endpoint + TokenCredential - regional endpoint with token authentication
+    - endpoint + None - on-prem container (no authentication)
+    - AzureKeyCredential only - global translator endpoint with global Translator resource (uses default endpoint)
+    - TokenCredential only - global translator endpoint with token authentication (uses default endpoint)
+    - TokenCredential + region + resource_id - global translator endpoint with regional Translator resource
+
+    :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
+     https://api.cognitive.microsofttranslator.com). Defaults to the global translator endpoint.
+    :type endpoint: str
+    :param credential: Credential used to authenticate with the Translator service. Optional for
+     unauthenticated operations like get_languages.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials.TokenCredential or None
+    :param region: Azure region of the Translator resource, required when using global endpoint with regional resource.
+    :type region: str or None
+    :param resource_id: Azure resource ID, required with TokenCredential when using global endpoint with regional resource.
+    :type resource_id: str or None
+    :param audience: Scopes of the credentials.
+    :type audience: str or None
+    :param api_version: Default value is "2026-06-06". Note that overriding this default value may
      result in unsupported behavior.
+    :type api_version: str
     """
 
-    @overload
     def __init__(
         self,
+        endpoint: str = "https://api.cognitive.microsofttranslator.com",
+        credential: Optional[Union[AzureKeyCredential, TokenCredential]] = None,
         *,
-        credential: TokenCredential,
         region: Optional[str] = None,
-        endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
         audience: Optional[str] = None,
-        api_version: str = "2025-10-01-preview",
-        **kwargs
-    ): ...
+        api_version: str = "2026-06-06",
+        **kwargs: Any,
+    ) -> None:
+        if resource_id and not region:
+            raise ValueError("'region' must be provided when 'resource_id' is specified.")
 
-    @overload
-    def __init__(
-        self,
-        *,
-        credential: AzureKeyCredential,
-        region: Optional[str] = None,
-        endpoint: Optional[str] = None,
-        api_version: str = "2025-10-01-preview",
-        **kwargs
-    ): ...
+        translation_endpoint = get_translation_endpoint(endpoint, api_version)
 
-    @overload
-    def __init__(self, *, endpoint: str, api_version: str = "2025-10-01-preview", **kwargs): ...
+        # Add translator-specific header policy for regional resources
+        if region or resource_id:
+            per_call_policies: List[SansIOHTTPPolicy] = list(kwargs.pop("per_call_policies", []) or [])
+            per_call_policies.insert(0, TranslatorHeaderPolicy(region=region, resource_id=resource_id))
+            kwargs["per_call_policies"] = per_call_policies
 
-    def __init__(self, **kwargs):
-        api_version = kwargs.get("api_version", "2025-10-01-preview")
-        set_authentication_policy(kwargs.get("credential"), kwargs)
-        translation_endpoint = get_translation_endpoint(
-            kwargs.pop("endpoint", "https://api.cognitive.microsofttranslator.com"), api_version
+        if audience:
+            kwargs["credential_scopes"] = [audience]
+
+        super().__init__(
+            endpoint=translation_endpoint,
+            credential=credential,
+            api_version=api_version,
+            **kwargs,
         )
-        super().__init__(endpoint=translation_endpoint, api_version=api_version, **kwargs)
 
 
 __all__ = ["TextTranslationClient"]

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_serialization.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_serialization.py
@@ -810,7 +810,7 @@ class Serializer(object):
             # If dependencies is empty, try with current data class
             # It has to be a subclass of Enum anyway
             enum_type = self.dependencies.get(data_type, data.__class__)
-            if issubclass(enum_type, Enum):
+            if enum_type and issubclass(enum_type, Enum):
                 return Serializer.serialize_enum(data, enum_obj=enum_type)
 
             iter_type = data_type[0] + data_type[-1]

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_utils/model_base.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_utils/model_base.py
@@ -37,6 +37,7 @@ __all__ = ["SdkJSONEncoder", "Model", "rest_field", "rest_discriminator"]
 
 TZ_UTC = timezone.utc
 _T = typing.TypeVar("_T")
+_NONE_TYPE = type(None)
 
 
 def _timedelta_as_isostr(td: timedelta) -> str:
@@ -171,6 +172,21 @@ _VALID_RFC7231 = re.compile(
     r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}\s\d{2}:\d{2}:\d{2}\sGMT"
 )
 
+_ARRAY_ENCODE_MAPPING = {
+    "pipeDelimited": "|",
+    "spaceDelimited": " ",
+    "commaDelimited": ",",
+    "newlineDelimited": "\n",
+}
+
+
+def _deserialize_array_encoded(delimit: str, attr):
+    if isinstance(attr, str):
+        if attr == "":
+            return []
+        return attr.split(delimit)
+    return attr
+
 
 def _deserialize_datetime(attr: typing.Union[str, datetime]) -> datetime:
     """Deserialize ISO-8601 formatted string into Datetime object.
@@ -202,7 +218,7 @@ def _deserialize_datetime(attr: typing.Union[str, datetime]) -> datetime:
     test_utc = date_obj.utctimetuple()
     if test_utc.tm_year > 9999 or test_utc.tm_year < 1:
         raise OverflowError("Hit max or min date")
-    return date_obj
+    return date_obj  # type: ignore[no-any-return]
 
 
 def _deserialize_datetime_rfc7231(attr: typing.Union[str, datetime]) -> datetime:
@@ -256,7 +272,7 @@ def _deserialize_time(attr: typing.Union[str, time]) -> time:
     """
     if isinstance(attr, time):
         return attr
-    return isodate.parse_time(attr)
+    return isodate.parse_time(attr)  # type: ignore[no-any-return]
 
 
 def _deserialize_bytes(attr):
@@ -315,6 +331,8 @@ _DESERIALIZE_MAPPING_WITHFORMAT = {
 def get_deserializer(annotation: typing.Any, rf: typing.Optional["_RestField"] = None):
     if annotation is int and rf and rf._format == "str":
         return _deserialize_int_as_str
+    if annotation is str and rf and rf._format in _ARRAY_ENCODE_MAPPING:
+        return functools.partial(_deserialize_array_encoded, _ARRAY_ENCODE_MAPPING[rf._format])
     if rf and rf._format:
         return _DESERIALIZE_MAPPING_WITHFORMAT.get(rf._format)
     return _DESERIALIZE_MAPPING.get(annotation)  # pyright: ignore
@@ -353,9 +371,39 @@ class _MyMutableMapping(MutableMapping[str, typing.Any]):
         return key in self._data
 
     def __getitem__(self, key: str) -> typing.Any:
+        # If this key has been deserialized (for mutable types), we need to handle serialization
+        if hasattr(self, "_attr_to_rest_field"):
+            cache_attr = f"_deserialized_{key}"
+            if hasattr(self, cache_attr):
+                rf = _get_rest_field(getattr(self, "_attr_to_rest_field"), key)
+                if rf:
+                    value = self._data.get(key)
+                    if isinstance(value, (dict, list, set)):
+                        # For mutable types, serialize and return
+                        # But also update _data with serialized form and clear flag
+                        # so mutations via this returned value affect _data
+                        serialized = _serialize(value, rf._format)
+                        # If serialized form is same type (no transformation needed),
+                        # return _data directly so mutations work
+                        if isinstance(serialized, type(value)) and serialized == value:
+                            return self._data.get(key)
+                        # Otherwise return serialized copy and clear flag
+                        try:
+                            object.__delattr__(self, cache_attr)
+                        except AttributeError:
+                            pass
+                        # Store serialized form back
+                        self._data[key] = serialized
+                        return serialized
         return self._data.__getitem__(key)
 
     def __setitem__(self, key: str, value: typing.Any) -> None:
+        # Clear any cached deserialized value when setting through dictionary access
+        cache_attr = f"_deserialized_{key}"
+        try:
+            object.__delattr__(self, cache_attr)
+        except AttributeError:
+            pass
         self._data.__setitem__(key, value)
 
     def __delitem__(self, key: str) -> None:
@@ -467,6 +515,8 @@ class _MyMutableMapping(MutableMapping[str, typing.Any]):
         return self._data.setdefault(key, default)
 
     def __eq__(self, other: typing.Any) -> bool:
+        if isinstance(other, _MyMutableMapping):
+            return self._data == other._data
         try:
             other_model = self.__class__(other)
         except Exception:
@@ -483,6 +533,8 @@ def _is_model(obj: typing.Any) -> bool:
 
 def _serialize(o, format: typing.Optional[str] = None):  # pylint: disable=too-many-return-statements
     if isinstance(o, list):
+        if format in _ARRAY_ENCODE_MAPPING and all(isinstance(x, str) for x in o):
+            return _ARRAY_ENCODE_MAPPING[format].join(o)
         return [_serialize(x, format) for x in o]
     if isinstance(o, dict):
         return {k: _serialize(v, format) for k, v in o.items()}
@@ -578,6 +630,9 @@ class Model(_MyMutableMapping):
                         if len(items) > 0:
                             existed_attr_keys.append(xml_name)
                             dict_to_pass[rf._rest_name] = _deserialize(rf._type, items)
+                        elif not rf._is_optional:
+                            existed_attr_keys.append(xml_name)
+                            dict_to_pass[rf._rest_name] = []
                         continue
 
                     # text element is primitive type
@@ -758,6 +813,14 @@ def _deserialize_multiple_sequence(
     return type(obj)(_deserialize(deserializer, entry, module) for entry, deserializer in zip(obj, entry_deserializers))
 
 
+def _is_array_encoded_deserializer(deserializer: functools.partial) -> bool:
+    return (
+        isinstance(deserializer, functools.partial)
+        and isinstance(deserializer.args[0], functools.partial)
+        and deserializer.args[0].func == _deserialize_array_encoded  # pylint: disable=comparison-with-callable
+    )
+
+
 def _deserialize_sequence(
     deserializer: typing.Optional[typing.Callable],
     module: typing.Optional[str],
@@ -767,6 +830,19 @@ def _deserialize_sequence(
         return obj
     if isinstance(obj, ET.Element):
         obj = list(obj)
+
+    # encoded string may be deserialized to sequence
+    if isinstance(obj, str) and isinstance(deserializer, functools.partial):
+        # for list[str]
+        if _is_array_encoded_deserializer(deserializer):
+            return deserializer(obj)
+
+        # for list[Union[...]]
+        if isinstance(deserializer.args[0], list):
+            for sub_deserializer in deserializer.args[0]:
+                if _is_array_encoded_deserializer(sub_deserializer):
+                    return sub_deserializer(obj)
+
     return type(obj)(_deserialize(deserializer, entry, module) for entry in obj)
 
 
@@ -817,16 +893,18 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=too-many-retur
 
     # is it optional?
     try:
-        if any(a for a in annotation.__args__ if a == type(None)):  # pyright: ignore
+        if any(a is _NONE_TYPE for a in annotation.__args__):  # pyright: ignore
+            if rf:
+                rf._is_optional = True
             if len(annotation.__args__) <= 2:  # pyright: ignore
                 if_obj_deserializer = _get_deserialize_callable_from_annotation(
-                    next(a for a in annotation.__args__ if a != type(None)), module, rf  # pyright: ignore
+                    next(a for a in annotation.__args__ if a is not _NONE_TYPE), module, rf  # pyright: ignore
                 )
 
                 return functools.partial(_deserialize_with_optional, if_obj_deserializer)
             # the type is Optional[Union[...]], we need to remove the None type from the Union
             annotation_copy = copy.copy(annotation)
-            annotation_copy.__args__ = [a for a in annotation_copy.__args__ if a != type(None)]  # pyright: ignore
+            annotation_copy.__args__ = [a for a in annotation_copy.__args__ if a is not _NONE_TYPE]  # pyright: ignore
             return _get_deserialize_callable_from_annotation(annotation_copy, module, rf)
     except AttributeError:
         pass
@@ -910,16 +988,20 @@ def _deserialize_with_callable(
                 return float(value.text) if value.text else None
             if deserializer is bool:
                 return value.text == "true" if value.text else None
+            if deserializer and deserializer in _DESERIALIZE_MAPPING.values():
+                return deserializer(value.text) if value.text else None
+            if deserializer and deserializer in _DESERIALIZE_MAPPING_WITHFORMAT.values():
+                return deserializer(value.text) if value.text else None
         if deserializer is None:
             return value
         if deserializer in [int, float, bool]:
             return deserializer(value)
         if isinstance(deserializer, CaseInsensitiveEnumMeta):
             try:
-                return deserializer(value)
+                return deserializer(value.text if isinstance(value, ET.Element) else value)
             except ValueError:
                 # for unknown value, return raw value
-                return value
+                return value.text if isinstance(value, ET.Element) else value
         if isinstance(deserializer, type) and issubclass(deserializer, Model):
             return deserializer._deserialize(value, [])
         return typing.cast(typing.Callable[[typing.Any], typing.Any], deserializer)(value)
@@ -952,7 +1034,7 @@ def _failsafe_deserialize(
 ) -> typing.Any:
     try:
         return _deserialize(deserializer, response.json(), module, rf, format)
-    except DeserializationError:
+    except Exception:  # pylint: disable=broad-except
         _LOGGER.warning(
             "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
         )
@@ -965,13 +1047,14 @@ def _failsafe_deserialize_xml(
 ) -> typing.Any:
     try:
         return _deserialize_xml(deserializer, response.text())
-    except DeserializationError:
+    except Exception:  # pylint: disable=broad-except
         _LOGGER.warning(
             "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
         )
         return None
 
 
+# pylint: disable=too-many-instance-attributes
 class _RestField:
     def __init__(
         self,
@@ -991,6 +1074,7 @@ class _RestField:
         self._is_discriminator = is_discriminator
         self._visibility = visibility
         self._is_model = False
+        self._is_optional = False
         self._default = default
         self._format = format
         self._is_multipart_file_input = is_multipart_file_input
@@ -998,7 +1082,11 @@ class _RestField:
 
     @property
     def _class_type(self) -> typing.Any:
-        return getattr(self._type, "args", [None])[0]
+        result = getattr(self._type, "args", [None])[0]
+        # type may be wrapped by nested functools.partial so we need to check for that
+        if isinstance(result, functools.partial):
+            return getattr(result, "args", [None])[0]
+        return result
 
     @property
     def _rest_name(self) -> str:
@@ -1009,14 +1097,37 @@ class _RestField:
     def __get__(self, obj: Model, type=None):  # pylint: disable=redefined-builtin
         # by this point, type and rest_name will have a value bc we default
         # them in __new__ of the Model class
-        item = obj.get(self._rest_name)
+        # Use _data.get() directly to avoid triggering __getitem__ which clears the cache
+        item = obj._data.get(self._rest_name)
         if item is None:
             return item
         if self._is_model:
             return item
-        return _deserialize(self._type, _serialize(item, self._format), rf=self)
+
+        # For mutable types, we want mutations to directly affect _data
+        # Check if we've already deserialized this value
+        cache_attr = f"_deserialized_{self._rest_name}"
+        if hasattr(obj, cache_attr):
+            # Return the value from _data directly (it's been deserialized in place)
+            return obj._data.get(self._rest_name)
+
+        deserialized = _deserialize(self._type, _serialize(item, self._format), rf=self)
+
+        # For mutable types, store the deserialized value back in _data
+        # so mutations directly affect _data
+        if isinstance(deserialized, (dict, list, set)):
+            obj._data[self._rest_name] = deserialized
+            object.__setattr__(obj, cache_attr, True)  # Mark as deserialized
+            return deserialized
+
+        return deserialized
 
     def __set__(self, obj: Model, value) -> None:
+        # Clear the cached deserialized object when setting a new value
+        cache_attr = f"_deserialized_{self._rest_name}"
+        if hasattr(obj, cache_attr):
+            object.__delattr__(obj, cache_attr)
+
         if value is None:
             # we want to wipe out entries if users set attr to None
             try:
@@ -1184,7 +1295,7 @@ def _get_wrapped_element(
         _get_element(v, exclude_readonly, meta, wrapped_element)
     else:
         wrapped_element.text = _get_primitive_type_value(v)
-    return wrapped_element
+    return wrapped_element  # type: ignore[no-any-return]
 
 
 def _get_primitive_type_value(v) -> str:
@@ -1197,7 +1308,9 @@ def _get_primitive_type_value(v) -> str:
     return str(v)
 
 
-def _create_xml_element(tag, prefix=None, ns=None):
+def _create_xml_element(
+    tag: typing.Any, prefix: typing.Optional[str] = None, ns: typing.Optional[str] = None
+) -> ET.Element:
     if prefix and ns:
         ET.register_namespace(prefix, ns)
     if ns:

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_utils/serialization.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_utils/serialization.py
@@ -821,13 +821,20 @@ class Serializer:  # pylint: disable=too-many-public-methods
         :param str data_type: Type of object in the iterable.
         :rtype: str, int, float, bool
         :return: serialized object
+        :raises TypeError: raise if data_type is not one of str, int, float, bool.
         """
         custom_serializer = cls._get_custom_serializers(data_type, **kwargs)
         if custom_serializer:
             return custom_serializer(data)
         if data_type == "str":
             return cls.serialize_unicode(data)
-        return eval(data_type)(data)  # nosec # pylint: disable=eval-used
+        if data_type == "int":
+            return int(data)
+        if data_type == "float":
+            return float(data)
+        if data_type == "bool":
+            return bool(data)
+        raise TypeError("Unknown basic data type: {}".format(data_type))
 
     @classmethod
     def serialize_unicode(cls, data):
@@ -1757,7 +1764,7 @@ class Deserializer:
         :param str data_type: deserialization data type.
         :return: Deserialized basic type.
         :rtype: str, int, float or bool
-        :raises TypeError: if string format is not valid.
+        :raises TypeError: if string format is not valid or data_type is not one of str, int, float, bool.
         """
         # If we're here, data is supposed to be a basic type.
         # If it's still an XML node, take the text
@@ -1783,7 +1790,11 @@ class Deserializer:
 
         if data_type == "str":
             return self.deserialize_unicode(attr)
-        return eval(data_type)(attr)  # nosec # pylint: disable=eval-used
+        if data_type == "int":
+            return int(attr)
+        if data_type == "float":
+            return float(attr)
+        raise TypeError("Unknown basic data type: {}".format(data_type))
 
     @staticmethod
     def deserialize_unicode(data):

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_version.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "2.0.0b1"
+VERSION = "2.0.0"

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_client.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_client.py
@@ -7,10 +7,11 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
-from typing import Any, Awaitable
+from typing import Any, Awaitable, Optional, TYPE_CHECKING, Union
 from typing_extensions import Self
 
 from azure.core import AsyncPipelineClient
+from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline import policies
 from azure.core.rest import AsyncHttpResponse, HttpRequest
 
@@ -18,40 +19,37 @@ from .._utils.serialization import Deserializer, Serializer
 from ._configuration import TextTranslationClientConfiguration
 from ._operations import _TextTranslationClientOperationsMixin
 
+if TYPE_CHECKING:
+    from azure.core.credentials_async import AsyncTokenCredential
+
 
 class TextTranslationClient(_TextTranslationClientOperationsMixin):
-    """Text translation is a cloud-based REST API feature of the Translator service that uses neural
-    machine translation technology to enable quick and accurate source-to-target text translation
-    in real time across all supported languages.
-
-    The following methods are supported by the Text Translation feature:
-
-    Languages. Returns a list of languages supported by Translate, Transliterate, and Dictionary
-    Lookup operations.
-
-    Translate. Renders single source-language text to multiple target-language texts with a single
-    request.
-
-    Transliterate. Converts characters or letters of a source language to the corresponding
-    characters or letters of a target language.
-
-    Detect. Returns the source code language code and a boolean variable denoting whether the
-    detected language is supported for text translation and transliteration.
+    """Azure Translator is a cloud-based, multilingual, neural machine translation service. The Text
+    Translation API enables robust and scalable translation capabilities suitable for diverse
+    applications.
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-         `https://api.cognitive.microsofttranslator.com
+     `https://api.cognitive.microsofttranslator.com
      <https://api.cognitive.microsofttranslator.com>`_). Required.
     :type endpoint: str
-    :keyword api_version: Mandatory API version parameter. Default value is "2025-10-01-preview".
-     Note that overriding this default value may result in unsupported behavior.
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Default value is None.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword api_version: Mandatory API version parameter. Known values are "2026-06-06". Default
+     value is "2026-06-06". Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
-    def __init__(  # pylint: disable=missing-client-constructor-parameter-credential
-        self, endpoint: str, **kwargs: Any
+    def __init__(
+        self,
+        endpoint: str,
+        credential: Optional[Union[AzureKeyCredential, "AsyncTokenCredential"]] = None,
+        **kwargs: Any
     ) -> None:
         _endpoint = "{Endpoint}"
-        self._config = TextTranslationClientConfiguration(endpoint=endpoint, **kwargs)
+        self._config = TextTranslationClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
 
         _policies = kwargs.pop("policies", None)
         if _policies is None:

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_configuration.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_configuration.py
@@ -6,11 +6,15 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING, Union
 
+from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline import policies
 
 from .._version import VERSION
+
+if TYPE_CHECKING:
+    from azure.core.credentials_async import AsyncTokenCredential
 
 
 class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-attributes
@@ -20,25 +24,44 @@ class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-a
     attributes.
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-         `https://api.cognitive.microsofttranslator.com
+     `https://api.cognitive.microsofttranslator.com
      <https://api.cognitive.microsofttranslator.com>`_). Required.
     :type endpoint: str
-    :keyword api_version: Mandatory API version parameter. Default value is "2025-10-01-preview".
-     Note that overriding this default value may result in unsupported behavior.
+    :param credential: Credential used to authenticate requests to the service. Is either a key
+     credential type or a token credential type. Default value is None.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword api_version: Mandatory API version parameter. Known values are "2026-06-06". Default
+     value is "2026-06-06". Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
-    def __init__(self, endpoint: str, **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-10-01-preview")
+    def __init__(
+        self,
+        endpoint: str,
+        credential: Optional[Union[AzureKeyCredential, "AsyncTokenCredential"]] = None,
+        **kwargs: Any,
+    ) -> None:
+        api_version: str = kwargs.pop("api_version", "2026-06-06")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
 
         self.endpoint = endpoint
+        self.credential = credential
         self.api_version = api_version
+        self.credential_scopes = kwargs.pop("credential_scopes", ["https://cognitiveservices.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "ai-translation-text/{}".format(VERSION))
         self.polling_interval = kwargs.get("polling_interval", 30)
         self._configure(**kwargs)
+
+    def _infer_policy(self, **kwargs):
+        if isinstance(self.credential, AzureKeyCredential):
+            return policies.AzureKeyCredentialPolicy(self.credential, "Ocp-Apim-Subscription-Key", **kwargs)
+        if hasattr(self.credential, "get_token"):
+            return policies.AsyncBearerTokenCredentialPolicy(self.credential, *self.credential_scopes, **kwargs)
+        raise TypeError(f"Unsupported credential: {self.credential}")
 
     def _configure(self, **kwargs: Any) -> None:
         self.user_agent_policy = kwargs.get("user_agent_policy") or policies.UserAgentPolicy(**kwargs)
@@ -50,3 +73,5 @@ class TextTranslationClientConfiguration:  # pylint: disable=too-many-instance-a
         self.redirect_policy = kwargs.get("redirect_policy") or policies.AsyncRedirectPolicy(**kwargs)
         self.retry_policy = kwargs.get("retry_policy") or policies.AsyncRetryPolicy(**kwargs)
         self.authentication_policy = kwargs.get("authentication_policy")
+        if self.credential and not self.authentication_policy:
+            self.authentication_policy = self._infer_policy(**kwargs)

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_operations.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_operations.py
@@ -128,6 +128,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -153,7 +154,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["ETag"] = self._deserialize("str", response.headers.get("ETag"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.GetSupportedLanguagesResult, response.json())
 
@@ -244,7 +245,7 @@ class _TextTranslationClientOperationsMixin(
     @api_version_validation(
         method_added_on="2025-10-01-preview",
         params_added_on={"2025-10-01-preview": ["client_trace_id", "api_version", "content_type", "accept"]},
-        api_versions_list=["2025-10-01-preview"],
+        api_versions_list=["2025-10-01-preview", "2026-06-06"],
     )
     async def translate(
         self,
@@ -301,6 +302,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -327,7 +329,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["x-metered-usage"] = self._deserialize("int", response.headers.get("x-metered-usage"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.TranslationResult, response.json())
 
@@ -473,7 +475,7 @@ class _TextTranslationClientOperationsMixin(
                 "accept",
             ]
         },
-        api_versions_list=["2025-10-01-preview"],
+        api_versions_list=["2025-10-01-preview", "2026-06-06"],
     )
     async def transliterate(
         self,
@@ -548,6 +550,7 @@ class _TextTranslationClientOperationsMixin(
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
+        _decompress = kwargs.pop("decompress", True)
         _stream = kwargs.pop("stream", False)
         pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
             _request, stream=_stream, **kwargs
@@ -572,7 +575,7 @@ class _TextTranslationClientOperationsMixin(
         response_headers["X-RequestId"] = self._deserialize("str", response.headers.get("X-RequestId"))
 
         if _stream:
-            deserialized = response.iter_bytes()
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.TransliterateResult, response.json())
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_patch.py
@@ -25,7 +25,9 @@ JSON = MutableMapping[str, Any]
 class _TextTranslationClientOperationsMixin(ClientMixinABC[AsyncPipelineClient, TextTranslationClientConfiguration]):
     """Mixin class that delegates to the generated operations class while providing custom method signatures."""
 
-    def _get_generated_operations(self) -> _TextTranslationClientOperationsMixinGenerated:  # pylint: disable=protected-access
+    def _get_generated_operations(
+        self,
+    ) -> _TextTranslationClientOperationsMixinGenerated:  # pylint: disable=protected-access
         """Get an instance of the generated operations mixin.
 
         This creates a wrapper object that shares the same _client, _config, _serialize, and _deserialize

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_operations/_patch.py
@@ -190,6 +190,32 @@ class _TextTranslationClientOperationsMixin(ClientMixinABC[AsyncPipelineClient, 
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
+    @overload  # type: ignore[override]
+    async def translate(
+        self,
+        body: IO[bytes],
+        *,
+        client_trace_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> List[_models.TranslatedTextItem]:
+        """Translate text.
+
+        Translates text using a raw bytes stream as the request body.
+
+        :param body: The request body as a file-like stream of bytes. Required.
+        :type body: IO[bytes]
+        :keyword client_trace_id: A client-generated GUID to uniquely identify the request. Default
+         value is None.
+        :paramtype client_trace_id: str
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: list of TranslatedTextItem
+        :rtype: list[~azure.ai.translation.text.models.TranslatedTextItem]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
     async def translate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         body: Union[List[str], List[_models.TranslateInputItem], JSON, IO[bytes]],
@@ -328,6 +354,47 @@ class _TextTranslationClientOperationsMixin(ClientMixinABC[AsyncPipelineClient, 
 
         :param body: JSON body containing transliteration request. Required.
         :type body: JSON
+        :keyword language: Specifies the language of the text to convert from one script to another.
+         Possible languages are listed in the transliteration scope obtained by querying the service
+         for its supported languages. Required.
+        :paramtype language: str
+        :keyword from_script: Specifies the script used by the input text. Look up supported languages
+         using the transliteration scope,
+         to find input scripts available for the selected language. Required.
+        :paramtype from_script: str
+        :keyword to_script: Specifies the output script. Look up supported languages using the
+         transliteration scope, to find output
+         scripts available for the selected combination of input language and input script. Required.
+        :paramtype to_script: str
+        :keyword client_trace_id: A client-generated GUID to uniquely identify the request. Default
+         value is None.
+        :paramtype client_trace_id: str
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: list of TransliteratedText
+        :rtype: list[~azure.ai.translation.text.models.TransliteratedText]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload  # type: ignore[override]
+    async def transliterate(
+        self,
+        body: IO[bytes],
+        *,
+        language: str,
+        from_script: str,
+        to_script: str,
+        client_trace_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> List[_models.TransliteratedText]:
+        """Transliterate Text.
+
+        Transliterates text using a raw bytes stream as the request body.
+
+        :param body: The request body as a file-like stream of bytes. Required.
+        :type body: IO[bytes]
         :keyword language: Specifies the language of the text to convert from one script to another.
          Possible languages are listed in the transliteration scope obtained by querying the service
          for its supported languages. Required.

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -46,10 +46,13 @@ class TextTranslationClient(ServiceClientGenerated):
     :type endpoint: str
     :param credential: Credential used to authenticate with the Translator service. Optional for
      unauthenticated operations like get_languages.
-    :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials_async.AsyncTokenCredential or None
-    :param region: Azure region of the Translator resource. Required for AzureKeyCredential, optional for Entra ID regional resources.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or
+     ~azure.core.credentials_async.AsyncTokenCredential or None
+    :param region: Azure region of the Translator resource. Required for AzureKeyCredential,
+     optional for Entra ID regional resources.
     :type region: str or None
-    :param resource_id: Azure resource ID for Entra ID authentication. Required when using TokenCredential with global endpoint.
+    :param resource_id: Azure resource ID for Entra ID authentication. Required when using
+     TokenCredential with global endpoint.
     :type resource_id: str or None
     :param audience: Scopes of the credentials.
     :type audience: str or None

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -7,20 +7,12 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import Optional, Any, overload
-from azure.core.pipeline import PipelineRequest
-from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy, AzureKeyCredentialPolicy
+from typing import Optional, Any, Union, List
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-from .._patch import (
-    DEFAULT_ENTRA_ID_SCOPE,
-    DEFAULT_SCOPE,
-    get_translation_endpoint,
-    TranslatorAuthenticationPolicy,
-    is_cognitive_services_scope,
-)
-
+from .._patch import get_translation_endpoint, TranslatorHeaderPolicy
 from ._client import TextTranslationClient as ServiceClientGenerated
 
 
@@ -33,142 +25,69 @@ def patch_sdk():
     """
 
 
-class AsyncTranslatorEntraIdAuthenticationPolicy(AsyncBearerTokenCredentialPolicy):  # pylint: disable=name-too-long
-    """Translator Entra Id Authentication Policy. Adds headers that are required by Translator Service
-    when global endpoint is used with Entra Id policy.
-    Ocp-Apim-Subscription-Region header contains region of the Translator resource.
-    Ocp-Apim-ResourceId header contains Azure resource Id - Translator resource.
-
-    :param credential: Translator Entra Id Credentials used to access Translator Resource for global endpoint.
-    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword str region: Used for National Clouds.
-    :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audience: Scopes of the credentials.
-    """
-
-    def __init__(
-        self, credential: AsyncTokenCredential, resource_id: str, region: str, audience: str, **kwargs: Any
-    ) -> None:
-        super(AsyncTranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audience, **kwargs)
-        self.resource_id = resource_id
-        self.region = region
-        self.translator_credential = credential
-
-    async def on_request(self, request: PipelineRequest) -> None:
-        request.http_request.headers["Ocp-Apim-ResourceId"] = self.resource_id
-        request.http_request.headers["Ocp-Apim-Subscription-Region"] = self.region
-        await super().on_request(request)
-
-
-def set_authentication_policy(credential, kwargs):
-    if isinstance(credential, AzureKeyCredential):
-        if not kwargs.get("authentication_policy"):
-            if kwargs.get("region"):
-                kwargs["authentication_policy"] = TranslatorAuthenticationPolicy(credential, kwargs["region"])
-            else:
-                kwargs["authentication_policy"] = AzureKeyCredentialPolicy(
-                    name="Ocp-Apim-Subscription-Key", credential=credential
-                )
-    elif hasattr(credential, "get_token"):
-        if not kwargs.get("authentication_policy"):
-            if kwargs.get("region") and kwargs.get("resource_id"):
-                scope = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE).rstrip("/").rstrip(DEFAULT_SCOPE) + DEFAULT_SCOPE
-                kwargs["authentication_policy"] = AsyncTranslatorEntraIdAuthenticationPolicy(
-                    credential,
-                    kwargs["resource_id"],
-                    kwargs["region"],
-                    scope,
-                )
-            else:
-                if kwargs.get("resource_id") or kwargs.get("region"):
-                    raise ValueError(
-                        """Both 'resource_id' and 'region' must be provided with a TokenCredential
-                         for regional resource authentication."""
-                    )
-                scope: str = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE)
-                if not is_cognitive_services_scope(scope):
-                    scope = scope.rstrip("/").rstrip(DEFAULT_SCOPE) + DEFAULT_SCOPE
-                kwargs["authentication_policy"] = AsyncBearerTokenCredentialPolicy(credential, scope)
-
-
 class TextTranslationClient(ServiceClientGenerated):
-    """Text translation is a cloud-based REST API feature of the Translator service that uses neural
-    machine translation technology to enable quick and accurate source-to-target text translation
-    in real time across all supported languages.
-
-    The following methods are supported by the Text Translation feature:
-
-    Languages. Returns a list of languages supported by Translate, Transliterate, and Dictionary
-    Lookup operations.
-
-    Translate. Renders single source-language text to multiple target-language texts with a single
-    request.
-
-    Transliterate. Converts characters or letters of a source language to the corresponding
-    characters or letters of a target language.
-
-    Detect. Returns the source code language code and a boolean variable denoting whether the
-    detected language is supported for text translation and transliteration.
-
-    Dictionary lookup. Returns equivalent words for the source term in the target language.
-
-    Dictionary example Returns grammatical structure and context examples for the source term and
-    target term pair.
+    """Azure Translator is a cloud-based, multilingual, neural machine translation service. The Text
+    Translation API enables robust and scalable translation capabilities suitable for diverse
+    applications.
 
     Combinations of endpoint and credential values:
-    str + AzureKeyCredential - used custom domain translator endpoint
-    str + AzureKeyCredential + Region - used for global translator endpoint
-    str + AsyncTokenCredential - used for regional endpoint with token authentication
-    str + None - used with text translation on-prem container
-    None + AzureKeyCredential - used for global translator endpoint with global Translator resource
-    None + AsyncTokenCredential - general translator endpoint with token authentication
-    None + AsyncTokenCredential + Region - general translator endpoint with regional Translator resource
 
-    :keyword str endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-     https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
-    :keyword credential: Credential used to authenticate with the Translator service
-    :paramtype credential: Union[AzureKeyCredential, AsyncTokenCredential]
-    :keyword str region: Used for National Clouds.
-    :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audience: Scopes of the credentials.
-    :keyword  str api_version: Default value is "2025-10-01-preview". Note that overriding this default value may
+    - endpoint + AzureKeyCredential - custom domain translator endpoint
+    - endpoint + AzureKeyCredential + region - global translator endpoint with regional resource
+    - endpoint + AsyncTokenCredential - regional endpoint with token authentication
+    - endpoint + None - on-prem container (no authentication)
+    - AzureKeyCredential only - global translator endpoint with global Translator resource (uses default endpoint)
+    - AsyncTokenCredential only - global translator endpoint with token authentication (uses default endpoint)
+    - AsyncTokenCredential + region + resource_id - global translator endpoint with regional Translator resource
+
+    :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
+     https://api.cognitive.microsofttranslator.com). Defaults to the global translator endpoint.
+    :type endpoint: str
+    :param credential: Credential used to authenticate with the Translator service. Optional for
+     unauthenticated operations like get_languages.
+    :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials_async.AsyncTokenCredential or None
+    :param region: Azure region of the Translator resource, required when using global endpoint with regional resource.
+    :type region: str or None
+    :param resource_id: Azure resource ID, required with TokenCredential when using global endpoint with regional resource.
+    :type resource_id: str or None
+    :param audience: Scopes of the credentials.
+    :type audience: str or None
+    :param api_version: Default value is "2026-06-06". Note that overriding this default value may
      result in unsupported behavior.
+    :type api_version: str
     """
 
-    @overload
     def __init__(
         self,
+        endpoint: str = "https://api.cognitive.microsofttranslator.com",
+        credential: Optional[Union[AzureKeyCredential, AsyncTokenCredential]] = None,
         *,
-        credential: AsyncTokenCredential,
         region: Optional[str] = None,
-        endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
         audience: Optional[str] = None,
-        api_version: str = "2025-10-01-preview",
-        **kwargs
-    ): ...
+        api_version: str = "2026-06-06",
+        **kwargs: Any,
+    ) -> None:
+        if resource_id and not region:
+            raise ValueError("'region' must be provided when 'resource_id' is specified.")
 
-    @overload
-    def __init__(
-        self,
-        *,
-        credential: AzureKeyCredential,
-        region: Optional[str] = None,
-        endpoint: Optional[str] = None,
-        api_version: str = "2025-10-01-preview",
-        **kwargs
-    ): ...
+        translation_endpoint = get_translation_endpoint(endpoint, api_version)
 
-    @overload
-    def __init__(self, *, endpoint: str, api_version: str = "2025-10-01-preview", **kwargs): ...
+        # Add translator-specific header policy for regional resources
+        if region or resource_id:
+            per_call_policies: List[SansIOHTTPPolicy] = list(kwargs.pop("per_call_policies", []) or [])
+            per_call_policies.insert(0, TranslatorHeaderPolicy(region=region, resource_id=resource_id))
+            kwargs["per_call_policies"] = per_call_policies
 
-    def __init__(self, **kwargs):
-        api_version = kwargs.get("api_version", "2025-10-01-preview")
-        set_authentication_policy(kwargs.get("credential"), kwargs)
-        translation_endpoint = get_translation_endpoint(
-            kwargs.pop("endpoint", "https://api.cognitive.microsofttranslator.com"), api_version
+        if audience:
+            kwargs["credential_scopes"] = [audience]
+
+        super().__init__(
+            endpoint=translation_endpoint,
+            credential=credential,
+            api_version=api_version,
+            **kwargs,
         )
-        super().__init__(endpoint=translation_endpoint, api_version=api_version, **kwargs)
 
 
 __all__ = ["TextTranslationClient"]

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -32,13 +32,14 @@ class TextTranslationClient(ServiceClientGenerated):
 
     Combinations of endpoint and credential values:
 
-    - endpoint + AzureKeyCredential - custom domain translator endpoint
-    - endpoint + AzureKeyCredential + region - global translator endpoint with regional resource
-    - endpoint + AsyncTokenCredential - regional endpoint with token authentication
-    - endpoint + None - on-prem container (no authentication)
-    - AzureKeyCredential only - global translator endpoint with global Translator resource (uses default endpoint)
-    - AsyncTokenCredential only - global translator endpoint with token authentication (uses default endpoint)
-    - AsyncTokenCredential + region + resource_id - global translator endpoint with regional Translator resource
+    - (no args) - global endpoint, no auth (get_languages only)
+    - endpoint only - custom endpoint or container, no auth
+    - AzureKeyCredential + region - global endpoint with subscription key
+    - AsyncTokenCredential + audience - global endpoint with Cognitive Services token
+    - AsyncTokenCredential + resource_id - global endpoint with Entra ID (global resource)
+    - AsyncTokenCredential + region + resource_id - global endpoint with Entra ID (regional resource)
+    - endpoint + AzureKeyCredential - custom endpoint with subscription key
+    - endpoint + AsyncTokenCredential - custom endpoint with Entra ID
 
     :param endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
      https://api.cognitive.microsofttranslator.com). Defaults to the global translator endpoint.
@@ -46,9 +47,9 @@ class TextTranslationClient(ServiceClientGenerated):
     :param credential: Credential used to authenticate with the Translator service. Optional for
      unauthenticated operations like get_languages.
     :type credential: ~azure.core.credentials.AzureKeyCredential or ~azure.core.credentials_async.AsyncTokenCredential or None
-    :param region: Azure region of the Translator resource, required when using global endpoint with regional resource.
+    :param region: Azure region of the Translator resource. Required for AzureKeyCredential, optional for Entra ID regional resources.
     :type region: str or None
-    :param resource_id: Azure resource ID, required with TokenCredential when using global endpoint with regional resource.
+    :param resource_id: Azure resource ID for Entra ID authentication. Required when using TokenCredential with global endpoint.
     :type resource_id: str or None
     :param audience: Scopes of the credentials.
     :type audience: str or None
@@ -68,8 +69,9 @@ class TextTranslationClient(ServiceClientGenerated):
         api_version: str = "2026-06-06",
         **kwargs: Any,
     ) -> None:
-        if resource_id and not region:
-            raise ValueError("'region' must be provided when 'resource_id' is specified.")
+        # Validate credential + region/resource_id combinations
+        if region and credential is not None and not isinstance(credential, AzureKeyCredential) and not resource_id:
+            raise ValueError("'resource_id' must be provided when using TokenCredential with 'region'.")
 
         translation_endpoint = get_translation_endpoint(endpoint, api_version)
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/__init__.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/__init__.py
@@ -40,6 +40,8 @@ from ._enums import (  # type: ignore
     ProfanityAction,
     ProfanityMarker,
     TextType,
+    TranslationGender,
+    TranslationTone,
 )
 from ._patch import __all__ as _patch_all
 from ._patch import *
@@ -69,6 +71,8 @@ __all__ = [
     "ProfanityAction",
     "ProfanityMarker",
     "TextType",
+    "TranslationGender",
+    "TranslationTone",
 ]
 __all__.extend([p for p in _patch_all if p not in __all__])  # pyright: ignore
 _patch_sdk()

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_enums.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_enums.py
@@ -23,7 +23,7 @@ class ProfanityAction(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Translator profanity actions."""
 
     NO_ACTION = "NoAction"
-    """No Action is taken on profanity"""
+    """No Action is taken on profanity."""
     MARKED = "Marked"
     """Profanity is marked."""
     DELETED = "Deleted"
@@ -46,3 +46,25 @@ class TextType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Plain text."""
     HTML = "Html"
     """HTML-encoded text."""
+
+
+class TranslationGender(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Desired gender for the translated text."""
+
+    NEUTRAL = "neutral"
+    """Neutral gender."""
+    MALE = "male"
+    """Male gender."""
+    FEMALE = "female"
+    """Female gender."""
+
+
+class TranslationTone(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Desired tone for the translated text."""
+
+    NEUTRAL = "neutral"
+    """Neutral tone."""
+    FORMAL = "formal"
+    """Formal tone."""
+    INFORMAL = "informal"
+    """Informal tone."""

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_models.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_models.py
@@ -20,16 +20,16 @@ class DetectedLanguage(_Model):
 
     :ivar language: A string representing the code of the detected language. Required.
     :vartype language: str
-    :ivar score: A float value indicating the confidence in the result.
-     The score is between zero and one and a low score indicates a low confidence. Required.
+    :ivar score: A float value indicating the confidence in the result. The score is between zero
+     and one and a low score indicates a low confidence. Required.
     :vartype score: float
     """
 
     language: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
     """A string representing the code of the detected language. Required."""
     score: float = rest_field(visibility=["read", "create", "update", "delete", "query"])
-    """A float value indicating the confidence in the result.
-     The score is between zero and one and a low score indicates a low confidence. Required."""
+    """A float value indicating the confidence in the result. The score is between zero and one and a
+     low score indicates a low confidence. Required."""
 
     @overload
     def __init__(
@@ -275,8 +275,7 @@ class TranslatedTextItem(_Model):
      when language auto-detection is requested.
     :vartype detected_language: ~azure.ai.translation.text.models.DetectedLanguage
     :ivar translations: An array of translation results. The size of the array matches the number
-     of target
-     languages specified through the to query parameter. Required.
+     of target languages specified through the to query parameter. Required.
     :vartype translations: list[~azure.ai.translation.text.models.TranslationText]
     """
 
@@ -286,8 +285,8 @@ class TranslatedTextItem(_Model):
     """The detectedLanguage property is only present in the result object when language auto-detection
      is requested."""
     translations: list["_models.TranslationText"] = rest_field(visibility=["read"])
-    """An array of translation results. The size of the array matches the number of target
-     languages specified through the to query parameter. Required."""
+    """An array of translation results. The size of the array matches the number of target languages
+     specified through the to query parameter. Required."""
 
     @overload
     def __init__(
@@ -324,9 +323,8 @@ class TranslateInputItem(_Model):
      Note: the dynamic dictionary feature is case-sensitive.
     :vartype language: str
     :ivar text_type: Defines whether the text being translated is plain text or HTML text. Any HTML
-     needs to be a well-formed,
-     complete element. Possible values are: plain (default) or html. Known values are: "Plain" and
-     "Html".
+     needs to be a well-formed, complete element. Possible values are: plain (default) or html.
+     Known values are: "Plain" and "Html".
     :vartype text_type: str or ~azure.ai.translation.text.models.TextType
     :ivar targets: Translation target parameters. Required.
     :vartype targets: list[~azure.ai.translation.text.models.TranslationTarget]
@@ -348,9 +346,8 @@ class TranslateInputItem(_Model):
         name="textType", visibility=["read", "create", "update", "delete", "query"]
     )
     """Defines whether the text being translated is plain text or HTML text. Any HTML needs to be a
-     well-formed,
-     complete element. Possible values are: plain (default) or html. Known values are: \"Plain\" and
-     \"Html\"."""
+     well-formed, complete element. Possible values are: plain (default) or html. Known values are:
+     \"Plain\" and \"Html\"."""
     targets: list["_models.TranslationTarget"] = rest_field(visibility=["read", "create", "update", "delete", "query"])
     """Translation target parameters. Required."""
 
@@ -378,8 +375,8 @@ class TranslateInputItem(_Model):
 
 class TranslationLanguage(_Model):
     """The value of the translation property is a dictionary of (key, value) pairs. Each key is a BCP
-    47 language tag.
-    A key identifies a language for which text can be translated to or translated from.
+    47 language tag. A key identifies a language for which text can be translated to or translated
+    from.
 
     :ivar name: Display name of the language in the locale requested via Accept-Language header.
      Required.
@@ -441,19 +438,18 @@ class TranslationTarget(_Model):
     """Target language and translation configuration parameters.
 
     :ivar language: Specifies the language of the output text. The target language must be one of
-     the supported languages included
-     in the translation scope. It's possible to translate to multiple languages simultaneously by
-     including
-     multiple string values in the targetsLanguage array. Required.
+     the supported languages included in the translation scope. It's possible to translate to
+     multiple languages simultaneously by including multiple string values in the targetsLanguage
+     array. Required.
     :vartype language: str
     :ivar script: Specifies the script of the translated text.
     :vartype script: str
-    :ivar profanity_action: Specifies how profanities should be treated in translations.
-     Possible values are: NoAction (default), Marked or Deleted. Known values are: "NoAction",
-     "Marked", and "Deleted".
+    :ivar profanity_action: Specifies how profanities should be treated in translations. Possible
+     values are: NoAction (default), Marked or Deleted. Known values are: "NoAction", "Marked", and
+     "Deleted".
     :vartype profanity_action: str or ~azure.ai.translation.text.models.ProfanityAction
-    :ivar profanity_marker: Specifies how profanities should be marked in translations.
-     Possible values are: Asterisk (default) or Tag. Known values are: "Asterisk" and "Tag".
+    :ivar profanity_marker: Specifies how profanities should be marked in translations. Possible
+     values are: Asterisk (default) or Tag. Known values are: "Asterisk" and "Tag".
     :vartype profanity_marker: str or ~azure.ai.translation.text.models.ProfanityMarker
     :ivar deployment_name: Default is 'general', which uses NMT system.
      'abc-inc-gpt-4o', and 'abc-inc-gpt-4o-mini' are examples of deployment names which use GPT-4o
@@ -484,12 +480,12 @@ class TranslationTarget(_Model):
      specifies that the service is allowed to fall back to a general system when a custom system
      doesn't exist.
     :vartype allow_fallback: bool
-    :ivar grade: Defines complexity of LLM prompts to provide high accuracy translation.
-    :vartype grade: str
-    :ivar tone: Desired tone of target translation.
-    :vartype tone: str
-    :ivar gender: Desired gender of target translation.
-    :vartype gender: str
+    :ivar tone: Desired tone of target translation. Accepted values are formal, informal, or
+     neutral. Known values are: "neutral", "formal", and "informal".
+    :vartype tone: str or ~azure.ai.translation.text.models.TranslationTone
+    :ivar gender: Desired gender of target translation. Accepted values are female, male, or
+     neutral. Known values are: "neutral", "male", and "female".
+    :vartype gender: str or ~azure.ai.translation.text.models.TranslationGender
     :ivar adaptive_dataset_id: Reference dataset ID having sentence pair to generate adaptive
      customized translation.
     :vartype adaptive_dataset_id: str
@@ -499,23 +495,20 @@ class TranslationTarget(_Model):
 
     language: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
     """Specifies the language of the output text. The target language must be one of the supported
-     languages included
-     in the translation scope. It's possible to translate to multiple languages simultaneously by
-     including
-     multiple string values in the targetsLanguage array. Required."""
+     languages included in the translation scope. It's possible to translate to multiple languages
+     simultaneously by including multiple string values in the targetsLanguage array. Required."""
     script: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
     """Specifies the script of the translated text."""
     profanity_action: Optional[Union[str, "_models.ProfanityAction"]] = rest_field(
         name="profanityAction", visibility=["read", "create", "update", "delete", "query"]
     )
-    """Specifies how profanities should be treated in translations.
-     Possible values are: NoAction (default), Marked or Deleted. Known values are: \"NoAction\",
-     \"Marked\", and \"Deleted\"."""
+    """Specifies how profanities should be treated in translations. Possible values are: NoAction
+     (default), Marked or Deleted. Known values are: \"NoAction\", \"Marked\", and \"Deleted\"."""
     profanity_marker: Optional[Union[str, "_models.ProfanityMarker"]] = rest_field(
         name="profanityMarker", visibility=["read", "create", "update", "delete", "query"]
     )
-    """Specifies how profanities should be marked in translations.
-     Possible values are: Asterisk (default) or Tag. Known values are: \"Asterisk\" and \"Tag\"."""
+    """Specifies how profanities should be marked in translations. Possible values are: Asterisk
+     (default) or Tag. Known values are: \"Asterisk\" and \"Tag\"."""
     deployment_name: Optional[str] = rest_field(
         name="deploymentName", visibility=["read", "create", "update", "delete", "query"]
     )
@@ -549,12 +542,16 @@ class TranslationTarget(_Model):
      allowFallback=true
      specifies that the service is allowed to fall back to a general system when a custom system
      doesn't exist."""
-    grade: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
-    """Defines complexity of LLM prompts to provide high accuracy translation."""
-    tone: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
-    """Desired tone of target translation."""
-    gender: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
-    """Desired gender of target translation."""
+    tone: Optional[Union[str, "_models.TranslationTone"]] = rest_field(
+        visibility=["read", "create", "update", "delete", "query"]
+    )
+    """Desired tone of target translation. Accepted values are formal, informal, or neutral. Known
+     values are: \"neutral\", \"formal\", and \"informal\"."""
+    gender: Optional[Union[str, "_models.TranslationGender"]] = rest_field(
+        visibility=["read", "create", "update", "delete", "query"]
+    )
+    """Desired gender of target translation. Accepted values are female, male, or neutral. Known
+     values are: \"neutral\", \"male\", and \"female\"."""
     adaptive_dataset_id: Optional[str] = rest_field(
         name="adaptiveDatasetId", visibility=["read", "create", "update", "delete", "query"]
     )
@@ -574,9 +571,8 @@ class TranslationTarget(_Model):
         profanity_marker: Optional[Union[str, "_models.ProfanityMarker"]] = None,
         deployment_name: Optional[str] = None,
         allow_fallback: Optional[bool] = None,
-        grade: Optional[str] = None,
-        tone: Optional[str] = None,
-        gender: Optional[str] = None,
+        tone: Optional[Union[str, "_models.TranslationTone"]] = None,
+        gender: Optional[Union[str, "_models.TranslationGender"]] = None,
         adaptive_dataset_id: Optional[str] = None,
         reference_text_pairs: Optional[list["_models.ReferenceTextPair"]] = None,
     ) -> None: ...
@@ -782,10 +778,9 @@ class TransliterateResult(_Model):
 
 
 class TransliterationLanguage(_Model):
-    """The value of the transliteration property is a dictionary of (key, value) pairs.
-    Each key is a BCP 47 language tag. A key identifies a language for which text can be converted
-    from one script
-    to another script.
+    """The value of the transliteration property is a dictionary of (key, value) pairs. Each key is a
+    BCP 47 language tag. A key identifies a language for which text can be converted from one
+    script to another script.
 
     :ivar name: Display name of the language in the locale requested via Accept-Language header.
      Required.

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/models/_patch.py
@@ -6,9 +6,22 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+import sys
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+
+# Models used only as internal request/response envelopes by the patched
+# translate/transliterate methods. Users interact with simpler inputs
+# (List[str], List[TranslateInputItem], List[InputTextItem], JSON, IO[bytes])
+# and receive unwrapped List[TranslatedTextItem]/List[TransliteratedText]
+# results, so these envelope types should not be part of the public surface.
+_INTERNAL_MODELS = {
+    "TranslateBody",
+    "TransliterateBody",
+    "TranslationResult",
+    "TransliterateResult",
+}
 
 
 def patch_sdk():
@@ -18,3 +31,13 @@ def patch_sdk():
     you can't accomplish using the techniques described in
     https://aka.ms/azsdk/python/dpcodegen/python/customize
     """
+    # Remove internal envelope models from the public ``__all__`` of the
+    # models package. The names remain importable for internal use (the
+    # generated operations still reference them via ``_models.<Name>``),
+    # but they are excluded from ``from ... import *``, Sphinx autodoc,
+    # and APIView's public-surface analysis.
+    package_name = __package__ or __name__.rsplit(".", 1)[0]
+    mod = sys.modules[package_name]
+    current_all = getattr(mod, "__all__", None)
+    if current_all is not None:
+        setattr(mod, "__all__", [n for n in current_all if n not in _INTERNAL_MODELS])

--- a/sdk/translation/azure-ai-translation-text/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-text/pyproject.toml
@@ -32,7 +32,7 @@ keywords = ["azure", "azure sdk"]
 
 dependencies = [
     "isodate>=0.6.1",
-    "azure-core>=1.35.0",
+    "azure-core>=1.37.0",
     "typing-extensions>=4.6.0",
 ]
 dynamic = [

--- a/sdk/translation/azure-ai-translation-text/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-text/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 description = "Microsoft Corporation Azure Ai Translation Text Client Library for Python"
 license = "MIT"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",

--- a/sdk/translation/azure-ai-translation-text/tests/conftest.py
+++ b/sdk/translation/azure-ai-translation-text/tests/conftest.py
@@ -1,5 +1,10 @@
 import pytest
-from devtools_testutils import test_proxy, add_remove_header_sanitizer, remove_batch_sanitizers, set_custom_default_matcher
+from devtools_testutils import (
+    test_proxy,
+    add_remove_header_sanitizer,
+    remove_batch_sanitizers,
+    set_custom_default_matcher,
+)
 
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 # def start_proxy(test_proxy):

--- a/sdk/translation/azure-ai-translation-text/tests/conftest.py
+++ b/sdk/translation/azure-ai-translation-text/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from devtools_testutils import test_proxy, add_remove_header_sanitizer, remove_batch_sanitizers
+from devtools_testutils import test_proxy, add_remove_header_sanitizer, remove_batch_sanitizers, set_custom_default_matcher
 
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 # def start_proxy(test_proxy):
@@ -14,3 +14,7 @@ def add_sanitizers(test_proxy):
     #  - AZSDK3430: $..id
     #  - AZSDK3424: $..to
     remove_batch_sanitizers(["AZSDK3430", "AZSDK3424"])
+
+    # Ignore api-version during request matching so recordings with
+    # 2025-10-01-preview can be reused with 2026-06-06
+    set_custom_default_matcher(ignored_query_parameters="api-version")

--- a/sdk/translation/azure-ai-translation-text/tsp-location.yaml
+++ b/sdk/translation/azure-ai-translation-text/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/data-plane/TextTranslation
-commit: b1f7c6b317d9a060abe3050b1e45b739837ffd13
+commit: 57e2a8c9b11d29493001b66c8855a191ac71528b
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
# Description

Stable release of azure-ai-translation-text v2.0.0:

GA release of the Azure AI Translator API 2026-06-06, including translations using LLM models, adaptive custom translation, tone variant translations, and gender-specific translations.
Minor improvements including adding TranslationTone and TranslationGender enum types for strongly-typed tone and gender options on TranslationTarget and removing unsupported grade property.

API Spec PR: https://github.com/Azure/azure-rest-api-specs/pull/40036

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
