### PR TITLE
auto fallback when loading settings from env

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features Added
 
+- `AZURE_LOG_LEVEL` now accepts `VERBOSE` (case-insensitive) as an alias for `DEBUG`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Invalid values for the `AZURE_LOG_LEVEL`, `AZURE_TRACING_ENABLED`, and `AZURE_SDK_TRACING_IMPLEMENTATION` environment variables no longer raise errors. Instead, a warning is logged and the default value is used (`INFO` for `AZURE_LOG_LEVEL`).
 
 ## 1.40.0 (2026-04-30)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- `AZURE_LOG_LEVEL` now accepts `VERBOSE` (case-insensitive) as an alias for `DEBUG`.
+- `AZURE_LOG_LEVEL` now accepts `VERBOSE` (case-insensitive) as an alias for `DEBUG`. #46668
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Invalid values for the `AZURE_LOG_LEVEL`, `AZURE_TRACING_ENABLED`, and `AZURE_SDK_TRACING_IMPLEMENTATION` environment variables no longer raise errors. Instead, a warning is logged and the default value is used (`INFO` for `AZURE_LOG_LEVEL`).
+- Invalid values for the `AZURE_LOG_LEVEL`, `AZURE_TRACING_ENABLED`, and `AZURE_SDK_TRACING_IMPLEMENTATION` environment variables no longer raise errors. Instead, a warning is logged and the default value is used (`INFO` for `AZURE_LOG_LEVEL`). #46668
 
 ## 1.40.0 (2026-04-30)
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -759,9 +759,9 @@ The following environment variables are recognized by `azure-core`. They are res
 
 | Variable | Description | Accepted Values | Default |
 | --- | --- | --- | --- |
-| `AZURE_LOG_LEVEL` | Logging level for all Azure SDK clients. | `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` (case-insensitive) | `INFO` |
-| `AZURE_TRACING_ENABLED` | Enable/disable distributed tracing. | `true`/`false`, `yes`/`no`, `1`/`0`, `on`/`off` (case-insensitive) | Auto-detected based on `AZURE_SDK_TRACING_IMPLEMENTATION` |
-| `AZURE_SDK_TRACING_IMPLEMENTATION` | Tracing implementation to use. Requires the corresponding plugin package (`azure-core-tracing-opentelemetry`). | `opentelemetry` | None |
+| `AZURE_LOG_LEVEL` | Logging level for all Azure SDK clients. Invalid values fall back to `INFO` with a warning. | `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `VERBOSE` (case-insensitive; `VERBOSE` treated as `DEBUG`) | `INFO` |
+| `AZURE_TRACING_ENABLED` | Enable/disable distributed tracing. Invalid values fall back to the default with a warning. | `true`/`false`, `yes`/`no`, `1`/`0`, `on`/`off` (case-insensitive) | Auto-detected based on `AZURE_SDK_TRACING_IMPLEMENTATION` |
+| `AZURE_SDK_TRACING_IMPLEMENTATION` | Tracing implementation to use. Requires the corresponding plugin package (`azure-core-tracing-opentelemetry`). Invalid values fall back to the default with a warning. | `opentelemetry` | None |
 | `AZURE_SDK_CLOUD_CONF` | Azure cloud environment. | `AZURE_PUBLIC_CLOUD`, `AZURE_CHINA_CLOUD`, `AZURE_US_GOVERNMENT` | `AZURE_PUBLIC_CLOUD` |
 
 These settings can also be read or set programmatically:

--- a/sdk/core/azure-core/ENVIRONMENT_VARIABLES.md
+++ b/sdk/core/azure-core/ENVIRONMENT_VARIABLES.md
@@ -12,7 +12,9 @@ Controls the logging level for all Azure SDK clients.
 |---|---|
 | **Used by** | `azure.core.settings.Settings.log_level` |
 | **Default** | `INFO` |
-| **Accepted values** | `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` (case-insensitive) |
+| **Accepted values** | `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `VERBOSE` (case-insensitive). `VERBOSE` is treated as `DEBUG`. |
+
+If the value is not one of the accepted values, a warning is logged and `INFO` is used.
 
 **Example:**
 
