### PR TITLE
Migrate agentserver tracing from azure-monitor-opentelemetry-exporter…

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -570,7 +570,9 @@ def _ensure_trace_provider(resource: Any, span_processors: Optional[list[Any]] =
     Used as a fallback when the microsoft-opentelemetry distro is not installed.
 
     :param resource: OTel resource describing this service.
+    :type resource: ~typing.Any
     :param span_processors: Optional span processors to register.
+    :type span_processors: list[~typing.Any] or None
     """
     if resource is None:
         return None

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -14,8 +14,9 @@ tracing exporters, and span operations:
   - Console ``StreamHandler`` on the **root** logger (so both SDK and
     user ``logging.info()`` calls are visible).
   - Suppression of noisy Azure SDK / OTel exporter loggers.
-  - Azure Monitor trace + log export (when connection string available).
-  - OTLP trace + log export (when ``OTEL_EXPORTER_OTLP_ENDPOINT`` set).
+  - Trace and log export via ``microsoft-opentelemetry`` distro (auto-detects
+    Azure Monitor from ``APPLICATIONINSIGHTS_CONNECTION_STRING`` and OTLP
+    from ``OTEL_EXPORTER_OTLP_ENDPOINT``).
 
   Users may pass a custom callable (or ``None``) via the
   ``configure_observability`` constructor parameter to override or
@@ -29,7 +30,7 @@ tracing exporters, and span operations:
 - :func:`set_current_span` / :func:`detach_context` — explicit context management
 
 OpenTelemetry is a required dependency — these functions always create
-real spans.  Azure Monitor export is optional (lazy-imported).
+real spans.  Azure Monitor export is optional (auto-configured by the distro).
 """
 import logging
 import os
@@ -132,14 +133,13 @@ def configure_observability(
 
     # Suppress noisy Azure SDK and OTel exporter logs
     logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
-    logging.getLogger("azure.monitor.opentelemetry.exporter").setLevel(logging.WARNING)
 
     # Tracing and OTel export
     _configure_tracing(connection_string=connection_string)
 
 
 def _configure_tracing(connection_string: Optional[str] = None) -> None:
-    """Configure OpenTelemetry exporters for Azure Monitor and OTLP.
+    """Configure OpenTelemetry exporters via the microsoft-opentelemetry distro.
 
     Internal helper called by :func:`configure_observability`.
 
@@ -148,20 +148,62 @@ def _configure_tracing(connection_string: Optional[str] = None) -> None:
     :type connection_string: str or None
     """
     resource = _create_resource()
-    provider = _ensure_trace_provider(resource)
+    if resource is None:
+        return
 
-    if provider is not None:
-        _register_enrichment_processor(provider)
+    # Build custom processors
+    agent_name = _config.resolve_agent_name() or None
+    agent_version = _config.resolve_agent_version() or None
+    project_id = _config.resolve_project_id() or None
 
-    if connection_string:
-        if resource is not None:
-            _setup_trace_export(provider, connection_string)
-            _setup_log_export(resource, connection_string)
+    if agent_name and agent_version:
+        agent_id = f"{agent_name}:{agent_version}"
+    elif agent_name:
+        agent_id = agent_name
+    else:
+        agent_id = None
 
-    otlp_endpoint = _config.resolve_otlp_endpoint()
-    if otlp_endpoint and resource is not None:
-        _setup_otlp_trace_export(provider, otlp_endpoint)
-        _setup_otlp_log_export(resource, otlp_endpoint)
+    span_processors = [
+        _FoundryEnrichmentSpanProcessor(
+            agent_name=agent_name, agent_version=agent_version,
+            agent_id=agent_id, project_id=project_id,
+        ),
+    ]
+    log_record_processors = [_BaggageLogRecordProcessor()]  # type: ignore[list-item]
+
+    try:
+        _setup_distro_export(
+            resource=resource,
+            span_processors=span_processors,
+            log_record_processors=log_record_processors,
+            connection_string=connection_string,
+        )
+    except ImportError:
+        logger.warning("microsoft-opentelemetry is not installed — tracing export disabled.")
+        # Still set up TracerProvider with enrichment processor so spans are created
+        _ensure_trace_provider(resource, span_processors)
+
+
+def _setup_distro_export(
+    *,
+    resource: Any,
+    span_processors: list[Any],
+    log_record_processors: list[Any],
+    connection_string: Optional[str] = None,
+) -> None:
+    """Delegate to microsoft-opentelemetry distro for exporter configuration.
+
+    Separated into its own function so tests can easily mock it without
+    intercepting lazy imports.
+    """
+    from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+    use_microsoft_opentelemetry(
+        resource=resource,
+        span_processors=span_processors,
+        log_record_processors=log_record_processors,
+        connection_string=connection_string,
+    )
 
 
 # ======================================================================
@@ -508,7 +550,11 @@ def _create_resource() -> Any:
     return Resource.create({_ATTR_SERVICE_NAME: service_name})
 
 
-def _ensure_trace_provider(resource: Any) -> Any:
+def _ensure_trace_provider(resource: Any, span_processors: Optional[list[Any]] = None) -> Any:
+    """Get or create a TracerProvider, optionally adding span processors.
+
+    Used as a fallback when the microsoft-opentelemetry distro is not installed.
+    """
     if resource is None:
         return None
     try:
@@ -517,129 +563,13 @@ def _ensure_trace_provider(resource: Any) -> Any:
         return None
     current = trace.get_tracer_provider()
     if hasattr(current, "add_span_processor"):
-        return current
-    provider = SdkTracerProvider(resource=resource)
-    trace.set_tracer_provider(provider)
+        provider = current
+    else:
+        provider = SdkTracerProvider(resource=resource)
+        trace.set_tracer_provider(provider)
+    for proc in (span_processors or []):
+        provider.add_span_processor(proc)
     return provider
-
-
-_enrichment_configured = False
-_az_trace_configured = False
-_az_log_configured = False
-_otlp_trace_configured = False
-_otlp_log_configured = False
-
-
-def _register_enrichment_processor(provider: Any) -> None:
-    global _enrichment_configured  # pylint: disable=global-statement
-    if _enrichment_configured:
-        return
-    agent_name = _config.resolve_agent_name() or None
-    agent_version = _config.resolve_agent_version() or None
-    project_id = _config.resolve_project_id() or None
-
-    if agent_name and agent_version:
-        agent_id = f"{agent_name}:{agent_version}"
-    elif agent_name:
-        agent_id = agent_name
-    else:
-        agent_id = None
-
-    provider.add_span_processor(_FoundryEnrichmentSpanProcessor(
-        agent_name=agent_name, agent_version=agent_version,
-        agent_id=agent_id, project_id=project_id,
-    ))
-    _enrichment_configured = True
-
-
-def _setup_trace_export(provider: Any, connection_string: str) -> None:
-    global _az_trace_configured  # pylint: disable=global-statement
-    if _az_trace_configured or provider is None:
-        return
-    try:
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
-        from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter  # type: ignore[import-untyped]
-    except ImportError:
-        logger.warning("Trace export requires azure-monitor-opentelemetry-exporter.")
-        return
-    provider.add_span_processor(BatchSpanProcessor(
-        AzureMonitorTraceExporter(connection_string=connection_string)))
-    _az_trace_configured = True
-    logger.info("Application Insights trace exporter configured.")
-
-
-def _setup_log_export(resource: Any, connection_string: str) -> None:
-    global _az_log_configured  # pylint: disable=global-statement
-    if _az_log_configured:
-        return
-    try:
-        from opentelemetry._logs import set_logger_provider
-        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-
-        from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter  # type: ignore[import-untyped]
-    except ImportError:
-        logger.warning("Log export requires azure-monitor-opentelemetry-exporter.")
-        return
-    log_provider = LoggerProvider(resource=resource)
-    set_logger_provider(log_provider)
-    log_provider.add_log_record_processor(BatchLogRecordProcessor(
-        AzureMonitorLogExporter(connection_string=connection_string)))
-    log_provider.add_log_record_processor(_BaggageLogRecordProcessor())  # type: ignore[arg-type]
-    logging.getLogger().addHandler(LoggingHandler(logger_provider=log_provider))
-    _az_log_configured = True
-    logger.info("Application Insights log exporter configured.")
-
-
-def _setup_otlp_trace_export(provider: Any, endpoint: str) -> None:
-    global _otlp_trace_configured  # pylint: disable=global-statement
-    if _otlp_trace_configured or provider is None:
-        return
-    try:
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    except ImportError:
-        logger.warning("OTLP trace export requires opentelemetry-exporter-otlp-proto-grpc.")
-        return
-    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
-    _otlp_trace_configured = True
-    logger.info("OTLP trace exporter configured (endpoint=%s).", endpoint)
-
-
-def _setup_otlp_log_export(resource: Any, endpoint: str) -> None:
-    global _otlp_log_configured  # pylint: disable=global-statement
-    if _otlp_log_configured:
-        return
-    try:
-        from opentelemetry._logs import get_logger_provider
-        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-    except ImportError:
-        logger.warning("OTLP log export requires opentelemetry-exporter-otlp-proto-grpc.")
-        return
-    current = get_logger_provider()
-    if hasattr(current, "add_log_record_processor"):
-        log_provider = current
-    else:
-        from opentelemetry._logs import set_logger_provider
-        log_provider = LoggerProvider(resource=resource)
-        set_logger_provider(log_provider)
-    log_provider.add_log_record_processor(  # type: ignore[union-attr]
-        BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint))
-    )
-    log_provider.add_log_record_processor(  # type: ignore[union-attr]
-        _BaggageLogRecordProcessor()  # type: ignore[arg-type]
-    )
-    # Note: LoggingHandler is NOT added here to avoid duplicating the
-    # handler already installed by _setup_log_export. The OTel LoggerProvider
-    # receives log records via the handler added there (or from direct OTel
-    # log API usage).  If OTLP is the only exporter, add a handler:
-    if not _az_log_configured:
-        logging.getLogger().addHandler(LoggingHandler(logger_provider=log_provider))
-    _otlp_log_configured = True
-    logger.info("OTLP log exporter configured (endpoint=%s).", endpoint)
 
 
 def _extract_w3c_carrier(headers: Mapping[str, str]) -> dict[str, str]:

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -179,6 +179,7 @@ def _configure_tracing(connection_string: Optional[str] = None) -> None:
             log_record_processors=log_record_processors,
             connection_string=connection_string,
         )
+        logger.info("Tracing configured successfully via microsoft-opentelemetry distro.")
     except ImportError:
         logger.warning("microsoft-opentelemetry is not installed — tracing export disabled.")
         # Still set up TracerProvider with enrichment processor so spans are created

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -13,7 +13,7 @@ tracing exporters, and span operations:
 
   - Console ``StreamHandler`` on the **root** logger (so both SDK and
     user ``logging.info()`` calls are visible).
-  - Suppression of noisy Azure SDK / OTel exporter loggers.
+  - Suppression of noisy Azure Core HTTP logging policy output.
   - Trace and log export via ``microsoft-opentelemetry`` distro (auto-detects
     Azure Monitor from ``APPLICATIONINSIGHTS_CONNECTION_STRING`` and OTLP
     from ``OTEL_EXPORTER_OTLP_ENDPOINT``).
@@ -131,7 +131,7 @@ def configure_observability(
         setattr(_console, _CONSOLE_HANDLER_ATTR, True)
         root.addHandler(_console)
 
-    # Suppress noisy Azure SDK and OTel exporter logs
+    # Suppress the noisy Azure Core HTTP logging policy logger.
     logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 
     # Tracing and OTel export
@@ -568,8 +568,10 @@ def _ensure_trace_provider(resource: Any, span_processors: Optional[list[Any]] =
     else:
         provider = SdkTracerProvider(resource=resource)
         trace.set_tracer_provider(provider)
-    for proc in (span_processors or []):
-        provider.add_span_processor(proc)
+    if span_processors and not getattr(provider, "_agentserver_processors_added", False):
+        for proc in span_processors:
+            provider.add_span_processor(proc)
+        provider._agentserver_processors_added = True  # type: ignore[attr-defined]
     return provider
 
 

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -149,6 +149,7 @@ def _configure_tracing(connection_string: Optional[str] = None) -> None:
     """
     resource = _create_resource()
     if resource is None:
+        logger.warning("Failed to create OTel resource — tracing will not be configured.")
         return
 
     # Build custom processors

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -197,14 +197,19 @@ def _setup_distro_export(
 
     Separated into its own function so tests can easily mock it without
     intercepting lazy imports.
+
+    :keyword resource: OTel resource describing this service.
+    :keyword span_processors: Span processors to register.
+    :keyword log_record_processors: Log record processors to register.
+    :keyword connection_string: Application Insights connection string.
     """
     from microsoft.opentelemetry import use_microsoft_opentelemetry
 
-    kwargs: dict[str, Any] = dict(
-        resource=resource,
-        span_processors=span_processors,
-        log_record_processors=log_record_processors,
-    )
+    kwargs: dict[str, Any] = {
+        "resource": resource,
+        "span_processors": span_processors,
+        "log_record_processors": log_record_processors,
+    }
 
     # Azure Monitor export is off by default in the distro — enable it
     # when a connection string is available.
@@ -563,6 +568,9 @@ def _ensure_trace_provider(resource: Any, span_processors: Optional[list[Any]] =
     """Get or create a TracerProvider, optionally adding span processors.
 
     Used as a fallback when the microsoft-opentelemetry distro is not installed.
+
+    :param resource: OTel resource describing this service.
+    :param span_processors: Optional span processors to register.
     """
     if resource is None:
         return None
@@ -579,7 +587,7 @@ def _ensure_trace_provider(resource: Any, span_processors: Optional[list[Any]] =
     if span_processors and not getattr(provider, "_agentserver_processors_added", False):
         for proc in span_processors:
             provider.add_span_processor(proc)
-        provider._agentserver_processors_added = True  # type: ignore[attr-defined]
+        provider._agentserver_processors_added = True  # type: ignore[attr-defined]  # pylint: disable=protected-access
     return provider
 
 

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_tracing.py
@@ -200,12 +200,19 @@ def _setup_distro_export(
     """
     from microsoft.opentelemetry import use_microsoft_opentelemetry
 
-    use_microsoft_opentelemetry(
+    kwargs: dict[str, Any] = dict(
         resource=resource,
         span_processors=span_processors,
         log_record_processors=log_record_processors,
-        connection_string=connection_string,
     )
+
+    # Azure Monitor export is off by default in the distro — enable it
+    # when a connection string is available.
+    if connection_string:
+        kwargs["enable_azure_monitor"] = True
+        kwargs["azure_monitor_connection_string"] = connection_string
+
+    use_microsoft_opentelemetry(**kwargs)
 
 
 # ======================================================================

--- a/sdk/agentserver/azure-ai-agentserver-core/dev_requirements.txt
+++ b/sdk/agentserver/azure-ai-agentserver-core/dev_requirements.txt
@@ -1,5 +1,4 @@
 -e ../../../eng/tools/azure-sdk-tools
--e ../../monitor/azure-monitor-opentelemetry-exporter
 -e ../../monitor/azure-monitor-query
 -e ../../identity/azure-identity
 pytest

--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -25,8 +25,7 @@ dependencies = [
     "hypercorn>=0.17.0",
     "opentelemetry-api>=1.40.0",
     "opentelemetry-sdk>=1.40.0",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.40.0",
-    "azure-monitor-opentelemetry-exporter>=1.0.0b49",
+    "microsoft-opentelemetry>=0.5.0",
 ]
 
 [build-system]
@@ -74,4 +73,3 @@ pylint = true
 type_check_samples = false
 
 [tool.uv.sources]
-azure-monitor-opentelemetry-exporter = { path = "../../monitor/azure-monitor-opentelemetry-exporter" }

--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "hypercorn>=0.17.0",
     "opentelemetry-api>=1.40.0",
     "opentelemetry-sdk>=1.40.0",
-    "microsoft-opentelemetry>=0.5.0",
+    "microsoft-opentelemetry>=0.1.0b1",
 ]
 
 [build-system]

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
@@ -117,11 +117,11 @@ class TestAppInsightsConnectionString:
 
 
 # ------------------------------------------------------------------ #
-# _setup_azure_monitor (mocked)
+# _setup_distro_export (mocked)
 # ------------------------------------------------------------------ #
 
 
-class TestSetupAzureMonitor:
+class TestSetupDistroExport:
     """Verify _configure_tracing calls the distro with the right args."""
 
     def test_distro_called_when_conn_str_provided(self) -> None:

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
@@ -122,27 +122,25 @@ class TestAppInsightsConnectionString:
 
 
 class TestSetupAzureMonitor:
-    """Verify _configure_tracing calls the right exporter setup functions."""
+    """Verify _configure_tracing calls the distro with the right args."""
 
-    def test_setup_azure_monitor_called_when_conn_str_provided(self) -> None:
-        with mock.patch("azure.ai.agentserver.core._tracing._setup_trace_export") as mock_trace:
-            with mock.patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                with mock.patch("azure.ai.agentserver.core._tracing._setup_otlp_trace_export"):
-                    with mock.patch("azure.ai.agentserver.core._tracing._setup_otlp_log_export"):
-                        from azure.ai.agentserver.core import _tracing
-                        _tracing._configure_tracing(connection_string="InstrumentationKey=test")
-                        mock_trace.assert_called_once()
-                        args = mock_trace.call_args[0]
-                        assert args[1] == "InstrumentationKey=test"
+    def test_distro_called_when_conn_str_provided(self) -> None:
+        with mock.patch("azure.ai.agentserver.core._tracing._setup_distro_export") as mock_distro:
+            from azure.ai.agentserver.core import _tracing
+            _tracing._configure_tracing(connection_string="InstrumentationKey=test")
+            mock_distro.assert_called_once()
+            kwargs = mock_distro.call_args[1]
+            assert kwargs["connection_string"] == "InstrumentationKey=test"
+            assert len(kwargs["span_processors"]) >= 1
+            assert len(kwargs["log_record_processors"]) >= 1
 
-    def test_setup_azure_monitor_not_called_when_no_conn_str(self) -> None:
-        with mock.patch("azure.ai.agentserver.core._tracing._setup_trace_export") as mock_trace:
-            with mock.patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                with mock.patch("azure.ai.agentserver.core._tracing._setup_otlp_trace_export"):
-                    with mock.patch("azure.ai.agentserver.core._tracing._setup_otlp_log_export"):
-                        from azure.ai.agentserver.core import _tracing
-                        _tracing._configure_tracing(connection_string=None)
-                        mock_trace.assert_not_called()
+    def test_distro_called_without_conn_str(self) -> None:
+        with mock.patch("azure.ai.agentserver.core._tracing._setup_distro_export") as mock_distro:
+            from azure.ai.agentserver.core import _tracing
+            _tracing._configure_tracing(connection_string=None)
+            mock_distro.assert_called_once()
+            kwargs = mock_distro.call_args[1]
+            assert kwargs["connection_string"] is None
 
 
 # ------------------------------------------------------------------ #

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing.py
@@ -53,11 +53,11 @@ class TestTracingToggle:
             mock_configure.assert_called_once()
 
     def test_observability_receives_appinsights_env_var(self) -> None:
-        with mock.patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+        with mock.patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
             mock_configure = mock.MagicMock()
             AgentServerHost(configure_observability=mock_configure)
             mock_configure.assert_called_once()
-            assert mock_configure.call_args[1]["connection_string"] == "InstrumentationKey=test"
+            assert mock_configure.call_args[1]["connection_string"] == "InstrumentationKey=00000000-0000-0000-0000-000000000000"
 
     def test_observability_receives_otlp_env_var(self) -> None:
         with mock.patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"}):
@@ -78,7 +78,7 @@ class TestTracingToggle:
 
     def test_observability_disabled_when_none(self) -> None:
         """Passing configure_observability=None disables all SDK-managed observability."""
-        with mock.patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+        with mock.patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
             # Should not raise even with App Insights configured
             AgentServerHost(configure_observability=None)
 
@@ -127,10 +127,10 @@ class TestSetupDistroExport:
     def test_distro_called_when_conn_str_provided(self) -> None:
         with mock.patch("azure.ai.agentserver.core._tracing._setup_distro_export") as mock_distro:
             from azure.ai.agentserver.core import _tracing
-            _tracing._configure_tracing(connection_string="InstrumentationKey=test")
+            _tracing._configure_tracing(connection_string="InstrumentationKey=00000000-0000-0000-0000-000000000000")
             mock_distro.assert_called_once()
             kwargs = mock_distro.call_args[1]
-            assert kwargs["connection_string"] == "InstrumentationKey=test"
+            assert kwargs["connection_string"] == "InstrumentationKey=00000000-0000-0000-0000-000000000000"
             assert len(kwargs["span_processors"]) >= 1
             assert len(kwargs["log_record_processors"]) >= 1
 

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing_e2e.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/test_tracing_e2e.py
@@ -115,6 +115,34 @@ def _make_streaming_echo_app():
     return app, request_ids
 
 
+def _make_echo_app_with_child_span():
+    """Create an AgentServerHost whose handler creates a child span inside request_span.
+
+    Returns (app, request_ids, child_span_ids).  The child span simulates a
+    framework creating its own span inside the invoke_agent span context.
+    ``child_span_ids`` captures the hex span-id of each child so the test can
+    query App Insights by that value.
+    """
+    request_ids: list[str] = []
+    child_span_ids: list[str] = []
+    child_tracer = trace.get_tracer("test.framework")
+
+    async def echo_handler(request: Request) -> Response:
+        req_id = str(uuid.uuid4())
+        request_ids.append(req_id)
+        with app.request_span(dict(request.headers), req_id, "invoke_agent"):
+            with child_tracer.start_as_current_span("framework_child") as child:
+                child_span_ids.append(format(child.context.span_id, "016x"))
+                body = await request.body()
+                resp = Response(content=body, media_type="application/octet-stream")
+                resp.headers["x-request-id"] = req_id
+                return resp
+
+    routes = [Route("/echo", echo_handler, methods=["POST"])]
+    app = AgentServerHost(routes=routes)
+    return app, request_ids, child_span_ids
+
+
 def _make_failing_echo_app():
     """Create an app whose handler raises inside request_span. Returns (app, request_ids)."""
     request_ids: list[str] = []
@@ -245,4 +273,61 @@ class TestAppInsightsIngestionE2E:
         assert len(rows) > 0, (
             f"Span with response_id={req_id} and gen_ai.system attribute "
             "not found in App Insights"
+        )
+
+    def test_span_parenting_in_appinsights(
+        self,
+        appinsights_connection_string,
+        appinsights_resource_id,
+        logs_query_client,
+    ):
+        """Verify a child span created inside request_span is parented correctly in App Insights.
+
+        The parent (invoke_agent, SpanKind.SERVER) lands in ``requests``.
+        The child (framework_child, SpanKind.INTERNAL) lands in ``dependencies``.
+        We capture the child's span-id locally, use it to find the child row in
+        ``dependencies``, then follow its ``operation_ParentId`` back to the
+        parent row in ``requests``.
+        """
+        app, request_ids, child_span_ids = _make_echo_app_with_child_span()
+        client = TestClient(app)
+        resp = client.post("/echo", content=b"parenting e2e")
+        assert resp.status_code == 200
+        req_id = request_ids[-1]
+        child_span_id = child_span_ids[-1]
+        _flush_provider()
+
+        # Step 1: Find the child span in the dependencies table using its span-id.
+        child_query = (
+            "dependencies "
+            f"| where id == '{child_span_id}' "
+            "| where name == 'framework_child' "
+            "| project id, name, operation_Id, operation_ParentId "
+            "| take 1"
+        )
+        child_rows = _poll_appinsights(logs_query_client, appinsights_resource_id, child_query)
+        assert len(child_rows) > 0, (
+            f"Child framework_child span (id={child_span_id}) not found in "
+            f"dependencies table after {_APPINSIGHTS_POLL_TIMEOUT}s"
+        )
+
+        operation_id = child_rows[0][2]       # operation_Id column
+        child_parent_id = child_rows[0][3]    # operation_ParentId column
+
+        # Step 2: Find the parent span in the requests table using the child's operation_ParentId.
+        parent_query = (
+            "requests "
+            f"| where id == '{child_parent_id}' "
+            f"| where operation_Id == '{operation_id}' "
+            "| project id, name, operation_Id "
+            "| take 1"
+        )
+        parent_rows = _poll_appinsights(logs_query_client, appinsights_resource_id, parent_query)
+        assert len(parent_rows) > 0, (
+            f"Parent span (id={child_parent_id}) referenced by child's "
+            f"operation_ParentId not found in requests table"
+        )
+
+        assert parent_rows[0][1] == "invoke_agent", (
+            f"Expected parent span name 'invoke_agent', got '{parent_rows[0][1]}'"
         )

--- a/sdk/agentserver/azure-ai-agentserver-invocations/dev_requirements.txt
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/dev_requirements.txt
@@ -1,7 +1,6 @@
 # keep in sync with pyproject.toml#dependency-groups.dev
 -e ../../../eng/tools/azure-sdk-tools
 -e ../azure-ai-agentserver-core
-../../monitor/azure-monitor-opentelemetry-exporter
 ../../monitor/azure-monitor-query
 ../../identity/azure-identity
 pytest

--- a/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
 # keep in sync with dev_requirements.txt
 dev = [
     "azure-identity",
-    "azure-monitor-opentelemetry-exporter",
     "azure-monitor-query",
     "azure-sdk-tools",
     "httpx",
@@ -86,6 +85,5 @@ type_check_samples = false
 [tool.uv.sources]
 azure-ai-agentserver-core = { path = "../azure-ai-agentserver-core", editable = true }
 azure-identity = { path = "../../identity/azure-identity" }
-azure-monitor-opentelemetry-exporter = { path = "../../monitor/azure-monitor-opentelemetry-exporter" }
 azure-monitor-query = { path = "../../monitor/azure-monitor-query" }
 azure-sdk-tools = { path = "../../../eng/tools/azure-sdk-tools" }

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -60,7 +60,7 @@ def _get_spans():
 def _make_server_with_child_span():
     """Server whose handler creates a child span (simulating a framework)."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")
 
@@ -75,7 +75,7 @@ def _make_server_with_child_span():
 def _make_streaming_server_with_child_span():
     """Server with streaming response whose handler creates a child span."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -60,9 +60,8 @@ def _get_spans():
 def _make_server_with_child_span():
     """Server whose handler creates a child span (simulating a framework)."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                app = InvocationAgentServerHost()
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")
 
     @app.invoke_handler
@@ -76,9 +75,8 @@ def _make_server_with_child_span():
 def _make_streaming_server_with_child_span():
     """Server with streaming response whose handler creates a child span."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                app = InvocationAgentServerHost()
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")
 
     @app.invoke_handler

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -29,26 +29,30 @@ try:
 except ImportError:
     _HAS_OTEL = False
 
-if _HAS_OTEL:
-    # Reuse the global provider if already set by another test module,
-    # otherwise create one. This avoids overriding the provider when
-    # multiple test files run in the same process.
-    _existing = trace.get_tracer_provider()
-    if hasattr(_existing, "add_span_processor"):
-        _PROVIDER = _existing
-    else:
-        _PROVIDER = SdkTracerProvider()
-        trace.set_tracer_provider(_PROVIDER)
-    _EXPORTER = InMemorySpanExporter()
-    _PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
-else:
-    _EXPORTER = None
+# Provider setup is deferred to a fixture so that set_tracer_provider() is
+# NOT called at import time.  Module-level calls would consume the global
+# Once guard and break e2e tests that rely on the distro to set the provider.
+_PROVIDER = None
+_EXPORTER = None
+_SETUP_DONE = False
 
 pytestmark = pytest.mark.skipif(not _HAS_OTEL, reason="opentelemetry not installed")
 
 
 @pytest.fixture(autouse=True)
 def _clear():
+    """Set up the OTel provider on first use, then clear spans before each test."""
+    global _PROVIDER, _EXPORTER, _SETUP_DONE
+    if _HAS_OTEL and not _SETUP_DONE:
+        _existing = trace.get_tracer_provider()
+        if hasattr(_existing, "add_span_processor"):
+            _PROVIDER = _existing
+        else:
+            _PROVIDER = SdkTracerProvider()
+            trace.set_tracer_provider(_PROVIDER)
+        _EXPORTER = InMemorySpanExporter()
+        _PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+        _SETUP_DONE = True
     if _EXPORTER:
         _EXPORTER.clear()
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_span_parenting.py
@@ -59,7 +59,7 @@ def _get_spans():
 
 def _make_server_with_child_span():
     """Server whose handler creates a child span (simulating a framework)."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")
@@ -74,7 +74,7 @@ def _make_server_with_child_span():
 
 def _make_streaming_server_with_child_span():
     """Server with streaming response whose handler creates a child span."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
     child_tracer = trace.get_tracer("test.framework")

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
@@ -66,7 +66,7 @@ def _get_spans():
 
 def _make_tracing_server(**kwargs):
     """Create an InvocationAgentServerHost with tracing enabled."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
@@ -80,7 +80,7 @@ def _make_tracing_server(**kwargs):
 
 def _make_tracing_server_with_get_cancel(**kwargs):
     """Create a tracing-enabled server with get/cancel handlers."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
@@ -112,7 +112,7 @@ def _make_tracing_server_with_get_cancel(**kwargs):
 
 def _make_failing_tracing_server(**kwargs):
     """Create a tracing-enabled server whose handler raises."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
@@ -125,7 +125,7 @@ def _make_failing_tracing_server(**kwargs):
 
 def _make_streaming_tracing_server(**kwargs):
     """Create a tracing-enabled server with streaming response."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
@@ -237,7 +237,7 @@ def test_cancel_invocation_creates_span():
 
 def test_tracing_via_appinsights_env_var():
     """Tracing is enabled when APPLICATIONINSIGHTS_CONNECTION_STRING is set."""
-    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
+    with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000"}):
         with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
@@ -15,9 +15,14 @@ from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 
 # ---------------------------------------------------------------------------
-# Module-level OTel setup with in-memory exporter
+# Lazy OTel setup with in-memory exporter
 # ---------------------------------------------------------------------------
 # We use the real OTel SDK to capture spans in memory.
+# IMPORTANT: Provider setup is deferred to a fixture so that
+# set_tracer_provider() is NOT called at import time.  When pytest collects
+# tests it imports every module — module-level set_tracer_provider() would
+# consume the global Once guard and break e2e tests that rely on the
+# microsoft-opentelemetry distro to set the provider.
 
 try:
     from opentelemetry import trace
@@ -29,26 +34,27 @@ try:
 except ImportError:
     _HAS_OTEL = False
 
-# Module-level provider so all tests share the same exporter
-if _HAS_OTEL:
-    _existing = trace.get_tracer_provider()
-    if hasattr(_existing, "add_span_processor"):
-        _MODULE_PROVIDER = _existing
-    else:
-        _MODULE_PROVIDER = SdkTracerProvider()
-        trace.set_tracer_provider(_MODULE_PROVIDER)
-    _MODULE_EXPORTER = InMemorySpanExporter()
-    _MODULE_PROVIDER.add_span_processor(SimpleSpanProcessor(_MODULE_EXPORTER))
-else:
-    _MODULE_EXPORTER = None
-    _MODULE_PROVIDER = None
+_MODULE_PROVIDER = None
+_MODULE_EXPORTER = None
+_MODULE_SETUP_DONE = False
 
 pytestmark = pytest.mark.skipif(not _HAS_OTEL, reason="opentelemetry not installed")
 
 
 @pytest.fixture(autouse=True)
 def _clear_spans():
-    """Clear exported spans before each test."""
+    """Set up the OTel provider on first use, then clear spans before each test."""
+    global _MODULE_PROVIDER, _MODULE_EXPORTER, _MODULE_SETUP_DONE
+    if _HAS_OTEL and not _MODULE_SETUP_DONE:
+        _existing = trace.get_tracer_provider()
+        if hasattr(_existing, "add_span_processor"):
+            _MODULE_PROVIDER = _existing
+        else:
+            _MODULE_PROVIDER = SdkTracerProvider()
+            trace.set_tracer_provider(_MODULE_PROVIDER)
+        _MODULE_EXPORTER = InMemorySpanExporter()
+        _MODULE_PROVIDER.add_span_processor(SimpleSpanProcessor(_MODULE_EXPORTER))
+        _MODULE_SETUP_DONE = True
     if _MODULE_EXPORTER:
         _MODULE_EXPORTER.clear()
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
@@ -67,7 +67,7 @@ def _get_spans():
 def _make_tracing_server(**kwargs):
     """Create an InvocationAgentServerHost with tracing enabled."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
@@ -81,7 +81,7 @@ def _make_tracing_server(**kwargs):
 def _make_tracing_server_with_get_cancel(**kwargs):
     """Create a tracing-enabled server with get/cancel handlers."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
     store: dict[str, bytes] = {}
@@ -113,7 +113,7 @@ def _make_tracing_server_with_get_cancel(**kwargs):
 def _make_failing_tracing_server(**kwargs):
     """Create a tracing-enabled server whose handler raises."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
@@ -126,7 +126,7 @@ def _make_failing_tracing_server(**kwargs):
 def _make_streaming_tracing_server(**kwargs):
     """Create a tracing-enabled server with streaming response."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
@@ -238,7 +238,7 @@ def test_cancel_invocation_creates_span():
 def test_tracing_via_appinsights_env_var():
     """Tracing is enabled when APPLICATIONINSIGHTS_CONNECTION_STRING is set."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export", create=True):
             app = InvocationAgentServerHost()
 
     @app.invoke_handler

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_tracing.py
@@ -67,9 +67,8 @@ def _get_spans():
 def _make_tracing_server(**kwargs):
     """Create an InvocationAgentServerHost with tracing enabled."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                server = InvocationAgentServerHost(**kwargs)
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
     async def handle(request: Request) -> Response:
@@ -82,9 +81,8 @@ def _make_tracing_server(**kwargs):
 def _make_tracing_server_with_get_cancel(**kwargs):
     """Create a tracing-enabled server with get/cancel handlers."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                server = InvocationAgentServerHost(**kwargs)
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            server = InvocationAgentServerHost(**kwargs)
 
     store: dict[str, bytes] = {}
 
@@ -115,9 +113,8 @@ def _make_tracing_server_with_get_cancel(**kwargs):
 def _make_failing_tracing_server(**kwargs):
     """Create a tracing-enabled server whose handler raises."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                server = InvocationAgentServerHost(**kwargs)
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
     async def handle(request: Request) -> Response:
@@ -129,9 +126,8 @@ def _make_failing_tracing_server(**kwargs):
 def _make_streaming_tracing_server(**kwargs):
     """Create a tracing-enabled server with streaming response."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                server = InvocationAgentServerHost(**kwargs)
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            server = InvocationAgentServerHost(**kwargs)
 
     @server.invoke_handler
     async def handle(request: Request) -> StreamingResponse:
@@ -242,9 +238,8 @@ def test_cancel_invocation_creates_span():
 def test_tracing_via_appinsights_env_var():
     """Tracing is enabled when APPLICATIONINSIGHTS_CONNECTION_STRING is set."""
     with patch.dict(os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"}):
-        with patch("azure.ai.agentserver.core._tracing._setup_trace_export"):
-            with patch("azure.ai.agentserver.core._tracing._setup_log_export"):
-                app = InvocationAgentServerHost()
+        with patch("azure.ai.agentserver.core._tracing._setup_distro_export"):
+            app = InvocationAgentServerHost()
 
     @app.invoke_handler
     async def handle(request: Request) -> Response:
@@ -457,3 +452,4 @@ def test_agent_name_only_in_span_name():
 
 def test_project_endpoint_env_var():
     """FOUNDRY_PROJECT_ENDPOINT constant matches the expected env var name."""
+

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -78,6 +78,7 @@ httpx
 pandas
 nltk
 azure-monitor-opentelemetry
+microsoft-opentelemetry
 python-dotenv
 pyrit
 prompty


### PR DESCRIPTION
… to microsoft-opentelemetry

Replace manual Azure Monitor and OTLP exporter wiring (~100 lines) with a single use_microsoft_opentelemetry() call via the new microsoft-opentelemetry distro. The distro auto-detects exporters from environment variables.

Changes:
- core pyproject.toml: swap azure-monitor-opentelemetry-exporter + otlp-grpc for microsoft-opentelemetry>=0.5.0
- core _tracing.py: refactor _configure_tracing() to delegate to new _setup_distro_export() wrapper; remove 4 _setup_* functions and guard flags
- Update all test mocks in core and invocations to patch the single _setup_distro_export target instead of multiple _setup_* functions
- Remove azure-monitor-opentelemetry-exporter from dev_requirements.txt in both core and invocations packages

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
