### PR TITLE
[Cosmos] Fix new pylint errors

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_http_logging_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_http_logging_policy.py
@@ -400,8 +400,8 @@ class CosmosHttpLoggingPolicy(HttpLoggingPolicy):
                 request.context.pop("logger_attributes", None)
 
             except Exception as err:  # pylint: disable=broad-except
-                logger.warning("Failed to log request: %s",
-                               repr(err))  # pylint: disable=do-not-log-exceptions-if-not-debug
+                logger.warning(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                    "Failed to log request: %s", repr(err))
             return
         super().on_request(request)
 
@@ -496,8 +496,8 @@ class CosmosHttpLoggingPolicy(HttpLoggingPolicy):
                     log_string += "\nResponse error message: {}".format(_format_error(http_response.text()))
                 logger.info(log_string, extra=log_data)
             except Exception as err:  # pylint: disable=broad-except
-                logger.warning("Failed to log response: %s", repr(err),
-                               extra=log_data)  # pylint: disable=do-not-log-exceptions-if-not-debug
+                logger.warning(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                    "Failed to log response: %s", repr(err), extra=log_data)
             return
         super().on_response(request, response)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -191,13 +191,11 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             def runner():
                 try:
                     target(**kwargs)
-                except Exception:  # pylint: disable=broad-exception-caught
-                    # Background failures must not crash the foreground thread.
-                    # Emit an operator-visible warning without exception detail, plus a
-                    # debug-level entry that carries the full traceback.
-                    logger.warning(
-                        "Cosmos endpoint health-check refresh failed (see debug logs for detail).")
-                    logger.debug("Health check task failed.", exc_info=True)
+                except Exception as exception: #pylint: disable=broad-exception-caught
+                    # background failures should not crash main thread
+                    # Intentionally swallow to avoid affecting foreground; logging could be added.
+                    logger.error(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                        "Health check task failed: %s", exception, exc_info=True)
             t = threading.Thread(target=runner, name="cosmos-endpoint-refresh", daemon=True)
             self._refresh_thread = t
             t.start()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -191,11 +191,13 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             def runner():
                 try:
                     target(**kwargs)
-                except Exception as exception: #pylint: disable=broad-exception-caught
-                    # background failures should not crash main thread
-                    # Intentionally swallow to avoid affecting foreground; log at debug
-                    # level only (do-not-log-exceptions-if-not-debug guideline).
-                    logger.debug("Health check task failed: %s", exception, exc_info=True)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    # Background failures must not crash the foreground thread.
+                    # Emit an operator-visible warning without exception detail, plus a
+                    # debug-level entry that carries the full traceback.
+                    logger.warning(
+                        "Cosmos endpoint health-check refresh failed (see debug logs for detail).")
+                    logger.debug("Health check task failed.", exc_info=True)
             t = threading.Thread(target=runner, name="cosmos-endpoint-refresh", daemon=True)
             self._refresh_thread = t
             t.start()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -193,8 +193,9 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                     target(**kwargs)
                 except Exception as exception: #pylint: disable=broad-exception-caught
                     # background failures should not crash main thread
-                    # Intentionally swallow to avoid affecting foreground; logging could be added.
-                    logger.error("Health check task failed: %s", exception, exc_info=True)
+                    # Intentionally swallow to avoid affecting foreground; log at debug
+                    # level only (do-not-log-exceptions-if-not-debug guideline).
+                    logger.debug("Health check task failed: %s", exception, exc_info=True)
             t = threading.Thread(target=runner, name="cosmos-endpoint-refresh", daemon=True)
             self._refresh_thread = t
             t.start()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
@@ -147,5 +147,5 @@ class QueryAdvice:
 
             return cls(entries)
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            _LOGGER.warning("Failed to parse query advice from response header: %s", e)
+            _LOGGER.debug("Failed to parse query advice from response header: %s", e)
             return None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
@@ -147,9 +147,6 @@ class QueryAdvice:
 
             return cls(entries)
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            # Surface contract drift / unexpected header shape at warning level (without
-            # the exception object), then capture full detail at debug.
-            _LOGGER.warning(
-                "Could not parse query advice from response header (advice will be skipped).")
-            _LOGGER.debug("Query advice parse error: %r", e, exc_info=True)
+            _LOGGER.warning(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                "Failed to parse query advice from response header: %s", e)
             return None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
@@ -151,5 +151,5 @@ class QueryAdvice:
             # the exception object), then capture full detail at debug.
             _LOGGER.warning(
                 "Could not parse query advice from response header (advice will be skipped).")
-            _LOGGER.debug("Query advice parse error: %r", e)
+            _LOGGER.debug("Query advice parse error: %r", e, exc_info=True)
             return None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_query_advisor/_query_advice.py
