### PR TITLE
fix(azure-ai-projects): call is_recording() as method, not property reference

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/_responses_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/telemetry/_responses_instrumentor.py
@@ -523,7 +523,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
 
     def _set_span_attribute_safe(self, span: "AbstractSpan", key: str, value: Any) -> None:
         """Safely set a span attribute only if the value is meaningful."""
-        if not span or not span.span_instance.is_recording:
+        if not span or not span.span_instance.is_recording():
             return
 
         # Only set attribute if value exists and is meaningful
@@ -846,7 +846,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
         conversation_id: Optional[str] = None,
     ) -> None:
         """Add workflow action events to the span for workflow agents."""
-        if not span or not span.span_instance.is_recording:
+        if not span or not span.span_instance.is_recording():
             return
 
         # Check if response has output items
@@ -1149,7 +1149,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
         conversation_id: Optional[str] = None,
     ) -> None:
         """Add tool call events to the span from response output."""
-        if not span or not span.span_instance.is_recording:
+        if not span or not span.span_instance.is_recording():
             return
 
         # Extract function calls and tool calls from response output
@@ -1638,7 +1638,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
             gen_ai_provider=RESPONSES_PROVIDER,
         )
 
-        if span and span.span_instance.is_recording:
+        if span and span.span_instance.is_recording():
             # Set operation name attribute (start_span doesn't set this automatically)
             self._set_attributes(
                 span,
@@ -2614,7 +2614,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                     # Join all accumulated output content
                     complete_content = "".join(self.accumulated_output)
 
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         # Add tool call events if we detected any output items (tool calls, etc.)
                         if self.has_output_items:
                             # Create mock response with output items for event generation
@@ -2721,7 +2721,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                     )
 
                     # End span with proper status
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         self.span.span_instance.set_status(
                             # pyright: ignore [reportPossiblyUnboundVariable]
                             StatusCode.OK
@@ -2764,7 +2764,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                             span_attributes=span_attributes,
                             error_type=str(type(e).__name__),
                         )
-                        if self.span.span_instance.is_recording:
+                        if self.span.span_instance.is_recording():
                             self.span.span_instance.set_status(
                                 # pyright: ignore [reportPossiblyUnboundVariable]
                                 StatusCode.ERROR,
@@ -2791,7 +2791,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                         span_attributes=span_attributes,
                     )
 
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         # Note: For streaming responses, response metadata like tokens, finish_reasons
                         # are typically not available in individual chunks, so we focus on content.
 
@@ -3092,7 +3092,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                     # Join all accumulated output content
                     complete_content = "".join(self.accumulated_output)
 
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         # Add tool call events if we detected any output items (tool calls, etc.)
                         if self.has_output_items:
                             # Create mock response with output items for event generation
@@ -3199,7 +3199,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                     )
 
                     # End span with proper status
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         self.span.span_instance.set_status(
                             # pyright: ignore [reportPossiblyUnboundVariable]
                             StatusCode.OK
@@ -3241,7 +3241,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                             span_attributes=span_attributes,
                             error_type=str(type(e).__name__),
                         )
-                        if self.span.span_instance.is_recording:
+                        if self.span.span_instance.is_recording():
                             self.span.span_instance.set_status(
                                 # pyright: ignore [reportPossiblyUnboundVariable]
                                 StatusCode.ERROR,
@@ -3268,7 +3268,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
                         span_attributes=span_attributes,
                     )
 
-                    if self.span.span_instance.is_recording:
+                    if self.span.span_instance.is_recording():
                         # Note: For streaming responses, response metadata like tokens, finish_reasons
                         # are typically not available in individual chunks, so we focus on content.
 
@@ -3407,7 +3407,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
             gen_ai_provider=RESPONSES_PROVIDER,
         )
 
-        if span and span.span_instance.is_recording:
+        if span and span.span_instance.is_recording():
             self._set_span_attribute_safe(span, GEN_AI_OPERATION_NAME, OperationName.CREATE_CONVERSATION.value)
 
         return span
@@ -3605,7 +3605,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
             gen_ai_provider=RESPONSES_PROVIDER,
         )
 
-        if span and span.span_instance.is_recording:
+        if span and span.span_instance.is_recording():
             # Set operation name attribute (start_span doesn't set this automatically)
             self._set_attributes(
                 span,
@@ -3624,7 +3624,7 @@ class _ResponsesInstrumentorPreview:  # pylint: disable=too-many-instance-attrib
         item: Any,
     ) -> None:
         """Add a conversation item event to the span."""
-        if not span or not span.span_instance.is_recording:
+        if not span or not span.span_instance.is_recording():
             return
 
         # Extract basic item information


### PR DESCRIPTION
`_ResponsesInstrumentorPreview` checks `span.span_instance.is_recording` without parentheses at 15 call sites. Since `is_recording` is a method on OpenTelemetry spans, the expression evaluates to a bound method object which is always truthy — the guard never fires.

When the underlying span is a `NonRecordingSpan` (returned by `azure-core-tracing-opentelemetry` when tracing is disabled or the span context is invalid), downstream code accesses `.attributes` which only exists on SDK `ReadableSpan`, crashing every LLM call with:

    AttributeError: 'NonRecordingSpan' object has no attribute 'attributes'

Fix: add `()` to all 15 `is_recording` references so the method is actually invoked and returns `False` for non-recording spans.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
