### PR TITLE
Clean up remaining `python 3.9` utilization

### DIFF
--- a/sdk/agentserver/platform-matrix.json
+++ b/sdk/agentserver/platform-matrix.json
@@ -9,7 +9,7 @@
       "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" },
       "windows-2022": { "OSVmImage": "env:WINDOWSVMIMAGE", "Pool": "env:WINDOWSPOOL" }
     },
-    "PythonVersion": [ "3.10", "3.12" ],
+    "PythonVersion": [ "3.12" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
@@ -27,10 +27,10 @@
     },
     {
       "CoverageConfig": {
-        "ubuntu2404_39_coverage": {
+        "ubuntu2404_310_coverage": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "",
           "TestSamples": "false"
         }

--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -24,20 +24,20 @@
         "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
       }
     },
-    "PythonVersion": ["pypy3.11", "3.10", "3.11"],
+    "PythonVersion": ["pypy3.11", "3.11", "3.12"],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
   "include": [
     {
       "CoverageConfig": {
-        "ubuntu2404_39_coverage": {
+        "ubuntu2404_310_coverage": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "",
           "TestSamples": "false",
-          "AZURE_TEST_AGENT": "UBUNTU_2404_PYTHON39",
+          "AZURE_TEST_AGENT": "UBUNTU_2404_PYTHON310",
           "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
         }
       }

--- a/sdk/cosmos/cosmos-emulator-internal-matrix.json
+++ b/sdk/cosmos/cosmos-emulator-internal-matrix.json
@@ -15,14 +15,14 @@
         }
       },
       "EmulatorConfig": {
-        "Emulator Tests Python 3.9 Standard": {
-            "PythonVersion": "3.9",
+        "Emulator Tests Python 3.10 Standard": {
+            "PythonVersion": "3.10",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "whl,sdist"
         },
-        "Emulator Tests Python 3.10 Standard": {
-            "PythonVersion": "3.10",
+        "Emulator Tests Python 3.11 Standard": {
+            "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "whl,sdist"
@@ -40,14 +40,14 @@
             "ChecksOverride": "whl,sdist"
         },
 
-        "Emulator Tests Python 3.9 Special": {
-            "PythonVersion": "3.9",
+        "Emulator Tests Python 3.10 Special": {
+            "PythonVersion": "3.10",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "import_all,whl_no_aio"
         },
-        "Emulator Tests Python 3.10 Special": {
-            "PythonVersion": "3.10",
+        "Emulator Tests Python 3.11 Special": {
+            "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "import_all,whl_no_aio"
@@ -71,14 +71,14 @@
             "ChecksOverride": "import_all,whl_no_aio"
         },
 
-        "Emulator Tests Python 3.9 Dependency Checks": {
-            "PythonVersion": "3.9",
+        "Emulator Tests Python 3.10 Dependency Checks": {
+            "PythonVersion": "3.10",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "latestdependency,mindependency"
         },
-        "Emulator Tests Python 3.10 Dependency Checks": {
-            "PythonVersion": "3.10",
+        "Emulator Tests Python 3.11 Dependency Checks": {
+            "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "latestdependency,mindependency"

--- a/sdk/cosmos/cosmos-emulator-public-matrix.json
+++ b/sdk/cosmos/cosmos-emulator-public-matrix.json
@@ -15,6 +15,12 @@
         }
       },
       "EmulatorConfig": {
+        "Emulator Tests Python 3.10 Standard": {
+            "PythonVersion": "3.10",
+            "CoverageArg": "--disablecov",
+            "TestSamples": "false",
+            "ChecksOverride": "whl,sdist"
+        },
         "Emulator Tests Python 3.11 Standard": {
             "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",

--- a/sdk/cosmos/cosmos-emulator-public-matrix.json
+++ b/sdk/cosmos/cosmos-emulator-public-matrix.json
@@ -15,8 +15,8 @@
         }
       },
       "EmulatorConfig": {
-        "Emulator Tests Python 3.10 Standard": {
-            "PythonVersion": "3.10",
+        "Emulator Tests Python 3.11 Standard": {
+            "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "whl,sdist"
@@ -40,14 +40,14 @@
             "ChecksOverride": "whl,sdist"
         },
 
-        "Emulator Tests Python 3.9 Dependency Checks": {
-            "PythonVersion": "3.9",
+        "Emulator Tests Python 3.10 Dependency Checks": {
+            "PythonVersion": "3.10",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "mindependency"
         },
-        "Emulator Tests Python 3.10 Dependency Checks": {
-            "PythonVersion": "3.10",
+        "Emulator Tests Python 3.11 Dependency Checks": {
+            "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "mindependency"

--- a/sdk/cosmos/live-platform-matrix.json
+++ b/sdk/cosmos/live-platform-matrix.json
@@ -44,10 +44,10 @@
     },
     {
       "CircuitBreakerMultiRegionTestConfig": {
-        "Ubuntu2404_39_circuit_breaker": {
+        "Ubuntu2404_310_circuit_breaker": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "--disablecov",
           "TestSamples": "false",
           "TestMarkArgument": "cosmosCircuitBreakerMultiRegion"
@@ -102,10 +102,10 @@
     },
     {
       "CoverageConfig": {
-        "ubuntu2404_39_coverage_query": {
+        "ubuntu2404_310_coverage_query": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "",
           "TestSamples": "false",
           "TestMarkArgument": "cosmosQuery"

--- a/sdk/evaluation/platform-matrix.json
+++ b/sdk/evaluation/platform-matrix.json
@@ -9,17 +9,17 @@
       "macos-latest": { "OSVmImage": "env:MACVMIMAGE", "Pool": "env:MACPOOL" },
       "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" }
     },
-    "PythonVersion": [ "3.9", "3.11", "3.10" ],
+    "PythonVersion": [ "3.11", "3.10" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
   "include": [
     {
       "CoverageConfig": {
-        "ubuntu2404_39_coverage": {
+        "ubuntu2404_310_coverage": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "",
           "TestSamples": "false"
         }

--- a/sdk/identity/platform-matrix.json
+++ b/sdk/identity/platform-matrix.json
@@ -8,10 +8,10 @@
   "include": [
     {
       "Config": {
-        "ubuntu_24.04_3.9_msal": {
+        "ubuntu_24.04_3.10_msal": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "--disablecov",
           "InjectedPackages": "git+https://github.com/AzureAD/microsoft-authentication-library-for-python@dev",
           "UnsupportedToxEnvironments": "mindependency,latestdependency"

--- a/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
@@ -8,7 +8,7 @@
           "ArmTemplateParameters": "@{ enableHsm = $true }"
         }
       },
-      "PythonVersion": "3.9",
+      "PythonVersion": "3.10",
       "CoverageArg": ""
     }
   ]

--- a/sdk/planetarycomputer/platform-matrix.json
+++ b/sdk/planetarycomputer/platform-matrix.json
@@ -9,7 +9,7 @@
       "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" },
       "windows-2022": { "OSVmImage": "env:WINDOWSVMIMAGE", "Pool": "env:WINDOWSPOOL" }
     },
-    "PythonVersion": [ "3.10", "3.12" ],
+    "PythonVersion": [ "3.12" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },
@@ -27,10 +27,10 @@
     },
     {
       "CoverageConfig": {
-        "ubuntu2404_39_coverage": {
+        "ubuntu2404_310_coverage": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
-          "PythonVersion": "3.9",
+          "PythonVersion": "3.10",
           "CoverageArg": "",
           "TestSamples": "false"
         }


### PR DESCRIPTION
Direct follow-up to #46508

As promised, cleaning up remaining matrix items.