### PR TITLE
feat(agentserver): error source classification + Foundry pipeline gzip-body fix

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `_platform_headers` module with cross-cutting protocol header name constants (`x-request-id`, `x-platform-server`, `x-agent-session-id`, `x-platform-error-source`, `x-platform-error-detail`, and others). Protocol packages now import shared header name strings from core instead of maintaining their own copies.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_platform_headers.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_platform_headers.py
@@ -1,11 +1,11 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT license.
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
 """Platform HTTP header name constants used across the AgentServer packages.
 
+Defines the HTTP header names used across the AgentServer platform.
 These headers form the wire contract between the Foundry platform, agent
-containers, and downstream storage services.  All header name constants
-are defined here to eliminate scattered string literals and ensure
-consistency across logging policies, middleware, and endpoint handlers.
+containers, and downstream storage services.
 
 **Response headers** (set by the server on every response):
 
@@ -83,8 +83,6 @@ CLIENT_REQUEST_ID: str = "x-ms-client-request-id"
 Logged for diagnostic correlation with upstream Azure SDK callers.
 """
 
-# -- Storage diagnostics (response headers from Foundry) --------------------
-
 APIM_REQUEST_ID: str = "apim-request-id"
 """The ``apim-request-id`` header — APIM gateway correlation header.
 Extracted from Foundry storage responses for diagnostic logging.
@@ -103,49 +101,4 @@ ERROR_DETAIL: str = "x-platform-error-detail"
 """The ``x-platform-error-detail`` header — internal diagnostic detail
 for platform telemetry.  Not intended for end-user display.
 Present on error responses when additional diagnostic context is available.
-"""
-
-ERROR_SOURCE_USER: str = "user"
-"""Error source value indicating the caller's input is invalid.
-The caller can fix the request and retry.
-"""
-
-ERROR_SOURCE_PLATFORM: str = "platform"
-"""Error source value indicating the error was caused by the SDK, library,
-or a platform dependency — not by the caller or the developer's handler.
-"""
-
-ERROR_SOURCE_UPSTREAM: str = "upstream"
-"""Error source value indicating the developer's handler code or an external
-service it called failed or returned incorrect behaviour.
-"""
-
-# -- Platform error tagging -------------------------------------------------
-
-PLATFORM_ERROR_TAG: str = "Azure.AI.AgentServer.PlatformError"
-"""Key for tagging exceptions as platform errors.
-
-Infrastructure code sets this key on exceptions to signal that the error
-originated from the SDK's own infrastructure (storage transport, auth,
-persistence pipeline).  Exceptions with this tag are classified as
-``platform``; all others default to ``upstream`` (developer handler code)
-in the exception filter.
-"""
-
-# -- Error detail formatting ------------------------------------------------
-
-MAX_ERROR_DETAIL_LENGTH: int = 2048
-"""Maximum length for the ``x-platform-error-detail`` header value.
-
-Keeps the header within safe limits for reverse proxies and load balancers
-while preserving enough of the exception string to be diagnostically useful.
-"""
-
-# -- HttpContext item key ---------------------------------------------------
-
-REQUEST_ID_ITEM_KEY: str = "agentserver.request_id"
-"""Key used to store the resolved request ID in ASGI scope state.
-
-Downstream handlers and middleware can read this value to correlate the
-request ID without re-resolving it.
 """

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features Added
 
+- Error source classification headers: All HTTP error responses now include `x-platform-error-source` with a value of `user`, `platform`, or `upstream` to indicate which component caused the error. Developer handler exceptions and missing handler registrations are classified as `upstream`. Exceptions tagged with the platform error tag are classified as `platform` and additionally include `x-platform-error-detail` with truncated exception details (max 2048 characters) for diagnostics.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Platform header name constants (e.g. `x-platform-error-source`, `x-platform-error-detail`) are now imported from `azure-ai-agentserver-core` (`_platform_headers` module) instead of being defined locally. Error source classification helpers remain internal to this package.
 
 ## 1.0.0b3 (2026-04-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_constants.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_constants.py
@@ -1,18 +1,20 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+from azure.ai.agentserver.core._platform_headers import SESSION_ID as _SESSION_ID
 
 
 class InvocationConstants:
     """Invocation protocol constants.
 
     Protocol-specific headers, env vars, and defaults for the invocation
