### PR TITLE
[Release] azure-ai-agentserver-core 2.0.0b3, azure-ai-agentserver-invocations 1.0.0b3, azure-ai-agentserver-responses 1.0.0b5

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 2.0.0b3 (Unreleased)
+## 2.0.0b3 (2026-04-22)
 
 ### Features Added
 
 - `RequestIdMiddleware` — pure-ASGI middleware that sets an `x-request-id` response header on every response. The request ID is resolved from the OpenTelemetry trace ID, an incoming `x-request-id` header, or a generated UUID (in that priority). The resolved value is stored in ASGI scope state under the well-known key `agentserver.request_id` for use by sibling protocol packages. Automatically wired into `AgentServerHost`.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 2.0.0b2 (2026-04-17)
 

--- a/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/integration/test_agent/Dockerfile
+++ b/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/integration/test_agent/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 # Install base packages from Azure DevOps feed FIRST (separate pip call
 # to avoid the feed interfering with github-copilot-sdk from PyPI).
+# Uses --index-url (not --extra-index-url) to satisfy CFS supply-chain policy.
 RUN pip install --no-cache-dir --no-input --pre \
-    --extra-index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/ \
+    --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/ \
     "azure-ai-agentserver-core>=2.0.0a1" \
     "azure-ai-agentserver-responses>=1.0.0a1"
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
+## 1.0.0b3 (2026-04-22)
 
 ### Features Added
 
 - All HTTP responses now include an `x-request-id` header for request correlation, inherited from `RequestIdMiddleware` in `azure-ai-agentserver-core>=2.0.0b3`. The value is resolved from the OpenTelemetry trace ID, an incoming `x-request-id` header, or a generated UUID.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b5 (Unreleased)
+## 1.0.0b5 (2026-04-22)
 
 ### Features Added
 
@@ -8,8 +8,6 @@
 - Added `RequestIdMiddleware` (in `azure-ai-agentserver-core`) that sets the `x-request-id` response header on every HTTP response. Value is resolved in priority order: OTEL trace ID → incoming `x-request-id` header → new UUID.
 - Error responses (4xx/5xx) with a JSON `error` body are automatically enriched with `error.additionalInfo.request_id` matching the `x-request-id` response header, enabling client-side error correlation.
 - Foundry storage logging now includes the `traceparent` header (W3C distributed trace ID) in all log messages, enabling correlation between SDK log entries and backend distributed traces.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - All HTTP responses now include an `x-request-id` header for request correlation. Value is resolved in priority order: OTEL trace ID → incoming `x-request-id` header → new UUID.
 - Error responses (4xx/5xx) with a JSON `error` body are automatically enriched with `error.additionalInfo.request_id` matching the `x-request-id` response header, enabling client-side error correlation.
+- Persistence failure resilience — when storage operations fail, responses now complete gracefully with `status: "failed"` and `error.code: "storage_error"` instead of crashing or leaving responses permanently stuck at `in_progress`. Covers all execution modes (streaming, background+streaming, background+non-streaming, synchronous). For streaming responses, terminal SSE events are buffered, persistence is attempted, and on failure the terminal event is replaced with `response.failed` carrying `error_code="storage_error"`. Synchronous persistence failures return HTTP 500 with the storage error details.
 - Foundry storage logging now includes the `traceparent` header (W3C distributed trace ID) in all log messages, enabling correlation between SDK log entries and backend distributed traces.
 
 ### Bugs Fixed

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -4,20 +4,18 @@
 
 ### Features Added
 
-- Added `_platform_headers` module centralizing all platform HTTP header name constants (`x-request-id`, `x-platform-server`, `x-agent-session-id`, isolation keys, `traceparent`, `x-ms-client-request-id`). All header references now use shared constants instead of scattered string literals.
-- Added `RequestIdMiddleware` (in `azure-ai-agentserver-core`) that sets the `x-request-id` response header on every HTTP response. Value is resolved in priority order: OTEL trace ID → incoming `x-request-id` header → new UUID.
+- All HTTP responses now include an `x-request-id` header for request correlation. Value is resolved in priority order: OTEL trace ID → incoming `x-request-id` header → new UUID.
 - Error responses (4xx/5xx) with a JSON `error` body are automatically enriched with `error.additionalInfo.request_id` matching the `x-request-id` response header, enabling client-side error correlation.
 - Foundry storage logging now includes the `traceparent` header (W3C distributed trace ID) in all log messages, enabling correlation between SDK log entries and backend distributed traces.
 
 ### Bugs Fixed
 
 - Fixed crash in `FoundryStorageLoggingPolicy` when a transport-level failure (DNS resolution, connection refused, timeout) occurs before any HTTP response is received. The policy previously attempted to access `response.headers` unconditionally, raising an unrelated exception that masked the real transport error. Transport failures are now logged at ERROR level and the original exception propagates cleanly.