@@ -147,5 +147,9 @@ class QueryAdvice:
 
             return cls(entries)
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            _LOGGER.debug("Failed to parse query advice from response header: %s", e)
+            # Surface contract drift / unexpected header shape at warning level (without
+            # the exception object), then capture full detail at debug.
+            _LOGGER.warning(
+                "Could not parse query advice from response header (advice will be skipped).")
+            _LOGGER.debug("Query advice parse error: %r", e)
             return None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
@@ -116,7 +116,10 @@ class ReadItemsHelperSync:
                 indexed_results.extend(chunk_results)
                 total_request_charge += chunk_ru_charge
         except (Exception, KeyboardInterrupt) as e:
-            self.logger.error("Error in query execution: %s", str(e))
+            # Log at debug level only — exception is re-raised below so callers can log
+            # full details. Avoid logging exception detail at error/warning level
+            # (azure-pylint-guidelines-checker rule do-not-log-exceptions-if-not-debug).
+            self.logger.debug("Error in query execution: %s", str(e))
             # Cancel all pending futures
             for f in futures:
                 if not f.done():

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
@@ -115,11 +115,8 @@ class ReadItemsHelperSync:
                 chunk_results, chunk_ru_charge = future.result()
                 indexed_results.extend(chunk_results)
                 total_request_charge += chunk_ru_charge
-        except (Exception, KeyboardInterrupt) as e:
-            # Log at debug level only — exception is re-raised below so callers can log
-            # full details. Avoid logging exception detail at error/warning level
-            # (azure-pylint-guidelines-checker rule do-not-log-exceptions-if-not-debug).
-            self.logger.debug("Error in query execution: %s", str(e))
+        except (Exception, KeyboardInterrupt):
+            # Exception is re-raised below; caller is responsible for logging detail.
             # Cancel all pending futures
             for f in futures:
                 if not f.done():

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_read_items_helper.py
@@ -115,8 +115,9 @@ class ReadItemsHelperSync:
                 chunk_results, chunk_ru_charge = future.result()
                 indexed_results.extend(chunk_results)
                 total_request_charge += chunk_ru_charge
-        except (Exception, KeyboardInterrupt):
-            # Exception is re-raised below; caller is responsible for logging detail.
+        except (Exception, KeyboardInterrupt) as e:
+            self.logger.error(  # pylint: disable=do-not-log-exceptions-if-not-debug,do-not-log-raised-errors
+                "Error in query execution: %s", str(e))
             # Cancel all pending futures
             for f in futures:
                 if not f.done():

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -28,7 +28,6 @@ from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from ... import _base, http_constants
 from ..collection_routing_map import CollectionRoutingMap
-from ...exceptions import CosmosHttpResponseError
 from .._routing_map_provider_common import (
     prepare_fetch_options_and_headers,
     process_fetched_ranges,
@@ -225,18 +224,17 @@ class PartitionKeyRangeCache(object):
             )
 
             ranges: List[Dict[str, Any]] = []
-            try:
-                pk_range_generator = self._document_client._ReadPartitionKeyRanges(
-                    collection_link,
-                    change_feed_options,
-                    **request_kwargs
-                )
-                async for item in pk_range_generator:
-                    ranges.append(item)
-
-            except CosmosHttpResponseError as e:
-                logger.error("Failed to read partition key ranges for collection '%s': %s", collection_link, e)
-                raise
+            # Note: CosmosHttpResponseError raised by the partition-key range read is
+            # propagated unchanged to the caller, which is responsible for handling and
+            # logging. We deliberately do not log the exception here to comply with the
+            # do-not-log-exceptions-if-not-debug and do-not-log-raised-errors guidelines.
+            pk_range_generator = self._document_client._ReadPartitionKeyRanges(
+                collection_link,
+                change_feed_options,
+                **request_kwargs
+            )
+            async for item in pk_range_generator:
+                ranges.append(item)
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -28,6 +28,7 @@ from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from ... import _base, http_constants
 from ..collection_routing_map import CollectionRoutingMap
+from ...exceptions import CosmosHttpResponseError
 from .._routing_map_provider_common import (
     prepare_fetch_options_and_headers,
     process_fetched_ranges,
@@ -224,17 +225,21 @@ class PartitionKeyRangeCache(object):
             )
 
             ranges: List[Dict[str, Any]] = []
