### PR TITLE
Add ownership checks for storage directories

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0b52 (Unreleased)
 
 ### Features Added
+- Add ownership checks for storage directories
 - Add logger name to custom dimensions for Message, Exception and Event telemetry
   ([#46096](https://github.com/Azure/azure-sdk-for-python/pull/46096))
 - Add support for populating SDK version from distro and Microsoft OpenTelemetry distro environment variables

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Add ownership checks for storage directories
+  ([#46725](https://github.com/Azure/azure-sdk-for-python/pull/46725))
 - Add logger name to custom dimensions for Message, Exception and Event telemetry
   ([#46096](https://github.com/Azure/azure-sdk-for-python/pull/46096))
 - Add support for populating SDK version from distro and Microsoft OpenTelemetry distro environment variables

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -66,9 +66,9 @@ class LocalFileBlob:
     def put(self, data: List[Any], lease_period: int = 0) -> Union[StorageExportResult, str]:
         try:
             fullpath = self.fullpath + ".tmp"
-            # Use O_CREAT | O_EXCL | O_WRONLY to atomically create the file
+            # Use O_CREAT | O_EXCL | O_WRONLY to atomically create the file  # cspell:disable-line
             # and fail if it already exists, preventing race conditions.
-            fd = os.open(fullpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            fd = os.open(fullpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)  # cspell:disable-line
             try:
                 file = os.fdopen(fd, "w", encoding="utf-8")
             except Exception:
@@ -263,7 +263,7 @@ class LocalFileStorage:
                     return True
             # Unix
             else:
-                open_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # pylint: disable=no-member
+                open_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # pylint: disable=no-member  # cspell:disable-line
                 dir_fd = os.open(self._path, open_flags)
                 try:
                     dir_stat = os.fstat(dir_fd)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -69,7 +69,12 @@ class LocalFileBlob:
             # Use O_CREAT | O_EXCL | O_WRONLY to atomically create the file
             # and fail if it already exists, preventing race conditions.
             fd = os.open(fullpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as file:
+            try:
+                file = os.fdopen(fd, "w", encoding="utf-8")
+            except Exception:
+                os.close(fd)
+                raise
+            with file:
                 for item in data:
                     file.write(json.dumps(item))
                     # The official Python doc: Do not use os.linesep as a line
@@ -258,22 +263,27 @@ class LocalFileStorage:
                     return True
             # Unix
             else:
-                dir_stat = os.lstat(self._path)
-                owner_uid = dir_stat.st_uid
-                current_uid = os.getuid()  # pylint: disable=no-member
-                if owner_uid not in (current_uid, 0):
-                    logger.error(
-                        "Storage directory %s is owned by uid %d, not the current user (%d) or admin (uid 0). "
-                        "Refusing to use this directory.",
-                        self._path,
-                        owner_uid,
-                        current_uid,
-                    )
-                    set_local_storage_setup_state_exception(
-                        f"Directory owned by uid {owner_uid}, expected {current_uid} or 0"
-                    )
-                    return False
-                os.chmod(self._path, 0o700)
+                open_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # pylint: disable=no-member
+                dir_fd = os.open(self._path, open_flags)
+                try:
+                    dir_stat = os.fstat(dir_fd)
+                    owner_uid = dir_stat.st_uid
+                    current_uid = os.getuid()  # pylint: disable=no-member
+                    if owner_uid not in (current_uid, 0):
+                        logger.error(
+                            "Storage directory %s is owned by uid %d, not the current user (%d) or admin (uid 0). "
+                            "Refusing to use this directory.",
+                            self._path,
+                            owner_uid,
+                            current_uid,
+                        )
+                        set_local_storage_setup_state_exception(
+                            f"Directory owned by uid {owner_uid}, expected {current_uid} or 0"
+                        )
+                        return False
+                    os.fchmod(dir_fd, 0o700)  # pylint: disable=no-member
+                finally:
+                    os.close(dir_fd)
                 return True
         except OSError as error:
             if getattr(error, "errno", None) == errno.EROFS:  # cspell:disable-line

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -264,8 +264,8 @@ class LocalFileStorage:
             # Unix
             else:
                 open_flags = (
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-                )  # pylint: disable=no-member  # cspell:disable-line
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # cspell:disable-line
+                )  # pylint: disable=no-member
                 dir_fd = os.open(self._path, open_flags)
                 try:
                     dir_stat = os.fstat(dir_fd)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -281,7 +281,7 @@ class LocalFileStorage:
                             f"Directory owned by uid {owner_uid}, expected {current_uid} or 0"
                         )
                         return False
-                    os.fchmod(dir_fd, 0o700)  # pylint: disable=no-member
+                    os.fchmod(dir_fd, 0o700)  # pylint: disable=no-member  # cspell:disable-line
                 finally:
                     os.close(dir_fd)
                 return True

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -66,7 +66,10 @@ class LocalFileBlob:
     def put(self, data: List[Any], lease_period: int = 0) -> Union[StorageExportResult, str]:
         try:
             fullpath = self.fullpath + ".tmp"
-            with open(fullpath, "w", encoding="utf-8") as file:
+            # Use O_CREAT | O_EXCL | O_WRONLY to atomically create the file
+            # and fail if it already exists, preventing race conditions.
+            fd = os.open(fullpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as file:
                 for item in data:
                     file.write(json.dumps(item))
                     # The official Python doc: Do not use os.linesep as a line
@@ -255,6 +258,21 @@ class LocalFileStorage:
                     return True
             # Unix
             else:
+                dir_stat = os.lstat(self._path)
+                owner_uid = dir_stat.st_uid
+                current_uid = os.getuid()  # pylint: disable=no-member
+                if owner_uid not in (current_uid, 0):
+                    logger.error(
+                        "Storage directory %s is owned by uid %d, not the current user (%d) or admin (uid 0). "
+                        "Refusing to use this directory.",
+                        self._path,
+                        owner_uid,
+                        current_uid,
+                    )
+                    set_local_storage_setup_state_exception(
+                        f"Directory owned by uid {owner_uid}, expected {current_uid} or 0"
+                    )
+                    return False
                 os.chmod(self._path, 0o700)
                 return True
         except OSError as error:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -263,7 +263,9 @@ class LocalFileStorage:
                     return True
             # Unix
             else:
-                open_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # pylint: disable=no-member  # cspell:disable-line
+                open_flags = (
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                )  # pylint: disable=no-member  # cspell:disable-line
                 dir_fd = os.open(self._path, open_flags)
                 try:
                     dir_stat = os.fstat(dir_fd)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -975,7 +975,9 @@ class TestLocalFileStorage(unittest.TestCase):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
                             with mock.patch(
-                                f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod  # cspell:disable-line
+                                f"{STORAGE_MODULE}.os.fchmod",  # cspell:disable-line
+                                create=True,
+                                side_effect=mock_fchmod,  # cspell:disable-line
                             ):
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
@@ -1057,7 +1059,9 @@ class TestLocalFileStorage(unittest.TestCase):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
                             with mock.patch(
-                                f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod  # cspell:disable-line
+                                f"{STORAGE_MODULE}.os.fchmod",  # cspell:disable-line
+                                create=True,
+                                side_effect=mock_fchmod,  # cspell:disable-line
                             ):
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -83,7 +83,7 @@ class TestLocalFileBlob(unittest.TestCase):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "write_error_blob"))
         test_input = [1, 2, 3]
 
-        with mock.patch("builtins.open", side_effect=PermissionError("Cannot write to file")):
+        with mock.patch("os.open", side_effect=PermissionError("Cannot write to file")):
             result = blob.put(test_input)
             self.assertIsInstance(result, str)
             self.assertIn("Cannot write to file", result)
@@ -619,29 +619,34 @@ class TestLocalFileStorage(unittest.TestCase):
         # Clear any existing exception state (set to empty string, not None)
         set_local_storage_setup_state_exception("")
 
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 1000
+
         # Mock Unix environment and chmod failure
         with mock.patch("os.name", "posix"):  # Unix
             with mock.patch("os.makedirs"):  # Allow directory creation
-                with mock.patch("os.chmod", side_effect=OSError(test_error_message)):
-                    stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
+                with mock.patch("os.lstat", return_value=mock_stat_result):
+                    with mock.patch("os.getuid", create=True, return_value=1000):
+                        with mock.patch("os.chmod", side_effect=OSError(test_error_message)):
+                            stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
 
-                    # Storage should be disabled due to chmod failure
-                    self.assertFalse(stor._enabled)
+                            # Storage should be disabled due to chmod failure
+                            self.assertFalse(stor._enabled)
 
-                    # Exception state should be set with the error message
-                    exception_state = get_local_storage_setup_state_exception()
-                    self.assertEqual(exception_state, test_error_message)
+                            # Exception state should be set with the error message
+                            exception_state = get_local_storage_setup_state_exception()
+                            self.assertEqual(exception_state, test_error_message)
 
-                    # When storage is disabled, put() behavior depends on readonly state
-                    result = stor.put(test_input)
-                    if get_local_storage_setup_state_readonly():
-                        # Readonly takes priority over exception state
-                        self.assertEqual(result, StorageExportResult.CLIENT_READONLY)
-                    else:
-                        # If readonly not set, should return the exception message
-                        self.assertEqual(result, test_error_message)
+                            # When storage is disabled, put() behavior depends on readonly state
+                            result = stor.put(test_input)
+                            if get_local_storage_setup_state_readonly():
+                                # Readonly takes priority over exception state
+                                self.assertEqual(result, StorageExportResult.CLIENT_READONLY)
+                            else:
+                                # If readonly not set, should return the exception message
+                                self.assertEqual(result, test_error_message)
 
-                    stor.close()
+                            stor.close()
 
         # Clean up
         set_local_storage_setup_state_exception("")
@@ -949,26 +954,31 @@ class TestLocalFileStorage(unittest.TestCase):
             def mock_makedirs(path, mode=0o777, exist_ok=False):
                 makedirs_calls.append((path, oct(mode), exist_ok))
 
+            mock_stat_result = mock.MagicMock()
+            mock_stat_result.st_uid = 1000
+
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs", side_effect=mock_makedirs):
-                with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
-                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                        stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
 
-                        self.assertTrue(stor._enabled)
+                                self.assertTrue(stor._enabled)
 
-                        self.assertEqual(
-                            makedirs_calls,
-                            [(storage_abs_path, "0o777", True)],
-                            f"Unexpected makedirs calls: {makedirs_calls}",
-                        )
+                                self.assertEqual(
+                                    makedirs_calls,
+                                    [(storage_abs_path, "0o777", True)],
+                                    f"Unexpected makedirs calls: {makedirs_calls}",
+                                )
 
-                        self.assertEqual(
-                            {(storage_abs_path, "0o700")},
-                            set(chmod_calls),
-                            f"Unexpected chmod calls: {chmod_calls}",
-                        )
+                                self.assertEqual(
+                                    {(storage_abs_path, "0o700")},
+                                    set(chmod_calls),
+                                    f"Unexpected chmod calls: {chmod_calls}",
+                                )
 
-                        stor.close()
+                                stor.close()
 
         # Clean up
         set_local_storage_setup_state_exception("")
@@ -1024,17 +1034,211 @@ class TestLocalFileStorage(unittest.TestCase):
                     raise PermissionError(test_error_message)
                 raise OSError(f"Unexpected chmod call: {path}, {oct(mode)}")
 
+            mock_stat_result = mock.MagicMock()
+            mock_stat_result.st_uid = 1000
+
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
-                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                        stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
 
-                        self.assertFalse(stor._enabled)
+                                self.assertFalse(stor._enabled)
 
-                        exception_state = get_local_storage_setup_state_exception()
-                        self.assertEqual(exception_state, test_error_message)
+                                exception_state = get_local_storage_setup_state_exception()
+                                self.assertEqual(exception_state, test_error_message)
 
-                        stor.close()
+                                stor.close()
 
         # Clean up
         set_local_storage_setup_state_exception("")
+
+    def test_check_and_set_folder_permissions_unix_ownership_by_current_user(self):
+        """Directory owned by the current user should pass ownership check."""
+        from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+            set_local_storage_setup_state_exception,
+        )
+
+        set_local_storage_setup_state_exception("")
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 4242
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+                                self.assertTrue(stor._enabled)
+                                mock_chmod.assert_called_with(storage_abs_path, 0o700)
+                                stor.close()
+
+        set_local_storage_setup_state_exception("")
+
+    def test_check_and_set_folder_permissions_unix_ownership_by_root(self):
+        """Directory owned by root (uid 0) should pass ownership check."""
+        from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+            set_local_storage_setup_state_exception,
+        )
+
+        set_local_storage_setup_state_exception("")
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 0  # root
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+                                self.assertTrue(stor._enabled)
+                                mock_chmod.assert_called_with(storage_abs_path, 0o700)
+                                stor.close()
+
+        set_local_storage_setup_state_exception("")
+
+    def test_check_and_set_folder_permissions_unix_ownership_by_different_user(self):
+        """Directory owned by a different non-root user should fail ownership check."""
+        from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+            get_local_storage_setup_state_exception,
+            set_local_storage_setup_state_exception,
+        )
+
+        set_local_storage_setup_state_exception("")
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 9999  # attacker
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+                                self.assertFalse(stor._enabled)
+                                mock_chmod.assert_not_called()
+                                exception_state = get_local_storage_setup_state_exception()
+                                self.assertIn("owned by uid 9999", exception_state)
+                                stor.close()
+
+        set_local_storage_setup_state_exception("")
+
+    def test_attack_scenario_precreated_directory_by_attacker(self):
+        """
+        Simulates the attack described in the vulnerability report:
+        An unprivileged attacker pre-creates the storage directory in /tmp with
+        their own uid. When the legitimate process starts, it should detect the
+        ownership mismatch and refuse to use the directory, preventing data exfiltration.
+        """
+        from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+            get_local_storage_setup_state_exception,
+            set_local_storage_setup_state_exception,
+        )
+
+        set_local_storage_setup_state_exception("")
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        # Attacker pre-created the directory — it is owned by attacker uid 5000
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 5000  # attacker's uid
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):  # dir already exists
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):  # legitimate user
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+
+                                # Storage MUST be disabled — attacker owns the dir
+                                self.assertFalse(stor._enabled)
+                                # chmod must NOT be called — we refuse to use the directory
+                                mock_chmod.assert_not_called()
+                                # No data can be written
+                                result = stor.put([{"telemetry": "sensitive_data"}])
+                                self.assertNotEqual(result, StorageExportResult.LOCAL_FILE_BLOB_SUCCESS)
+                                # Exception state captures the ownership mismatch
+                                exception_state = get_local_storage_setup_state_exception()
+                                self.assertIn("owned by uid 5000", exception_state)
+                                self.assertIn("expected 1000", exception_state)
+
+                                stor.close()
+
+        set_local_storage_setup_state_exception("")
+
+    def test_attack_scenario_symlink_to_attacker_controlled_path(self):
+        """
+        Simulates a symlink attack: attacker creates a symlink at the expected
+        storage path pointing to a root-owned or attacker-controlled directory.
+        os.lstat checks the symlink itself (not the target), so if the symlink
+        is owned by the attacker, the check should fail.
+        """
+        from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+            get_local_storage_setup_state_exception,
+            set_local_storage_setup_state_exception,
+        )
+
+        set_local_storage_setup_state_exception("")
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        # lstat on a symlink returns the symlink's own metadata, not the target.
+        # The symlink was created by attacker (uid 7777).
+        mock_symlink_stat = mock.MagicMock()
+        mock_symlink_stat.st_uid = 7777  # attacker created the symlink
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_symlink_stat):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+
+                                # Storage MUST be disabled — symlink owned by attacker
+                                self.assertFalse(stor._enabled)
+                                mock_chmod.assert_not_called()
+                                exception_state = get_local_storage_setup_state_exception()
+                                self.assertIn("owned by uid 7777", exception_state)
+
+                                stor.close()
+
+        set_local_storage_setup_state_exception("")
+
+    def test_attack_scenario_file_race_condition_oexcl(self):
+        """
+        Simulates O_EXCL protection: if an attacker manages to pre-create a
+        .tmp file at the exact path our blob will use, os.open with O_EXCL
+        must fail with FileExistsError, preventing data from being written
+        to an attacker-controlled file.
+        """
+        storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
+
+        mock_stat_result = mock.MagicMock()
+        mock_stat_result.st_uid = 1000
+
+        with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
+            with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
+                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
+                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                        with mock.patch(f"{STORAGE_MODULE}.os.chmod"):
+                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                stor = LocalFileStorage(storage_abs_path)
+                                self.assertTrue(stor._enabled)
+
+                                # Now simulate the attack: attacker pre-created the .tmp file
+                                with mock.patch("os.open", side_effect=FileExistsError("File exists")):
+                                    result = stor.put([{"secret": "credential_data"}])
+                                    # put() must fail — data must NOT be written
+                                    self.assertIsInstance(result, str)
+                                    self.assertIn("File exists", result)
+
+                                stor.close()

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import errno
 import os
 import shutil
 import unittest
