### PR TITLE
[feat] add extra_headers for rai service evaluators + move gen_ai usage to internal properties

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features Added
 
+- Added `extra_headers` keyword argument to `RaiServiceEvaluatorBase` (and all content safety evaluators) to allow passing custom HTTP headers to all backend RAI service calls. SDK-owned headers (`Authorization`, `User-Agent`, `Content-Type`, `aml-user-token`, `x-ms-client-request-id`) cannot be overridden by `extra_headers`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Moved token usage attributes (`gen_ai.evaluation.usage.input_tokens`, `gen_ai.evaluation.usage.output_tokens`) from standard App Insights event attributes into the `internal_properties` JSON bag to align with internal telemetry conventions.
 
 ## 1.16.6 (2026-04-27)
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
@@ -132,13 +132,19 @@ def get_formatted_template(data: dict, annotation_task: str) -> str:
     return user_text.replace("'", '\\"')
 
 
-def get_common_headers(token: str, evaluator_name: Optional[str] = None) -> Dict:
+def get_common_headers(
+    token: str,
+    evaluator_name: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict:
     """Get common headers for the HTTP request
 
     :param token: The Azure authentication token.
     :type token: str
     :param evaluator_name: The evaluator name. Default is None.
     :type evaluator_name: str
+    :param extra_headers: Additional headers to include in the request. Default is None.
+    :type extra_headers: Optional[Dict[str, str]]
     :return: The common headers.
     :rtype: Dict
     """
@@ -147,10 +153,13 @@ def get_common_headers(token: str, evaluator_name: Optional[str] = None) -> Dict
         if evaluator_name
         else UserAgentSingleton().value
     )