@@ -36,6 +38,8 @@ If disabled, distributed tracing is disabled entirely, regardless of the other c
 
 If not set, tracing is automatically enabled if a tracing implementation is configured (via `AZURE_SDK_TRACING_IMPLEMENTATION`), and disabled otherwise.
 
+If the value is not one of the accepted values, a warning is logged and the default behavior is used.
+
 **Example:**
 
 ```bash
@@ -55,6 +59,8 @@ Specifies which distributed tracing implementation the SDK should use.
 The corresponding tracing plugin package must be installed:
 
 - `opentelemetry` — requires `azure-core-tracing-opentelemetry`
+
+If the value is not one of the accepted values, a warning is logged and the default (None) is used.
 
 **Example:**
 

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -163,7 +163,7 @@ def convert_logging(value: Union[str, int]) -> int:
     if val == "VERBOSE":
         val = "DEBUG"
     level = _levels.get(val)
-    if not level:
+    if level is None:
         _LOGGER.warning(
             "Invalid log level %r for AZURE_LOG_LEVEL; falling back to INFO. Valid values are: %s.",
             value,

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
 ValidInputType = TypeVar("ValidInputType")
 ValueType = TypeVar("ValueType")
 
+_LOGGER = logging.getLogger(__name__)
+
 
 __all__ = ("settings", "Settings")
 
@@ -94,11 +96,14 @@ def convert_bool(value: Union[str, bool]) -> bool:
 def convert_tracing_enabled(value: Optional[Union[str, bool]]) -> bool:
     """Convert tracing value to bool with regard to tracing implementation.
 
+    If the value cannot be converted to a bool, a warning is logged and the
+    default behavior is used (auto-detect based on whether a tracing
+    implementation is configured).
+
     :param value: the value to convert
     :type value: str or bool or None
     :returns: A boolean value matching the intent of the input
     :rtype: bool
-    :raises ValueError: If conversion to bool fails
     """
     if value is None:
         # If tracing_enabled was not explicitly set to a boolean, determine tracing enablement
@@ -106,7 +111,17 @@ def convert_tracing_enabled(value: Optional[Union[str, bool]]) -> bool:
         if settings.tracing_implementation():
             return True
         return False
-    return convert_bool(value)
+    try:
+        return convert_bool(value)
+    except ValueError:
+        _LOGGER.warning(
+            "Invalid value %r for AZURE_TRACING_ENABLED; falling back to default behavior. "
+            "Valid values are: 'true'/'false', 'yes'/'no', '1'/'0', 'on'/'off' (case-insensitive).",
+            value,
+        )
+        if settings.tracing_implementation():
+            return True
+        return False
 
 
 _levels = {
@@ -129,12 +144,15 @@ def convert_logging(value: Union[str, int]) -> int:
     * "warning"
     * "info"
     * "debug"
+    * "verbose" (treated as "debug")
+
+    If the value cannot be converted, a warning is logged and ``logging.INFO``
+    is returned.
 
     :param value: the value to convert
     :type value: str or int
     :returns: A log level as an int. See the logging module for details.
     :rtype: int
-    :raises ValueError: If conversion to log level fails
 
     """
     if isinstance(value, int):
@@ -142,9 +160,16 @@ def convert_logging(value: Union[str, int]) -> int:
         # https://docs.python.org/3/library/logging.html#levels
         return value
     val = value.upper()
+    if val == "VERBOSE":
+        val = "DEBUG"
     level = _levels.get(val)
     if not level:
-        raise ValueError("Cannot convert {} to log level, valid values are: {}".format(value, ", ".join(_levels)))
+        _LOGGER.warning(
+            "Invalid log level %r for AZURE_LOG_LEVEL; falling back to INFO. Valid values are: %s.",
+            value,
+            ", ".join(_levels),
+        )
+        return logging.INFO
     return level
 
 
@@ -218,10 +243,11 @@ def convert_tracing_impl(value: Optional[Union[str, Type[AbstractSpan]]]) -> Opt
     * "opencensus"
     * "opentelemetry"
 
+    If the value cannot be converted, a warning is logged and ``None`` is returned.
+
     :param value: the value to convert
     :type value: string
     :returns: AbstractSpan
-    :raises ValueError: If conversion to AbstractSpan fails
 
     """
     if value is None:
@@ -234,11 +260,13 @@ def convert_tracing_impl(value: Optional[Union[str, Type[AbstractSpan]]]) -> Opt
     get_wrapper_class = _tracing_implementation_dict.get(value, lambda: _unset)
     wrapper_class: Optional[Union[_Unset, Type[AbstractSpan]]] = get_wrapper_class()
     if wrapper_class is _unset:
-        raise ValueError(
-            "Cannot convert {} to AbstractSpan, valid values are: {}".format(
-                value, ", ".join(_tracing_implementation_dict)
-            )
+        _LOGGER.warning(
+            "Invalid tracing implementation %r for AZURE_SDK_TRACING_IMPLEMENTATION; falling back to default (None). "
+            "Valid values are: %s.",
+            value,
+            ", ".join(_tracing_implementation_dict),
         )
+        return None
     return wrapper_class
 
 
@@ -433,12 +461,15 @@ class Settings:
     The following environment variables are used by the settings:
 
     * ``AZURE_LOG_LEVEL`` - Logging level. Accepted values: ``CRITICAL``, ``ERROR``, ``WARNING``,
-      ``INFO``, ``DEBUG`` (case-insensitive). Default: ``INFO``.
+      ``INFO``, ``DEBUG``, ``VERBOSE`` (case-insensitive). ``VERBOSE`` is treated as ``DEBUG``.
+      If the value is invalid, a warning is logged and ``INFO`` is used. Default: ``INFO``.
     * ``AZURE_TRACING_ENABLED`` - Enable/disable tracing. Accepted values: ``true``/``false``,
-      ``yes``/``no``, ``1``/``0``, ``on``/``off`` (case-insensitive). Default: auto-detected
-      based on whether a tracing implementation is configured.
+      ``yes``/``no``, ``1``/``0``, ``on``/``off`` (case-insensitive). If the value is invalid,
+      a warning is logged and the default is used. Default: auto-detected based on whether a
+      tracing implementation is configured.
     * ``AZURE_SDK_TRACING_IMPLEMENTATION`` - Tracing implementation. Accepted values:
-      ``opentelemetry``. Default: None.
+      ``opentelemetry``. If the value is invalid, a warning is logged and the default is used.
+      Default: None.
     * ``AZURE_SDK_CLOUD_CONF`` - Azure cloud environment. Accepted values:
       ``AZURE_PUBLIC_CLOUD``, ``AZURE_CHINA_CLOUD``, ``AZURE_US_GOVERNMENT``.
       Default: ``AZURE_PUBLIC_CLOUD``.

--- a/sdk/core/azure-core/tests/test_settings.py
+++ b/sdk/core/azure-core/tests/test_settings.py
@@ -167,16 +167,22 @@ class TestConverters(object):
         assert m.convert_logging(level) == level
 
     def test_convert_logging_bad(self):
-        with pytest.raises(ValueError):
-            m.convert_logging("junk")
+        # Invalid values now fall back to INFO with a warning logged.
+        assert m.convert_logging("junk") == logging.INFO
+
+    def test_convert_logging_verbose(self):
+        # "verbose" is accepted as an alias for "debug".
+        assert m.convert_logging("verbose") == logging.DEBUG
+        assert m.convert_logging("VERBOSE") == logging.DEBUG
 
     def test_convert_azure_cloud(self):
         with pytest.raises(ValueError):
             m.convert_azure_cloud(10)
 
     def test_convert_tracing_impl_bad(self):
-        with pytest.raises(ValueError):
-            m.convert_tracing_impl("foo")
+        m.convert_tracing_impl.cache_clear()
+        # Invalid values now fall back to None with a warning logged.
+        assert m.convert_tracing_impl("foo") is None
 
     def test_convert_tracing_impl_caching(self):
         m.convert_tracing_impl.cache_clear()


### PR DESCRIPTION
Invalid values for the `AZURE_LOG_LEVEL`, `AZURE_TRACING_ENABLED`, and `AZURE_SDK_TRACING_IMPLEMENTATION` environment variables no longer raise errors.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