@@ -20,6 +21,14 @@ TEST_FOLDER = os.path.abspath(".test.storage")
 DUMMY_INSTRUMENTATION_KEY = "00000000-0000-0000-0000-000000000000"
 TEST_USER = "multiuser-test"
 STORAGE_MODULE = "azure.monitor.opentelemetry.exporter._storage"
+
+# Ensure Unix-only constants exist for cross-platform testing.
+# These are used by the fd-based permission checks in the Unix code path;
+# since os.open is mocked in those tests, the actual values don't matter.
+if not hasattr(os, "O_DIRECTORY"):
+    os.O_DIRECTORY = 0o200000
+if not hasattr(os, "O_NOFOLLOW"):
+    os.O_NOFOLLOW = 0o400000
 
 
 def throw(exc_type, *args, **kwargs):
@@ -83,7 +92,7 @@ class TestLocalFileBlob(unittest.TestCase):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "write_error_blob"))
         test_input = [1, 2, 3]
 
-        with mock.patch("os.open", side_effect=PermissionError("Cannot write to file")):
+        with mock.patch(f"{STORAGE_MODULE}.os.open", side_effect=PermissionError("Cannot write to file")):
             result = blob.put(test_input)
             self.assertIsInstance(result, str)
             self.assertIn("Cannot write to file", result)
