### PR TITLE
Fix orphaned worker processes on changelog generation timeout

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -39,8 +39,22 @@ def is_arm_sdk(package_name: str) -> bool:
 
 
 def execute_func_with_timeout(func, timeout: int = 900) -> Any:
-    """Execute function with timeout"""
-    return multiprocessing.Pool(processes=1).apply_async(func).get(timeout)
+    """Execute function with timeout.
+
+    On timeout, the worker pool is forcefully terminated to prevent orphaned
+    child processes from continuing to run.
+    """
+    pool = multiprocessing.Pool(processes=1)
+    try:
+        result = pool.apply_async(func)
+        return result.get(timeout)
+    except multiprocessing.TimeoutError:
+        pool.terminate()
+        pool.join()
+        raise
+    finally:
+        pool.terminate()
+        pool.join()
 
 
 def get_changelog_content(

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -219,7 +219,7 @@ def main(generate_input, generate_output):
                 Path(sdk_code_path).absolute(),
                 enable_changelog=data.get("enableChangelog", True),
                 package_result=result[package_name],
-                timeout=900 if data.get("runMode") in ["spec-pull-request"] else 7200,
+                timeout=1800 if data.get("runMode") in ["spec-pull-request"] else 7200,
             )
 
             # update version in _version.py and CHANGELOG.md


### PR DESCRIPTION
When changelog generation times out, the multiprocessing pool worker and its child processes (azpysdk breaking) were not terminated, causing a race condition where the finally block deleted stable.json while orphaned processes were still running. This resulted in FileNotFoundError in the breaking change checker.

Changes:
- execute_func_with_timeout now properly calls pool.terminate() and pool.join() on timeout to kill worker processes before cleanup
- Extended spec-pull-request timeout from 900s to 1800s for large packages like azure-mgmt-network

The original issue comes from this [PR](https://github.com/Azure/azure-rest-api-specs/pull/42403)'s SDK validation.