-            # Note: CosmosHttpResponseError raised by the partition-key range read is
-            # propagated unchanged to the caller, which is responsible for handling and
-            # logging. We deliberately do not log the exception here to comply with the
-            # do-not-log-exceptions-if-not-debug and do-not-log-raised-errors guidelines.
-            pk_range_generator = self._document_client._ReadPartitionKeyRanges(
-                collection_link,
-                change_feed_options,
-                **request_kwargs
-            )
-            async for item in pk_range_generator:
-                ranges.append(item)
+            try:
+                pk_range_generator = self._document_client._ReadPartitionKeyRanges(
+                    collection_link,
+                    change_feed_options,
+                    **request_kwargs
+                )
+                async for item in pk_range_generator:
+                    ranges.append(item)
+            except CosmosHttpResponseError:
+                # Preserve collection context at debug level for diagnostics; the
+                # exception itself is propagated unchanged for the caller to handle.
+                logger.debug(
+                    "Failed to read partition key ranges for collection '%s'.",
+                    collection_link, exc_info=True)
+                raise
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -233,12 +233,10 @@ class PartitionKeyRangeCache(object):
                 )
                 async for item in pk_range_generator:
                     ranges.append(item)
-            except CosmosHttpResponseError:
-                # Preserve collection context at debug level for diagnostics; the
-                # exception itself is propagated unchanged for the caller to handle.
-                logger.debug(
-                    "Failed to read partition key ranges for collection '%s'.",
-                    collection_link, exc_info=True)
+
+            except CosmosHttpResponseError as e:
+                logger.error(  # pylint: disable=do-not-log-exceptions-if-not-debug,do-not-log-raised-errors
+                    "Failed to read partition key ranges for collection '%s': %s", collection_link, e)
                 raise
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -28,6 +28,7 @@ from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from .. import _base, http_constants
 from .collection_routing_map import CollectionRoutingMap
+from ..exceptions import CosmosHttpResponseError
 from ._routing_map_provider_common import (
     prepare_fetch_options_and_headers,
     process_fetched_ranges,
@@ -212,16 +213,20 @@ class PartitionKeyRangeCache(object):
             )
 
             ranges: List[Dict[str, Any]] = []
-            # Note: CosmosHttpResponseError raised by the partition-key range read is
-            # propagated unchanged to the caller, which is responsible for handling and
-            # logging. We deliberately do not log the exception here to comply with the
-            # do-not-log-exceptions-if-not-debug and do-not-log-raised-errors guidelines.
-            pk_range_generator = self._document_client._ReadPartitionKeyRanges(
-                collection_link,
-                change_feed_options,
-                **request_kwargs
-            )
-            ranges.extend(list(pk_range_generator))
+            try:
+                pk_range_generator = self._document_client._ReadPartitionKeyRanges(
+                    collection_link,
+                    change_feed_options,
+                    **request_kwargs
+                )
+                ranges.extend(pk_range_generator)
+            except CosmosHttpResponseError:
+                # Preserve collection context at debug level for diagnostics; the
+                # exception itself is propagated unchanged for the caller to handle.
+                logger.debug(
+                    "Failed to read partition key ranges for collection '%s'.",
+                    collection_link, exc_info=True)
+                raise
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -28,7 +28,6 @@ from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from .. import _base, http_constants
 from .collection_routing_map import CollectionRoutingMap
-from ..exceptions import CosmosHttpResponseError
 from ._routing_map_provider_common import (
     prepare_fetch_options_and_headers,
     process_fetched_ranges,
@@ -213,17 +212,16 @@ class PartitionKeyRangeCache(object):
             )
 
             ranges: List[Dict[str, Any]] = []
-            try:
-                pk_range_generator = self._document_client._ReadPartitionKeyRanges(
-                    collection_link,
-                    change_feed_options,
-                    **request_kwargs
-                )
-                ranges.extend(list(pk_range_generator))
-
-            except CosmosHttpResponseError as e:
-                logger.error("Failed to read partition key ranges for collection '%s': %s", collection_link, e)
-                raise
+            # Note: CosmosHttpResponseError raised by the partition-key range read is
+            # propagated unchanged to the caller, which is responsible for handling and
+            # logging. We deliberately do not log the exception here to comply with the
+            # do-not-log-exceptions-if-not-debug and do-not-log-raised-errors guidelines.
+            pk_range_generator = self._document_client._ReadPartitionKeyRanges(
+                collection_link,
+                change_feed_options,
+                **request_kwargs
+            )
+            ranges.extend(list(pk_range_generator))
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -219,13 +219,11 @@ class PartitionKeyRangeCache(object):
                     change_feed_options,
                     **request_kwargs
                 )
-                ranges.extend(pk_range_generator)
-            except CosmosHttpResponseError:
-                # Preserve collection context at debug level for diagnostics; the
-                # exception itself is propagated unchanged for the caller to handle.
-                logger.debug(
-                    "Failed to read partition key ranges for collection '%s'.",
-                    collection_link, exc_info=True)
+                ranges.extend(list(pk_range_generator))
+
+            except CosmosHttpResponseError as e:
+                logger.error(  # pylint: disable=do-not-log-exceptions-if-not-debug,do-not-log-raised-errors
+                    "Failed to read partition key ranges for collection '%s': %s", collection_link, e)
                 raise
 
             new_etag = response_headers.get(http_constants.HttpHeaders.ETag)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -151,7 +151,9 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
                 await self.refresh_task
                 self.refresh_task = None
             except (Exception, asyncio.CancelledError) as exception: #pylint: disable=broad-exception-caught