@@ -622,31 +631,33 @@ class TestLocalFileStorage(unittest.TestCase):
         mock_stat_result = mock.MagicMock()
         mock_stat_result.st_uid = 1000
 
-        # Mock Unix environment and chmod failure
+        # Mock Unix environment and fchmod failure
         with mock.patch("os.name", "posix"):  # Unix
             with mock.patch("os.makedirs"):  # Allow directory creation
-                with mock.patch("os.lstat", return_value=mock_stat_result):
-                    with mock.patch("os.getuid", create=True, return_value=1000):
-                        with mock.patch("os.chmod", side_effect=OSError(test_error_message)):
-                            stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
+                with mock.patch("os.open", return_value=99):
+                    with mock.patch("os.fstat", return_value=mock_stat_result):
+                        with mock.patch("os.getuid", create=True, return_value=1000):
+                            with mock.patch("os.fchmod", create=True, side_effect=OSError(test_error_message)):
+                                with mock.patch("os.close"):
+                                    stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
 
-                            # Storage should be disabled due to chmod failure
-                            self.assertFalse(stor._enabled)
+                                    # Storage should be disabled due to fchmod failure
+                                    self.assertFalse(stor._enabled)
 
-                            # Exception state should be set with the error message
-                            exception_state = get_local_storage_setup_state_exception()
-                            self.assertEqual(exception_state, test_error_message)
+                                    # Exception state should be set with the error message
+                                    exception_state = get_local_storage_setup_state_exception()
+                                    self.assertEqual(exception_state, test_error_message)
 