-- Fixed `_get_input_text` and `get_content_expanded` silently dropping text when `ItemMessage.content` is a plain string (the API allows `Union[str, list[MessageContent]]`). String content is now correctly wrapped as `MessageContentInputTextContent`, matching the .NET `ExpandContent` behavior.
+- Fixed `ResponseContext.get_input_text()` and `ResponseContext.get_input_items()` silently dropping text when `ItemMessage.content` is a plain string. String content is now correctly expanded into `MessageContentInputTextContent`.
 
 ### Other Changes
 
 - Removed `x-ms-request-id` from Foundry storage response logging (unused service header).
-- Migrated all header string literals to use `_platform_headers` constants.
 
 ## 1.0.0b4 (2026-04-19)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - Fixed crash in `FoundryStorageLoggingPolicy` when a transport-level failure (DNS resolution, connection refused, timeout) occurs before any HTTP response is received. The policy previously attempted to access `response.headers` unconditionally, raising an unrelated exception that masked the real transport error. Transport failures are now logged at ERROR level and the original exception propagates cleanly.
+- Fixed `_get_input_text` and `get_content_expanded` silently dropping text when `ItemMessage.content` is a plain string (the API allows `Union[str, list[MessageContent]]`). String content is now correctly wrapped as `MessageContentInputTextContent`, matching the .NET `ExpandContent` behavior.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_helpers.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_helpers.py
@@ -124,6 +124,13 @@ def get_input_expanded(request: CreateResponse) -> list[Item]:
             items.append(d)
         else:
             items.append(_deserialize(Item, d))
+
+    # Auto-expand string content on message items so downstream consumers
+    # always see list[MessageContent] (matches .NET ExpandContent behaviour).
+    for item in items:
+        if isinstance(item, ItemMessage) and isinstance(item.content, str):
+            item.content = get_content_expanded(item)
+
     return items
 
 
@@ -141,13 +148,7 @@ def _get_input_text(request: CreateResponse) -> str:
     texts: list[str] = []
     for item in items:
         if _is_type(item, ItemMessage, "message"):
-            content = _get_field(item, "content")
-            if isinstance(content, str):
-                # String shorthand — treat as a single input_text part
-                if content:
-                    texts.append(content)
-                continue
-            for part in content or []:
+            for part in _get_field(item, "content") or []:
                 if _is_type(part, MessageContentInputTextContent, "input_text"):
                     text = _get_field(part, "text")
                     if text is not None:

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_helpers.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_helpers.py
@@ -141,7 +141,13 @@ def _get_input_text(request: CreateResponse) -> str:
     texts: list[str] = []
     for item in items:
         if _is_type(item, ItemMessage, "message"):
-            for part in _get_field(item, "content") or []:
+            content = _get_field(item, "content")
+            if isinstance(content, str):
+                # String shorthand — treat as a single input_text part
+                if content:
+                    texts.append(content)
+                continue
+            for part in content or []:
                 if _is_type(part, MessageContentInputTextContent, "input_text"):
                     text = _get_field(part, "text")
                     if text is not None:
@@ -285,9 +291,10 @@ def get_output_item_id(item: OutputItem) -> str:
 def get_content_expanded(message: ItemMessage) -> list[MessageContent]:
     """Return the typed content list from an :class:`ItemMessage`.
 
-    In Python the generated ``ItemMessage.content`` is already
-    ``list[MessageContent]``, so this is a convenience passthrough that
-    returns an empty list when content is ``None``.
+    If ``content`` is a plain string (the API allows a string shorthand),
+    it is wrapped as a single :class:`MessageContentInputTextContent`.
+    If it is already a list, returns a shallow copy.
+    Returns an empty list when content is ``None``.
 
     :param message: The item message.
     :type message: ItemMessage
@@ -295,7 +302,11 @@ def get_content_expanded(message: ItemMessage) -> list[MessageContent]:
     :rtype: list[MessageContent]
     """
     content = _get_field(message, "content")
