### PR TITLE
Fix Copilot review comments on cu-sdk-setup scripts

### DIFF
--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/.github/skills/cu-sdk-setup/scripts/setup_user_env.ps1
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/.github/skills/cu-sdk-setup/scripts/setup_user_env.ps1
@@ -311,7 +311,14 @@ function Set-EnvValue {
     $pattern = "(?m)^$([regex]::Escape($Key))=.*$"
     $replacement = "$Key=$Value"
     if ([regex]::IsMatch($content, $pattern)) {
-        $content = [regex]::Replace($content, $pattern, $replacement)
+        # Use a MatchEvaluator so $ and \ in user-supplied values (API keys,
+        # endpoints) are written literally instead of being interpreted as
+        # regex replacement metacharacters ($1, $&, $$, etc.).
+        $content = [regex]::Replace(
+            $content,
+            $pattern,
+            [System.Text.RegularExpressions.MatchEvaluator] { param($match) $replacement }
+        )
     } else {
         if ($content -and -not $content.EndsWith("`n")) { $content += "`n" }
         $content += "$replacement`n"

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/.github/skills/cu-sdk-setup/scripts/setup_user_env.sh
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/.github/skills/cu-sdk-setup/scripts/setup_user_env.sh
@@ -371,7 +371,7 @@ PY
 
     # GPT_4_1_MINI_DEPLOYMENT
     if [ -z "$gpt41mini" ]; then
-        read -r -p "Enter GPT_4_1_MINI_DEPLOYMENT (default: gpt-4.1-mini): " gpt41mini || gpt41mini="" gpt41mini
+        read -r -p "Enter GPT_4_1_MINI_DEPLOYMENT (default: gpt-4.1-mini): " gpt41mini || gpt41mini=""
         gpt41mini="${gpt41mini:-gpt-4.1-mini}"
     else
         echo "  ✓ Using detected GPT_4_1_MINI_DEPLOYMENT=$gpt41mini"


### PR DESCRIPTION
Fixes the two Copilot review comments on PR #46618.

### setup_user_env.sh (line 374)
Removed stray trailing gpt41mini token from the read fallback. With set -e, running the script non-interactively (or hitting EOF on the prompt) would treat the token as a command and abort the script.

### setup_user_env.ps1 (Set-EnvValue)
Switched `[regex]::Replace` to a `MatchEvaluator` script block so values containing regex replacement metacharacters ($1, $&, $$, ${name}, \) are written to .env literally. This affects user-supplied API keys and endpoints that may contain `$`.

### Verification
- ash -n setup_user_env.sh → clean
- PowerShell AST parser → clean
- Behavior test: Set-EnvValue -Key FOO -Value 'sk-$1-$&-$$-${name}' writes the literal value to .env (verified on a temp .env file).