-                            # When storage is disabled, put() behavior depends on readonly state
-                            result = stor.put(test_input)
-                            if get_local_storage_setup_state_readonly():
-                                # Readonly takes priority over exception state
-                                self.assertEqual(result, StorageExportResult.CLIENT_READONLY)
-                            else:
-                                # If readonly not set, should return the exception message
-                                self.assertEqual(result, test_error_message)
+                                    # When storage is disabled, put() behavior depends on readonly state
+                                    result = stor.put(test_input)
+                                    if get_local_storage_setup_state_readonly():
+                                        # Readonly takes priority over exception state
+                                        self.assertEqual(result, StorageExportResult.CLIENT_READONLY)
+                                    else:
+                                        # If readonly not set, should return the exception message
+                                        self.assertEqual(result, test_error_message)
 
-                            stor.close()
+                                    stor.close()
 
         # Clean up
         set_local_storage_setup_state_exception("")
@@ -945,11 +956,11 @@ class TestLocalFileStorage(unittest.TestCase):
         storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
-            chmod_calls = []
+            fchmod_calls = []
             makedirs_calls = []
 
-            def mock_chmod(path, mode):
-                chmod_calls.append((path, oct(mode)))
+            def mock_fchmod(fd, mode):
+                fchmod_calls.append((fd, oct(mode)))
 
             def mock_makedirs(path, mode=0o777, exist_ok=False):
                 makedirs_calls.append((path, oct(mode), exist_ok))