-                logger.error("Health check task failed: %s", exception, exc_info=True)
+                # Background refresh failures must not affect foreground request flow.
+                # Log at debug only (do-not-log-exceptions-if-not-debug guideline).
+                logger.debug("Health check task failed: %s", exception, exc_info=True)
         if current_time_millis() - self.last_refresh_time > self.refresh_time_interval_in_ms:
             self.refresh_needed = True
         if self.refresh_needed:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -150,17 +150,9 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             try:
                 await self.refresh_task
                 self.refresh_task = None
-            except Exception:  # pylint: disable=broad-exception-caught
-                # Background refresh failures must not affect foreground request flow.
-                # Emit an operator-visible warning without exception detail, plus a
-                # debug-level entry that carries the full traceback.
-                #
-                # asyncio.CancelledError is intentionally NOT caught here: since
-                # Python 3.8 it derives from BaseException (not Exception), so it
-                # propagates naturally and the surrounding task is properly cancelled.
-                logger.warning(
-                    "Cosmos endpoint health-check refresh failed (see debug logs for detail).")
-                logger.debug("Health check task failed.", exc_info=True)
+            except (Exception, asyncio.CancelledError) as exception: #pylint: disable=broad-exception-caught
+                logger.error(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                    "Health check task failed: %s", exception, exc_info=True)
         if current_time_millis() - self.last_refresh_time > self.refresh_time_interval_in_ms:
             self.refresh_needed = True
         if self.refresh_needed:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -150,10 +150,14 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             try:
                 await self.refresh_task
                 self.refresh_task = None
-            except (Exception, asyncio.CancelledError):  # pylint: disable=broad-exception-caught
+            except Exception:  # pylint: disable=broad-exception-caught
                 # Background refresh failures must not affect foreground request flow.
                 # Emit an operator-visible warning without exception detail, plus a
                 # debug-level entry that carries the full traceback.
+                #
+                # asyncio.CancelledError is intentionally NOT caught here: since
+                # Python 3.8 it derives from BaseException (not Exception), so it
+                # propagates naturally and the surrounding task is properly cancelled.
                 logger.warning(
                     "Cosmos endpoint health-check refresh failed (see debug logs for detail).")
                 logger.debug("Health check task failed.", exc_info=True)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -150,10 +150,13 @@ class _GlobalEndpointManager(object): # pylint: disable=too-many-instance-attrib
             try:
                 await self.refresh_task
                 self.refresh_task = None
-            except (Exception, asyncio.CancelledError) as exception: #pylint: disable=broad-exception-caught
+            except (Exception, asyncio.CancelledError):  # pylint: disable=broad-exception-caught
                 # Background refresh failures must not affect foreground request flow.
-                # Log at debug only (do-not-log-exceptions-if-not-debug guideline).
-                logger.debug("Health check task failed: %s", exception, exc_info=True)
+                # Emit an operator-visible warning without exception detail, plus a
+                # debug-level entry that carries the full traceback.
+                logger.warning(
+                    "Cosmos endpoint health-check refresh failed (see debug logs for detail).")
+                logger.debug("Health check task failed.", exc_info=True)
         if current_time_millis() - self.last_refresh_time > self.refresh_time_interval_in_ms:
             self.refresh_needed = True
         if self.refresh_needed:


### PR DESCRIPTION
## Summary

The `Build Analyze` (pylint) job for `sdk/cosmos/azure-cosmos` was failing with **9 new pylint errors** introduced by recent commits (between 2025-08 and 2026-04). All flagged production code is in `azure/cosmos/`. This PR applies minimal, surgical fixes — no behavioural changes, no test edits.

### Errors fixed (by category)

| Code | Rule | Files |
|------|------|-------|
| `C4766` | `do-not-log-exceptions-if-not-debug` | `_read_items_helper.py`, `_cosmos_http_logging_policy.py` (×2), `_global_endpoint_manager.py`, `_query_advisor/_query_advice.py`, `_routing/routing_map_provider.py`, `_routing/aio/routing_map_provider.py`, `aio/_global_endpoint_manager_async.py` |
| `C4762` | `do-not-log-raised-errors` | `_routing/routing_map_provider.py`, `_routing/aio/routing_map_provider.py` |


### Disable comments

Disabled these new pylint errors as logging exceptions is still critical. 

