### PR TITLE
[Test/do-not-merge] chronus-verify CI smoke test for #46585

### DIFF
--- a/sdk/template/azure-template/azure/template/template_code.py
+++ b/sdk/template/azure-template/azure/template/template_code.py
@@ -6,5 +6,6 @@
 
 
 def template_main() -> bool:
+    # Test change for chronus-verify CI workflow (PR #46585) — no-op.
     print("Package code.")
     return True


### PR DESCRIPTION
Smoke-test PR for the chronus-verify CI workflow added in #46585.

Touches sdk/template/azure-template/ without adding a chronus change entry, so we expect:

1. Chronus Verify job to **fail**.
2. A sticky PR comment to be posted with /chronus add instructions.

The /chronus add slash command itself cannot be tested until #46585 merges (issue_comment workflows only run from the default branch).

**Will be closed without merging.**