### PR TITLE
Dealing with a supply chain warnings that are tripping up `Secure Supply Chain Analysis` injected task

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/integration/test_agent/Dockerfile
+++ b/sdk/agentserver/azure-ai-agentserver-githubcopilot/tests/integration/test_agent/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 # Install base packages from Azure DevOps feed FIRST (separate pip call
 # to avoid the feed interfering with github-copilot-sdk from PyPI).
-# Uses --index-url (not --extra-index-url) to satisfy CFS supply-chain policy.
+# Uses --index-url to satisfy CFS supply-chain policy.
 RUN pip install --no-cache-dir --no-input --pre \
     --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/ \
     "azure-ai-agentserver-core>=2.0.0a1" \

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/assets/responses-echo-agent/Dockerfile
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/assets/responses-echo-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM mcr.microsoft.com/mirror/docker/library/python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
[Example build failure caused by these](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6194494&view=logs&j=6e28604c-c655-5dcf-8c56-152d3f87ff2e&t=e6cd620c-afa3-5e46-25b5-bd480e67fd61&l=29)

The changes should be totally transparent, and the warning on PRESENCE of `--extra-index-url` is in and of itself, a little bit extra haha.