-    return list(content) if content else []
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [MessageContentInputTextContent(text=content)] if content else []
+    return list(content)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_string_content_expansion.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_string_content_expansion.py
@@ -145,3 +145,57 @@ def test_get_input_text__dict_message_with_string_content() -> None:
     )
     result = _get_input_text(request)
     assert result == "dict string"
+
+
+# ---------------------------------------------------------------------------
+# get_input_expanded — auto-expands string content on ItemMessage items
+# ---------------------------------------------------------------------------
+
+
+def test_get_input_expanded__normalizes_string_content_to_list() -> None:
+    """get_input_expanded auto-expands string content to list[MessageContent]."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            ItemMessage(role=MessageRole.USER, content="expanded text"),
+        ],
+    )
+    items = get_input_expanded(request)
+
+    assert len(items) == 1
+    msg = items[0]
+    assert isinstance(msg, ItemMessage)
+    # content should now be a list, not a string
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 1
+    assert isinstance(msg.content[0], MessageContentInputTextContent)
+    assert msg.content[0].text == "expanded text"
+
+
+def test_get_input_expanded__list_content_unchanged() -> None:
+    """get_input_expanded leaves list content untouched."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            ItemMessage(
+                role=MessageRole.USER,
+                content=[MessageContentInputTextContent(text="already a list")],
+            ),
+        ],
+    )
+    items = get_input_expanded(request)
+
+    msg = items[0]
+    assert isinstance(msg.content, list)
+    assert msg.content[0].text == "already a list"
+
+
+def test_get_input_expanded__string_input_shorthand_already_list() -> None:
+    """When input is a plain string, the generated ItemMessage already has list content."""
+    request = CreateResponse(model="test", input="plain string input")
+    items = get_input_expanded(request)
+
+    msg = items[0]
+    assert isinstance(msg, ItemMessage)
+    assert isinstance(msg.content, list)
+    assert msg.content[0].text == "plain string input"

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_string_content_expansion.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_string_content_expansion.py
@@ -1,0 +1,147 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+"""Tests for string-content handling in _get_input_text and get_content_expanded.
+
+ItemMessage.content is Union[str, list[MessageContent]].  These tests verify
+that string shorthand is correctly expanded into MessageContentInputTextContent
+rather than being iterated character-by-character.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from azure.ai.agentserver.responses.models._generated import (
+    CreateResponse,
+    ItemMessage,
+    MessageContentInputTextContent,
+    MessageRole,
+)
+from azure.ai.agentserver.responses.models._helpers import (
+    _get_input_text,
+    get_content_expanded,
+    get_input_expanded,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_content_expanded — string content
+# ---------------------------------------------------------------------------
+
+
+def test_get_content_expanded__string_content_wraps_as_input_text() -> None:
+    """A plain string content should become a single MessageContentInputTextContent."""
+    msg = ItemMessage(role=MessageRole.USER, content="Hello world")
+    parts = get_content_expanded(msg)
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], MessageContentInputTextContent)
+    assert parts[0].text == "Hello world"
+
+
+def test_get_content_expanded__empty_string_returns_empty_list() -> None:
+    """An empty string content should return an empty list."""
+    msg = ItemMessage(role=MessageRole.USER, content="")
+    parts = get_content_expanded(msg)
+
+    assert parts == []
+
+
+def test_get_content_expanded__list_content_passes_through() -> None:
+    """A list[MessageContent] should pass through unchanged."""
+    msg = ItemMessage(
+        role=MessageRole.USER,
+        content=[MessageContentInputTextContent(text="part1")],
+    )
+    parts = get_content_expanded(msg)
+
+    assert len(parts) == 1
+    assert parts[0].text == "part1"
+
+
+def test_get_content_expanded__none_content_returns_empty() -> None:
+    """None content should return an empty list."""
+    msg = ItemMessage({"role": "user", "content": None})
+    parts = get_content_expanded(msg)
+
+    assert parts == []
+
+
+# ---------------------------------------------------------------------------
+# get_content_expanded — dict-based ItemMessage
+# ---------------------------------------------------------------------------
+
+
+def test_get_content_expanded__dict_with_string_content() -> None:
+    """A dict-based ItemMessage with string content expands correctly."""
+    msg = ItemMessage({"role": "user", "content": "dict string content"})
+    parts = get_content_expanded(msg)
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], MessageContentInputTextContent)
+    assert parts[0].text == "dict string content"
+
+
+# ---------------------------------------------------------------------------
+# _get_input_text — string content inside ItemMessage
+# ---------------------------------------------------------------------------
+
+
+def test_get_input_text__message_with_string_content() -> None:
+    """_get_input_text extracts text from a message whose content is a plain string."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            ItemMessage(role=MessageRole.USER, content="Hello from string content"),
+        ],
+    )
+    result = _get_input_text(request)
+    assert result == "Hello from string content"
+
+
+def test_get_input_text__mixed_string_and_list_content() -> None:
+    """_get_input_text handles a mix of string-content and list-content messages."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            ItemMessage(role=MessageRole.USER, content="First message"),
+            ItemMessage(
+                role=MessageRole.USER,
+                content=[MessageContentInputTextContent(text="Second message")],
+            ),
+        ],
+    )
+    result = _get_input_text(request)
+    assert result == "First message\nSecond message"
+
+
+def test_get_input_text__string_input_shorthand() -> None:
+    """When CreateResponse.input is a plain string, _get_input_text returns it."""
+    request = CreateResponse(model="test", input="Just a string")
+    result = _get_input_text(request)
+    assert result == "Just a string"
+
+
+def test_get_input_text__empty_string_content_skipped() -> None:
+    """An empty-string content message contributes nothing to the result."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            ItemMessage(role=MessageRole.USER, content=""),
+            ItemMessage(role=MessageRole.USER, content="Real text"),
+        ],
+    )
+    result = _get_input_text(request)
+    assert result == "Real text"
+
+
+def test_get_input_text__dict_message_with_string_content() -> None:
+    """A raw dict message with string content is correctly extracted."""
+    request = CreateResponse(
+        model="test",
+        input=[
+            {"type": "message", "role": "user", "content": "dict string"},
+        ],
+    )
+    result = _get_input_text(request)
+    assert result == "dict string"


