### PR TITLE
Resolve last `release`-related Network Isolation issues

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -124,17 +124,16 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-
-                      - task: UsePythonVersion@0
-                        inputs:
-                          versionSpec: '3.9'
-
                       - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
                         parameters:
                           DevFeedName: ${{ parameters.DevFeedName }}
                           EnableTwineAuth: false
                           EnablePipAuth: true
                           EnableUvAuth: false
+
+                      - task: UsePythonVersion@0
+                        inputs:
+                          versionSpec: '3.9'
 
                       - script: |
                           python -m pip install -r $(Pipeline.Workspace)/release_artifact/release_requirements.txt

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -198,6 +198,13 @@ stages:
                 artifact: ${{parameters.ArtifactName}}
                 timeoutInMinutes: 5
 
+              - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+                parameters:
+                  DevFeedName: ${{ parameters.DevFeedName }}
+                  EnableTwineAuth: false
+                  EnablePipAuth: true
+                  EnableUvAuth: false
+
               - task: UsePythonVersion@0
                 inputs:
                   versionSpec: '3.9'

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -242,8 +242,12 @@ function IsPythonPackageVersionPublished($pkgId, $pkgVersion)
     }
 
     $pipOutput = pip $pipArgs 2>&1
+    $pipExitCode = $LASTEXITCODE
+    # Reset $LASTEXITCODE so a non-zero pip exit code doesn't leak out and cause
+    # the PowerShell ADO task to report failure after the script finishes.
+    $global:LASTEXITCODE = 0
 
-    if ($LASTEXITCODE -eq 0)
+    if ($pipExitCode -eq 0)
     {
       Write-Host "Package $pkgId==$pkgVersion was found on the package index."
       return $True

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -220,28 +220,52 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 }
 
 # Returns the pypi publish status of a package id and version.
+# Uses pip download against the configured package index (PIP_INDEX_URL) rather than
+# calling pypi.org directly, so this works in network-isolated (CFS) environments.
+# The Azure Artifacts feed has upstream to PyPI, so packages on PyPI are still found.
 function IsPythonPackageVersionPublished($pkgId, $pkgVersion)
 {
+  $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "pkg-verify-$([System.Guid]::NewGuid())"
+  New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+
   try
   {
-    $existingVersion = (Invoke-RestMethod -MaximumRetryCount 3 -RetryIntervalSec 10 -Method "Get" -uri "https://pypi.org/pypi/$pkgId/$pkgVersion/json").info.version
-    # if existingVersion exists, then it's already been published
-    return $True
-  }
-  catch
-  {
-    $statusCode = $_.Exception.Response.StatusCode.value__
-    $statusDescription = $_.Exception.Response.StatusDescription
+    Write-Host "Checking whether $pkgId==$pkgVersion is already published (using pip download)"
 
-    # if this is 404ing, then this pkg has never been published before
-    if ($statusCode -eq 404)
+    $pipArgs = @("download", "--no-deps", "--no-cache-dir", "--dest", $tmpDir, "$pkgId==$pkgVersion")
+
+    if ($env:PIP_INDEX_URL) {
+      Write-Host "Using index from PIP_INDEX_URL"
+    }
+    else {
+      Write-Host "PIP_INDEX_URL is not set; pip will fall back to public PyPI."
+    }
+
+    $pipOutput = pip $pipArgs 2>&1
+
+    if ($LASTEXITCODE -eq 0)
     {
+      Write-Host "Package $pkgId==$pkgVersion was found on the package index."
+      return $True
+    }
+
+    $outputStr = $pipOutput -join "`n"
+
+    # pip reports "No matching distribution found" when the version doesn't exist.
+    if ($outputStr -match "No matching distribution found" -or $outputStr -match "Could not find a version that satisfies")
+    {
+      Write-Host "Package $pkgId==$pkgVersion was not found on the package index (not yet published)."
       return $False
     }
-    Write-Host "PyPI Invocation failed:"
-    Write-Host "StatusCode:" $statusCode
-    Write-Host "StatusDescription:" $statusDescription
+
+    # Any other failure is unexpected — fail hard to avoid accidentally re-publishing.
+    Write-Host "Package version check failed unexpectedly:"
+    Write-Host $outputStr
     exit(1)
+  }
+  finally
+  {
+    Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
   }
 }
 


### PR DESCRIPTION
- [x] WAS going to pypi to check of package is released, now attempt to pip download so that overriden PIP_INDEX_URL will be checked instead.
- [x] ~~Still facing failure~~ The issue was that we were exiting with the last $LASTEXITCODE. This was causing failure because the _success_ case is not being able to resolve the dep. Instead we were treating that as the error case accidentally.

[Proven successful](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6190067&view=results)