@@ -958,25 +969,27 @@ class TestLocalFileStorage(unittest.TestCase):
             mock_stat_result.st_uid = 1000
 
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs", side_effect=mock_makedirs):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
 
-                                self.assertTrue(stor._enabled)
+                                        self.assertTrue(stor._enabled)
 
-                                self.assertEqual(
-                                    makedirs_calls,
-                                    [(storage_abs_path, "0o777", True)],
-                                    f"Unexpected makedirs calls: {makedirs_calls}",
-                                )
+                                        self.assertEqual(
+                                            makedirs_calls,
+                                            [(storage_abs_path, "0o777", True)],
+                                            f"Unexpected makedirs calls: {makedirs_calls}",
+                                        )
 
-                                self.assertEqual(
-                                    {(storage_abs_path, "0o700")},
-                                    set(chmod_calls),
-                                    f"Unexpected chmod calls: {chmod_calls}",
-                                )
+                                        self.assertEqual(
+                                            [(99, "0o700")],
+                                            fchmod_calls,
+                                            f"Unexpected fchmod calls: {fchmod_calls}",
+                                        )
 
                                 stor.close()
 
@@ -1029,27 +1042,27 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
 
-            def mock_chmod(path, mode):
-                if mode == 0o700:
-                    raise PermissionError(test_error_message)
-                raise OSError(f"Unexpected chmod call: {path}, {oct(mode)}")
+            def mock_fchmod(fd, mode):
+                raise PermissionError(test_error_message)
 
             mock_stat_result = mock.MagicMock()
             mock_stat_result.st_uid = 1000
 
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod", side_effect=mock_chmod):
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
 
-                                self.assertFalse(stor._enabled)
+                                        self.assertFalse(stor._enabled)
 
-                                exception_state = get_local_storage_setup_state_exception()
-                                self.assertEqual(exception_state, test_error_message)
+                                        exception_state = get_local_storage_setup_state_exception()
+                                        self.assertEqual(exception_state, test_error_message)
 
-                                stor.close()
+                                        stor.close()
 
         # Clean up
         set_local_storage_setup_state_exception("")
@@ -1068,14 +1081,16 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
-                                self.assertTrue(stor._enabled)
-                                mock_chmod.assert_called_with(storage_abs_path, 0o700)
-                                stor.close()
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
+                                        self.assertTrue(stor._enabled)
+                                        mock_fchmod.assert_called_with(99, 0o700)
+                                        stor.close()
 
         set_local_storage_setup_state_exception("")
 
@@ -1093,14 +1108,16 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
-                                self.assertTrue(stor._enabled)
-                                mock_chmod.assert_called_with(storage_abs_path, 0o700)
-                                stor.close()
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
+                                        self.assertTrue(stor._enabled)
+                                        mock_fchmod.assert_called_with(99, 0o700)
+                                        stor.close()
 
         set_local_storage_setup_state_exception("")
 
