### PR TITLE
Update azure-ai-projects TypeSpec commit to 58fe6d5

### DIFF
--- a/sdk/ai/azure-ai-projects/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai-foundry/data-plane/Foundry
-commit: 94f9262ac1a87141d3367df1dcb9cc6acf433dfc
+commit: 58fe6d500410102577db8706ce7d0c16bce0259d
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
## Summary

Regenerated the azure-ai-projects SDK from TypeSpec commit `58fe6d500410102577db8706ce7d0c16bce0259d` and applied post-emitter fixes.

## Changes
- Updated `tsp-location.yaml` commit hash to `58fe6d500410102577db8706ce7d0c16bce0259d`
- Ran `tsp-client update` to regenerate SDK from the new TypeSpec
- Ran `post-emitter-fixes.cmd` to apply package-specific fixes

## Testing
- All **584 tests passed**, 109 skipped (live tests requiring credentials)
- Package imports successfully