### PR TITLE
[ContentUnderstanding] Add preview disclaimer for to_llm_input

### DIFF
--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
@@ -520,6 +520,12 @@ asyncio.run(analyze_invoice())
 
 #### Convert results to LLM-ready text
 
+> [!NOTE]
+> **Preview feature**: `to_llm_input()` is currently in preview and may change in
+> future releases. We welcome feedback — please file suggestions or issues on
+> [GitHub Issues](https://github.com/Azure/azure-sdk-for-python/issues) with the
+> `Cognitive - Content Understanding` label.
+
 Use the `to_llm_input()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.
 This works with all content types (documents, images, audio, video) and handles multi-segment

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
@@ -11,6 +11,8 @@ Use the client library for Azure AI Content Understanding to:
 * **Create custom analyzers** - Build domain-specific analyzers for specialized content extraction needs across all four modalities (documents, video, audio, and images)
 * **Classify documents and video** - Automatically categorize and extract information from documents and video by type
 
+If you have encountered issues or want to suggest features, please [file an issue][file_issue].
+
 [Source code][python_cu_src] | [Package (PyPI)][python_cu_pypi] | [Product documentation][python_cu_product_docs] | [Samples][python_cu_samples]
 
 ## Table of Contents
@@ -522,9 +524,8 @@ asyncio.run(analyze_invoice())
 
 > [!NOTE]
 > **Preview feature**: `to_llm_input()` is currently in preview and may change in
-> future releases. We welcome feedback — please file suggestions or issues on
-> [GitHub Issues](https://github.com/Azure/azure-sdk-for-python/issues) with the
-> `Cognitive - Content Understanding` label.
+> future releases. We welcome feedback — please
+> [file an issue][file_issue].
 
 Use the `to_llm_input()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.
@@ -701,6 +702,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [pip]: https://pypi.org/project/pip/
 [cla]: https://cla.microsoft.com
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
+[file_issue]: https://github.com/Azure/azure-sdk-for-python/issues/new?labels=Cognitive%20-%20Content%20Understanding&title=[ContentUnderstanding]%20&body=%23%23%20Library%20Version%0A%0A%23%23%20Repro%20Steps%0A%0A%23%23%20Expected%20Result%0A%0A%23%23%20Actual%20Result
 [code_of_conduct_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [opencode_email]: mailto:opencode@microsoft.com
 [aiohttp]: https://pypi.org/project/aiohttp/

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/README.md
@@ -522,10 +522,8 @@ asyncio.run(analyze_invoice())
 
 #### Convert results to LLM-ready text
 
-> [!NOTE]
-> **Preview feature**: `to_llm_input()` is currently in preview and may change in
-> future releases. We welcome feedback — please
-> [file an issue][file_issue].
+> **Note:** `to_llm_input()` is currently in preview and may change in future
+> releases. We welcome feedback — please [file an issue][file_issue].
 
 Use the `to_llm_input()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.


### PR DESCRIPTION
## Description

Adds a preview feature disclaimer to the `to_llm_input()` section in the README using GitHub admonition syntax (`> [!NOTE]`), directing users to file feedback on GitHub Issues with the `Cognitive - Content Understanding` label.

Cross-language change requested in https://github.com/Azure/azure-sdk-for-java/pull/49000.

### Changes

- `README.md`: Added `> [!NOTE]` preview disclaimer above the `to_llm_input()` usage section

### Related PRs

- Java: https://github.com/Azure/azure-sdk-for-java/pull/49000
- .NET: https://github.com/Azure/azure-sdk-for-net/pull/58929
- JS: https://github.com/Azure/azure-sdk-for-js/pull/new/cu_sdk/llm_input_preview_note

## All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
  - Documentation-only change; no code affected.