### PR TITLE
Improve span parenting tests with trace-ID-scoped validation

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -1,19 +1,18 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-"""Tests that the invoke_agent span is set as the current span in context,
+"""Tests that agentserver spans are set as the current span in context,
 so that child spans created by framework handlers are correctly parented.
 
-These tests call the endpoint handler directly (bypassing ASGI transport)
-because HTTPX's ASGITransport runs the app in a different async context,
-which prevents OTel ContextVar propagation from working correctly.
+These tests use Starlette's ``TestClient`` which runs synchronously in the
+same thread context, so OTel ContextVar propagation works correctly.
 """
 import os
 from unittest.mock import patch
 
 import pytest
 from starlette.requests import Request
-from starlette.responses import Response, StreamingResponse
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.testclient import TestClient
 
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
@@ -38,6 +37,9 @@ _SETUP_DONE = False
 
 pytestmark = pytest.mark.skipif(not _HAS_OTEL, reason="opentelemetry not installed")
 
+# Span name used by all framework child spans in these tests.
+_FRAMEWORK_CHILD_SPAN = "framework_child_span"
+
 
 @pytest.fixture(autouse=True)
 def _clear():
@@ -61,76 +63,193 @@ def _get_spans():
     return list(_EXPORTER.get_finished_spans()) if _EXPORTER else []
 
 
-def _make_server_with_child_span():
-    """Server whose handler creates a child span (simulating a framework)."""
+def _make_tracing_app(**kwargs):
+    """Create an InvocationAgentServerHost with tracing enabled (exporters mocked)."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
-            app = InvocationAgentServerHost()
+            return InvocationAgentServerHost(**kwargs)
+
+
+def _find_parent_from_child(child_span, spans, expected_parent_operation: str):
+    """Starting from the child span, use its parent span ID and trace ID to
+    locate the parent in the exported spans and validate the relationship.
+
+    This approach is parallel-safe: even if leaked spans from other tests
+    exist in the exporter, we only look up the specific parent that the
+    child references.
+
+    :param child_span: The framework child span (captured directly in the test).
+    :param spans: All exported spans.
+    :param expected_parent_operation: Expected agentserver operation name in the parent span.
+    """
+    # Child must have a parent link
+    assert child_span.parent is not None, (
+        f"Child span '{child_span.name}' has no parent — it is a root span."
+    )
+
+    child_parent_span_id = child_span.parent.span_id
+    child_trace_id = child_span.context.trace_id
+
+    # Find the parent span by matching the span_id the child points to
+    parent_matches = [
+        s for s in spans
+        if s.context.span_id == child_parent_span_id
+    ]
+    assert len(parent_matches) == 1, (
+        f"Expected exactly 1 span with span_id={format(child_parent_span_id, '016x')}, "
+        f"got {len(parent_matches)}: {[s.name for s in parent_matches]}"
+    )
+    parent = parent_matches[0]
+
+    # Validate the parent is the expected agentserver operation
+    assert expected_parent_operation in parent.name, (
+        f"Child's parent span is '{parent.name}', expected it to contain '{expected_parent_operation}'."
+    )
+
+    # Validate both are in the same trace
+    assert parent.context.trace_id == child_trace_id, (
+        f"Parent trace ({format(parent.context.trace_id, '032x')}) "
+        f"!= child trace ({format(child_trace_id, '032x')})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invoke: non-streaming
+# ---------------------------------------------------------------------------
+
+
+def test_framework_span_is_child_of_invoke_span():
+    """A span created inside the handler should be a child of invoke_agent."""
+    app = _make_tracing_app()
     child_tracer = trace.get_tracer("test.framework")
+    captured_child = {}
 
     @app.invoke_handler
     async def handle(request: Request) -> Response:
-        with child_tracer.start_as_current_span("framework_invoke_agent") as _span:
+        with child_tracer.start_as_current_span(_FRAMEWORK_CHILD_SPAN) as span:
+            captured_child["span"] = span
             return Response(content=b"ok")
 
-    return app
+    client = TestClient(app)
+    resp = client.post("/invocations", content=b"test")
+    assert resp.status_code == 200
+
+    _find_parent_from_child(captured_child["span"], _get_spans(), "invoke_agent")
 
 
-def _make_streaming_server_with_child_span():
-    """Server with streaming response whose handler creates a child span."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
-            app = InvocationAgentServerHost()
+# ---------------------------------------------------------------------------
+# Invoke: streaming — child span created before returning StreamingResponse
+# ---------------------------------------------------------------------------
+
+
+def test_framework_span_is_child_streaming_before_return():
+    """Child span created in handler body (before StreamingResponse) is parented."""
+    app = _make_tracing_app()
     child_tracer = trace.get_tracer("test.framework")
+    captured_child = {}
 
     @app.invoke_handler
     async def handle(request: Request) -> StreamingResponse:
-        with child_tracer.start_as_current_span("framework_invoke_agent"):
+        with child_tracer.start_as_current_span(_FRAMEWORK_CHILD_SPAN) as span:
+            captured_child["span"] = span
             async def generate():
                 yield b"chunk\n"
             return StreamingResponse(generate(), media_type="text/plain")
 
-    return app
-
-
-def _assert_child_parented(spans, streaming: bool = False):
-    """Assert the framework span is a child of the invoke_agent span."""
-    parent_spans = [s for s in spans if "invoke_agent" in s.name and s.name != "framework_invoke_agent"]
-    child_spans = [s for s in spans if s.name == "framework_invoke_agent"]
-
-    assert len(parent_spans) >= 1, f"Expected invoke_agent span, got: {[s.name for s in spans]}"
-    assert len(child_spans) == 1, f"Expected framework span, got: {[s.name for s in spans]}"
-
-    parent = parent_spans[0]
-    child = child_spans[0]
-
-    label = "streaming" if streaming else "non-streaming"
-    assert child.parent is not None, f"Framework span has no parent in {label} case"
-    assert child.parent.span_id == parent.context.span_id, (
-        f"Framework span parent ({format(child.parent.span_id, '016x')}) "
-        f"!= invoke_agent span ({format(parent.context.span_id, '016x')}). "
-        f"Spans are siblings, not parent-child ({label})."
-    )
-
-
-def test_framework_span_is_child_of_invoke_span():
-    """A span created inside the handler should be a child of the
-    agentserver invoke_agent span, not a sibling."""
-    server = _make_server_with_child_span()
-    # TestClient runs synchronously in the same thread context,
-    # so OTel ContextVar propagation works correctly.
-    client = TestClient(server)
+    client = TestClient(app)
     resp = client.post("/invocations", content=b"test")
     assert resp.status_code == 200
 
-    _assert_child_parented(_get_spans(), streaming=False)
+    _find_parent_from_child(captured_child["span"], _get_spans(), "invoke_agent")
 
 
-def test_framework_span_is_child_streaming():
-    """Same parent-child relationship holds for streaming responses."""
-    server = _make_streaming_server_with_child_span()
-    client = TestClient(server)
+# ---------------------------------------------------------------------------
+# Invoke: streaming — child span created DURING async iteration
+# ---------------------------------------------------------------------------
+
+
+def test_framework_span_is_child_streaming_during_iteration():
+    """Child span created inside the async generator (while yielding chunks)
+    is correctly parented via _wrap_streaming_response's context re-attachment."""
+    app = _make_tracing_app()
+    child_tracer = trace.get_tracer("test.framework")
+    captured_child = {}
+
+    @app.invoke_handler
+    async def handle(request: Request) -> StreamingResponse:
+        async def generate():
+            # Child span created mid-stream — tests set_current_span / detach_context
+            with child_tracer.start_as_current_span(_FRAMEWORK_CHILD_SPAN) as span:
+                captured_child["span"] = span
+                yield b"chunk1\n"
+            yield b"chunk2\n"
+
+        return StreamingResponse(generate(), media_type="text/plain")
+
+    client = TestClient(app)
     resp = client.post("/invocations", content=b"test")
     assert resp.status_code == 200
 
-    _assert_child_parented(_get_spans(), streaming=True)
+    _find_parent_from_child(captured_child["span"], _get_spans(), "invoke_agent")
+
+
+# ---------------------------------------------------------------------------
+# Invoke: error path — child span is still parented when handler raises
+# ---------------------------------------------------------------------------
+
+
+def test_framework_span_is_child_when_handler_raises():
+    """If the handler creates a child span then raises, the child is still
+    correctly parented under invoke_agent."""
+    app = _make_tracing_app()
+    child_tracer = trace.get_tracer("test.framework")
+    captured_child = {}
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        with child_tracer.start_as_current_span(_FRAMEWORK_CHILD_SPAN) as span:
+            captured_child["span"] = span
+            raise ValueError("boom")
+
+    client = TestClient(app)
+    resp = client.post("/invocations", content=b"test")
+    assert resp.status_code == 500
+
+    _find_parent_from_child(captured_child["span"], _get_spans(), "invoke_agent")
+
+
+# ---------------------------------------------------------------------------
+# GET invocation: child span parenting via _traced_invocation_endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_framework_span_is_child_of_get_invocation_span():
+    """Child span inside get_handler is parented under get_invocation span."""
+    app = _make_tracing_app()
+    child_tracer = trace.get_tracer("test.framework")
+    captured_child = {}
+    store: dict[str, bytes] = {}
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        store[request.state.invocation_id] = await request.body()
+        return Response(content=b"ok")
+
+    @app.get_invocation_handler
+    async def get_handler(request: Request) -> Response:
+        with child_tracer.start_as_current_span(_FRAMEWORK_CHILD_SPAN) as span:
+            captured_child["span"] = span
+            inv_id = request.path_params["invocation_id"]
+            if inv_id in store:
+                return Response(content=store[inv_id])
+            return JSONResponse({"error": {"code": "not_found", "message": "Not found"}}, status_code=404)
+
+    client = TestClient(app)
+    resp = client.post("/invocations", content=b"data")
+    inv_id = resp.headers["x-agent-invocation-id"]
+
+    # Clear invoke spans so only get_invocation + child remain
+    _EXPORTER.clear()
+    client.get(f"/invocations/{inv_id}")
+
+    _find_parent_from_child(captured_child["span"], _get_spans(), "get_invocation")

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -92,11 +92,15 @@ def _find_parent_from_child(child_span, spans, expected_parent_operation: str):
 
     # Find the parent span by matching the span_id the child points to
     parent_matches = [
+    # Find the parent span by matching the exact trace_id + span_id the child points to
+    parent_matches = [
         s for s in spans
-        if s.context.span_id == child_parent_span_id
+        if s.context.trace_id == child_trace_id
+        and s.context.span_id == child_parent_span_id
     ]
     assert len(parent_matches) == 1, (
-        f"Expected exactly 1 span with span_id={format(child_parent_span_id, '016x')}, "
+        f"Expected exactly 1 span with trace_id={format(child_trace_id, '032x')} "
+        f"and span_id={format(child_parent_span_id, '016x')}, "
         f"got {len(parent_matches)}: {[s.name for s in parent_matches]}"
     )
     parent = parent_matches[0]
@@ -246,10 +250,13 @@ def test_framework_span_is_child_of_get_invocation_span():
 
     client = TestClient(app)
     resp = client.post("/invocations", content=b"data")
+    assert resp.status_code == 200
     inv_id = resp.headers["x-agent-invocation-id"]
 
     # Clear invoke spans so only get_invocation + child remain
     _EXPORTER.clear()
-    client.get(f"/invocations/{inv_id}")
+    get_resp = client.get(f"/invocations/{inv_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.content == b"data"
 
     _find_parent_from_child(captured_child["span"], _get_spans(), "get_invocation")


### PR DESCRIPTION
- Capture child span directly in each test and use its parent span ID to locate the parent in exported spans (parallel-safe)
- Add _find_parent_from_child helper that validates parent-child by following the child's parent reference instead of name-matching
- Add streaming mid-iteration parenting test (tests _wrap_streaming_response)
- Add error-path parenting test (handler raises after creating child span)
- Add GET invocation parenting test (covers _traced_invocation_endpoint)
- Extract shared _make_tracing_app helper to reduce duplication

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
