### PR TITLE
[Cosmos] Migrate Python Cosmos weekly pipeline to TME

### DIFF
--- a/sdk/cosmos/tests.yml
+++ b/sdk/cosmos/tests.yml
@@ -5,7 +5,7 @@ extends:
     parameters:
       CloudConfig:
         Public:
-          ServiceConnection: azure-sdk-tests-cosmos
+          ServiceConnection: azure-sdk-tests-cosmos-tme
       MatrixConfigs:
         - Name: Cosmos_live_test
           Path: sdk/cosmos/live-platform-matrix.json


### PR DESCRIPTION
## Migrate Python Cosmos weekly live tests to the TME tenant

Companion to the Java migration (Azure/azure-sdk-for-java#48877). Re-points the Python Cosmos live test pipeline at the new TME-hosted service connection so live tests run in the **Azure SDK Test Resources – TME** subscription instead of the corp `azure-sdk-tests-cosmos` subscription.

### Target tenant / subscription

- Tenant: `70a036f6-8e4d-4615-bad6-149c02e7720d` (Azure SDK Test Resources – TME)
- Subscription: `7cc44528-8730-4b11-ae30-5738d333ff2d` (migrated into TME tenant)
- Service connection: `azure-sdk-tests-cosmos-tme` (to be created by EngSys)

### Changes

| File | Change |
|---|---|
| `sdk/cosmos/tests.yml` | `ServiceConnection: azure-sdk-tests-cosmos` → `azure-sdk-tests-cosmos-tme` |

### Manual prerequisites (EngSys + service team)

These must be in place **before** this PR is merged / the next pipeline run, otherwise the weekly will fail at the auth step.

1. **Create the federated-identity service connection** `azure-sdk-tests-cosmos-tme` in the `azure-sdk` ADO org targeting tenant `70a036f6-8e4d-4615-bad6-149c02e7720d`, subscription `7cc44528-8730-4b11-ae30-5738d333ff2d`. SOP: <https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/206/Subscription-and-Tenant-Usage>.
2. **Provision an SPN** in the TME tenant with `Contributor` on the migrated subscription and grant the new service connection access to it.
3. **Re-create any long-lived Cosmos test accounts** the Python live tests rely on inside the TME subscription (the `New-TestResources.ps1` per-run RGs are auto-prefixed with `SSS3PT_` so account-key auth keeps S360 quiet — see the Java PR for context).
4. **Update / mirror any pipeline variable groups** (e.g. `Cosmos - Live tests`) consumed by the Python pipeline so the secrets / endpoints point at the TME-side resources.
5. **Validate** with a manual run of the `python - cosmos - tests` weekly pipeline before the next scheduled trigger.

### Out of scope

- Spark / Kafka pipelines (Python doesn't have direct equivalents under `sdk/cosmos`).
- Switching from account-key to RBAC / federated identity — keeping account-key auth and relying on the `SSS3PT_` RG prefix that `eng/common/TestResources/New-TestResources.ps1` adds automatically when `TenantId` is in `$wellKnownTMETenants`.

### References

- Java sibling PR: Azure/azure-sdk-for-java#48877
- Subscription and Tenant Usage wiki: <https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/206/Subscription-and-Tenant-Usage>
- Secret auth migration wiki: <https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/?pagePath=%2FEngineering-System%2FSecurity%2FSecret-auth-migration>