-    endpoints.
+    endpoints.  Cross-cutting header names (e.g. session ID) are imported
+    from :mod:`azure.ai.agentserver.core._platform_headers`.
     """
 
     # Request / response headers
     INVOCATION_ID_HEADER = "x-agent-invocation-id"
-    SESSION_ID_HEADER = "x-agent-session-id"
+    SESSION_ID_HEADER = _SESSION_ID
 
     # Span attribute keys
     ATTR_SPAN_INVOCATION_ID = "azure.ai.agentserver.invocations.invocation_id"

--- a/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_invocation.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_invocation.py
@@ -29,10 +29,48 @@ from azure.ai.agentserver.core import (  # pylint: disable=no-name-in-module
     set_current_span,
     trace_stream,
 )
+from azure.ai.agentserver.core._platform_headers import (
+    CHAT_ISOLATION_KEY,
+    ERROR_DETAIL,
+    ERROR_SOURCE,
+    USER_ISOLATION_KEY,
+)
 
 from ._constants import InvocationConstants
 
 logger = logging.getLogger("azure.ai.agentserver")
+
+# ---------------------------------------------------------------------------
+# Internal error-source classification
+# ---------------------------------------------------------------------------
+
+_ERROR_SOURCE_UPSTREAM: str = "upstream"
+_ERROR_SOURCE_PLATFORM: str = "platform"
+_PLATFORM_ERROR_TAG: str = "Azure.AI.AgentServer.PlatformError"
+_MAX_ERROR_DETAIL_LENGTH: int = 2048
+
+
+def _apply_error_source_headers(
+    headers: dict[str, str],
+    error_source: str,
+    error_detail: Optional[str] = None,
+) -> dict[str, str]:
+    """Return a new dict with error source classification headers merged in."""
+    merged = {**headers, ERROR_SOURCE: error_source}
+    if error_detail:
+        merged[ERROR_DETAIL] = error_detail
+    return merged
+
+
+def _classify_error(exc: BaseException) -> tuple[str, Optional[str]]:
+    """Classify an exception: platform-tagged → (platform, detail), else → (upstream, None)."""
+    if getattr(exc, _PLATFORM_ERROR_TAG, False) is True:
+        detail = repr(exc)
+        if len(detail) > _MAX_ERROR_DETAIL_LENGTH:
+            suffix = "...[truncated]"
+            detail = detail[: _MAX_ERROR_DETAIL_LENGTH - len(suffix)] + suffix
+        return _ERROR_SOURCE_PLATFORM, detail
+    return _ERROR_SOURCE_UPSTREAM, None
 
 # Maximum length and allowed characters for user-provided IDs (defense in depth).
 _MAX_ID_LENGTH = 256
@@ -254,12 +292,20 @@ class InvocationAgentServerHost(AgentServerHost):
     async def _dispatch_get_invocation(self, request: Request) -> Response:
         if self._get_invocation_fn is not None:
             return await self._get_invocation_fn(request)
-        return create_error_response("not_found", "get_invocation not implemented", status_code=404)
+        return create_error_response(
+            "not_found", "get_invocation not implemented",
+            status_code=404,
+            headers=_apply_error_source_headers({}, _ERROR_SOURCE_UPSTREAM),
+        )
 
     async def _dispatch_cancel_invocation(self, request: Request) -> Response:
         if self._cancel_invocation_fn is not None:
             return await self._cancel_invocation_fn(request)
-        return create_error_response("not_found", "cancel_invocation not implemented", status_code=404)
+        return create_error_response(
+            "not_found", "cancel_invocation not implemented",
+            status_code=404,
+            headers=_apply_error_source_headers({}, _ERROR_SOURCE_UPSTREAM),
+        )
 
     def get_openapi_spec(self) -> Optional[dict[str, Any]]:
         """Return the stored OpenAPI spec, or None."""
@@ -333,7 +379,11 @@ class InvocationAgentServerHost(AgentServerHost):
     async def _get_openapi_spec_endpoint(self, request: Request) -> Response:  # pylint: disable=unused-argument
         spec = self.get_openapi_spec()
         if spec is None:
-            return create_error_response("not_found", "No OpenAPI spec registered", status_code=404)
+            return create_error_response(
+                "not_found", "No OpenAPI spec registered",
+                status_code=404,
+                headers=_apply_error_source_headers({}, _ERROR_SOURCE_UPSTREAM),
+            )
         return JSONResponse(spec)
 
     async def _create_invocation_endpoint(self, request: Request) -> Response:
@@ -352,8 +402,8 @@ class InvocationAgentServerHost(AgentServerHost):
         request.state.session_id = session_id
 
         # Platform isolation headers — expose to handlers
-        request.state.user_isolation_key = request.headers.get("x-agent-user-isolation-key", "")
-        request.state.chat_isolation_key = request.headers.get("x-agent-chat-isolation-key", "")
+        request.state.user_isolation_key = request.headers.get(USER_ISOLATION_KEY, "")
+        request.state.chat_isolation_key = request.headers.get(CHAT_ISOLATION_KEY, "")
 
         with self.request_span(
             request.headers, invocation_id, "invoke_agent",
@@ -395,12 +445,16 @@ class InvocationAgentServerHost(AgentServerHost):
                     "not_implemented",
                     str(exc),
                     status_code=501,
-                    headers={
-                        InvocationConstants.INVOCATION_ID_HEADER: invocation_id,
-                        InvocationConstants.SESSION_ID_HEADER: session_id,
-                    },
+                    headers=_apply_error_source_headers(
+                        {
+                            InvocationConstants.INVOCATION_ID_HEADER: invocation_id,
+                            InvocationConstants.SESSION_ID_HEADER: session_id,
+                        },
+                        _ERROR_SOURCE_UPSTREAM,
+                    ),
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
+                error_source, error_detail = _classify_error(exc)
                 self._safe_set_attrs(otel_span, {
                     InvocationConstants.ATTR_SPAN_ERROR_CODE: "internal_error",
                     InvocationConstants.ATTR_SPAN_ERROR_MESSAGE: str(exc),
@@ -411,10 +465,14 @@ class InvocationAgentServerHost(AgentServerHost):
                     "internal_error",
                     "Internal server error",
                     status_code=500,
-                    headers={
-                        InvocationConstants.INVOCATION_ID_HEADER: invocation_id,
-                        InvocationConstants.SESSION_ID_HEADER: session_id,
-                    },
+                    headers=_apply_error_source_headers(
+                        {
+                            InvocationConstants.INVOCATION_ID_HEADER: invocation_id,
+                            InvocationConstants.SESSION_ID_HEADER: session_id,
+                        },
+                        error_source,
+                        error_detail,
+                    ),
                 )
             finally:
                 _invocation_id_var.reset(inv_token)
@@ -459,6 +517,7 @@ class InvocationAgentServerHost(AgentServerHost):
                 response.headers[InvocationConstants.INVOCATION_ID_HEADER] = invocation_id
                 return response
             except Exception as exc:  # pylint: disable=broad-exception-caught
+                error_source, error_detail = _classify_error(exc)
                 self._safe_set_attrs(_otel_span, {
                     InvocationConstants.ATTR_SPAN_ERROR_CODE: "internal_error",
                     InvocationConstants.ATTR_SPAN_ERROR_MESSAGE: str(exc),
@@ -469,7 +528,11 @@ class InvocationAgentServerHost(AgentServerHost):
                     "internal_error",
                     "Internal server error",
                     status_code=500,
-                    headers={InvocationConstants.INVOCATION_ID_HEADER: invocation_id},
+                    headers=_apply_error_source_headers(
+                        {InvocationConstants.INVOCATION_ID_HEADER: invocation_id},
+                        error_source,
+                        error_detail,
+                    ),
                 )
             finally:
                 _invocation_id_var.reset(inv_token)

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_error_source_classification.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_error_source_classification.py
@@ -1,0 +1,314 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+"""Tests for error source classification on invocations endpoints.
+
+Validates that every error response from the invocations protocol includes
+``x-platform-error-source`` with the correct value (``user``, ``platform``,
+or ``upstream``) and optionally ``x-platform-error-detail``.
+"""
+from __future__ import annotations
+
+import pytest
+from azure.ai.agentserver.core._platform_headers import (
+    ERROR_DETAIL,
+    ERROR_SOURCE,
+)
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+from starlette.responses import Response
+
+from azure.ai.agentserver.invocations import InvocationAgentServerHost
+
+# Error-source values and platform error tag are internal to each protocol
+# package.  Duplicate the string literals here for test assertions.
+ERROR_SOURCE_UPSTREAM = "upstream"
+ERROR_SOURCE_PLATFORM = "platform"
+PLATFORM_ERROR_TAG = "Azure.AI.AgentServer.PlatformError"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(app: InvocationAgentServerHost) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+def _make_no_handler_app() -> InvocationAgentServerHost:
+    """App with no invoke handler registered → NotImplementedError."""
+    return InvocationAgentServerHost()
+
+
+def _make_upstream_error_app() -> InvocationAgentServerHost:
+    """App whose invoke handler always raises a generic exception."""
+    app = InvocationAgentServerHost()
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        raise RuntimeError("handler bug")
+
+    return app
+
+
+def _make_platform_error_app() -> InvocationAgentServerHost:
+    """App whose invoke handler raises an exception tagged as platform."""
+    app = InvocationAgentServerHost()
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        exc = RuntimeError("storage transport failure")
+        setattr(exc, PLATFORM_ERROR_TAG, True)
+        raise exc
+
+    return app
+
+
+def _make_echo_app() -> InvocationAgentServerHost:
+    """App with a working echo handler."""
+    app = InvocationAgentServerHost()
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        body = await request.body()
+        return Response(content=body, media_type="application/octet-stream")
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations — success (no error headers)
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessNoErrorHeaders:
+    """Successful responses must NOT contain error source headers."""
+
+    @pytest.mark.asyncio
+    async def test_success_has_no_error_source(self) -> None:
+        client = _make_client(_make_echo_app())
+        resp = await client.post("/invocations", content=b"hello")
+        assert resp.status_code == 200
+        assert ERROR_SOURCE not in resp.headers
+        assert ERROR_DETAIL not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations — NoImplementedError (501)
+# ---------------------------------------------------------------------------
+
+
+class TestNotImplementedUpstream:
+    """NotImplementedError from missing handler → upstream."""
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_classified_upstream(self) -> None:
+        client = _make_client(_make_no_handler_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert resp.status_code == 501
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_has_invocation_id(self) -> None:
+        client = _make_client(_make_no_handler_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert "x-agent-invocation-id" in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_no_error_detail(self) -> None:
+        """upstream errors should NOT have x-platform-error-detail."""
+        client = _make_client(_make_no_handler_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert ERROR_DETAIL not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations — handler exception (500 upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerExceptionUpstream:
+    """Generic exception from developer handler → upstream."""
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_classified_upstream(self) -> None:
+        client = _make_client(_make_upstream_error_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_no_error_detail(self) -> None:
+        """upstream errors should NOT have x-platform-error-detail."""
+        client = _make_client(_make_upstream_error_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert ERROR_DETAIL not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations — platform-tagged exception (500 platform)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformTaggedError:
+    """Exception tagged with PLATFORM_ERROR_TAG → platform with detail."""
+
+    @pytest.mark.asyncio
+    async def test_platform_tagged_classified_platform(self) -> None:
+        client = _make_client(_make_platform_error_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_PLATFORM
+
+    @pytest.mark.asyncio
+    async def test_platform_tagged_has_error_detail(self) -> None:
+        """platform errors MUST include x-platform-error-detail."""
+        client = _make_client(_make_platform_error_app())
+        resp = await client.post("/invocations", content=b"test")
+        assert ERROR_DETAIL in resp.headers
+        assert "storage transport failure" in resp.headers[ERROR_DETAIL]
+
+
+# ---------------------------------------------------------------------------
+# GET /invocations/{id} — no handler registered (404 upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestGetDispatchNotImplemented:
+    """Default dispatch_get_invocation (no handler) → 404 upstream."""
+
+    @pytest.mark.asyncio
+    async def test_get_not_implemented_upstream(self) -> None:
+        client = _make_client(_make_echo_app())  # no get_invocation_handler
+        resp = await client.get("/invocations/inv-123")
+        assert resp.status_code == 404
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations/{id}/cancel — no handler registered (404 upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelDispatchNotImplemented:
+    """Default dispatch_cancel_invocation (no handler) → 404 upstream."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_not_implemented_upstream(self) -> None:
+        client = _make_client(_make_echo_app())  # no cancel_invocation_handler
+        resp = await client.post("/invocations/inv-123/cancel")
+        assert resp.status_code == 404
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+
+# ---------------------------------------------------------------------------
+# GET /invocations/docs/openapi.json — no spec (404 upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenApiNotRegistered:
+    """No OpenAPI spec registered → 404 upstream."""
+
+    @pytest.mark.asyncio
+    async def test_no_spec_upstream(self) -> None:
+        client = _make_client(_make_echo_app())  # no openapi_spec
+        resp = await client.get("/invocations/docs/openapi.json")
+        assert resp.status_code == 404
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+
+# ---------------------------------------------------------------------------
+# GET /invocations/{id} — handler raises (500, classified)
+# ---------------------------------------------------------------------------
+
+
+class TestGetHandlerException:
+    """Exception in get_invocation_handler → upstream or platform."""
+
+    @pytest.mark.asyncio
+    async def test_get_handler_exception_upstream(self) -> None:
+        app = InvocationAgentServerHost()
+
+        @app.invoke_handler
+        async def invoke(request: Request) -> Response:
+            return Response(content=b"ok")
+
+        @app.get_invocation_handler
+        async def get_inv(request: Request) -> Response:
+            raise RuntimeError("oops")
+
+        client = _make_client(app)
+        resp = await client.get("/invocations/inv-123")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+        assert ERROR_DETAIL not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_get_handler_platform_error(self) -> None:
+        app = InvocationAgentServerHost()
+
+        @app.invoke_handler
+        async def invoke(request: Request) -> Response:
+            return Response(content=b"ok")
+
+        @app.get_invocation_handler
+        async def get_inv(request: Request) -> Response:
+            exc = RuntimeError("infra failure")
+            setattr(exc, PLATFORM_ERROR_TAG, True)
+            raise exc
+
+        client = _make_client(app)
+        resp = await client.get("/invocations/inv-123")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_PLATFORM
+        assert "infra failure" in resp.headers[ERROR_DETAIL]
+
+
+# ---------------------------------------------------------------------------
+# POST /invocations/{id}/cancel — handler raises (500, classified)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelHandlerException:
+    """Exception in cancel_invocation_handler → upstream or platform."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_handler_exception_upstream(self) -> None:
+        app = InvocationAgentServerHost()
+
+        @app.invoke_handler
+        async def invoke(request: Request) -> Response:
+            return Response(content=b"ok")
+
+        @app.cancel_invocation_handler
+        async def cancel_inv(request: Request) -> Response:
+            raise ValueError("bad cancel")
+
+        client = _make_client(app)
+        resp = await client.post("/invocations/inv-123/cancel")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_UPSTREAM
+
+    @pytest.mark.asyncio
+    async def test_cancel_handler_platform_error(self) -> None:
+        app = InvocationAgentServerHost()
+
+        @app.invoke_handler
+        async def invoke(request: Request) -> Response:
+            return Response(content=b"ok")
+
+        @app.cancel_invocation_handler
+        async def cancel_inv(request: Request) -> Response:
+            exc = RuntimeError("platform cancel failure")
+            setattr(exc, PLATFORM_ERROR_TAG, True)
+            raise exc
+
+        client = _make_client(app)
+        resp = await client.post("/invocations/inv-123/cancel")
+        assert resp.status_code == 500
+        assert resp.headers[ERROR_SOURCE] == ERROR_SOURCE_PLATFORM
+        assert "platform cancel failure" in resp.headers[ERROR_DETAIL]

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Removed `ContentDecodePolicy` from the `FoundryStorageProvider` HTTP pipeline.  The policy eagerly decoded every response body as JSON and crashed with `UnicodeDecodeError` when the storage backend (or an intermediary gateway/load-balancer) returned a non-UTF-8 body — for example a gzip-compressed payload, an HTML error page, or a transport-corrupted response.  The crash propagated up before our error-classification code could see the response, masking the underlying status with a generic decode error.  Our serializers and error-extraction helpers already call `http_resp.text()` lazily with defensive error handling, so the eager decode policy was never needed.
+
 ### Other Changes
 
 - Platform header name constants (e.g. `x-platform-error-source`, `x-platform-error-detail`) are now imported from `azure-ai-agentserver-core` (`_platform_headers` module). Error source classification helpers remain internal to this package.

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Platform header name constants (e.g. `x-platform-error-source`, `x-platform-error-detail`) are now imported from `azure-ai-agentserver-core` (`_platform_headers` module). Error source classification helpers remain internal to this package.
+
 ## 1.0.0b5 (2026-04-22)
 
 ### Features Added

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Error source classification headers: All HTTP error responses now include `x-platform-error-source` with a value of `user`, `platform`, or `upstream` to indicate which component caused the error. Client validation errors (400/404) are classified as `user`, Foundry storage infrastructure errors (transport failures, 5xx) as `platform`, and developer handler exceptions as `upstream`. Platform errors additionally include `x-platform-error-detail` with truncated exception details (max 2048 characters) for diagnostics. Matches the container image specification §8 error source classification.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_platform_headers.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_platform_headers.py
@@ -13,6 +13,11 @@ consistency across logging policies, middleware, and endpoint handlers.
 - :data:`SERVER_VERSION` — server SDK identity.
 - :data:`SESSION_ID` — resolved session ID (when applicable).
 
+**Error response headers** (set on 4xx/5xx responses):
+
+- :data:`ERROR_SOURCE` — classifies error origin (``user``, ``platform``, or ``upstream``).
+- :data:`ERROR_DETAIL` — internal diagnostic detail for platform telemetry.
+
 **Request headers** (set by the platform or client):
 
 - :data:`REQUEST_ID` — client-provided correlation ID (echoed back on the response).
@@ -83,6 +88,57 @@ Logged for diagnostic correlation with upstream Azure SDK callers.
 APIM_REQUEST_ID: str = "apim-request-id"
 """The ``apim-request-id`` header — APIM gateway correlation header.
 Extracted from Foundry storage responses for diagnostic logging.
