### PR TITLE
[azure-mgmt-relationships] Disable verifytypes check for management package

### DIFF
--- a/sdk/relationships/azure-mgmt-relationships/pyproject.toml
+++ b/sdk/relationships/azure-mgmt-relationships/pyproject.toml
@@ -71,6 +71,7 @@ pytyped = [
 breaking = false
 pyright = false
 mypy = false
+verifytypes = false
 
 [packaging]
 package_name = "azure-mgmt-relationships"


### PR DESCRIPTION
## Description

This PR disables the `verifytypes` check for the `azure-mgmt-relationships` package by adding `verifytypes = false` to `pyproject.toml`.

## Issue

The CI pipeline was failing at the 'Run verifytypes' stage because the package lacks full type annotations (expected for auto-generated management-plane packages).

## Changes

- Added `verifytypes = false` to `[tool.azure-sdk-build]` in `sdk/relationships/azure-mgmt-relationships/pyproject.toml`

This is consistent with other management-plane packages like `azure-mgmt-resource` that also disable this check.