### PR TITLE
Ensure that `azure-storage-extensions` is added to build set on changes to other data-plane storage packages

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -54,6 +54,11 @@ extends:
       safeName: azurestoragequeue
     - name: azure-storage-extensions
       safeName: azurestorageextensions
+      triggeringPaths:
+        - /sdk/storage/azure-storage-blob
+        - /sdk/storage/azure-storage-file-datalake
+        - /sdk/storage/azure-storage-file-share
+        - /sdk/storage/azure-storage-queue
       # Pure C-based storage extension package, not generating docs at this moment.
       skipPublishDocGithubIo: true
       skipPublishDocMs: true


### PR DESCRIPTION
There is a PR incoming to `main` that will add `azure-storage-extensions` to the dev_requirements.txt for the 4 data-plane storage packages.

When that _happens_, we will immediately see timeouts during the test phase, as if `azure-storage-extensions` is NOT triggered by a change, then each test platform will need to assemble the wheel on the fly.

This is an expensive assembly that we enable with direct usage of `cibuildwheel`, so by adding these data plane packages to the triggering paths for `azure-storage-extensions`, we'll always have `azure-storage-extensions` added to the build set, and as such will be available for install.