+"""
+
+# -- Error source classification --------------------------------------------
+
+ERROR_SOURCE: str = "x-platform-error-source"
+"""The ``x-platform-error-source`` header — classifies every error response
+so the platform can route actionable errors to the right team.
+Present on all 4xx/5xx responses from protocol endpoints.
+Values: ``user``, ``platform``, ``upstream``.
+"""
+
+ERROR_DETAIL: str = "x-platform-error-detail"
+"""The ``x-platform-error-detail`` header — internal diagnostic detail
+for platform telemetry.  Not intended for end-user display.
+Present on error responses when additional diagnostic context is available.
+"""
+
+ERROR_SOURCE_USER: str = "user"
+"""Error source value indicating the caller's input is invalid.
+The caller can fix the request and retry.
+"""
+
+ERROR_SOURCE_PLATFORM: str = "platform"
+"""Error source value indicating the error was caused by the SDK, library,
+or a platform dependency — not by the caller or the developer's handler.
+"""
+
+ERROR_SOURCE_UPSTREAM: str = "upstream"
+"""Error source value indicating the developer's handler code or an external
+service it called failed or returned incorrect behaviour.
+"""
+
+# -- Platform error tagging -------------------------------------------------
+
+PLATFORM_ERROR_TAG: str = "Azure.AI.AgentServer.PlatformError"
+"""Key for tagging exceptions as platform errors.
+
+Infrastructure code sets this key on exceptions to signal that the error
+originated from the SDK's own infrastructure (storage transport, auth,
+persistence pipeline).  Exceptions with this tag are classified as
+``platform``; all others default to ``upstream`` (developer handler code)
+in the exception filter.
+"""
+
+# -- Error detail formatting ------------------------------------------------
+
+MAX_ERROR_DETAIL_LENGTH: int = 2048
+"""Maximum length for the ``x-platform-error-detail`` header value.
+
+Keeps the header within safe limits for reverse proxies and load balancers
+while preserving enough of the exception string to be diagnostically useful.
 """
 
 # -- HttpContext item key ---------------------------------------------------

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_endpoint_handler.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_endpoint_handler.py
@@ -28,6 +28,13 @@ from azure.ai.agentserver.core import (  # pylint: disable=import-error,no-name-
     set_current_span,
     trace_stream,
 )
+from azure.ai.agentserver.core._platform_headers import (
+    CHAT_ISOLATION_KEY,
+    CLIENT_HEADER_PREFIX,
+    SESSION_ID,
+    USER_ISOLATION_KEY,
+)
+from azure.ai.agentserver.core._request_id import REQUEST_ID_STATE_KEY
 from azure.ai.agentserver.responses.models._generated import (
     AgentReference,
     CreateResponse,
@@ -36,17 +43,6 @@ from azure.ai.agentserver.responses.models._generated import (
 
 from .._id_generator import IdGenerator
 from .._options import ResponsesServerOptions
-from .._platform_headers import (
-    CHAT_ISOLATION_KEY,
-    CLIENT_HEADER_PREFIX,
-    ERROR_SOURCE,
-    ERROR_SOURCE_PLATFORM,
-    ERROR_SOURCE_UPSTREAM,
-    ERROR_SOURCE_USER,
-    REQUEST_ID_ITEM_KEY,
-    SESSION_ID,
-    USER_ISOLATION_KEY,
-)
 from .._response_context import IsolationContext, ResponseContext
 from ..models._helpers import get_input_expanded, to_output_item
 from ..models.errors import RequestValidationError
@@ -76,7 +72,13 @@ from ._request_parsing import (
 )
 from ._runtime_state import _RuntimeState
 from ._validation import (
+    ERROR_SOURCE_PLATFORM,
+    ERROR_SOURCE_UPSTREAM,
+    ERROR_SOURCE_USER,
     _apply_error_source_headers,
+    parse_and_validate_create_response,
+)
+from ._validation import (
     deleted_response as _deleted_response,
 )
 from ._validation import (
@@ -92,12 +94,8 @@ from ._validation import (
     invalid_request_response as _invalid_request,
 )
 from ._validation import (
-    is_platform_error,
-)
-from ._validation import (
     not_found_response as _not_found,
 )
-from ._validation import parse_and_validate_create_response
 from ._validation import (
     service_unavailable_response as _service_unavailable,
 )
@@ -188,7 +186,7 @@ def _get_scope_request_id(request: Request) -> str | None:
     """
     state = request.scope.get("state")
     if isinstance(state, dict):
