### PR TITLE
docs(azure-appconfiguration-provider): update readme to correct feature_flags_enabled to feature_flag_enabled

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration-provider/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/README.md
@@ -191,7 +191,7 @@ alpha = config["feature_management"]["feature_flags"]["Alpha"]
 print(alpha["enabled"])
 ```
 
-By default all feature flags with no label are loaded when `feature_flag_enabled` is set to `True`. . If you want to load feature flags with a specific label you can use `SettingSelector` to filter the feature flags.
+By default all feature flags with no label are loaded when `feature_flag_enabled` is set to `True`. If you want to load feature flags with a specific label you can use `SettingSelector` to filter the feature flags.
 
 ```python
 from azure.appconfiguration.provider import load, SettingSelector

--- a/sdk/appconfiguration/azure-appconfiguration-provider/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/README.md
@@ -201,7 +201,7 @@ alpha = config["feature_management"]["feature_flags"]["Alpha"]
 print(alpha["enabled"])
 ```
 
-To enable refresh for feature flags you need to enable refresh. This will allow the provider to refresh feature flags the same way it refreshes configurations. Unlike configurations, all loaded feature flags are monitored for changes and will cause a refresh. Refresh of configuration settings and feature flags are independent of each other. Both are trigged by the `refresh` method, but a feature flag changing will not cause a refresh of configurations and vice versa. Also, if refresh for configuration settings is not enabled, feature flags can still be enabled for refresh.
+To enable refresh for feature flags you need to enable refresh. This will allow the provider to refresh feature flags the same way it refreshes configurations. Unlike configurations, all loaded feature flags are monitored for changes and will cause a refresh. Refresh of configuration settings and feature flags are independent of each other. Both are triggered by the `refresh` method, but a feature flag changing will not cause a refresh of configurations and vice versa. Also, if refresh for configuration settings is not enabled, feature flags can still be enabled for refresh.
 
 ```python
 config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flag_enabled=True, feature_flag_refresh_enabled=True)

--- a/sdk/appconfiguration/azure-appconfiguration-provider/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/README.md
@@ -186,17 +186,17 @@ config = load(endpoint=endpoint, credential=DefaultAzureCredential(), replica_di
 Feature Flags can be loaded from config stores using the provider. Feature flags are loaded as a dictionary of key/value pairs stored in the provider under the `feature_management`, then `feature_flags`.
 
 ```python
-config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flags_enabled=True)
+config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flag_enabled=True)
 alpha = config["feature_management"]["feature_flags"]["Alpha"]
 print(alpha["enabled"])
 ```
 
-By default all feature flags with no label are loaded when `feature_flags_enabled` is set to `True`. . If you want to load feature flags with a specific label you can use `SettingSelector` to filter the feature flags.
+By default all feature flags with no label are loaded when `feature_flag_enabled` is set to `True`. . If you want to load feature flags with a specific label you can use `SettingSelector` to filter the feature flags.
 
 ```python
 from azure.appconfiguration.provider import load, SettingSelector
 
-config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flags_enabled=True, feature_flag_selectors=[SettingSelector(key_filter="*", label_filter="dev")])
+config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flag_enabled=True, feature_flag_selectors=[SettingSelector(key_filter="*", label_filter="dev")])
 alpha = config["feature_management"]["feature_flags"]["Alpha"]
 print(alpha["enabled"])
 ```
@@ -204,7 +204,7 @@ print(alpha["enabled"])
 To enable refresh for feature flags you need to enable refresh. This will allow the provider to refresh feature flags the same way it refreshes configurations. Unlike configurations, all loaded feature flags are monitored for changes and will cause a refresh. Refresh of configuration settings and feature flags are independent of each other. Both are trigged by the `refresh` method, but a feature flag changing will not cause a refresh of configurations and vice versa. Also, if refresh for configuration settings is not enabled, feature flags can still be enabled for refresh.
 
 ```python
-config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flags_enabled=True, feature_flag_refresh_enabled=True)
+config = load(endpoint=endpoint, credential=DefaultAzureCredential(), feature_flag_enabled=True, feature_flag_refresh_enabled=True)
 
 ...
 


### PR DESCRIPTION
# Description

docs(azure-appconfiguration-provider): update readme to correct feature_flags_enabled to feature_flag_enabled

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.


Fixes: #46466