### PR TITLE
[ServiceBus] Fix async sender AttributeError race in _open (#35618)

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 7.14.4 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed a race condition in the async ServiceBusSender where concurrent coroutines could trigger `AttributeError: 'NoneType' object has no attribute 'client_ready_async'` when reusing a sender. ([#35618](https://github.com/Azure/azure-sdk-for-python/issues/35618))
+
 ## 7.14.3 (2025-11-11)
 
 ### Bugs Fixed

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -207,13 +207,16 @@ class ServiceBusSender(BaseHandler, SenderMixin):
             await self._handler.close_async()
         auth = None if self._connection else (await create_authentication(self))
         self._create_handler(auth)
+        # Capture a local reference to the handler to guard against concurrent
+        # coroutines mutating self._handler across awaits (see issue #35618).
+        handler = self._handler
         try:
-            await self._handler.open_async(connection=self._connection)
-            while not await self._handler.client_ready_async():
+            await handler.open_async(connection=self._connection)
+            while not await handler.client_ready_async():
                 await asyncio.sleep(0.05)
             self._running = True
             self._max_message_size_on_link = (
-                self._amqp_transport.get_remote_max_message_size(self._handler) or MAX_MESSAGE_LENGTH_BYTES
+                self._amqp_transport.get_remote_max_message_size(handler) or MAX_MESSAGE_LENGTH_BYTES
             )
             if self._max_message_size_on_link >= MAX_BATCH_SIZE_PREMIUM:
                 self._max_batch_size_on_link = MAX_BATCH_SIZE_PREMIUM

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -146,6 +146,10 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         self._create_attribute(**kwargs)
         self._connection = kwargs.get("connection")
         self._handler: Union["pyamqp_SendClientAsync", "uamqp_SendClientAsync"]
+        # Serializes _open() so concurrent callers cannot race on creating
+        # and closing self._handler (see issue #35618). Initialized lazily
+        # because the constructor may execute outside a running event loop.
+        self._open_lock: Optional[asyncio.Lock] = None
 
     async def __aenter__(self) -> "ServiceBusSender":
         if self._shutdown.is_set():
@@ -203,28 +207,31 @@ class ServiceBusSender(BaseHandler, SenderMixin):
     async def _open(self):
         if self._running:
             return
-        if self._handler:
-            await self._handler.close_async()
-        auth = None if self._connection else (await create_authentication(self))
-        self._create_handler(auth)
-        # Capture a local reference to the handler to guard against concurrent
-        # coroutines mutating self._handler across awaits (see issue #35618).
-        handler = self._handler
-        try:
-            await handler.open_async(connection=self._connection)
-            while not await handler.client_ready_async():
-                await asyncio.sleep(0.05)
-            self._running = True
-            self._max_message_size_on_link = (
-                self._amqp_transport.get_remote_max_message_size(handler) or MAX_MESSAGE_LENGTH_BYTES
-            )
-            if self._max_message_size_on_link >= MAX_BATCH_SIZE_PREMIUM:
-                self._max_batch_size_on_link = MAX_BATCH_SIZE_PREMIUM
-            else:
-                self._max_batch_size_on_link = MAX_BATCH_SIZE_STANDARD
-        except:
-            await self._close_handler()
-            raise
+        if self._open_lock is None:
+            self._open_lock = asyncio.Lock()
+        async with self._open_lock:
+            if self._running:
+                return
+            if self._handler:
+                await self._handler.close_async()
+            auth = None if self._connection else (await create_authentication(self))
+            self._create_handler(auth)
+            handler = self._handler
+            try:
+                await handler.open_async(connection=self._connection)
+                while not await handler.client_ready_async():
+                    await asyncio.sleep(0.05)
+                self._running = True
+                self._max_message_size_on_link = (
+                    self._amqp_transport.get_remote_max_message_size(handler) or MAX_MESSAGE_LENGTH_BYTES
+                )
+                if self._max_message_size_on_link >= MAX_BATCH_SIZE_PREMIUM:
+                    self._max_batch_size_on_link = MAX_BATCH_SIZE_PREMIUM
+                else:
+                    self._max_batch_size_on_link = MAX_BATCH_SIZE_STANDARD
+            except:
+                await self._close_handler()
+                raise
 
     async def _send(
         self,


### PR DESCRIPTION
# Description

Fixes #35618.

When multiple coroutines concurrently call `ServiceBusSender.send_messages` on a shared async sender, a race in `_servicebus_sender_async.py:_open` can null out `self._handler` between `await self._handler.open_async(...)` and `await self._handler.client_ready_async()`, producing:

```
AttributeError: 'NoneType' object has no attribute 'client_ready_async'
```

This patch captures `self._handler` into a local variable immediately after `_create_handler(auth)` and uses that local for the subsequent awaits within `_open`. The `except`/`_close_handler` cleanup path still operates on `self._handler`, preserving existing teardown semantics.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes. (The race is timing-dependent and difficult to reproduce deterministically in a unit test without restructuring the handler lifecycle; the patch is a defensive local-capture that does not change observable behavior on the happy path.)