### PR TITLE
Check New Image Names

### DIFF
--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -9,9 +9,9 @@ variables:
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: ubuntu-24.04
+    value: ubuntu-24.04-gen2
   - name: LINUXNEXTVMIMAGE
-    value: ubuntu-24.04
+    value: ubuntu-24.04-gen2
   - name: WINDOWSVMIMAGE
     value: windows-2022
   - name: MACVMIMAGE

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -9,11 +9,11 @@ variables:
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: ubuntu-24.04-gen2
+    value: ubuntu-22.04-gen2
   - name: LINUXNEXTVMIMAGE
     value: ubuntu-24.04-gen2
   - name: WINDOWSVMIMAGE
-    value: windows-2022
+    value: windows-2022-gen2
   - name: MACVMIMAGE
     value: macos-latest
 

--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -13,3 +13,4 @@ opentelemetry-sdk~=1.26
 opentelemetry-instrumentation-requests>=0.50b0
 ../../identity/azure-identity
 packaging # for version parsing in test_basic_transport_async.py
+


### PR DESCRIPTION
The existing `ubuntu 24.04` aren't getting new updates. Let's check the gen2 that we learned about earlier today. Big non-blocking error disappear and pipeline still works?

