### PR TITLE
[Core] Remove _FixedOffset and use stdlib

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
@@ -37,7 +37,7 @@ from azure.core.pipeline.transport import (
 from azure.core.rest import HttpResponse, AsyncHttpResponse, HttpRequest
 
 
-from ...utils._utils import _FixedOffset, case_insensitive_dict, CaseInsensitiveSet
+from ...utils._utils import case_insensitive_dict, CaseInsensitiveSet
 from .. import PipelineResponse
 
 
@@ -56,7 +56,7 @@ def _parse_http_date(text: str) -> datetime.datetime:
     if not parsed_date:
         raise ValueError("Invalid HTTP date")
     tz_offset = cast(int, parsed_date[9])  # Look at the code, tz_offset is always an int, at worst 0
-    return datetime.datetime(*parsed_date[:6], tzinfo=_FixedOffset(tz_offset / 60))
+    return datetime.datetime(*parsed_date[:6], tzinfo=datetime.timezone(datetime.timedelta(minutes=tz_offset / 60)))
 
 
 def parse_retry_after(retry_after: str) -> float:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
@@ -56,7 +56,7 @@ def _parse_http_date(text: str) -> datetime.datetime:
     if not parsed_date:
         raise ValueError("Invalid HTTP date")
     tz_offset = cast(int, parsed_date[9])  # Look at the code, tz_offset is always an int, at worst 0
-    return datetime.datetime(*parsed_date[:6], tzinfo=datetime.timezone(datetime.timedelta(minutes=tz_offset / 60)))
+    return datetime.datetime(*parsed_date[:6], tzinfo=datetime.timezone(datetime.timedelta(seconds=tz_offset)))
 
 
 def parse_retry_after(retry_after: str) -> float:

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -23,30 +23,6 @@ from datetime import timezone
 TZ_UTC = timezone.utc
 
 
-class _FixedOffset(datetime.tzinfo):
-    """Fixed offset in minutes east from UTC.
-
-    Copy/pasted from Python doc
-
-    :param int offset: offset in minutes
-    """
-
-    def __init__(self, offset):
-        self.__offset = datetime.timedelta(minutes=offset)
-
-    def utcoffset(self, dt):  # pylint: disable=unused-argument
-        return self.__offset
-
-    def tzname(self, dt):  # pylint: disable=unused-argument
-        return str(self.__offset.total_seconds() / 3600)
-
-    def __repr__(self):
-        return "<FixedOffset {}>".format(self.tzname(None))
-
-    def dst(self, dt):  # pylint: disable=unused-argument
-        return datetime.timedelta(0)
-
-
 def _convert_to_isoformat(date_time):
     """Deserialize a date in RFC 3339 format to datetime object.
     Check https://tools.ietf.org/html/rfc3339#section-5.8 for examples.

--- a/sdk/core/azure-core/pyproject.toml
+++ b/sdk/core/azure-core/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-
 ]
 dependencies = [
     "requests>=2.21.0",

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -46,7 +46,6 @@ from azure.core.pipeline import PipelineResponse, Pipeline, PipelineContext
 from azure.core.pipeline.transport import HttpTransport
 
 from azure.core.polling.base_polling import LROBasePolling, OperationResourcePolling
-from azure.core.pipeline.policies._utils import _FixedOffset
 from utils import request_and_responses_product, REQUESTS_TRANSPORT_RESPONSES, create_transport_response, HTTP_REQUESTS
 from azure.core.pipeline._tools import is_rest
 from rest_client import MockRestClient
@@ -253,13 +252,13 @@ def test_delay_extraction_httpdate(polling_response, http_response):
 
     from datetime import datetime as basedatetime
 
-    now_mock_datetime = datetime.datetime(1995, 11, 20, 18, 12, 8, tzinfo=_FixedOffset(-5 * 60))
+    now_mock_datetime = datetime.datetime(1995, 11, 20, 18, 12, 8, tzinfo=datetime.timezone(datetime.timedelta(hours=-5)))
     with mock.patch("datetime.datetime") as mock_datetime:
         mock_datetime.now.return_value = now_mock_datetime
         mock_datetime.side_effect = lambda *args, **kw: basedatetime(*args, **kw)
 
         assert polling._extract_delay() == 60 * 60  # one hour in seconds
-        assert str(mock_datetime.now.call_args[0][0]) == "<FixedOffset -5.0>"
+        assert str(mock_datetime.now.call_args[0][0]) == "UTC-05:00"
 
 
 @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(REQUESTS_TRANSPORT_RESPONSES))

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -252,7 +252,9 @@ def test_delay_extraction_httpdate(polling_response, http_response):
 
     from datetime import datetime as basedatetime
 
-    now_mock_datetime = datetime.datetime(1995, 11, 20, 18, 12, 8, tzinfo=datetime.timezone(datetime.timedelta(hours=-5)))
+    now_mock_datetime = datetime.datetime(
+        1995, 11, 20, 18, 12, 8, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+    )
     with mock.patch("datetime.datetime") as mock_datetime:
         mock_datetime.now.return_value = now_mock_datetime
         mock_datetime.side_effect = lambda *args, **kw: basedatetime(*args, **kw)

--- a/sdk/core/corehttp/corehttp/runtime/policies/_utils.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_utils.py
@@ -30,7 +30,7 @@ from typing import Optional, cast, Union, TYPE_CHECKING
 from urllib.parse import urlparse
 
 from ...rest import HttpResponse, AsyncHttpResponse, HttpRequest
-from ...utils._utils import _FixedOffset, case_insensitive_dict
+from ...utils._utils import case_insensitive_dict
 
 if TYPE_CHECKING:
     from ...runtime.pipeline import PipelineResponse
@@ -49,7 +49,7 @@ def _parse_http_date(text: str) -> datetime.datetime:
     if not parsed_date:
         raise ValueError("Invalid HTTP date")
     tz_offset = cast(int, parsed_date[9])  # Look at the code, tz_offset is always an int, at worst 0
-    return datetime.datetime(*parsed_date[:6], tzinfo=_FixedOffset(tz_offset / 60))
+    return datetime.datetime(*parsed_date[:6], tzinfo=datetime.timezone(datetime.timedelta(seconds=tz_offset)))
 
 
 def parse_retry_after(retry_after: str) -> float:

--- a/sdk/core/corehttp/corehttp/utils/_utils.py
+++ b/sdk/core/corehttp/corehttp/utils/_utils.py
@@ -4,7 +4,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import datetime
 from typing import (
     Any,
     AsyncContextManager,

--- a/sdk/core/corehttp/corehttp/utils/_utils.py
+++ b/sdk/core/corehttp/corehttp/utils/_utils.py
@@ -26,30 +26,6 @@ if TYPE_CHECKING:
     from corehttp.rest._helpers import FileType, FilesType
 
 
-class _FixedOffset(datetime.tzinfo):
-    """Fixed offset in minutes east from UTC.
-
-    Copy/pasted from Python doc
-
-    :param int offset: offset in minutes
-    """
-
-    def __init__(self, offset):
-        self.__offset = datetime.timedelta(minutes=offset)
-
-    def utcoffset(self, dt):
-        return self.__offset
-
-    def tzname(self, dt):
-        return str(self.__offset.total_seconds() / 3600)
-
-    def __repr__(self):
-        return "<FixedOffset {}>".format(self.tzname(None))
-
-    def dst(self, dt):
-        return datetime.timedelta(0)
-
-
 def case_insensitive_dict(
     *args: Optional[Union[Mapping[str, Any], Iterable[Tuple[str, Any]]]], **kwargs: Any
 ) -> MutableMapping[str, Any]:

--- a/sdk/core/corehttp/pyproject.toml
+++ b/sdk/core/corehttp/pyproject.toml
@@ -9,14 +9,13 @@ authors = [
 ]
 description = "CoreHTTP Library for Python"
 keywords = ["typespec", "core"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
* Removed _FixedOffset since we can now use the stdlib itself from core and corehttp
* `azure-ai-anamolydetector` was importing this and would be breaking, but its inactive and will be deprecated in a separate PR
