### PR TITLE
Update Python Version Support Policy End Date

### DIFF
--- a/doc/python_version_support_policy.md
+++ b/doc/python_version_support_policy.md
@@ -10,10 +10,10 @@ End of support means, in the SDK context, that new features will not be supporte
 | 3.6 ([PEP 494](https://www.python.org/dev/peps/pep-0494/#lifespan))  | December 2021    | August 2022    |
 | 3.7 ([PEP 537](https://www.python.org/dev/peps/pep-0537/#lifespan))  | June 2023        | December 2023  |
 | 3.8 ([PEP 569](https://www.python.org/dev/peps/pep-0569/#lifespan))  | October 2024     | April 2025     |
-| 3.9 ([PEP 596](https://www.python.org/dev/peps/pep-0596/#lifespan))  | October 2025     | April 2026     |
-| 3.10 ([PEP 619](https://www.python.org/dev/peps/pep-0619/#lifespan)) | October 2026     | April 2027     |
-| 3.11 ([PEP 664](https://www.python.org/dev/peps/pep-0664/#lifespan)) | October 2027     | April 2028     |
-| 3.12 ([PEP 693](https://www.python.org/dev/peps/pep-0693/#lifespan)) | October 2028     | April 2029     |
-| 3.13 ([PEP 719](https://www.python.org/dev/peps/pep-0719/#lifespan)) | October 2029     | April 2030     |
-| 3.14 ([PEP 745](https://www.python.org/dev/peps/pep-0745/#lifespan)) | October 2030     | April 2031     |
-| 3.15 ([PEP 790](https://www.python.org/dev/peps/pep-0790/#lifespan)) | October 2031     | April 2032     |
+| 3.9 ([PEP 596](https://www.python.org/dev/peps/pep-0596/#lifespan))  | October 2025     | April 30 2026     |
+| 3.10 ([PEP 619](https://www.python.org/dev/peps/pep-0619/#lifespan)) | October 2026     | April 30 2027     |
+| 3.11 ([PEP 664](https://www.python.org/dev/peps/pep-0664/#lifespan)) | October 2027     | April 30 2028     |
+| 3.12 ([PEP 693](https://www.python.org/dev/peps/pep-0693/#lifespan)) | October 2028     | April 30 2029     |
+| 3.13 ([PEP 719](https://www.python.org/dev/peps/pep-0719/#lifespan)) | October 2029     | April 30 2030     |
+| 3.14 ([PEP 745](https://www.python.org/dev/peps/pep-0745/#lifespan)) | October 2030     | April 30 2031     |
+| 3.15 ([PEP 790](https://www.python.org/dev/peps/pep-0790/#lifespan)) | October 2031     | April 30 2032     |

--- a/doc/python_version_support_policy.md
+++ b/doc/python_version_support_policy.md
@@ -10,10 +10,10 @@ End of support means, in the SDK context, that new features will not be supporte
 | 3.6 ([PEP 494](https://www.python.org/dev/peps/pep-0494/#lifespan))  | December 2021    | August 2022    |
 | 3.7 ([PEP 537](https://www.python.org/dev/peps/pep-0537/#lifespan))  | June 2023        | December 2023  |
 | 3.8 ([PEP 569](https://www.python.org/dev/peps/pep-0569/#lifespan))  | October 2024     | April 2025     |
-| 3.9 ([PEP 596](https://www.python.org/dev/peps/pep-0596/#lifespan))  | October 2025     | April 30 2026     |
-| 3.10 ([PEP 619](https://www.python.org/dev/peps/pep-0619/#lifespan)) | October 2026     | April 30 2027     |
-| 3.11 ([PEP 664](https://www.python.org/dev/peps/pep-0664/#lifespan)) | October 2027     | April 30 2028     |
-| 3.12 ([PEP 693](https://www.python.org/dev/peps/pep-0693/#lifespan)) | October 2028     | April 30 2029     |
-| 3.13 ([PEP 719](https://www.python.org/dev/peps/pep-0719/#lifespan)) | October 2029     | April 30 2030     |
-| 3.14 ([PEP 745](https://www.python.org/dev/peps/pep-0745/#lifespan)) | October 2030     | April 30 2031     |
-| 3.15 ([PEP 790](https://www.python.org/dev/peps/pep-0790/#lifespan)) | October 2031     | April 30 2032     |
+| 3.9 ([PEP 596](https://www.python.org/dev/peps/pep-0596/#lifespan))  | October 2025     | April 30, 2026     |
+| 3.10 ([PEP 619](https://www.python.org/dev/peps/pep-0619/#lifespan)) | October 2026     | April 30, 2027     |
+| 3.11 ([PEP 664](https://www.python.org/dev/peps/pep-0664/#lifespan)) | October 2027     | April 30, 2028     |
+| 3.12 ([PEP 693](https://www.python.org/dev/peps/pep-0693/#lifespan)) | October 2028     | April 30, 2029     |
+| 3.13 ([PEP 719](https://www.python.org/dev/peps/pep-0719/#lifespan)) | October 2029     | April 30, 2030     |
+| 3.14 ([PEP 745](https://www.python.org/dev/peps/pep-0745/#lifespan)) | October 2030     | April 30, 2031     |
+| 3.15 ([PEP 790](https://www.python.org/dev/peps/pep-0790/#lifespan)) | October 2031     | April 30, 2032     |

--- a/doc/python_version_support_policy.md
+++ b/doc/python_version_support_policy.md
@@ -4,6 +4,8 @@ This page describes the Python version support policy for the Azure SDK for Pyth
 
 End of support means, in the SDK context, that new features will not be supported for those unsupported Python versions. It will still be possible to install older SDK versions from PyPI as necessary.
 
+> **Note:** The "SDKs End Of Support" date is inclusive — the listed day is the last supported day, and the next day is the first unsupported day.
+
 | Python Version | PSF End of Support | SDKs End Of Support |
 |----------------|--------------------|---------------------|
 | 2.7 ([PEP 373](https://peps.python.org/pep-0373/))                   | April 2020       | January 2022   |


### PR DESCRIPTION
Update the dates to be explicitly end of April iow going forward May 1st is when older versions of python are no longer supported