### PR TITLE
[Core] Set kwarg explicitly in method signatures

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -27,7 +27,7 @@
 import logging
 import sys
 import urllib.parse
-from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union, Any, Type, Mapping, Dict
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union, Any, Type, Mapping, Dict, Iterable
 from types import TracebackType
 
 from azure.core.pipeline import PipelineRequest, PipelineResponse

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -103,14 +103,19 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
     _RESPONSE_ID = "x-ms-request-id"
     _RESPONSE_ID_ATTR = "az.service_request_id"
 
-    def __init__(self, *, instrumentation_config: Optional[Mapping[str, Any]] = None, **kwargs: Any):
+    def __init__(
+        self,
+        *,
+        instrumentation_config: Optional[Mapping[str, Any]] = None,
+        additional_allowed_query_params: Optional[Iterable[str]] = None,
+        **kwargs: Any,
+    ):
         self._network_span_namer = kwargs.get("network_span_namer", _default_network_span_namer)
         self._tracing_attributes = kwargs.get("tracing_attributes", {})
         self._instrumentation_config = instrumentation_config
         self.allowed_query_params: set[str] = CaseInsensitiveSet(self.__class__.DEFAULT_QUERY_PARAMS_ALLOWLIST)
-        additional_params = kwargs.get("additional_allowed_query_params")
-        if additional_params:
-            self.allowed_query_params.update(additional_params)
+        if additional_allowed_query_params:
+            self.allowed_query_params.update(additional_allowed_query_params)
 
     def on_request(self, request: PipelineRequest[HTTPRequestType]) -> None:
         """Starts a span for the network call.

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -444,14 +444,18 @@ class HttpLoggingPolicy(
     MULTI_RECORD_LOG: str = "AZURE_SDK_LOGGING_MULTIRECORD"
 
     def __init__(
-        self, logger: Optional[logging.Logger] = None, *, http_logging_level: int = logging.INFO, **kwargs: Any
+        self,
+        logger: Optional[logging.Logger] = None,
+        *,
+        http_logging_level: int = logging.INFO,
+        additional_allowed_query_params: Optional[Iterable[str]] = None,
+        **kwargs: Any
     ):  # pylint: disable=unused-argument
         self.logger: logging.Logger = logger or logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
         self.http_logging_level: int = http_logging_level
         self.allowed_query_params: Set[str] = CaseInsensitiveSet(self.__class__.DEFAULT_QUERY_PARAMS_ALLOWLIST)
-        additional_query_params = kwargs.get("additional_allowed_query_params")
-        if additional_query_params:
-            self.allowed_query_params.update(additional_query_params)
+        if additional_allowed_query_params:
+            self.allowed_query_params.update(additional_allowed_query_params)
         self.allowed_header_names: Set[str] = CaseInsensitiveSet(self.__class__.DEFAULT_HEADERS_ALLOWLIST)
 
     def _redact_header(self, key: str, value: str) -> str:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -35,7 +35,7 @@ import xml.etree.ElementTree as ET
 import types
 import re
 import uuid
-from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, Set, MutableMapping
+from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, Set, MutableMapping, Iterable
 
 from azure.core import __version__ as azcore_version
 from azure.core.exceptions import DecodeError


### PR DESCRIPTION
The `additional_allowed_query_params` kwarg should be in the signatures to improve type-hinting.