@@ -1119,16 +1136,18 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
-                                self.assertFalse(stor._enabled)
-                                mock_chmod.assert_not_called()
-                                exception_state = get_local_storage_setup_state_exception()
-                                self.assertIn("owned by uid 9999", exception_state)
-                                stor.close()
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
+                                        self.assertFalse(stor._enabled)
+                                        mock_fchmod.assert_not_called()
+                                        exception_state = get_local_storage_setup_state_exception()
+                                        self.assertIn("owned by uid 9999", exception_state)
+                                        stor.close()
 
         set_local_storage_setup_state_exception("")
 
@@ -1153,34 +1172,35 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):  # dir already exists
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):  # legitimate user
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):  # legitimate user
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
 
-                                # Storage MUST be disabled — attacker owns the dir
-                                self.assertFalse(stor._enabled)
-                                # chmod must NOT be called — we refuse to use the directory
-                                mock_chmod.assert_not_called()
-                                # No data can be written
-                                result = stor.put([{"telemetry": "sensitive_data"}])
-                                self.assertNotEqual(result, StorageExportResult.LOCAL_FILE_BLOB_SUCCESS)
-                                # Exception state captures the ownership mismatch
-                                exception_state = get_local_storage_setup_state_exception()
-                                self.assertIn("owned by uid 5000", exception_state)
-                                self.assertIn("expected 1000", exception_state)
+                                        # Storage MUST be disabled — attacker owns the dir
+                                        self.assertFalse(stor._enabled)
+                                        # fchmod must NOT be called — we refuse to use the directory
+                                        mock_fchmod.assert_not_called()
+                                        # No data can be written
+                                        result = stor.put([{"telemetry": "sensitive_data"}])
+                                        self.assertNotEqual(result, StorageExportResult.LOCAL_FILE_BLOB_SUCCESS)
+                                        # Exception state captures the ownership mismatch
+                                        exception_state = get_local_storage_setup_state_exception()
+                                        self.assertIn("owned by uid 5000", exception_state)
+                                        self.assertIn("expected 1000", exception_state)
 
-                                stor.close()
+                                        stor.close()
 
         set_local_storage_setup_state_exception("")
 
     def test_attack_scenario_symlink_to_attacker_controlled_path(self):
         """
         Simulates a symlink attack: attacker creates a symlink at the expected
-        storage path pointing to a root-owned or attacker-controlled directory.
-        os.lstat checks the symlink itself (not the target), so if the symlink
-        is owned by the attacker, the check should fail.
+        storage path. With O_NOFOLLOW, os.open() refuses to follow the symlink
+        and raises OSError, preventing the SDK from using the attacker's target.
         """
         from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
             get_local_storage_setup_state_exception,
@@ -1190,26 +1210,21 @@ class TestLocalFileStorage(unittest.TestCase):
         set_local_storage_setup_state_exception("")
         storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
 
-        # lstat on a symlink returns the symlink's own metadata, not the target.
-        # The symlink was created by attacker (uid 7777).
-        mock_symlink_stat = mock.MagicMock()
-        mock_symlink_stat.st_uid = 7777  # attacker created the symlink
+        # os.open with O_NOFOLLOW raises OSError (ELOOP) when path is a symlink
+        symlink_error = OSError(errno.ELOOP, "Too many levels of symbolic links")
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_symlink_stat):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod") as mock_chmod:
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
+                with mock.patch(f"{STORAGE_MODULE}.os.open", side_effect=symlink_error):
+                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                        stor = LocalFileStorage(storage_abs_path)
 
-                                # Storage MUST be disabled — symlink owned by attacker
-                                self.assertFalse(stor._enabled)
-                                mock_chmod.assert_not_called()
-                                exception_state = get_local_storage_setup_state_exception()
-                                self.assertIn("owned by uid 7777", exception_state)
+                        # Storage MUST be disabled — symlink detected by O_NOFOLLOW
+                        self.assertFalse(stor._enabled)
+                        exception_state = get_local_storage_setup_state_exception()
+                        self.assertIn("Too many levels of symbolic links", exception_state)
 
-                                stor.close()
+                        stor.close()
 
         set_local_storage_setup_state_exception("")
 
@@ -1227,18 +1242,20 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
-                with mock.patch(f"{STORAGE_MODULE}.os.lstat", return_value=mock_stat_result):
-                    with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                        with mock.patch(f"{STORAGE_MODULE}.os.chmod"):
-                            with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
-                                stor = LocalFileStorage(storage_abs_path)
-                                self.assertTrue(stor._enabled)
+                with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
+                    with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
+                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True):
+                                with mock.patch(f"{STORAGE_MODULE}.os.close"):
+                                    with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
+                                        stor = LocalFileStorage(storage_abs_path)
+                                        self.assertTrue(stor._enabled)
 
