### PR TITLE
[sdk generation pipeline] update timeout value for changelog generation

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -219,7 +219,7 @@ def main(generate_input, generate_output):
                 Path(sdk_code_path).absolute(),
                 enable_changelog=data.get("enableChangelog", True),
                 package_result=result[package_name],
-                timeout=1800 if data.get("runMode") in ["spec-pull-request"] else 7200,
+                timeout=900 if data.get("runMode") in ["spec-pull-request"] else 7200,
             )
 
             # update version in _version.py and CHANGELOG.md


### PR DESCRIPTION
1800s is too long for changelog generation in spec pull request CI