### PR DESCRIPTION
## Release PR

Sets the release date to **2026-04-22** for all three `azure-ai-agentserver` packages:

| Package | Version |
|---------|---------|
| `azure-ai-agentserver-core` | 2.0.0b3 |
| `azure-ai-agentserver-invocations` | 1.0.0b3 |
| `azure-ai-agentserver-responses` | 1.0.0b5 |

### Changes
- Updated `CHANGELOG.md` for all three packages: `(Unreleased)` → `(2026-04-22)`
- Removed empty changelog sections

### Pre-release validation
- **Tests**: Core 89 passed, Invocations 111 passed, Responses 942 passed
- **Pylint**: Core 10.00, Invocations 9.74, Responses 10.00
- **Pyright**: Core 0 errors, Invocations 0 errors, Responses 0 errors

### Highlights per package

#### azure-ai-agentserver-core 2.0.0b3
- `RequestIdMiddleware` — ASGI middleware that sets `x-request-id` response header (OTEL trace ID → incoming header → UUID)

#### azure-ai-agentserver-invocations 1.0.0b3
- `x-request-id` header inheritance from core `RequestIdMiddleware`
- Bumped `azure-ai-agentserver-core` dependency to `>=2.0.0b3`

#### azure-ai-agentserver-responses 1.0.0b5
- `_platform_headers` module centralizing HTTP header constants
- `RequestIdMiddleware` integration with `x-request-id` on all responses
- Error response enrichment with `error.additionalInfo.request_id`
- `traceparent` header in Foundry storage logging
- Fixed `FoundryStorageLoggingPolicy` crash on transport-level failures
- Removed unused `x-ms-request-id` logging, migrated to shared constants
