### PR TITLE
[Release] azure-ai-agentserver-core 2.0.0b4, invocations 1.0.0b4 (2026-05-01)

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b4 (Unreleased)
+## 2.0.0b4 (2026-05-01)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 2.0.0b4 (2026-05-01)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+
+- Migrated tracing export from `azure-monitor-opentelemetry-exporter` and `opentelemetry-exporter-otlp-proto-grpc` to the unified `microsoft-opentelemetry` distro. The distro auto-detects exporters from environment variables. No changes to public API or behavior.
 
 ## 2.0.0b3 (2026-04-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 1.0.0b4 (2026-05-01)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+
+- Updated tracing infrastructure to use `microsoft-opentelemetry` distro (inherited from `azure-ai-agentserver-core>=2.0.0b4`). No changes to public API or behavior.
 
 ## 1.0.0b3 (2026-04-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b4 (Unreleased)
+## 1.0.0b4 (2026-05-01)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 1.0.0b6 (2026-05-01)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+
+- Internal configuration cleanup (no functional changes).
 
 ## 1.0.0b5 (2026-04-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.0.0b6 (2026-05-01)
+## 1.0.0b6 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
 
 ### Other Changes
-
-- Internal configuration cleanup (no functional changes).
 
 ## 1.0.0b5 (2026-04-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b6 (Unreleased)
+## 1.0.0b6 (2026-05-01)
 
 ### Features Added
 


### PR DESCRIPTION
## Release packages (2026-05-01)

### azure-ai-agentserver-core 2.0.0b4

**Other Changes:**
- Migrated tracing export from `azure-monitor-opentelemetry-exporter` and `opentelemetry-exporter-otlp-proto-grpc` to the unified `microsoft-opentelemetry` distro. The distro auto-detects exporters from environment variables. No changes to public API or behavior.

### azure-ai-agentserver-invocations 1.0.0b4

**Other Changes:**
- Updated tracing infrastructure to use `microsoft-opentelemetry` distro (inherited from `azure-ai-agentserver-core>=2.0.0b4`). No changes to public API or behavior.