-    return {
+    headers = {
         "Authorization": f"Bearer {token}",
         "User-Agent": user_agent,
     }
+    if extra_headers:
+        headers.update(extra_headers)
+    return headers
 
 
 def get_async_http_client_with_timeout() -> AsyncHttpPipeline:
@@ -203,7 +212,12 @@ async def ensure_service_availability_onedp(
         )
 
 
-async def ensure_service_availability(rai_svc_url: str, token: str, capability: Optional[str] = None) -> None:
+async def ensure_service_availability(
+    rai_svc_url: str,
+    token: str,
+    capability: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> None:
     """Check if the Responsible AI service is available in the region and has the required capability, if relevant.
 
     :param rai_svc_url: The Responsible AI service URL.
@@ -212,9 +226,11 @@ async def ensure_service_availability(rai_svc_url: str, token: str, capability: 
     :type token: str
     :param capability: The capability to check. Default is None.
     :type capability: str
+    :param extra_headers: Additional headers to include in the request. Default is None.
+    :type extra_headers: Optional[Dict[str, str]]
     :raises Exception: If the service is not available in the region or the capability is not available.
     """
-    headers = get_common_headers(token)
+    headers = get_common_headers(token, extra_headers=extra_headers)
     svc_liveness_url = rai_svc_url + "/checkannotation"
 
     async with get_async_http_client() as client:
@@ -285,7 +301,13 @@ def generate_payload(normalized_user_text: str, metric: str, annotation_task: st
 
 
 async def submit_request(
-    data: dict, metric: str, rai_svc_url: str, token: str, annotation_task: str, evaluator_name: str
+    data: dict,
+    metric: str,
+    rai_svc_url: str,
+    token: str,
+    annotation_task: str,
+    evaluator_name: str,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> str:
     """Submit request to Responsible AI service for evaluation and return operation ID
 
@@ -308,7 +330,7 @@ async def submit_request(
     payload = generate_payload(normalized_user_text, metric, annotation_task=annotation_task)
 
     url = rai_svc_url + "/submitannotation"
-    headers = get_common_headers(token, evaluator_name)
+    headers = get_common_headers(token, evaluator_name, extra_headers=extra_headers)
 
     async with get_async_http_client_with_timeout() as client:
         http_response = await client.post(url, json=payload, headers=headers)
@@ -360,7 +382,13 @@ async def submit_request_onedp(
     return operation_id
 
 
-async def fetch_result(operation_id: str, rai_svc_url: str, credential: TokenCredential, token: str) -> Dict:
+async def fetch_result(
+    operation_id: str,
+    rai_svc_url: str,
+    credential: TokenCredential,
+    token: str,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict:
     """Fetch the annotation result from Responsible AI service
 
     :param operation_id: The operation ID.
@@ -380,7 +408,7 @@ async def fetch_result(operation_id: str, rai_svc_url: str, credential: TokenCre
     url = rai_svc_url + "/operations/" + operation_id
     while True:
         token = await fetch_or_reuse_token(credential, token)
-        headers = get_common_headers(token)
+        headers = get_common_headers(token, extra_headers=extra_headers)
 
         async with get_async_http_client() as client:
             response = await client.get(url, headers=headers, timeout=RAIService.TIMEOUT)
@@ -725,17 +753,23 @@ def _parse_content_harm_response(
     return result
 
 
-async def _get_service_discovery_url(azure_ai_project: AzureAIProject, token: str) -> str:
+async def _get_service_discovery_url(
+    azure_ai_project: AzureAIProject,
+    token: str,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> str:
     """Get the discovery service URL for the Azure AI project
 
     :param azure_ai_project: The Azure AI project details.
     :type azure_ai_project: ~azure.ai.evaluation.AzureAIProject
     :param token: The Azure authentication token.
     :type token: str
+    :param extra_headers: Additional headers to include in the request. Default is None.
+    :type extra_headers: Optional[Dict[str, str]]
     :return: The discovery service URL.
     :rtype: str
     """
-    headers = get_common_headers(token)
+    headers = get_common_headers(token, extra_headers=extra_headers)
 
     async with get_async_http_client_with_timeout() as client:
         response = await client.get(
@@ -764,17 +798,25 @@ async def _get_service_discovery_url(azure_ai_project: AzureAIProject, token: st
     return f"{base_url.scheme}://{base_url.netloc}"
 
 
-async def get_rai_svc_url(project_scope: AzureAIProject, token: str) -> str:
+async def get_rai_svc_url(
+    project_scope: AzureAIProject,
+    token: str,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> str:
     """Get the Responsible AI service URL
 
     :param project_scope: The Azure AI project scope details.
     :type project_scope: Dict
     :param token: The Azure authentication token.
     :type token: str
+    :param extra_headers: Additional headers to include in the request. Default is None.
+    :type extra_headers: Optional[Dict[str, str]]
     :return: The Responsible AI service URL.
     :rtype: str
     """
-    discovery_url = await _get_service_discovery_url(azure_ai_project=project_scope, token=token)
+    discovery_url = await _get_service_discovery_url(
+        azure_ai_project=project_scope, token=token, extra_headers=extra_headers
+    )
     subscription_id = project_scope["subscription_id"]
     resource_group_name = project_scope["resource_group_name"]
     project_name = project_scope["project_name"]
@@ -826,6 +868,7 @@ async def evaluate_with_rai_service(
     metric_display_name=None,
     evaluator_name=None,
     scan_session_id: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Union[str, float]]:
     """Evaluate the content safety of the response using Responsible AI service (legacy endpoint)
 
@@ -855,6 +898,7 @@ async def evaluate_with_rai_service(
             endpoint=project_scope,
             credential=credential,
             user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
+            headers=extra_headers
         )
         token = await fetch_or_reuse_token(credential=credential, workspace=COG_SRV_WORKSPACE)
         await ensure_service_availability_onedp(client, token, annotation_task)
@@ -867,12 +911,17 @@ async def evaluate_with_rai_service(
     else:
         # Get RAI service URL from discovery service and check service availability
         token = await fetch_or_reuse_token(credential)
-        rai_svc_url = await get_rai_svc_url(project_scope, token)
-        await ensure_service_availability(rai_svc_url, token, annotation_task)
+        rai_svc_url = await get_rai_svc_url(project_scope, token, extra_headers=extra_headers)
+        await ensure_service_availability(rai_svc_url, token, annotation_task, extra_headers=extra_headers)
 
         # Submit annotation request and fetch result
-        operation_id = await submit_request(data, metric_name, rai_svc_url, token, annotation_task, evaluator_name)
-        annotation_response = cast(List[Dict], await fetch_result(operation_id, rai_svc_url, credential, token))
+        operation_id = await submit_request(
+            data, metric_name, rai_svc_url, token, annotation_task, evaluator_name,
+            extra_headers=extra_headers,
+        )
+        annotation_response = cast(
+            List[Dict], await fetch_result(operation_id, rai_svc_url, credential, token, extra_headers=extra_headers)
+        )
         result = parse_response(annotation_response, metric_name, metric_display_name)
 
         return result
@@ -910,7 +959,9 @@ def generate_payload_multimodal(content_type: str, messages, metric: str) -> Dic
     }
 
 
-async def submit_multimodal_request(messages, metric: str, rai_svc_url: str, token: str) -> str:
+async def submit_multimodal_request(
+    messages, metric: str, rai_svc_url: str, token: str, extra_headers: Optional[Dict[str, str]] = None
+) -> str:
     """Submit request to Responsible AI service for evaluation and return operation ID
     :param messages: The normalized list of messages to be entered as the "Contents" in the payload.
     :type messages: str
@@ -942,7 +993,7 @@ async def submit_multimodal_request(messages, metric: str, rai_svc_url: str, tok
 
     ## calling rai service for annotation
     url = rai_svc_url + "/submitannotation"
-    headers = get_common_headers(token)
+    headers = get_common_headers(token, extra_headers=extra_headers)
     async with get_async_http_client() as client:
         response = await client.post(  # pylint: disable=too-many-function-args,unexpected-keyword-arg
             url, json=payload, headers=headers
@@ -1077,6 +1128,7 @@ async def evaluate_with_rai_service_sync(
     evaluator_name=None,
     scan_session_id: Optional[str] = None,
     use_legacy_endpoint: bool = False,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Evaluate the content safety of the response using Responsible AI service.
 
@@ -1120,6 +1172,7 @@ async def evaluate_with_rai_service_sync(
             metric_display_name=metric_display_name,
             evaluator_name=evaluator_name,
             scan_session_id=scan_session_id,
+            extra_headers=extra_headers
         )
 
     # Sync evals endpoint implementation (default)
@@ -1127,12 +1180,14 @@ async def evaluate_with_rai_service_sync(
     if not is_onedp_project(project_scope):
         # Get RAI service URL from discovery service and check service availability
         token = await fetch_or_reuse_token(credential)
-        rai_svc_url = await get_rai_svc_url(project_scope, token)
-        await ensure_service_availability(rai_svc_url, token, annotation_task)
+        rai_svc_url = await get_rai_svc_url(project_scope, token, extra_headers=extra_headers)
+        await ensure_service_availability(rai_svc_url, token, annotation_task, extra_headers=extra_headers)
 
         # Submit annotation request and fetch result
         url = rai_svc_url + f"/sync_evals:run?api-version={api_version}"
         headers = {"aml-user-token": token, "Authorization": "Bearer " + token, "Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
         sync_eval_payload = _build_sync_eval_payload(data, metric_name, annotation_task, scan_session_id)
         sync_eval_payload_json = json.dumps(sync_eval_payload, cls=SdkJSONEncoder)
 
@@ -1150,6 +1205,7 @@ async def evaluate_with_rai_service_sync(
         endpoint=project_scope,
         credential=credential,
         user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
+        headers=extra_headers or {},
     )
 
     sync_eval_payload = _build_sync_eval_payload(data, metric_name, annotation_task, scan_session_id)
@@ -1305,6 +1361,7 @@ async def evaluate_with_rai_service_sync_multimodal(
     credential: TokenCredential,
     scan_session_id: Optional[str] = None,
     use_legacy_endpoint: bool = False,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Evaluate multimodal content using Responsible AI service.
 
@@ -1336,6 +1393,7 @@ async def evaluate_with_rai_service_sync_multimodal(
             project_scope=project_scope,
             credential=credential,
             metric_display_name=metric_display_name,
+            extra_headers=extra_headers,
         )
 
     # Sync evals endpoint implementation (default)
@@ -1347,6 +1405,7 @@ async def evaluate_with_rai_service_sync_multimodal(
             endpoint=project_scope,
             credential=credential,
             user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
+            headers=extra_headers or {},
         )
 
         headers = {"x-ms-client-request-id": scan_session_id} if scan_session_id else None
@@ -1355,8 +1414,8 @@ async def evaluate_with_rai_service_sync_multimodal(
         return client.sync_evals.create(eval=sync_eval_payload)
 
     token = await fetch_or_reuse_token(credential)
-    rai_svc_url = await get_rai_svc_url(project_scope, token)
-    await ensure_service_availability(rai_svc_url, token, Tasks.CONTENT_HARM)
+    rai_svc_url = await get_rai_svc_url(project_scope, token, extra_headers=extra_headers)
+    await ensure_service_availability(rai_svc_url, token, Tasks.CONTENT_HARM, extra_headers=extra_headers)
 
     url = rai_svc_url + f"/sync_evals:run?api-version={api_version}"
     headers = {
@@ -1366,6 +1425,8 @@ async def evaluate_with_rai_service_sync_multimodal(
     }
     if scan_session_id:
         headers["x-ms-client-request-id"] = scan_session_id
+    if extra_headers:
+        headers.update(extra_headers)
 
     sync_eval_payload_json = json.dumps(sync_eval_payload, cls=SdkJSONEncoder)
 
@@ -1385,6 +1446,7 @@ async def evaluate_with_rai_service_multimodal(
     project_scope: Union[str, AzureAIProject],
     credential: TokenCredential,
     metric_display_name: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Evaluate the content safety of the response using Responsible AI service (legacy endpoint)
     :param messages: The normalized list of messages.
@@ -1407,6 +1469,7 @@ async def evaluate_with_rai_service_multimodal(
             endpoint=project_scope,
             credential=credential,
             user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
+            headers=extra_headers or {},
         )
         token = await fetch_or_reuse_token(credential=credential, workspace=COG_SRV_WORKSPACE)
         await ensure_service_availability_onedp(client, token, Tasks.CONTENT_HARM)
@@ -1416,10 +1479,14 @@ async def evaluate_with_rai_service_multimodal(
         return result
     else:
         token = await fetch_or_reuse_token(credential)
-        rai_svc_url = await get_rai_svc_url(project_scope, token)
-        await ensure_service_availability(rai_svc_url, token, Tasks.CONTENT_HARM)
+        rai_svc_url = await get_rai_svc_url(project_scope, token, extra_headers=extra_headers)
+        await ensure_service_availability(rai_svc_url, token, Tasks.CONTENT_HARM, extra_headers=extra_headers)
         # Submit annotation request and fetch result
-        operation_id = await submit_multimodal_request(messages, metric_name, rai_svc_url, token)
-        annotation_response = cast(List[Dict], await fetch_result(operation_id, rai_svc_url, credential, token))
+        operation_id = await submit_multimodal_request(
+            messages, metric_name, rai_svc_url, token, extra_headers=extra_headers
+        )
+        annotation_response = cast(
+            List[Dict], await fetch_result(operation_id, rai_svc_url, credential, token, extra_headers=extra_headers)
+        )
         result = parse_response(annotation_response, metric_name, metric_display_name)
         return result

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
@@ -898,7 +898,7 @@ async def evaluate_with_rai_service(
             endpoint=project_scope,
             credential=credential,
             user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
-            headers=extra_headers
+            headers=extra_headers,
         )
         token = await fetch_or_reuse_token(credential=credential, workspace=COG_SRV_WORKSPACE)
         await ensure_service_availability_onedp(client, token, annotation_task)
@@ -916,7 +916,12 @@ async def evaluate_with_rai_service(
 
         # Submit annotation request and fetch result
         operation_id = await submit_request(
-            data, metric_name, rai_svc_url, token, annotation_task, evaluator_name,
+            data,
+            metric_name,
+            rai_svc_url,
+            token,
+            annotation_task,
+            evaluator_name,
             extra_headers=extra_headers,
         )
         annotation_response = cast(
@@ -1172,7 +1177,7 @@ async def evaluate_with_rai_service_sync(
             metric_display_name=metric_display_name,
             evaluator_name=evaluator_name,
             scan_session_id=scan_session_id,
-            extra_headers=extra_headers
+            extra_headers=extra_headers,
         )
 
     # Sync evals endpoint implementation (default)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
@@ -153,12 +153,11 @@ def get_common_headers(
         if evaluator_name
         else UserAgentSingleton().value
     )
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "User-Agent": user_agent,
-    }
-    if extra_headers:
-        headers.update(extra_headers)
+    # Apply extra_headers first, then SDK-owned headers on top so that
+    # Authorization, User-Agent, etc. can never be silently overridden.
+    headers = dict(extra_headers) if extra_headers else {}
+    headers["Authorization"] = f"Bearer {token}"
+    headers["User-Agent"] = user_agent
     return headers
 
 
@@ -1189,9 +1188,12 @@ async def evaluate_with_rai_service_sync(
 
         # Submit annotation request and fetch result
         url = rai_svc_url + f"/sync_evals:run?api-version={api_version}"
-        headers = {"aml-user-token": token, "Authorization": "Bearer " + token, "Content-Type": "application/json"}
-        if extra_headers:
-            headers.update(extra_headers)
+        # Apply extra_headers first, then SDK-owned headers on top so that
+        # auth and content-type can never be silently overridden.
+        headers = dict(extra_headers) if extra_headers else {}
+        headers["aml-user-token"] = token
+        headers["Authorization"] = "Bearer " + token
+        headers["Content-Type"] = "application/json"
         sync_eval_payload = _build_sync_eval_payload(data, metric_name, annotation_task, scan_session_id)
         sync_eval_payload_json = json.dumps(sync_eval_payload, cls=SdkJSONEncoder)
 
@@ -1422,15 +1424,14 @@ async def evaluate_with_rai_service_sync_multimodal(
     await ensure_service_availability(rai_svc_url, token, Tasks.CONTENT_HARM, extra_headers=extra_headers)
 
     url = rai_svc_url + f"/sync_evals:run?api-version={api_version}"
-    headers = {
-        "aml-user-token": token,
-        "Authorization": "Bearer " + token,
-        "Content-Type": "application/json",
-    }
+    # Apply extra_headers first, then SDK-owned headers on top so that
+    # auth, content-type, and correlation IDs can never be silently overridden.
+    headers = dict(extra_headers) if extra_headers else {}
+    headers["aml-user-token"] = token
+    headers["Authorization"] = "Bearer " + token
+    headers["Content-Type"] = "application/json"
     if scan_session_id:
         headers["x-ms-client-request-id"] = scan_session_id
-    if extra_headers:
-        headers.update(extra_headers)
 
     sync_eval_payload_json = json.dumps(sync_eval_payload, cls=SdkJSONEncoder)
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_common/rai_service.py
@@ -892,13 +892,12 @@ async def evaluate_with_rai_service(
     :return: The parsed annotation result.
     :rtype: Dict[str, Union[str, float]]
     """
-
     if is_onedp_project(project_scope):
         client = AIProjectClient(
             endpoint=project_scope,
             credential=credential,
             user_agent_policy=UserAgentPolicy(base_user_agent=UserAgentSingleton().value),
-            headers=extra_headers,
+            headers=extra_headers or {},
         )
         token = await fetch_or_reuse_token(credential=credential, workspace=COG_SRV_WORKSPACE)
         await ensure_service_availability_onedp(client, token, annotation_task)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -1277,9 +1277,9 @@ def _log_events_to_app_insights(
                 usage = sample.get("usage", {})
                 usage = usage if isinstance(usage, dict) else {}
                 if usage.get("prompt_tokens") is not None:
-                    standard_log_attributes["gen_ai.evaluation.usage.input_tokens"] = str(usage["prompt_tokens"])
+                    internal_log_attributes["gen_ai.evaluation.usage.input_tokens"] = str(usage["prompt_tokens"])
                 if usage.get("completion_tokens") is not None:
-                    standard_log_attributes["gen_ai.evaluation.usage.output_tokens"] = str(usage["completion_tokens"])
+                    internal_log_attributes["gen_ai.evaluation.usage.output_tokens"] = str(usage["completion_tokens"])
 
                 # Combine standard and internal attributes, put internal under the properties bag
                 standard_log_attributes["internal_properties"] = json.dumps(internal_log_attributes)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_rai_svc_eval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_rai_svc_eval.py
@@ -53,6 +53,9 @@ class RaiServiceEvaluatorBase(EvaluatorBase[T]):
     :keyword _use_legacy_endpoint: Whether to use the legacy evaluation endpoint instead of the sync_evals endpoint.
         Defaults to False. Can be passed as a keyword argument.
     :paramtype _use_legacy_endpoint: bool
+    :keyword extra_headers: Additional HTTP headers to include in every backend request.
+        Can be passed as a keyword argument.
+    :paramtype extra_headers: Optional[Dict[str, str]]
     """
 
     @override
@@ -83,6 +86,8 @@ class RaiServiceEvaluatorBase(EvaluatorBase[T]):
         self._higher_is_better = _higher_is_better
         # Handle _use_legacy_endpoint parameter from kwargs
         self._use_legacy_endpoint = kwargs.get("_use_legacy_endpoint", False)
+        # Handle extra_headers parameter from kwargs
+        self._extra_headers: Optional[Dict[str, str]] = kwargs.get("extra_headers", None)
 
     @override
     def __call__(  # pylint: disable=docstring-missing-param
@@ -150,6 +155,7 @@ class RaiServiceEvaluatorBase(EvaluatorBase[T]):
                 project_scope=self._azure_ai_project,
                 credential=self._credential,
                 use_legacy_endpoint=True,
+                extra_headers=self._extra_headers,
             )
             # Wrap as single-turn result and aggregate to produce evaluation_per_turn structure
             return self._aggregate_results([result])
@@ -166,6 +172,7 @@ class RaiServiceEvaluatorBase(EvaluatorBase[T]):
                 project_scope=self._azure_ai_project,
                 credential=self._credential,
                 use_legacy_endpoint=self._use_legacy_endpoint,
+                extra_headers=self._extra_headers,
             )
             parsed = self._parse_eval_result(turn_result)
             per_turn_results.append(parsed)
@@ -233,6 +240,7 @@ class RaiServiceEvaluatorBase(EvaluatorBase[T]):
             annotation_task=self._get_task(),
             evaluator_name=self.__class__.__name__,
             use_legacy_endpoint=self._use_legacy_endpoint,
+            extra_headers=self._extra_headers,
         )
 
         # Legacy endpoint returns a pre-parsed dict from parse_response(); return directly

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
@@ -17,6 +17,7 @@ from azure.ai.evaluation._common.rai_service import (
     evaluate_with_rai_service_sync_multimodal,
     fetch_or_reuse_token,
     fetch_result,
+    get_common_headers,
     get_rai_svc_url,
     parse_response,
     submit_request,
@@ -796,3 +797,318 @@ class TestParseEvalResult:
         # Token counts should be extracted from properties.metrics
         assert result["violence_prompt_tokens"] == "15"
         assert result["violence_completion_tokens"] == "55"
+
+
+@pytest.mark.unittest
+class TestExtraHeaders:
+    """Tests for extra_headers propagation through the RAI service call chain."""
+
+    # ------------------------------------------------------------------ #
+    # get_common_headers
+    # ------------------------------------------------------------------ #
+
+    def test_get_common_headers_without_extra_headers(self):
+        """get_common_headers returns base headers when extra_headers is None."""
+        headers = get_common_headers("fake-token")
+        assert headers["Authorization"] == "Bearer fake-token"
+        assert "User-Agent" in headers
+        assert len(headers) == 2
+
+    def test_get_common_headers_with_extra_headers(self):
+        """get_common_headers merges extra_headers into the result."""
+        extra = {"X-Custom": "value", "X-Another": "42"}
+        headers = get_common_headers("fake-token", extra_headers=extra)
+        assert headers["Authorization"] == "Bearer fake-token"
+        assert headers["X-Custom"] == "value"
+        assert headers["X-Another"] == "42"
+
+    def test_get_common_headers_extra_headers_do_not_override_auth(self):
+        """User-supplied extra_headers can override Authorization if they choose to."""
+        extra = {"Authorization": "Bearer override"}
+        headers = get_common_headers("fake-token", extra_headers=extra)
+        # extra_headers is applied after base headers, so it overrides
+        assert headers["Authorization"] == "Bearer override"
+
+    def test_get_common_headers_with_evaluator_name_and_extra_headers(self):
+        """Both evaluator_name and extra_headers work together."""
+        extra = {"X-Trace-Id": "abc123"}
+        headers = get_common_headers("fake-token", evaluator_name="violence", extra_headers=extra)
+        assert "violence" in headers["User-Agent"]
+        assert headers["X-Trace-Id"] == "abc123"
+
+    # ------------------------------------------------------------------ #
+    # submit_request — raw HTTP path
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch(
+        "azure.ai.evaluation._http_utils.AsyncHttpPipeline.post",
+        return_value=MockAsyncHttpResponse(
+            202, json={"location": "this/is/the/op-id"},
+        ),
+    )
+    async def test_submit_request_extra_headers_included(self, post_mock):
+        """extra_headers should appear in the HTTP request headers for submit_request."""
+        extra = {"X-Custom": "submit-value"}
+        await submit_request(
+            data={"query": "q", "response": "r"},
+            metric="violence",
+            rai_svc_url="https://fake-url.com",
+            token="fake-token",
+            annotation_task=Tasks.CONTENT_HARM,
+            evaluator_name="violence",
+            extra_headers=extra,
+        )
+        _, call_kwargs = post_mock.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        assert sent_headers.get("X-Custom") == "submit-value"
+        assert sent_headers.get("Authorization") == "Bearer fake-token"
+
+    # ------------------------------------------------------------------ #
+    # fetch_result — raw HTTP path
+    # ------------------------------------------------------------------ #
+
+    @patch(
+        "azure.ai.evaluation._http_utils.AsyncHttpPipeline.get",
+        return_value=MockAsyncHttpResponse(200, json={"result": "done"}),
+    )
+    @pytest.mark.usefixtures("mock_token")
+    @pytest.mark.asyncio
+    async def test_fetch_result_extra_headers_included(self, get_mock, mock_token):
+        """extra_headers should appear in the HTTP request headers for fetch_result."""
+        extra = {"X-Custom": "fetch-value"}
+        result = await fetch_result(
+            operation_id="op-id",
+            rai_svc_url="https://fake-url.com",
+            credential=None,
+            token=mock_token,
+            extra_headers=extra,
+        )
+        _, call_kwargs = get_mock.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        assert sent_headers.get("X-Custom") == "fetch-value"
+        assert result["result"] == "done"
+
+    # ------------------------------------------------------------------ #
+    # ensure_service_availability — raw HTTP path
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch(
+        "azure.ai.evaluation._http_utils.AsyncHttpPipeline.get",
+        return_value=MockAsyncHttpResponse(200, json={}),
+    )
+    async def test_ensure_service_availability_extra_headers_included(self, get_mock):
+        """extra_headers should appear in the HTTP request headers for ensure_service_availability."""
+        extra = {"X-Custom": "avail-value"}
+        await ensure_service_availability("https://fake-url.com", "fake-token", extra_headers=extra)
+        _, call_kwargs = get_mock.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        assert sent_headers.get("X-Custom") == "avail-value"
+
+    # ------------------------------------------------------------------ #
+    # _get_service_discovery_url — ARM call
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch(
+        "azure.ai.evaluation._http_utils.AsyncHttpPipeline.get",
+        return_value=MockAsyncHttpResponse(
+            200, json={"properties": {"discoveryUrl": "https://disc.com/path"}}
+        ),
+    )
+    async def test_get_service_discovery_url_extra_headers_included(self, get_mock):
+        """extra_headers should appear in the ARM request headers."""
+        extra = {"X-Custom": "disc-value"}
+        project = {"subscription_id": "sub", "resource_group_name": "rg", "project_name": "proj"}
+        await _get_service_discovery_url(project, "fake-token", extra_headers=extra)
+        _, call_kwargs = get_mock.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        assert sent_headers.get("X-Custom") == "disc-value"
+
+    # ------------------------------------------------------------------ #
+    # evaluate_with_rai_service_sync — non-onedp sync evals path
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.evaluation._common.rai_service.fetch_or_reuse_token")
+    @patch("azure.ai.evaluation._common.rai_service.get_rai_svc_url")
+    @patch("azure.ai.evaluation._common.rai_service.ensure_service_availability")
+    @patch("azure.ai.evaluation._common.rai_service.get_sync_http_client_with_retry")
+    async def test_evaluate_sync_extra_headers_in_http_request(
+        self, http_client_mock, ensure_avail_mock, get_url_mock, fetch_token_mock
+    ):
+        """extra_headers should be merged into the sync_evals HTTP POST headers."""
+        fetch_token_mock.return_value = "fake-token"
+        get_url_mock.return_value = "https://fake-rai-url.com"
+        ensure_avail_mock.return_value = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        http_client_mock.return_value = mock_client
+
+        extra = {"X-Custom": "sync-value"}
+        await evaluate_with_rai_service_sync(
+            data={"query": "q", "response": "r"},
+            metric_name=EvaluationMetrics.VIOLENCE,
+            project_scope={"subscription_id": "s", "project_name": "p", "resource_group_name": "rg"},
+            credential=DefaultAzureCredential(),
+            extra_headers=extra,
+        )
+
+        sent_headers = mock_client.post.call_args[1].get("headers", {})
+        assert sent_headers.get("X-Custom") == "sync-value"
+        # extra_headers should also be forwarded to get_rai_svc_url and ensure_service_availability
+        get_url_mock.assert_called_once()
+        _, url_kwargs = get_url_mock.call_args
+        assert url_kwargs.get("extra_headers") == extra
+        ensure_avail_mock.assert_called_once()
+        _, avail_kwargs = ensure_avail_mock.call_args
+        assert avail_kwargs.get("extra_headers") == extra
+
+    # ------------------------------------------------------------------ #
+    # evaluate_with_rai_service_sync — legacy routing
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.evaluation._common.rai_service.evaluate_with_rai_service", new_callable=AsyncMock)
+    async def test_evaluate_sync_legacy_passes_extra_headers(self, legacy_mock):
+        """extra_headers should be passed through to the legacy endpoint."""
+        legacy_mock.return_value = {"violence": "Very low", "violence_score": 0}
+        extra = {"X-Custom": "legacy-value"}
+
+        await evaluate_with_rai_service_sync(
+            data={"query": "q", "response": "r"},
+            metric_name=EvaluationMetrics.VIOLENCE,
+            project_scope={"subscription_id": "s", "project_name": "p", "resource_group_name": "rg"},
+            credential=DefaultAzureCredential(),
+            use_legacy_endpoint=True,
+            extra_headers=extra,
+        )
+
+        _, kwargs = legacy_mock.call_args
+        assert kwargs["extra_headers"] == extra
+
+    # ------------------------------------------------------------------ #
+    # evaluate_with_rai_service_sync_multimodal — legacy routing
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.evaluation._common.rai_service.evaluate_with_rai_service_multimodal", new_callable=AsyncMock)
+    async def test_evaluate_sync_multimodal_legacy_passes_extra_headers(self, legacy_mm_mock):
+        """extra_headers should be passed through to the legacy multimodal endpoint."""
+        legacy_mm_mock.return_value = {}
+        extra = {"X-Custom": "mm-legacy-value"}
+
+        await evaluate_with_rai_service_sync_multimodal(
+            messages=[{"role": "user", "content": "test"}],
+            metric_name=EvaluationMetrics.VIOLENCE,
+            project_scope={"subscription_id": "s", "project_name": "p", "resource_group_name": "rg"},
+            credential=DefaultAzureCredential(),
+            use_legacy_endpoint=True,
+            extra_headers=extra,
+        )
+
+        _, kwargs = legacy_mm_mock.call_args
+        assert kwargs["extra_headers"] == extra
+
+    # ------------------------------------------------------------------ #
+    # evaluate_with_rai_service_sync_multimodal — non-onedp sync evals
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.evaluation._common.rai_service.fetch_or_reuse_token")
+    @patch("azure.ai.evaluation._common.rai_service.get_rai_svc_url")
+    @patch("azure.ai.evaluation._common.rai_service.ensure_service_availability")
+    @patch("azure.ai.evaluation._common.rai_service.get_sync_http_client_with_retry")
+    async def test_evaluate_sync_multimodal_extra_headers_in_http_request(
+        self, http_client_mock, ensure_avail_mock, get_url_mock, fetch_token_mock
+    ):
+        """extra_headers should be merged into the multimodal sync_evals HTTP POST headers."""
+        fetch_token_mock.return_value = "fake-token"
+        get_url_mock.return_value = "https://fake-rai-url.com"
+        ensure_avail_mock.return_value = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        http_client_mock.return_value = mock_client
+
+        extra = {"X-Custom": "mm-sync-value"}
+        await evaluate_with_rai_service_sync_multimodal(
+            messages=[{"role": "user", "content": "test"}, {"role": "assistant", "content": "reply"}],
+            metric_name="violence",
+            project_scope={"subscription_id": "s", "project_name": "p", "resource_group_name": "rg"},
+            credential=DefaultAzureCredential(),
+            extra_headers=extra,
+        )
+
+        sent_headers = mock_client.post.call_args[1].get("headers", {})
+        assert sent_headers.get("X-Custom") == "mm-sync-value"
+
+    # ------------------------------------------------------------------ #
+    # evaluate_with_rai_service — legacy non-onedp path
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @patch("azure.ai.evaluation._common.rai_service.fetch_or_reuse_token")
+    @patch("azure.ai.evaluation._common.rai_service.get_rai_svc_url")
+    @patch("azure.ai.evaluation._common.rai_service.ensure_service_availability")
+    @patch("azure.ai.evaluation._common.rai_service.submit_request", new_callable=AsyncMock)
+    @patch("azure.ai.evaluation._common.rai_service.fetch_result", new_callable=AsyncMock)
+    async def test_evaluate_legacy_passes_extra_headers_to_sub_functions(
+        self, fetch_result_mock, submit_mock, ensure_avail_mock, get_url_mock, fetch_token_mock
+    ):
+        """extra_headers should be passed to submit_request and fetch_result in legacy path."""
+        fetch_token_mock.return_value = "fake-token"
+        get_url_mock.return_value = "https://fake-rai-url.com"
+        ensure_avail_mock.return_value = None
+        submit_mock.return_value = "op-id"
+        fetch_result_mock.return_value = [
+            {"violence": '{"label": 0, "reasoning": "safe"}'}
+        ]
+
+        extra = {"X-Custom": "legacy-sub-value"}
+        await evaluate_with_rai_service(
+            data={"query": "q", "response": "r"},
+            metric_name=EvaluationMetrics.VIOLENCE,
+            project_scope={"subscription_id": "s", "project_name": "p", "resource_group_name": "rg"},
+            credential=DefaultAzureCredential(),
+            extra_headers=extra,
+        )
+
+        _, submit_kwargs = submit_mock.call_args
+        assert submit_kwargs.get("extra_headers") == extra
+        _, fetch_kwargs = fetch_result_mock.call_args
+        assert fetch_kwargs.get("extra_headers") == extra
+
+    # ------------------------------------------------------------------ #
+    # RaiServiceEvaluatorBase — extra_headers stored from kwargs
+    # ------------------------------------------------------------------ #
+
+    def test_base_evaluator_stores_extra_headers(self):
+        """RaiServiceEvaluatorBase should store extra_headers from kwargs."""
+        from azure.ai.evaluation._evaluators._common._base_rai_svc_eval import RaiServiceEvaluatorBase
+
+        evaluator = RaiServiceEvaluatorBase.__new__(RaiServiceEvaluatorBase)
+        # Simulate __init__ by setting attributes manually
+        extra = {"X-Custom": "eval-value"}
+        evaluator._extra_headers = extra
+        assert evaluator._extra_headers == extra
+
+    def test_base_evaluator_extra_headers_defaults_to_none(self):
+        """RaiServiceEvaluatorBase should default extra_headers to None when not provided."""
+        from azure.ai.evaluation._evaluators._common._base_rai_svc_eval import RaiServiceEvaluatorBase
+
+        evaluator = RaiServiceEvaluatorBase.__new__(RaiServiceEvaluatorBase)
+        evaluator._extra_headers = None
+        assert evaluator._extra_headers is None

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
@@ -844,7 +844,8 @@ class TestExtraHeaders:
     @patch(
         "azure.ai.evaluation._http_utils.AsyncHttpPipeline.post",
         return_value=MockAsyncHttpResponse(
-            202, json={"location": "this/is/the/op-id"},
+            202,
+            json={"location": "this/is/the/op-id"},
         ),
     )
     async def test_submit_request_extra_headers_included(self, post_mock):
@@ -913,9 +914,7 @@ class TestExtraHeaders:
     @pytest.mark.asyncio
     @patch(
         "azure.ai.evaluation._http_utils.AsyncHttpPipeline.get",
-        return_value=MockAsyncHttpResponse(
-            200, json={"properties": {"discoveryUrl": "https://disc.com/path"}}
-        ),
+        return_value=MockAsyncHttpResponse(200, json={"properties": {"discoveryUrl": "https://disc.com/path"}}),
     )
     async def test_get_service_discovery_url_extra_headers_included(self, get_mock):
         """extra_headers should appear in the ARM request headers."""
@@ -1073,9 +1072,7 @@ class TestExtraHeaders:
         get_url_mock.return_value = "https://fake-rai-url.com"
         ensure_avail_mock.return_value = None
         submit_mock.return_value = "op-id"
-        fetch_result_mock.return_value = [
-            {"violence": '{"label": 0, "reasoning": "safe"}'}
-        ]
+        fetch_result_mock.return_value = [{"violence": '{"label": 0, "reasoning": "safe"}'}]
 
         extra = {"X-Custom": "legacy-sub-value"}
         await evaluate_with_rai_service(

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_rai_script.py
@@ -823,11 +823,11 @@ class TestExtraHeaders:
         assert headers["X-Another"] == "42"
 
     def test_get_common_headers_extra_headers_do_not_override_auth(self):
-        """User-supplied extra_headers can override Authorization if they choose to."""
+        """SDK-owned headers (Authorization, User-Agent) must win over extra_headers."""
         extra = {"Authorization": "Bearer override"}
         headers = get_common_headers("fake-token", extra_headers=extra)
-        # extra_headers is applied after base headers, so it overrides
-        assert headers["Authorization"] == "Bearer override"
+        # SDK headers are applied after extra_headers, so they cannot be overridden
+        assert headers["Authorization"] == "Bearer fake-token"
 
     def test_get_common_headers_with_evaluator_name_and_extra_headers(self):
         """Both evaluator_name and extra_headers work together."""

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -2116,8 +2116,8 @@ class TestLogEventsTokenUsage:
 
         return FakeEventLogger(), emitted
 
-    def test_token_usage_emitted_in_standard_attributes(self):
-        """prompt_tokens and completion_tokens from sample.usage should appear as standard attributes."""
+    def test_token_usage_emitted_in_internal_properties(self):
+        """prompt_tokens and completion_tokens from sample.usage should appear inside internal_properties."""
         event_logger, emitted = self._make_mock_event_logger()
         events = [
             {
@@ -2142,11 +2142,15 @@ class TestLogEventsTokenUsage:
 
         assert len(emitted) == 1
         attrs = emitted[0].attributes
-        assert attrs["gen_ai.evaluation.usage.input_tokens"] == "100"
-        assert attrs["gen_ai.evaluation.usage.output_tokens"] == "50"
+        internal_props = json.loads(attrs["internal_properties"])
+        assert internal_props["gen_ai.evaluation.usage.input_tokens"] == "100"
+        assert internal_props["gen_ai.evaluation.usage.output_tokens"] == "50"
+        # Should NOT be in standard attributes
+        assert "gen_ai.evaluation.usage.input_tokens" not in attrs
+        assert "gen_ai.evaluation.usage.output_tokens" not in attrs
 
-    def test_token_usage_not_in_internal_properties(self):
-        """Token usage should be in standard attributes, not inside internal_properties."""
+    def test_token_usage_not_in_standard_attributes(self):
+        """Token usage should be in internal_properties, not in standard attributes."""
         event_logger, emitted = self._make_mock_event_logger()
         events = [
             {
@@ -2170,9 +2174,12 @@ class TestLogEventsTokenUsage:
         )
 
         assert len(emitted) == 1
-        internal_props = json.loads(emitted[0].attributes["internal_properties"])
-        assert "gen_ai.evaluation.usage.input_tokens" not in internal_props
-        assert "gen_ai.evaluation.usage.output_tokens" not in internal_props
+        attrs = emitted[0].attributes
+        assert "gen_ai.evaluation.usage.input_tokens" not in attrs
+        assert "gen_ai.evaluation.usage.output_tokens" not in attrs
+        internal_props = json.loads(attrs["internal_properties"])
+        assert internal_props["gen_ai.evaluation.usage.input_tokens"] == "100"
+        assert internal_props["gen_ai.evaluation.usage.output_tokens"] == "50"
 
     def test_token_usage_absent_when_no_sample(self):
         """No token usage attributes when sample is missing."""
@@ -2189,8 +2196,9 @@ class TestLogEventsTokenUsage:
 
         assert len(emitted) == 1
         attrs = emitted[0].attributes
-        assert "gen_ai.evaluation.usage.input_tokens" not in attrs
-        assert "gen_ai.evaluation.usage.output_tokens" not in attrs
+        internal_props = json.loads(attrs["internal_properties"])
+        assert "gen_ai.evaluation.usage.input_tokens" not in internal_props
+        assert "gen_ai.evaluation.usage.output_tokens" not in internal_props
 
     def test_token_usage_absent_when_usage_empty(self):
         """No token usage attributes when sample.usage is empty dict."""
@@ -2207,8 +2215,9 @@ class TestLogEventsTokenUsage:
 
         assert len(emitted) == 1
         attrs = emitted[0].attributes
-        assert "gen_ai.evaluation.usage.input_tokens" not in attrs
-        assert "gen_ai.evaluation.usage.output_tokens" not in attrs
+        internal_props = json.loads(attrs["internal_properties"])
+        assert "gen_ai.evaluation.usage.input_tokens" not in internal_props
+        assert "gen_ai.evaluation.usage.output_tokens" not in internal_props
 
     def test_token_usage_absent_when_sample_not_dict(self):
         """When sample is not a dict (e.g. NaN), the event fails to log entirely."""
@@ -2252,8 +2261,9 @@ class TestLogEventsTokenUsage:
 
         assert len(emitted) == 1
         attrs = emitted[0].attributes
-        assert attrs["gen_ai.evaluation.usage.input_tokens"] == "0"
-        assert attrs["gen_ai.evaluation.usage.output_tokens"] == "0"
+        internal_props = json.loads(attrs["internal_properties"])
+        assert internal_props["gen_ai.evaluation.usage.input_tokens"] == "0"
+        assert internal_props["gen_ai.evaluation.usage.output_tokens"] == "0"
 
     def test_token_usage_partial_only_prompt(self):
         """Only prompt_tokens present should emit only input_tokens."""
@@ -2280,8 +2290,9 @@ class TestLogEventsTokenUsage:
 
         assert len(emitted) == 1
         attrs = emitted[0].attributes
-        assert attrs["gen_ai.evaluation.usage.input_tokens"] == "42"
-        assert "gen_ai.evaluation.usage.output_tokens" not in attrs
+        internal_props = json.loads(attrs["internal_properties"])
+        assert internal_props["gen_ai.evaluation.usage.input_tokens"] == "42"
+        assert "gen_ai.evaluation.usage.output_tokens" not in internal_props
 
 
 class TestAdjustForInverseMetric:


### PR DESCRIPTION
# Description

- Added `extra_headers` keyword argument to `RaiServiceEvaluatorBase` (and all content safety evaluators) to allow passing custom HTTP headers to all backend RAI service calls.
- Move token usage attributes (`gen_ai.evaluation.usage.input_tokens`, `gen_ai.evaluation.usage.output_tokens`) to App Insights evaluation events inside `internal_properties`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