-        return state.get(REQUEST_ID_ITEM_KEY)
+        return state.get(REQUEST_ID_STATE_KEY)
     return None
 
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_endpoint_handler.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_endpoint_handler.py
@@ -39,6 +39,10 @@ from .._options import ResponsesServerOptions
 from .._platform_headers import (
     CHAT_ISOLATION_KEY,
     CLIENT_HEADER_PREFIX,
+    ERROR_SOURCE,
+    ERROR_SOURCE_PLATFORM,
+    ERROR_SOURCE_UPSTREAM,
+    ERROR_SOURCE_USER,
     REQUEST_ID_ITEM_KEY,
     SESSION_ID,
     USER_ISOLATION_KEY,
@@ -72,6 +76,7 @@ from ._request_parsing import (
 )
 from ._runtime_state import _RuntimeState
 from ._validation import (
+    _apply_error_source_headers,
     deleted_response as _deleted_response,
 )
 from ._validation import (
@@ -85,6 +90,9 @@ from ._validation import (
 )
 from ._validation import (
     invalid_request_response as _invalid_request,
+)
+from ._validation import (
+    is_platform_error,
 )
 from ._validation import (
     not_found_response as _not_found,
@@ -593,17 +601,29 @@ class _ResponseEndpointHandler:  # pylint: disable=too-many-instance-attributes
         except FoundryResourceNotFoundError as exc:
             span.end(exc)
             if exc.response_body is not None:
-                return JSONResponse(exc.response_body, status_code=404, headers=_hdrs)
+                return JSONResponse(
+                    exc.response_body,
+                    status_code=404,
+                    headers=_apply_error_source_headers(_hdrs, ERROR_SOURCE_USER),
+                )
             return _not_found(str(ctx.previous_response_id or ctx.conversation_id), _hdrs)
         except FoundryBadRequestError as exc:
             span.end(exc)
             if exc.response_body is not None:
-                return JSONResponse(exc.response_body, status_code=400, headers=_hdrs)
+                return JSONResponse(
+                    exc.response_body,
+                    status_code=400,
+                    headers=_apply_error_source_headers(_hdrs, ERROR_SOURCE_USER),
+                )
             return _invalid_request(str(exc), _hdrs)
         except FoundryApiError as exc:
             span.end(exc)
             if exc.response_body is not None:
-                return JSONResponse(exc.response_body, status_code=500, headers=_hdrs)
+                return JSONResponse(
+                    exc.response_body,
+                    status_code=500,
+                    headers=_apply_error_source_headers(_hdrs, ERROR_SOURCE_PLATFORM),
+                )
             return _error_response(exc, _hdrs)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error(
@@ -797,7 +817,13 @@ class _ResponseEndpointHandler:  # pylint: disable=too-many-instance-attributes
                                 "param": None,
                             }
                         }
-                        return JSONResponse(err_body, status_code=500, headers=self._session_headers(agent_session_id))
+                        return JSONResponse(
+                            err_body,
+                            status_code=500,
+                            headers=_apply_error_source_headers(
+                                self._session_headers(agent_session_id), ERROR_SOURCE_UPSTREAM
+                            ),
+                        )
                     finally:
                         disconnect_task.cancel()
 
@@ -831,7 +857,9 @@ class _ResponseEndpointHandler:  # pylint: disable=too-many-instance-attributes
                 return JSONResponse(
                     err_body,
                     status_code=500,
-                    headers=self._session_headers(agent_session_id),
+                    headers=_apply_error_source_headers(
+                        self._session_headers(agent_session_id), ERROR_SOURCE_UPSTREAM
+                    ),
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 logger.error("Unexpected error in create (response_id=%s)", ctx.response_id, exc_info=exc)

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_observability.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_observability.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, MutableMapping
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from .._platform_headers import REQUEST_ID
+from azure.ai.agentserver.core._platform_headers import REQUEST_ID
 
 if TYPE_CHECKING:
     from ._execution_context import _ExecutionContext

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_orchestrator.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_orchestrator.py
@@ -43,8 +43,8 @@ from ..streaming._sse import encode_keep_alive_comment, encode_sse_any_event, ne
 from ..streaming._state_machine import EventStreamValidator
 from ._event_subject import _ResponseEventSubject
 from ._execution_context import _ExecutionContext
-from .._platform_headers import PLATFORM_ERROR_TAG
 from ._runtime_state import _RuntimeState
+from ._validation import PLATFORM_ERROR_TAG
 
 if TYPE_CHECKING:
     from .._response_context import ResponseContext

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_orchestrator.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_orchestrator.py
@@ -43,6 +43,7 @@ from ..streaming._sse import encode_keep_alive_comment, encode_sse_any_event, ne
 from ..streaming._state_machine import EventStreamValidator
 from ._event_subject import _ResponseEventSubject
 from ._execution_context import _ExecutionContext
+from .._platform_headers import PLATFORM_ERROR_TAG
 from ._runtime_state import _RuntimeState
 
 if TYPE_CHECKING:
@@ -344,6 +345,7 @@ async def _run_background_non_stream(  # pylint: disable=too-many-locals,too-man
                         except Exception as persist_exc:  # pylint: disable=broad-exception-caught
                             # §3.3: Phase 1 create failure — mark persistence failed
                             # so the terminal update knows not to attempt update_response.
+                            setattr(persist_exc, PLATFORM_ERROR_TAG, True)
                             logger.error(
                                 "Phase 1 create_response failed for bg non-stream (response_id=%s): %s",
                                 response_id,
@@ -508,6 +510,7 @@ async def _run_background_non_stream(  # pylint: disable=too-many-locals,too-man
                         _resolved_items = await _resolve_input_items_for_persistence(context, record.input_items)
                         await provider.create_response(record.response, _resolved_items, None, isolation=_isolation)
                 except Exception as persist_exc:  # pylint: disable=broad-exception-caught
+                    setattr(persist_exc, PLATFORM_ERROR_TAG, True)
                     logger.error(
                         "Persistence failed at bg non-stream finalization (response_id=%s): %s",
                         response_id,
@@ -941,6 +944,7 @@ class _ResponseOrchestrator:  # pylint: disable=too-many-instance-attributes
                             isolation=_isolation,
                         )
                 except Exception as persist_exc:  # pylint: disable=broad-exception-caught
+                    setattr(persist_exc, PLATFORM_ERROR_TAG, True)
                     logger.error(
                         "Persistence failed at terminal event (response_id=%s): %s",
                         ctx.response_id,

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_validation.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_validation.py
@@ -10,6 +10,15 @@ from starlette.responses import JSONResponse
 
 from azure.ai.agentserver.responses._id_generator import IdGenerator
 from azure.ai.agentserver.responses._options import ResponsesServerOptions
+from azure.ai.agentserver.responses._platform_headers import (
+    ERROR_DETAIL,
+    ERROR_SOURCE,
+    ERROR_SOURCE_PLATFORM,
+    ERROR_SOURCE_UPSTREAM,
+    ERROR_SOURCE_USER,
+    MAX_ERROR_DETAIL_LENGTH,
+    PLATFORM_ERROR_TAG,
+)
 from azure.ai.agentserver.responses.models._generated import ApiErrorResponse, CreateResponse, Error
 from azure.ai.agentserver.responses.models._generated._validators import validate_CreateResponse
 from azure.ai.agentserver.responses.models.errors import RequestValidationError
@@ -265,6 +274,77 @@ def to_api_error_response(error: Exception) -> ApiErrorResponse:
 
 
 # ---------------------------------------------------------------------------
+# Error source classification (container-image-spec §8)
+# ---------------------------------------------------------------------------
+
+
+def is_platform_error(exc: BaseException) -> bool:
+    """Check whether *exc* has been tagged as a platform infrastructure error.
+
+    :param exc: The exception to inspect.
+    :type exc: BaseException
+    :returns: ``True`` if the exception carries the platform error tag.
+    :rtype: bool
+    """
+    return getattr(exc, PLATFORM_ERROR_TAG, False) is True
+
+
+def tag_platform_error(exc: BaseException) -> None:
+    """Tag *exc* as a platform infrastructure error.
+
+    The tag is set as an attribute on the exception object so that the
+    error-source classification logic can later distinguish platform errors
+    from upstream (developer handler) errors.
+
+    :param exc: The exception to tag.
+    :type exc: BaseException
+    """
+    setattr(exc, PLATFORM_ERROR_TAG, True)
+
+
+def format_error_detail(exc: BaseException) -> str:
+    """Format an exception for the ``x-platform-error-detail`` header.
+
+    Uses ``repr(exc)`` for diagnostic context and truncates to
+    :data:`MAX_ERROR_DETAIL_LENGTH`.
+
+    :param exc: The exception to format.
+    :type exc: BaseException
+    :returns: A truncated string suitable for the header value.
+    :rtype: str
+    """
+    detail = repr(exc)
+    if len(detail) > MAX_ERROR_DETAIL_LENGTH:
+        suffix = "...[truncated]"
+        detail = detail[: MAX_ERROR_DETAIL_LENGTH - len(suffix)] + suffix
+    return detail
+
+
+def _apply_error_source_headers(
+    headers: dict[str, str],
+    error_source: str,
+    error_detail: str | None = None,
+) -> dict[str, str]:
+    """Add error source classification headers to a headers dict.
+
+    Returns a **new** dict with the error source headers merged in.
+
+    :param headers: Existing response headers.
+    :type headers: dict[str, str]
+    :param error_source: One of ``user``, ``platform``, ``upstream``.
+    :type error_source: str
+    :param error_detail: Optional diagnostic detail for platform errors.
+    :type error_detail: str | None
+    :returns: A new dict with error source headers added.
+    :rtype: dict[str, str]
+    """
+    merged = {**headers, ERROR_SOURCE: error_source}
+    if error_detail:
+        merged[ERROR_DETAIL] = error_detail
+    return merged
+
+
+# ---------------------------------------------------------------------------
 # HTTP error response factories (moved from _http_errors.py)
 # ---------------------------------------------------------------------------
 
@@ -310,8 +390,22 @@ def _api_error(
     return JSONResponse(payload, status_code=status_code, headers=headers)
 
 
-def error_response(error: Exception, headers: dict[str, str], request_id: str | None = None) -> JSONResponse:
+def error_response(
+    error: Exception,
+    headers: dict[str, str],
+    request_id: str | None = None,
+    *,
+    error_source: str | None = None,
+) -> JSONResponse:
     """Map an exception to an appropriate HTTP error ``JSONResponse``.
+
+    Automatically classifies the error source when *error_source* is not
+    provided:
+
+    - :class:`RequestValidationError` / :class:`ValueError` → ``user``
+    - Exceptions tagged with :data:`PLATFORM_ERROR_TAG` → ``platform``
+      (includes ``x-platform-error-detail`` header)
+    - All other exceptions → ``upstream`` (developer handler code)
 
     :param error: The exception to convert to an error response.
     :type error: Exception
@@ -319,6 +413,8 @@ def error_response(error: Exception, headers: dict[str, str], request_id: str | 
     :type headers: dict[str, str]
     :param request_id: Resolved ``x-request-id`` value to embed in ``error.additionalInfo``.
     :type request_id: str | None
+    :keyword error_source: Override error source classification.
+    :paramtype error_source: str | None
     :return: A JSONResponse with the appropriate status code and error payload.
     :rtype: JSONResponse
     """
@@ -332,7 +428,19 @@ def error_response(error: Exception, headers: dict[str, str], request_id: str | 
         status_code = 404
     if request_id and isinstance(payload, dict):
         _enrich_error_payload(payload, request_id)
-    return JSONResponse(payload, status_code=status_code, headers=headers)
+
+    # Classify error source
+    if error_source is None:
+        if isinstance(error, (RequestValidationError, ValueError)):
+            error_source = ERROR_SOURCE_USER
+        elif is_platform_error(error):
+            error_source = ERROR_SOURCE_PLATFORM
+        else:
+            error_source = ERROR_SOURCE_UPSTREAM
+
+    detail = format_error_detail(error) if error_source == ERROR_SOURCE_PLATFORM else None
+    merged_headers = _apply_error_source_headers(headers, error_source, detail)
+    return JSONResponse(payload, status_code=status_code, headers=merged_headers)
 
 
 def not_found_response(
@@ -355,7 +463,7 @@ def not_found_response(
         param="response_id",
         error_type="invalid_request_error",
         status_code=404,
-        headers=headers,
+        headers=_apply_error_source_headers(headers, ERROR_SOURCE_USER),
         request_id=request_id,
     )
 
@@ -380,7 +488,7 @@ def invalid_request_response(
         param=param,
         error_type="invalid_request_error",
         status_code=400,
-        headers=headers,
+        headers=_apply_error_source_headers(headers, ERROR_SOURCE_USER),
         request_id=request_id,
     )
 
@@ -407,7 +515,7 @@ def invalid_parameters_response(
         param=param,
         error_type="invalid_request_error",
         status_code=400,
-        headers=headers,
+        headers=_apply_error_source_headers(headers, ERROR_SOURCE_USER),
         request_id=request_id,
     )
 
@@ -429,7 +537,7 @@ def invalid_mode_response(
     payload = _json_payload(build_invalid_mode_error_response(message, param=param))
     if request_id and isinstance(payload, dict):
         _enrich_error_payload(payload, request_id)
-    return JSONResponse(payload, status_code=400, headers=headers)
+    return JSONResponse(payload, status_code=400, headers=_apply_error_source_headers(headers, ERROR_SOURCE_USER))
 
 
 def service_unavailable_response(
@@ -452,7 +560,7 @@ def service_unavailable_response(
         param=None,
         error_type="server_error",
         status_code=503,
-        headers=headers,
+        headers=_apply_error_source_headers(headers, ERROR_SOURCE_PLATFORM),
         request_id=request_id,
     )
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_validation.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/hosting/_validation.py
@@ -8,17 +8,12 @@ from typing import Any, Mapping
 
 from starlette.responses import JSONResponse
 
-from azure.ai.agentserver.responses._id_generator import IdGenerator
-from azure.ai.agentserver.responses._options import ResponsesServerOptions
-from azure.ai.agentserver.responses._platform_headers import (
+from azure.ai.agentserver.core._platform_headers import (
     ERROR_DETAIL,
     ERROR_SOURCE,
-    ERROR_SOURCE_PLATFORM,
-    ERROR_SOURCE_UPSTREAM,
-    ERROR_SOURCE_USER,
-    MAX_ERROR_DETAIL_LENGTH,
-    PLATFORM_ERROR_TAG,
 )
+from azure.ai.agentserver.responses._id_generator import IdGenerator
+from azure.ai.agentserver.responses._options import ResponsesServerOptions
 from azure.ai.agentserver.responses.models._generated import ApiErrorResponse, CreateResponse, Error
 from azure.ai.agentserver.responses.models._generated._validators import validate_CreateResponse
 from azure.ai.agentserver.responses.models.errors import RequestValidationError
@@ -274,44 +269,30 @@ def to_api_error_response(error: Exception) -> ApiErrorResponse:
 
 
 # ---------------------------------------------------------------------------
-# Error source classification (container-image-spec §8)
+# Internal error-source classification constants & helpers
 # ---------------------------------------------------------------------------
+
+ERROR_SOURCE_USER: str = "user"
+ERROR_SOURCE_PLATFORM: str = "platform"
+ERROR_SOURCE_UPSTREAM: str = "upstream"
+PLATFORM_ERROR_TAG: str = "Azure.AI.AgentServer.PlatformError"
+MAX_ERROR_DETAIL_LENGTH: int = 2048
 
 
 def is_platform_error(exc: BaseException) -> bool:
-    """Check whether *exc* has been tagged as a platform infrastructure error.
-
-    :param exc: The exception to inspect.
-    :type exc: BaseException
-    :returns: ``True`` if the exception carries the platform error tag.
-    :rtype: bool
-    """
+    """Check whether *exc* has been tagged as a platform infrastructure error."""
     return getattr(exc, PLATFORM_ERROR_TAG, False) is True
 
 
 def tag_platform_error(exc: BaseException) -> None:
-    """Tag *exc* as a platform infrastructure error.
-
-    The tag is set as an attribute on the exception object so that the
-    error-source classification logic can later distinguish platform errors
-    from upstream (developer handler) errors.
-
-    :param exc: The exception to tag.
-    :type exc: BaseException
-    """
+    """Tag *exc* as a platform infrastructure error."""
     setattr(exc, PLATFORM_ERROR_TAG, True)
 
 
 def format_error_detail(exc: BaseException) -> str:
     """Format an exception for the ``x-platform-error-detail`` header.
 
-    Uses ``repr(exc)`` for diagnostic context and truncates to
-    :data:`MAX_ERROR_DETAIL_LENGTH`.
-
-    :param exc: The exception to format.
-    :type exc: BaseException
-    :returns: A truncated string suitable for the header value.
-    :rtype: str
+    Uses ``repr(exc)`` and truncates to :data:`MAX_ERROR_DETAIL_LENGTH`.
     """
     detail = repr(exc)
     if len(detail) > MAX_ERROR_DETAIL_LENGTH:
@@ -325,19 +306,7 @@ def _apply_error_source_headers(
     error_source: str,
     error_detail: str | None = None,
 ) -> dict[str, str]:
-    """Add error source classification headers to a headers dict.
-
-    Returns a **new** dict with the error source headers merged in.
-
-    :param headers: Existing response headers.
-    :type headers: dict[str, str]
-    :param error_source: One of ``user``, ``platform``, ``upstream``.
-    :type error_source: str
-    :param error_detail: Optional diagnostic detail for platform errors.
-    :type error_detail: str | None
-    :returns: A new dict with error source headers added.
-    :rtype: dict[str, str]
-    """
+    """Return a new dict with error source classification headers merged in."""
     merged = {**headers, ERROR_SOURCE: error_source}
     if error_detail:
         merged[ERROR_DETAIL] = error_detail

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_errors.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_errors.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from azure.ai.agentserver.responses._platform_headers import PLATFORM_ERROR_TAG
+
 if TYPE_CHECKING:
     from azure.core.rest import HttpResponse
 
@@ -56,7 +58,11 @@ def raise_for_storage_error(response: "HttpResponse") -> None:
         raise FoundryResourceNotFoundError(message, response_body=body)
     if status in (400, 409):
         raise FoundryBadRequestError(message, response_body=body)
-    raise FoundryApiError(message, response_body=body)
+    exc = FoundryApiError(message, response_body=body)
+    # Tag non-client storage errors as platform errors so the error source
+    # classification in response headers correctly reports "platform".
+    setattr(exc, PLATFORM_ERROR_TAG, True)
+    raise exc
 
 
 def _extract_error_message(response: "HttpResponse", status: int) -> tuple[str, dict[str, Any] | None]:

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_errors.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_errors.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from azure.ai.agentserver.responses._platform_headers import PLATFORM_ERROR_TAG
+from azure.ai.agentserver.responses.hosting._validation import PLATFORM_ERROR_TAG
 
 if TYPE_CHECKING:
     from azure.core.rest import HttpResponse

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_logging_policy.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_logging_policy.py
@@ -15,11 +15,7 @@ import time
 import urllib.parse
 from typing import cast
 
-from azure.core.pipeline import PipelineRequest, PipelineResponse
-from azure.core.pipeline.policies import AsyncHTTPPolicy
-from azure.core.rest import HttpResponse
-
-from .._platform_headers import (
+from azure.ai.agentserver.core._platform_headers import (
     APIM_REQUEST_ID,
     CHAT_ISOLATION_KEY,
     CLIENT_REQUEST_ID,
@@ -27,6 +23,9 @@ from .._platform_headers import (
     TRACEPARENT,
     USER_ISOLATION_KEY,
 )
+from azure.core.pipeline import PipelineRequest, PipelineResponse
+from azure.core.pipeline.policies import AsyncHTTPPolicy
+from azure.core.rest import HttpResponse
 
 logger = logging.getLogger("azure.ai.agentserver")
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
@@ -140,7 +140,15 @@ class FoundryStorageProvider:
                     _FOUNDRY_TOKEN_SCOPE,
                 ),
                 FoundryStorageLoggingPolicy(),
-                policies.ContentDecodePolicy(),
+                # NOTE: ``ContentDecodePolicy`` is intentionally NOT included.
+                # It eagerly decodes every response body as JSON and crashes
+                # with ``UnicodeDecodeError`` when the storage backend (or an
+                # intermediary gateway / load-balancer) returns a non-UTF-8
+                # body — for example a gzip-compressed payload, an HTML error
+                # page, or a transport-corrupted body.  We never read its
+                # output (``response.context['deserialized_data']``); our own
+                # ``_foundry_serializer`` and ``_foundry_errors`` modules call
+                # ``http_resp.text()`` directly with defensive error handling.
                 policies.DistributedTracingPolicy(),
             ],
         )

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
 
 from .._version import VERSION
-from .._platform_headers import CHAT_ISOLATION_KEY, USER_ISOLATION_KEY
+from .._platform_headers import CHAT_ISOLATION_KEY, PLATFORM_ERROR_TAG, USER_ISOLATION_KEY
 from ..models._generated import OutputItem, ResponseObject  # type: ignore[attr-defined]
 from ._foundry_errors import raise_for_storage_error
 from ._foundry_logging_policy import FoundryStorageLoggingPolicy
@@ -159,6 +159,31 @@ class FoundryStorageProvider:
         await self.aclose()
 
     # ------------------------------------------------------------------
+    # Internal transport helper
+    # ------------------------------------------------------------------
+
+    async def _send_storage_request(self, request: HttpRequest) -> Any:
+        """Send an HTTP request to the Foundry storage API.
+
+        Any transport-level exception (connection failure, timeout, etc.)
+        is tagged as a platform error before re-raising, matching the .NET
+        ``FoundryStorageProvider.SendStorageRequestAsync`` pattern.
+
+        :param request: The HTTP request to send.
+        :type request: ~azure.core.rest.HttpRequest
+        :returns: The HTTP response object.
+        :rtype: ~azure.core.rest.HttpResponse
+        :raises FoundryStorageError: When the response status code is non-2xx.
+        """
+        try:
+            http_resp = await self._client.send_request(request)
+        except Exception as exc:
+            setattr(exc, PLATFORM_ERROR_TAG, True)
+            raise
+        raise_for_storage_error(http_resp)
+        return http_resp
+
+    # ------------------------------------------------------------------
     # ResponseProviderProtocol implementation
     # ------------------------------------------------------------------
 
@@ -186,8 +211,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url("responses")
         request = HttpRequest("POST", url, content=body, headers={"Content-Type": _JSON_CONTENT_TYPE})
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        await self._send_storage_request(request)
 
     async def get_response(self, response_id: str, *, isolation: IsolationContext | None = None) -> ResponseObject:
         """Retrieve a stored response by its ID.
@@ -204,8 +228,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url(f"responses/{_encode(response_id)}")
         request = HttpRequest("GET", url)
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        http_resp = await self._send_storage_request(request)
         return deserialize_response(http_resp.text())
 
     async def update_response(self, response: ResponseObject, *, isolation: IsolationContext | None = None) -> None:
@@ -223,8 +246,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url(f"responses/{_encode(response_id)}")
         request = HttpRequest("POST", url, content=body, headers={"Content-Type": _JSON_CONTENT_TYPE})
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        await self._send_storage_request(request)
 
     async def delete_response(self, response_id: str, *, isolation: IsolationContext | None = None) -> None:
         """Delete a stored response and its associated data.
@@ -239,8 +261,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url(f"responses/{_encode(response_id)}")
         request = HttpRequest("DELETE", url)
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        await self._send_storage_request(request)
 
     async def get_input_items(
         self,
@@ -283,8 +304,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url(f"responses/{_encode(response_id)}/input_items", **extra)
         request = HttpRequest("GET", url)
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        http_resp = await self._send_storage_request(request)
         return deserialize_paged_items(http_resp.text())
 
     async def get_items(
@@ -308,8 +328,7 @@ class FoundryStorageProvider:
         url = self._settings.build_url("items/batch/retrieve")
         request = HttpRequest("POST", url, content=body, headers={"Content-Type": _JSON_CONTENT_TYPE})
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        http_resp = await self._send_storage_request(request)
         return deserialize_items_array(http_resp.text())
 
     async def get_history_item_ids(
@@ -343,6 +362,5 @@ class FoundryStorageProvider:
         url = self._settings.build_url("history/item_ids", **extra)
         request = HttpRequest("GET", url)
         _apply_isolation_headers(request, isolation)
-        http_resp = await self._client.send_request(request)
-        raise_for_storage_error(http_resp)
+        http_resp = await self._send_storage_request(request)
         return deserialize_history_ids(http_resp.text())

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_foundry_provider.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 from urllib.parse import quote as _url_quote
 
+from azure.ai.agentserver.core._platform_headers import CHAT_ISOLATION_KEY, USER_ISOLATION_KEY
+from azure.ai.agentserver.responses.hosting._validation import PLATFORM_ERROR_TAG
 from azure.core import AsyncPipelineClient
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest, policies
@@ -14,7 +16,6 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
 
 from .._version import VERSION
-from .._platform_headers import CHAT_ISOLATION_KEY, PLATFORM_ERROR_TAG, USER_ISOLATION_KEY
 from ..models._generated import OutputItem, ResponseObject  # type: ignore[attr-defined]
 from ._foundry_errors import raise_for_storage_error
 from ._foundry_logging_policy import FoundryStorageLoggingPolicy

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/contract/test_error_source_classification.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/contract/test_error_source_classification.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 
 from typing import Any, AsyncIterator
 
-from starlette.testclient import TestClient
-
-from azure.ai.agentserver.responses import ResponsesAgentServerHost
-from azure.ai.agentserver.responses._platform_headers import (
+from azure.ai.agentserver.core._platform_headers import (
     ERROR_DETAIL,
     ERROR_SOURCE,
 )
+from starlette.testclient import TestClient
+
+from azure.ai.agentserver.responses import ResponsesAgentServerHost
 from azure.ai.agentserver.responses.streaming._event_stream import ResponseEventStream
 
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/contract/test_error_source_classification.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/contract/test_error_source_classification.py
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+"""Contract tests for error source classification headers on HTTP responses.
+
+These tests verify that the ``x-platform-error-source`` and
+``x-platform-error-detail`` headers are set correctly on error and success
+responses, matching the container image spec §8 error source classification.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+from starlette.testclient import TestClient
+
+from azure.ai.agentserver.responses import ResponsesAgentServerHost
+from azure.ai.agentserver.responses._platform_headers import (
+    ERROR_DETAIL,
+    ERROR_SOURCE,
+)
+from azure.ai.agentserver.responses.streaming._event_stream import ResponseEventStream
+
+
+def _noop_handler(request: Any, context: Any, cancellation_signal: Any) -> AsyncIterator[Any]:
+    async def _events() -> AsyncIterator[Any]:
+        stream = ResponseEventStream(response_id=context.response_id, model=getattr(request, "model", None) or "")
+        yield stream.emit_created()
+        msg = stream.add_output_text_message()
+        yield msg.emit_added()
+        content = msg.add_text_content()
+        yield content.emit_added()
+        yield content.emit_text_done("hello")
+        yield content.emit_done()
+        yield msg.emit_done()
+        yield stream.emit_completed()
+
+    return _events()
+
+
+def _throwing_handler(request: Any, context: Any, cancellation_signal: Any) -> AsyncIterator[Any]:
+    async def _events() -> AsyncIterator[Any]:
+        raise RuntimeError("Simulated handler failure")
+        yield  # pragma: no cover
+
+    return _events()
+
+
+def _build_client(handler: Any = None) -> TestClient:
+    app = ResponsesAgentServerHost()
+    app.response_handler(handler or _noop_handler)
+    return TestClient(app)
+
+
+class TestErrorSourceOnSuccessResponses:
+    """Verify that successful responses do NOT include error source headers."""
+
+    def test_success_create_no_error_source_header(self) -> None:
+        client = _build_client()
+        resp = client.post(
+            "/responses",
+            json={"model": "test", "input": "hello", "stream": False, "store": True, "background": False},
+        )
+        assert resp.status_code == 200
+        assert ERROR_SOURCE not in resp.headers
+        assert ERROR_DETAIL not in resp.headers
+
+    def test_success_get_no_error_source_header(self) -> None:
+        client = _build_client()
+        create = client.post(
+            "/responses",
+            json={"model": "test", "input": "hello", "stream": False, "store": True, "background": False},
+        )
+        response_id = create.json()["id"]
+        get_resp = client.get(f"/responses/{response_id}")
+        assert get_resp.status_code == 200
+        assert ERROR_SOURCE not in get_resp.headers
+
+
+class TestErrorSourceOnValidationErrors:
+    """Verify user errors get ``x-platform-error-source: user``."""
+
+    def test_invalid_json_returns_user_error_source(self) -> None:
+        client = _build_client()
+        resp = client.post(
+            "/responses",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert resp.headers.get(ERROR_SOURCE) == "user"
+        assert ERROR_DETAIL not in resp.headers
+
+    def test_empty_body_returns_user_error_source(self) -> None:
+        client = _build_client()
+        resp = client.post(
+            "/responses",
+            content=b"",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert resp.headers.get(ERROR_SOURCE) == "user"
+
+    def test_malformed_response_id_returns_user_error_source(self) -> None:
+        client = _build_client()
+        resp = client.get("/responses/totally-invalid-id")
+        assert resp.status_code == 400
+        assert resp.headers.get(ERROR_SOURCE) == "user"
+
+    def test_not_found_returns_user_error_source(self) -> None:
+        from azure.ai.agentserver.responses._id_generator import IdGenerator
+
+        client = _build_client()
+        valid_id = IdGenerator.new_response_id()
+        resp = client.get(f"/responses/{valid_id}")
+        assert resp.status_code == 404
+        assert resp.headers.get(ERROR_SOURCE) == "user"
+
+    def test_invalid_limit_returns_user_error_source(self) -> None:
+        from azure.ai.agentserver.responses._id_generator import IdGenerator
+
+        client = _build_client()
+        valid_id = IdGenerator.new_response_id()
+        resp = client.get(f"/responses/{valid_id}/input_items?limit=abc")
+        assert resp.status_code == 400
+        assert resp.headers.get(ERROR_SOURCE) == "user"
+
+
+class TestErrorSourceOnUpstreamErrors:
+    """Verify handler errors get ``x-platform-error-source: upstream``."""
+
+    def test_sync_handler_exception_returns_upstream(self) -> None:
+        client = _build_client(_throwing_handler)
+        resp = client.post(
+            "/responses",
+            json={"model": "test", "input": "hello", "stream": False, "store": True, "background": False},
+        )
+        assert resp.status_code == 500
+        assert resp.headers.get(ERROR_SOURCE) == "upstream"
+        # Upstream errors should NOT include error detail
+        assert ERROR_DETAIL not in resp.headers
+
+
+class TestErrorSourceOnDraining:
+    """Verify service unavailable gets ``x-platform-error-source: platform``."""
+
+    def test_service_unavailable_returns_platform(self) -> None:
+        """When the server is draining, it returns 503 with error_source=platform."""
+        from azure.ai.agentserver.responses.hosting._validation import service_unavailable_response
+
+        resp = service_unavailable_response("shutting down", {})
+        assert resp.status_code == 503
+        assert resp.headers[ERROR_SOURCE] == "platform"

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_error_source_classification.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_error_source_classification.py
@@ -5,17 +5,17 @@
 from __future__ import annotations
 
 import pytest
-
-from azure.ai.agentserver.responses._platform_headers import (
+from azure.ai.agentserver.core._platform_headers import (
     ERROR_DETAIL,
     ERROR_SOURCE,
+)
+
+from azure.ai.agentserver.responses.hosting._validation import (
     ERROR_SOURCE_PLATFORM,
     ERROR_SOURCE_UPSTREAM,
     ERROR_SOURCE_USER,
     MAX_ERROR_DETAIL_LENGTH,
     PLATFORM_ERROR_TAG,
-)
-from azure.ai.agentserver.responses.hosting._validation import (
     _apply_error_source_headers,
     error_response,
     format_error_detail,
@@ -28,7 +28,6 @@ from azure.ai.agentserver.responses.hosting._validation import (
     tag_platform_error,
 )
 from azure.ai.agentserver.responses.models.errors import RequestValidationError
-
 
 # ---------------------------------------------------------------------------
 # is_platform_error / tag_platform_error
@@ -229,12 +228,8 @@ class TestFoundryErrorTagging:
     """Tests that FoundryApiError from raise_for_storage_error is tagged as platform."""
 
     def test_foundry_api_error_tagged_as_platform(self) -> None:
-        from azure.core.rest import HttpResponse
-
         from azure.ai.agentserver.responses.store._foundry_errors import (
             FoundryApiError,
-            FoundryBadRequestError,
-            FoundryResourceNotFoundError,
             raise_for_storage_error,
         )
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_error_source_classification.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_error_source_classification.py
@@ -1,0 +1,311 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+"""Unit tests for error source classification helpers and header application."""
+
+from __future__ import annotations
+
+import pytest
+
+from azure.ai.agentserver.responses._platform_headers import (
+    ERROR_DETAIL,
+    ERROR_SOURCE,
+    ERROR_SOURCE_PLATFORM,
+    ERROR_SOURCE_UPSTREAM,
+    ERROR_SOURCE_USER,
+    MAX_ERROR_DETAIL_LENGTH,
+    PLATFORM_ERROR_TAG,
+)
+from azure.ai.agentserver.responses.hosting._validation import (
+    _apply_error_source_headers,
+    error_response,
+    format_error_detail,
+    invalid_mode_response,
+    invalid_parameters_response,
+    invalid_request_response,
+    is_platform_error,
+    not_found_response,
+    service_unavailable_response,
+    tag_platform_error,
+)
+from azure.ai.agentserver.responses.models.errors import RequestValidationError
+
+
+# ---------------------------------------------------------------------------
+# is_platform_error / tag_platform_error
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformErrorTagging:
+    """Tests for is_platform_error and tag_platform_error."""
+
+    def test_untagged_exception_is_not_platform(self) -> None:
+        exc = RuntimeError("boom")
+        assert is_platform_error(exc) is False
+
+    def test_tagged_exception_is_platform(self) -> None:
+        exc = RuntimeError("storage down")
+        tag_platform_error(exc)
+        assert is_platform_error(exc) is True
+
+    def test_tag_platform_error_sets_attribute(self) -> None:
+        exc = Exception("oops")
+        tag_platform_error(exc)
+        assert getattr(exc, PLATFORM_ERROR_TAG) is True
+
+    def test_double_tagging_is_idempotent(self) -> None:
+        exc = RuntimeError("retry")
+        tag_platform_error(exc)
+        tag_platform_error(exc)
+        assert is_platform_error(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# format_error_detail
+# ---------------------------------------------------------------------------
+
+
+class TestFormatErrorDetail:
+    """Tests for format_error_detail."""
+
+    def test_short_detail_not_truncated(self) -> None:
+        exc = ValueError("short message")
+        detail = format_error_detail(exc)
+        assert detail == repr(exc)
+        assert len(detail) <= MAX_ERROR_DETAIL_LENGTH
+
+    def test_long_detail_truncated_to_max_length(self) -> None:
+        exc = ValueError("x" * (MAX_ERROR_DETAIL_LENGTH + 500))
+        detail = format_error_detail(exc)
+        assert len(detail) <= MAX_ERROR_DETAIL_LENGTH
+        assert detail.endswith("...[truncated]")
+
+    def test_truncated_detail_preserves_prefix(self) -> None:
+        msg = "A" * 5000
+        exc = RuntimeError(msg)
+        detail = format_error_detail(exc)
+        # Must start with the repr prefix
+        assert detail.startswith("RuntimeError(")
+
+
+# ---------------------------------------------------------------------------
+# _apply_error_source_headers
+# ---------------------------------------------------------------------------
+
+
+class TestApplyErrorSourceHeaders:
+    """Tests for _apply_error_source_headers."""
+
+    def test_adds_error_source_header(self) -> None:
+        headers = {"x-platform-server": "test/1.0"}
+        result = _apply_error_source_headers(headers, ERROR_SOURCE_USER)
+        assert result[ERROR_SOURCE] == "user"
+        # Original dict is unmodified
+        assert ERROR_SOURCE not in headers
+
+    def test_adds_error_detail_when_provided(self) -> None:
+        headers = {}
+        result = _apply_error_source_headers(headers, ERROR_SOURCE_PLATFORM, error_detail="disk full")
+        assert result[ERROR_SOURCE] == "platform"
+        assert result[ERROR_DETAIL] == "disk full"
+
+    def test_omits_error_detail_when_none(self) -> None:
+        headers = {}
+        result = _apply_error_source_headers(headers, ERROR_SOURCE_UPSTREAM)
+        assert result[ERROR_SOURCE] == "upstream"
+        assert ERROR_DETAIL not in result
+
+    def test_preserves_existing_headers(self) -> None:
+        headers = {"x-custom": "value", "x-platform-server": "v1"}
+        result = _apply_error_source_headers(headers, ERROR_SOURCE_USER)
+        assert result["x-custom"] == "value"
+        assert result["x-platform-server"] == "v1"
+        assert result[ERROR_SOURCE] == "user"
+
+    def test_returns_new_dict(self) -> None:
+        headers = {"a": "1"}
+        result = _apply_error_source_headers(headers, ERROR_SOURCE_USER)
+        assert result is not headers
+
+
+# ---------------------------------------------------------------------------
+# error_response auto-classification
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResponseClassification:
+    """Tests for error_response auto-classification of error source."""
+
+    def test_request_validation_error_classified_as_user(self) -> None:
+        exc = RequestValidationError("bad input", code="invalid_request")
+        resp = error_response(exc, {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+
+    def test_value_error_classified_as_user(self) -> None:
+        exc = ValueError("not a number")
+        resp = error_response(exc, {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+
+    def test_tagged_exception_classified_as_platform(self) -> None:
+        exc = RuntimeError("storage timeout")
+        tag_platform_error(exc)
+        resp = error_response(exc, {})
+        assert resp.headers[ERROR_SOURCE] == "platform"
+        assert ERROR_DETAIL in resp.headers
+
+    def test_platform_error_detail_contains_exception_repr(self) -> None:
+        exc = ConnectionError("refused")
+        tag_platform_error(exc)
+        resp = error_response(exc, {})
+        detail = resp.headers[ERROR_DETAIL]
+        assert "ConnectionError" in detail
+        assert "refused" in detail
+
+    def test_untagged_exception_classified_as_upstream(self) -> None:
+        exc = RuntimeError("handler bug")
+        resp = error_response(exc, {})
+        assert resp.headers[ERROR_SOURCE] == "upstream"
+        assert ERROR_DETAIL not in resp.headers
+
+    def test_explicit_error_source_overrides_classification(self) -> None:
+        exc = RuntimeError("whatever")
+        resp = error_response(exc, {}, error_source=ERROR_SOURCE_PLATFORM)
+        assert resp.headers[ERROR_SOURCE] == "platform"
+
+    def test_preserves_session_headers(self) -> None:
+        headers = {"x-agent-session-id": "sess1", "x-platform-server": "v1"}
+        exc = ValueError("err")
+        resp = error_response(exc, headers)
+        assert resp.headers["x-agent-session-id"] == "sess1"
+        assert resp.headers["x-platform-server"] == "v1"
+        assert resp.headers[ERROR_SOURCE] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Factory function error source headers
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunctionErrorSource:
+    """Tests that all error factory functions set the expected error source."""
+
+    def test_not_found_response_is_user(self) -> None:
+        resp = not_found_response("resp_123abc", {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+        assert resp.status_code == 404
+
+    def test_invalid_request_response_is_user(self) -> None:
+        resp = invalid_request_response("bad param", {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+        assert resp.status_code == 400
+
+    def test_invalid_parameters_response_is_user(self) -> None:
+        resp = invalid_parameters_response("bad temperature", {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+        assert resp.status_code == 400
+
+    def test_invalid_mode_response_is_user(self) -> None:
+        resp = invalid_mode_response("not streamable", {})
+        assert resp.headers[ERROR_SOURCE] == "user"
+        assert ERROR_DETAIL not in resp.headers
+        assert resp.status_code == 400
+
+    def test_service_unavailable_response_is_platform(self) -> None:
+        resp = service_unavailable_response("shutting down", {})
+        assert resp.headers[ERROR_SOURCE] == "platform"
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# FoundryApiError platform tagging
+# ---------------------------------------------------------------------------
+
+
+class TestFoundryErrorTagging:
+    """Tests that FoundryApiError from raise_for_storage_error is tagged as platform."""
+
+    def test_foundry_api_error_tagged_as_platform(self) -> None:
+        from azure.core.rest import HttpResponse
+
+        from azure.ai.agentserver.responses.store._foundry_errors import (
+            FoundryApiError,
+            FoundryBadRequestError,
+            FoundryResourceNotFoundError,
+            raise_for_storage_error,
+        )
+
+        class _FakeResponse:
+            status_code = 502
+            def text(self) -> str:
+                return '{"error": {"message": "bad gateway"}}'
+
+        with pytest.raises(FoundryApiError) as exc_info:
+            raise_for_storage_error(_FakeResponse())  # type: ignore[arg-type]
+
+        assert is_platform_error(exc_info.value) is True
+
+    def test_foundry_not_found_error_not_tagged(self) -> None:
+        from azure.ai.agentserver.responses.store._foundry_errors import (
+            FoundryResourceNotFoundError,
+            raise_for_storage_error,
+        )
+
+        class _FakeResponse:
+            status_code = 404
+            def text(self) -> str:
+                return '{"error": {"message": "not found"}}'
+
+        with pytest.raises(FoundryResourceNotFoundError) as exc_info:
+            raise_for_storage_error(_FakeResponse())  # type: ignore[arg-type]
+
+        assert is_platform_error(exc_info.value) is False
+
+    def test_foundry_bad_request_error_not_tagged(self) -> None:
+        from azure.ai.agentserver.responses.store._foundry_errors import (
+            FoundryBadRequestError,
+            raise_for_storage_error,
+        )
+
+        class _FakeResponse:
+            status_code = 400
+            def text(self) -> str:
+                return '{"error": {"message": "bad request"}}'
+
+        with pytest.raises(FoundryBadRequestError) as exc_info:
+            raise_for_storage_error(_FakeResponse())  # type: ignore[arg-type]
+
+        assert is_platform_error(exc_info.value) is False
+
+
+# ---------------------------------------------------------------------------
+# Platform header constant values
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSourceConstants:
+    """Ensure error source header constants match the container spec wire values."""
+
+    def test_error_source_header_name(self) -> None:
+        assert ERROR_SOURCE == "x-platform-error-source"
+
+    def test_error_detail_header_name(self) -> None:
+        assert ERROR_DETAIL == "x-platform-error-detail"
+
+    def test_error_source_user_value(self) -> None:
+        assert ERROR_SOURCE_USER == "user"
+
+    def test_error_source_platform_value(self) -> None:
+        assert ERROR_SOURCE_PLATFORM == "platform"
+
+    def test_error_source_upstream_value(self) -> None:
+        assert ERROR_SOURCE_UPSTREAM == "upstream"
+
+    def test_max_error_detail_length(self) -> None:
+        assert MAX_ERROR_DETAIL_LENGTH == 2048
+
+    def test_platform_error_tag_value(self) -> None:
+        assert PLATFORM_ERROR_TAG == "Azure.AI.AgentServer.PlatformError"

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_foundry_storage_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_foundry_storage_provider.py
@@ -10,16 +10,18 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from azure.ai.agentserver.core._platform_headers import (
+    CHAT_ISOLATION_KEY as _CHAT_ISOLATION_HEADER,
+)
+from azure.ai.agentserver.core._platform_headers import (
+    USER_ISOLATION_KEY as _USER_ISOLATION_HEADER,
+)
 
 from azure.ai.agentserver.responses._response_context import IsolationContext
 from azure.ai.agentserver.responses.store._foundry_errors import (
     FoundryApiError,
     FoundryBadRequestError,
     FoundryResourceNotFoundError,
-)
-from azure.ai.agentserver.responses._platform_headers import (
-    CHAT_ISOLATION_KEY as _CHAT_ISOLATION_HEADER,
-    USER_ISOLATION_KEY as _USER_ISOLATION_HEADER,
 )
 from azure.ai.agentserver.responses.store._foundry_provider import (
     FoundryStorageProvider,

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_foundry_storage_provider.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_foundry_storage_provider.py
@@ -620,6 +620,190 @@ async def test_error_mapping__error_message_falls_back_for_non_json_body(
     assert "502" in exc_info.value.message
 
 
+@pytest.mark.asyncio
+async def test_error_mapping__error_message_falls_back_for_binary_body(
+    credential: Any, settings: FoundryStorageSettings
+) -> None:
+    """A non-2xx response with a binary/non-UTF-8 body must NOT crash.
+
+    Regression test: a Foundry storage backend (or an intermediary
+    gateway) can return a gzip-compressed or otherwise binary body on
+    error responses.  Our code must not propagate ``UnicodeDecodeError``;
+    instead it should map to a :class:`FoundryApiError` with a generic
+    fallback message.
+    """
+    raw = MagicMock()
+    raw.status_code = 502
+    # Simulate the exact failure mode reported in production:
+    # ``response.text()`` raises ``UnicodeDecodeError`` because the
+    # backend returned a gzip / binary payload with a JSON content-type.
+    raw.text = MagicMock(side_effect=UnicodeDecodeError("utf-8", b"\x8b\x00", 0, 1, "invalid start byte"))
+    provider = _make_provider(credential, settings, raw)
+
+    with pytest.raises(FoundryApiError) as exc_info:
+        await provider.get_response("any_id")
+
+    assert "502" in exc_info.value.message
+
+
+# ===========================================================================
+# Pipeline composition — ContentDecodePolicy must NOT be present
+# ===========================================================================
+
+
+def test_pipeline__does_not_include_content_decode_policy(credential: Any) -> None:
+    """``ContentDecodePolicy`` is intentionally excluded from the pipeline.
+
+    Regression test for a production crash where ``ContentDecodePolicy``
+    eagerly decoded a binary / gzip-compressed response body as UTF-8 JSON
+    and raised ``UnicodeDecodeError`` before any of our error-handling
+    code could see the response status.  Our pipeline reads
+    ``http_resp.text()`` lazily with defensive ``try/except`` blocks and
+    therefore never needs the eager content-decode behaviour.
+    """
+    from azure.core.pipeline.policies import ContentDecodePolicy
+
+    # Patch from_env so the constructor is happy without env vars.
+    provider = FoundryStorageProvider(credential=credential, settings=_SETTINGS)
+    try:
+        # Walk the policy chain attached to the pipeline client.
+        pipeline = provider._client._pipeline  # pylint: disable=protected-access
+        policies_in_chain: list[Any] = []
+        # Some azure-core versions expose the policy list directly:
+        for attr in ("_impl_policies", "policies"):
+            chain = getattr(pipeline, attr, None)
+            if chain:
+                policies_in_chain = list(chain)
+                break
+
+        # Each chain entry wraps a policy via ``.policy`` or is the policy itself.
+        policy_classes = []
+        for entry in policies_in_chain:
+            policy = getattr(entry, "_policy", entry)
+            policy_classes.append(type(policy))
+
+        assert ContentDecodePolicy not in policy_classes, (
+            "ContentDecodePolicy must not be in the Foundry storage pipeline; "
+            "it crashes on binary response bodies."
+        )
+    finally:
+        # Explicit cleanup — we constructed a real client.
+        import asyncio
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+        loop.run_until_complete(provider.aclose())
+
+
+@pytest.mark.asyncio
+async def test_pipeline__handles_gzip_error_body_end_to_end(credential: Any) -> None:
+    """End-to-end regression test: a gzip-encoded error body must NOT crash.
+
+    Reproduces the production failure mode where a gateway/load-balancer
+    returned a status >= 400 with a gzip-compressed body and a JSON
+    content-type header.  With ``ContentDecodePolicy`` removed from the
+    pipeline, the response must propagate cleanly to our error handler
+    where it is mapped to :class:`FoundryApiError` and tagged as a
+    platform error.
+
+    This test exercises a *real* :class:`AsyncPipelineClient` with a fake
+    transport returning gzip bytes, validating the fix at the layer where
+    the original bug occurred.
+    """
+    import gzip
+    import json as _json
+
+    from azure.core.pipeline.transport import AsyncHttpTransport
+
+    plain = _json.dumps({"error": {"message": "Bad Gateway"}}).encode()
+    gzipped = gzip.compress(plain)
+    # Sanity-check our test setup: the second byte 0x8b is the exact
+    # byte mentioned in the production traceback.
+    assert gzipped[:2] == b"\x1f\x8b"
+
+    class _FakeAsyncTransport(AsyncHttpTransport):
+        async def open(self) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeAsyncTransport":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            pass
+
+        async def send(self, request: Any, **_kwargs: Any) -> Any:  # noqa: ARG002
+            resp = MagicMock()
+            resp.status_code = 502
+            resp.reason = "Bad Gateway"
+            resp.headers = {"Content-Type": "application/json", "Content-Encoding": "gzip"}
+            resp.content = gzipped
+            resp.encoding = "utf-8"
+
+            def _text(encoding: Any = None) -> str:
+                # Mirror what azure.core.rest does: decode raw bytes with
+                # the given encoding.  On gzip bytes this raises
+                # UnicodeDecodeError just like in production.
+                return gzipped.decode(encoding or "utf-8")
+
+            resp.text = _text
+            resp.context = {}
+            resp.request = request
+            return resp
+
+    # Build a real provider whose pipeline client uses our gzip-returning
+    # transport.  We rebuild the AsyncPipelineClient with the same policy
+    # list as the production constructor but plug in our transport.
+    # Use a real AccessToken (NamedTuple) rather than a MagicMock — the
+    # bearer-token policy compares ``expires_on`` to ``time.time()`` and
+    # MagicMock attributes don't satisfy the numeric comparison.
+    import time as _time
+
+    from azure.core import AsyncPipelineClient
+    from azure.core.credentials import AccessToken
+    from azure.core.pipeline import policies as _core_policies
+
+    real_token = AccessToken("tok_test", int(_time.time()) + 3600)
+
+    class _RealCred:
+        async def get_token(self, *_scopes: str, **_kw: Any) -> AccessToken:
+            return real_token
+
+        async def get_token_info(self, *_scopes: str, **_kw: Any) -> AccessToken:
+            return real_token
+
+        async def close(self) -> None:
+            pass
+
+    real_credential = _RealCred()
+
+    provider = FoundryStorageProvider.__new__(FoundryStorageProvider)
+    provider._settings = _SETTINGS
+    provider._client = AsyncPipelineClient(
+        base_url=_SETTINGS.storage_base_url,
+        transport=_FakeAsyncTransport(),
+        policies=[
+            _core_policies.RequestIdPolicy(),
+            _core_policies.HeadersPolicy(),
+            _core_policies.UserAgentPolicy(sdk_moniker="test/1.0"),
+            _core_policies.AsyncRetryPolicy(),
+            _core_policies.AsyncBearerTokenCredentialPolicy(real_credential, "https://test/.default"),
+            _core_policies.DistributedTracingPolicy(),
+        ],
+    )
+
+    try:
+        with pytest.raises(FoundryApiError) as exc_info:
+            await provider.get_response("any_id")
+        # Generic fallback message because the body could not be parsed.
+        assert "502" in exc_info.value.message
+    finally:
+        await provider.aclose()
+
+
 # ===========================================================================
 # HTTP client lifecycle
 # ===========================================================================

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_platform_headers.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_platform_headers.py
@@ -4,18 +4,18 @@
 
 from __future__ import annotations
 
-from azure.ai.agentserver.responses._platform_headers import (
+from azure.ai.agentserver.core._platform_headers import (
     APIM_REQUEST_ID,
     CHAT_ISOLATION_KEY,
     CLIENT_HEADER_PREFIX,
     CLIENT_REQUEST_ID,
     REQUEST_ID,
-    REQUEST_ID_ITEM_KEY,
     SERVER_VERSION,
     SESSION_ID,
     TRACEPARENT,
     USER_ISOLATION_KEY,
 )
+from azure.ai.agentserver.core._request_id import REQUEST_ID_STATE_KEY
 
 
 class TestPlatformHeaderConstants:
@@ -48,5 +48,5 @@ class TestPlatformHeaderConstants:
     def test_apim_request_id(self) -> None:
         assert APIM_REQUEST_ID == "apim-request-id"
 
-    def test_request_id_item_key(self) -> None:
-        assert REQUEST_ID_ITEM_KEY == "agentserver.request_id"
+    def test_request_id_state_key(self) -> None:
+        assert REQUEST_ID_STATE_KEY == "agentserver.request_id"


### PR DESCRIPTION
## Summary

This PR makes two related changes to the agentserver packages:

1. **Error source classification headers** on every HTTP error response from both the **responses** and **invocations** protocol packages, matching .NET PR [Azure/azure-sdk-for-net#58619](https://github.com/Azure/azure-sdk-for-net/pull/58619).
2. **Removes `ContentDecodePolicy` from the Foundry storage HTTP pipeline** to fix a production crash where binary/gzip-encoded error bodies caused `UnicodeDecodeError` to mask the real upstream status code.

It also centralizes wire-contract header name constants in `azure-ai-agentserver-core`, mirroring the .NET `PlatformHeaders.cs` pattern.

---

## Part 1 — Error source classification

### Core (`azure-ai-agentserver-core`)
- New `_platform_headers` module with cross-cutting header name constants (`x-request-id`, `x-platform-error-source`, `x-platform-error-detail`, `x-agent-session-id`, etc.)
- **Header name strings only** — no methods, no internal constants — matching .NET `PlatformHeaders.cs`

### Responses (`azure-ai-agentserver-responses`)
- Every HTTP error response now includes `x-platform-error-source`:
  - `user` — client validation errors (400, 404 from bad input)
  - `platform` — SDK / infrastructure failures (Foundry storage errors, transport failures) + `x-platform-error-detail` header
  - `upstream` — developer handler exceptions
- Deleted the `_platform_headers.py` shim — all files import header names directly from core
- `FoundryApiError` (5xx) and transport failures are tagged with `PLATFORM_ERROR_TAG`
- Persistence failures in the orchestrator are tagged as platform errors
- `service_unavailable_response` (503 draining) classified as `platform`
- Error source helpers remain internal to this package in `_validation.py`

### Invocations (`azure-ai-agentserver-invocations`)
- All HTTP error responses now include `x-platform-error-source`:
  - Missing handler registrations (404, 501) → `upstream`
  - Generic handler exceptions → classified via `_classify_error` (platform-tagged → `platform`, else → `upstream`)
- `SESSION_ID_HEADER` and isolation key headers now use shared constants from core
- Error source helpers defined locally with underscore prefix

### Design decisions
- Core contains **only header name string constants** (matching .NET `PlatformHeaders.cs`)
- Error source values (`user`/`platform`/`upstream`), platform error tag, and classification helpers are **internal to each protocol package** — not shared via core
- `format_error_detail` truncation accounts for suffix length (`detail[:2048 - len(suffix)] + suffix`) so headers never exceed 2048 chars

---

## Part 2 — Foundry pipeline gzip-body fix

### Production crash report

```
File '.../store/_foundry_logging_policy.py', line 113, in send
  response = await self.next.send(request)
File '.../core/pipeline/policies/_universal.py', line 728, in on_response
  response.context[self.CONTEXT_NAME] = self.deserialize_from_http_generics(...)
...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 0
```

`0x8b` is the second byte of the gzip magic (`0x1f 0x8b`).  When an intermediary gateway returned a non-2xx response with a binary / corrupted body and a JSON content-type, `ContentDecodePolicy.on_response` eagerly decoded the raw bytes as UTF-8 and crashed before any of our error-handling code could see the status code.  The crash propagated up as a generic decode failure that masked the real upstream error.

### Fix

Removed `ContentDecodePolicy` from the `FoundryStorageProvider` pipeline.  We never read its output (`response.context['deserialized_data']`) — our serializers and error-extraction helpers call `response.text()` lazily with defensive `try/except` blocks, so the eager decode policy was never needed.

### Verified the success path is not affected

I tested gzip-encoded responses end-to-end through the production policy chain against a real local HTTP server returning `Content-Encoding: gzip`:

| Scenario | Result |
|---|---|
| 200 + `Content-Encoding: gzip` JSON body | ✅ `resp.content` is decompressed by transport; `deserialize_response()` succeeds |
| 502 + `Content-Encoding: gzip` JSON body | ✅ `raise_for_storage_error` raises `FoundryApiError` with parsed message |
| 502 + corrupt / non-UTF-8 body | ✅ `_extract_error_message` falls back to generic `Foundry storage request failed with HTTP 502` |

The aiohttp transport ([_aiohttp.py L463-464](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py#L463-L464)) transparently decompresses `Content-Encoding: gzip` and `deflate` responses at the transport layer — well before our pipeline policies see the body.  Removing `ContentDecodePolicy` does not affect normal gzip-encoded responses.

### Comparison with other libraries in this repo
- `azure-identity`, `azure-cosmos`: include `ContentDecodePolicy` because they trust their AAD/Cosmos endpoints to always return valid UTF-8 JSON
- `azure-storage-blob`: includes it but bypasses for binary blob downloads via `stream=True`
- **Foundry storage** cannot make those assumptions because intermediary gateways/load-balancers can return arbitrary binary error bodies

---

## Tests

- **15 new invocations tests** covering all error-source paths (success, 501, 500 upstream, 500 platform, 404 get/cancel stubs, OpenAPI 404, handler exceptions)
- **~40 new responses tests** (unit + contract) covering error source classification, `format_error_detail` truncation, `FoundryApiError` tagging, all factory functions
- **3 new pipeline tests** for the Foundry gzip fix:
  - End-to-end test with a real `AsyncPipelineClient` + custom transport returning gzip bytes
  - Pipeline-composition assertion that `ContentDecodePolicy` is NOT in the policy chain
  - Defensive test for `response.text()` raising `UnicodeDecodeError` inside `_extract_error_message`
- All **1127 tests pass** (1001 responses + 126 invocations)
- **0 pyright errors**, **0 ruff errors** on changed files