### PR TITLE
Use constants to decide distro version

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.8.8 (Unreleased)
 
 ### Features Added
+- Set `AZURE_MONITOR_DISTRO_VERSION` environment variable to pass distro version to the exporter
+  ([#46666](https://github.com/Azure/azure-sdk-for-python/pull/46666))
 
 ### Breaking Changes
 - Dropped support for Python 3.9. This package now supports Python 3.10+. [Follows upstream otel dropping support](https://github.com/open-telemetry/opentelemetry-python/pull/5076)

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 from azure.monitor.opentelemetry.exporter._constants import (  # pylint: disable=import-error,no-name-in-module
+    _AZURE_MONITOR_DISTRO_VERSION,
     _AZURE_MONITOR_DISTRO_VERSION_ARG,
 )
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 
 from azure.monitor.opentelemetry.exporter._constants import (  # pylint: disable=import-error,no-name-in-module
-    _AZURE_MONITOR_DISTRO_VERSION,
     _AZURE_MONITOR_DISTRO_VERSION_ARG,
 )
 
@@ -51,6 +50,9 @@ SUPPORTED_OTEL_SAMPLERS = (
     PARENT_BASED_ALWAYS_OFF_SAMPLER,
     PARENT_BASED_TRACE_ID_RATIO_SAMPLER,
 )
+
+# Distro version
+AZURE_MONITOR_DISTRO_VERSION = "AZURE_MONITOR_DISTRO_VERSION"
 
 # --------------------Autoinstrumentation Configuration------------------------------------------
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_utils/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_utils/configurations.py
@@ -37,7 +37,7 @@ from opentelemetry.sdk.trace.sampling import (
 from azure.monitor.opentelemetry._constants import (
     _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME,
     _AZURE_VM_RESOURCE_DETECTOR_NAME,
-    _AZURE_MONITOR_DISTRO_VERSION,
+    AZURE_MONITOR_DISTRO_VERSION,
     _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES,
     _PREVIEW_INSTRUMENTED_LIBRARIES,
     BROWSER_SDK_LOADER_CONFIG_ARG,
@@ -93,7 +93,7 @@ def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
     for key, val in kwargs.items():
         configurations[key] = val
     configurations[DISTRO_VERSION_ARG] = VERSION
-    environ[_AZURE_MONITOR_DISTRO_VERSION] = VERSION
+    environ[AZURE_MONITOR_DISTRO_VERSION] = VERSION
 
     _default_disable_logging(configurations)
     _default_disable_metrics(configurations)

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_utils/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_utils/configurations.py
@@ -37,6 +37,7 @@ from opentelemetry.sdk.trace.sampling import (
 from azure.monitor.opentelemetry._constants import (
     _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME,
     _AZURE_VM_RESOURCE_DETECTOR_NAME,
+    _AZURE_MONITOR_DISTRO_VERSION,
     _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES,
     _PREVIEW_INSTRUMENTED_LIBRARIES,
     BROWSER_SDK_LOADER_CONFIG_ARG,
@@ -92,6 +93,7 @@ def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
     for key, val in kwargs.items():
         configurations[key] = val
     configurations[DISTRO_VERSION_ARG] = VERSION
+    environ[_AZURE_MONITOR_DISTRO_VERSION] = VERSION
 
     _default_disable_logging(configurations)
     _default_disable_metrics(configurations)

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -83,7 +83,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "azure-core-tracing-opentelemetry~=1.0.0b11",
-        "azure-monitor-opentelemetry-exporter~=1.0.0b49",
+        "azure-monitor-opentelemetry-exporter~=1.0.0b52",
         "opentelemetry-sdk==1.40",
         "opentelemetry-instrumentation-django==0.61b0",
         "opentelemetry-instrumentation-fastapi==0.61b0",

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
@@ -815,7 +815,7 @@ class TestConfigurations(TestCase):
     def test_distro_version_env_var_matches_exporter_constant(self, resource_create_mock):
         """Verify the distro sets the same env var name the exporter reads."""
         from azure.monitor.opentelemetry.exporter._constants import (
-            AZURE_MONITOR_DISTRO_VERSION as EXPORTER_ENV_VAR_NAME,
+            _AZURE_MONITOR_DISTRO_VERSION as EXPORTER_ENV_VAR_NAME,
         )
         from azure.monitor.opentelemetry._constants import (
             AZURE_MONITOR_DISTRO_VERSION as DISTRO_ENV_VAR_NAME,

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
@@ -810,6 +810,23 @@ class TestConfigurations(TestCase):
         _get_configurations()
         self.assertEqual(environ.get("AZURE_MONITOR_DISTRO_VERSION"), VERSION)
 
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("opentelemetry.sdk.resources.Resource.create", return_value=TEST_DEFAULT_RESOURCE)
+    def test_distro_version_env_var_matches_exporter_constant(self, resource_create_mock):
+        """Verify the distro sets the same env var name the exporter reads."""
+        from azure.monitor.opentelemetry.exporter._constants import (
+            AZURE_MONITOR_DISTRO_VERSION as EXPORTER_ENV_VAR_NAME,
+        )
+        from azure.monitor.opentelemetry._constants import (
+            AZURE_MONITOR_DISTRO_VERSION as DISTRO_ENV_VAR_NAME,
+        )
+
+        # The env var names must match so the exporter can read what the distro sets
+        self.assertEqual(DISTRO_ENV_VAR_NAME, EXPORTER_ENV_VAR_NAME)
+        # Verify the value is set correctly after configuration
+        _get_configurations()
+        self.assertEqual(environ.get(EXPORTER_ENV_VAR_NAME), VERSION)
+
     @patch.dict(
         "os.environ",
         {

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/utils/test_configurations.py
@@ -804,6 +804,12 @@ class TestConfigurations(TestCase):
         self.assertEqual(configurations["sampling_arg"], 1.0)
         self.assertEqual(configurations["sampler_type"], "parentbased_trace_id_ratio")
 
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("opentelemetry.sdk.resources.Resource.create", return_value=TEST_DEFAULT_RESOURCE)
+    def test_get_configurations_sets_distro_version_env_var(self, resource_create_mock):
+        _get_configurations()
+        self.assertEqual(environ.get("AZURE_MONITOR_DISTRO_VERSION"), VERSION)
+
     @patch.dict(
         "os.environ",
         {


### PR DESCRIPTION
# Description

Pass the azure monitor distro version the exporter to set the telemetry sdk version, which is then passed on application insights.

NOTE: This PR can be merged once the exporter is released, otherwise the tests will fail.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