-                                # Now simulate the attack: attacker pre-created the .tmp file
-                                with mock.patch("os.open", side_effect=FileExistsError("File exists")):
-                                    result = stor.put([{"secret": "credential_data"}])
-                                    # put() must fail — data must NOT be written
-                                    self.assertIsInstance(result, str)
-                                    self.assertIn("File exists", result)
+                                        # Now simulate the attack: attacker pre-created the .tmp file
+                                        with mock.patch(f"{STORAGE_MODULE}.os.open", side_effect=FileExistsError("File exists")):
+                                            result = stor.put([{"secret": "credential_data"}])
+                                            # put() must fail — data must NOT be written
+                                            self.assertIsInstance(result, str)
+                                            self.assertIn("File exists", result)
 
-                                stor.close()
+                                        stor.close()

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -1042,7 +1042,7 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
 
-            def mock_fchmod(fd, mode):
+            def mock_fchmod(fd, mode):  # cspell:disable-line 
                 raise PermissionError(test_error_message)
 
             mock_stat_result = mock.MagicMock()
@@ -1052,7 +1052,7 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1084,12 +1084,12 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
                                         self.assertTrue(stor._enabled)
-                                        mock_fchmod.assert_called_with(99, 0o700)
+                                        mock_fchmod.assert_called_with(99, 0o700)  # cspell:disable-line
                                         stor.close()
 
         set_local_storage_setup_state_exception("")
@@ -1111,12 +1111,12 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
                                         self.assertTrue(stor._enabled)
-                                        mock_fchmod.assert_called_with(99, 0o700)
+                                        mock_fchmod.assert_called_with(99, 0o700)  # cspell:disable-line
                                         stor.close()
 
         set_local_storage_setup_state_exception("")
@@ -1139,12 +1139,12 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
                                         self.assertFalse(stor._enabled)
-                                        mock_fchmod.assert_not_called()
+                                        mock_fchmod.assert_not_called()  # cspell:disable-line
                                         exception_state = get_local_storage_setup_state_exception()
                                         self.assertIn("owned by uid 9999", exception_state)
                                         stor.close()
@@ -1175,15 +1175,15 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):  # legitimate user
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
 
                                         # Storage MUST be disabled — attacker owns the dir
                                         self.assertFalse(stor._enabled)
-                                        # fchmod must NOT be called — we refuse to use the directory
-                                        mock_fchmod.assert_not_called()
+                                        # fchmod must NOT be called — we refuse to use the directory  # cspell:disable-line
+                                        mock_fchmod.assert_not_called()  # cspell:disable-line
                                         # No data can be written
                                         result = stor.put([{"telemetry": "sensitive_data"}])
                                         self.assertNotEqual(result, StorageExportResult.LOCAL_FILE_BLOB_SUCCESS)
@@ -1245,7 +1245,7 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True):  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -960,7 +960,7 @@ class TestLocalFileStorage(unittest.TestCase):
             makedirs_calls = []
 
             def mock_fchmod(fd, mode):  # cspell:disable-line
-                fchmod_calls.append((fd, oct(mode)))
+                fchmod_calls.append((fd, oct(mode)))  # cspell:disable-line
 
             def mock_makedirs(path, mode=0o777, exist_ok=False):
                 makedirs_calls.append((path, oct(mode), exist_ok))
@@ -972,7 +972,7 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):
+                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -987,8 +987,8 @@ class TestLocalFileStorage(unittest.TestCase):
 
                                         self.assertEqual(
                                             [(99, "0o700")],
-                                            fchmod_calls,
-                                            f"Unexpected fchmod calls: {fchmod_calls}",
+                                            fchmod_calls,  # cspell:disable-line
+                                            f"Unexpected fchmod calls: {fchmod_calls}",  # cspell:disable-line
                                         )
 
                                 stor.close()

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -631,17 +631,17 @@ class TestLocalFileStorage(unittest.TestCase):
         mock_stat_result = mock.MagicMock()
         mock_stat_result.st_uid = 1000
 
-        # Mock Unix environment and fchmod failure
+        # Mock Unix environment and fchmod failure  # cspell:disable-line
         with mock.patch("os.name", "posix"):  # Unix
             with mock.patch("os.makedirs"):  # Allow directory creation
                 with mock.patch("os.open", return_value=99):
                     with mock.patch("os.fstat", return_value=mock_stat_result):
                         with mock.patch("os.getuid", create=True, return_value=1000):
-                            with mock.patch("os.fchmod", create=True, side_effect=OSError(test_error_message)):
+                            with mock.patch("os.fchmod", create=True, side_effect=OSError(test_error_message)):  # cspell:disable-line
                                 with mock.patch("os.close"):
                                     stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
 
-                                    # Storage should be disabled due to fchmod failure
+                                    # Storage should be disabled due to fchmod failure  # cspell:disable-line
                                     self.assertFalse(stor._enabled)
 
                                     # Exception state should be set with the error message
@@ -956,10 +956,10 @@ class TestLocalFileStorage(unittest.TestCase):
         storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
