### PR TITLE
Add Python Team as Docs Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -849,7 +849,7 @@
 
 /scripts/                                                            @scbedd @mccoyp
 /scripts/breaking_changes_checker/                                   @catalinaperalta
-/doc/                                                                @scbedd @mccoyp
+/doc/                                                                @scbedd @Azure/azure-python-sdk
 /conda/                                                              @scbedd @xiangyan99 @lmazuel
 
 # Add owners for notifications for specific pipelines


### PR DESCRIPTION
Adding in the python sdk team as codeowners for docs