-            fchmod_calls = []
+            fchmod_calls = []  # cspell:disable-line
             makedirs_calls = []
 
-            def mock_fchmod(fd, mode):
+            def mock_fchmod(fd, mode):  # cspell:disable-line
                 fchmod_calls.append((fd, oct(mode)))
 
             def mock_makedirs(path, mode=0o777, exist_ok=False):
@@ -1210,8 +1210,8 @@ class TestLocalFileStorage(unittest.TestCase):
         set_local_storage_setup_state_exception("")
         storage_abs_path = _get_storage_directory(DUMMY_INSTRUMENTATION_KEY)
 
-        # os.open with O_NOFOLLOW raises OSError (ELOOP) when path is a symlink
-        symlink_error = OSError(errno.ELOOP, "Too many levels of symbolic links")
+        # os.open with O_NOFOLLOW raises OSError (ELOOP) when path is a symlink  # cspell:disable-line
+        symlink_error = OSError(errno.ELOOP, "Too many levels of symbolic links")  # cspell:disable-line
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):
@@ -1228,7 +1228,7 @@ class TestLocalFileStorage(unittest.TestCase):
 
         set_local_storage_setup_state_exception("")
 
-    def test_attack_scenario_file_race_condition_oexcl(self):
+    def test_attack_scenario_file_race_condition_oexcl(self):  # cspell:disable-line
         """
         Simulates O_EXCL protection: if an attacker manages to pre-create a
         .tmp file at the exact path our blob will use, os.open with O_EXCL

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_storage.py
@@ -637,7 +637,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch("os.open", return_value=99):
                     with mock.patch("os.fstat", return_value=mock_stat_result):
                         with mock.patch("os.getuid", create=True, return_value=1000):
-                            with mock.patch("os.fchmod", create=True, side_effect=OSError(test_error_message)):  # cspell:disable-line
+                            with mock.patch(
+                                "os.fchmod", create=True, side_effect=OSError(test_error_message)  # cspell:disable-line
+                            ):
                                 with mock.patch("os.close"):
                                     stor = LocalFileStorage(os.path.join(TEST_FOLDER, "chmod_failure_test"))
 
@@ -972,7 +974,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):  # cspell:disable-line
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod  # cspell:disable-line
+                            ):
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1042,7 +1046,7 @@ class TestLocalFileStorage(unittest.TestCase):
 
         with mock.patch(f"{STORAGE_MODULE}.os.name", "posix"):
 
-            def mock_fchmod(fd, mode):  # cspell:disable-line 
+            def mock_fchmod(fd, mode):  # cspell:disable-line
                 raise PermissionError(test_error_message)
 
             mock_stat_result = mock.MagicMock()
@@ -1052,7 +1056,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod):  # cspell:disable-line
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True, side_effect=mock_fchmod  # cspell:disable-line
+                            ):
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1084,7 +1090,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True  # cspell:disable-line
+                            ) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1111,7 +1119,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True  # cspell:disable-line
+                            ) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1139,7 +1149,9 @@ class TestLocalFileStorage(unittest.TestCase):
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
                         with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=4242):
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True  # cspell:disable-line
+                            ) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1174,8 +1186,12 @@ class TestLocalFileStorage(unittest.TestCase):
             with mock.patch(f"{STORAGE_MODULE}.os.makedirs"):  # dir already exists
                 with mock.patch(f"{STORAGE_MODULE}.os.open", return_value=99):
                     with mock.patch(f"{STORAGE_MODULE}.os.fstat", return_value=mock_stat_result):
-                        with mock.patch(f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000):  # legitimate user
-                            with mock.patch(f"{STORAGE_MODULE}.os.fchmod", create=True) as mock_fchmod:  # cspell:disable-line
+                        with mock.patch(
+                            f"{STORAGE_MODULE}.os.getuid", create=True, return_value=1000
+                        ):  # legitimate user
+                            with mock.patch(
+                                f"{STORAGE_MODULE}.os.fchmod", create=True  # cspell:disable-line
+                            ) as mock_fchmod:  # cspell:disable-line
                                 with mock.patch(f"{STORAGE_MODULE}.os.close"):
                                     with mock.patch(f"{STORAGE_MODULE}.os.path.abspath", side_effect=lambda path: path):
                                         stor = LocalFileStorage(storage_abs_path)
@@ -1252,7 +1268,9 @@ class TestLocalFileStorage(unittest.TestCase):
                                         self.assertTrue(stor._enabled)
 
                                         # Now simulate the attack: attacker pre-created the .tmp file
-                                        with mock.patch(f"{STORAGE_MODULE}.os.open", side_effect=FileExistsError("File exists")):
+                                        with mock.patch(
+                                            f"{STORAGE_MODULE}.os.open", side_effect=FileExistsError("File exists")
+                                        ):
                                             result = stor.put([{"secret": "credential_data"}])
                                             # put() must fail — data must NOT be written
                                             self.assertIsInstance(result, str)


### PR DESCRIPTION
# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
