### PR TITLE
Fix geojson.Geometry import in alternate-type baseline _patch.py

### DIFF
--- a/eng/tools/emitter/gen/azure/azure-client-generator-core-alternate-type/specs/azure/clientgenerator/core/alternatetype/models/_patch.py
+++ b/eng/tools/emitter/gen/azure/azure-client-generator-core-alternate-type/specs/azure/clientgenerator/core/alternatetype/models/_patch.py
@@ -10,6 +10,7 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 
 from typing import Type
 import geojson
+from geojson.geometry import Geometry
 from .._utils.model_base import TYPE_HANDLER_REGISTRY
 
 
@@ -41,7 +42,7 @@ def feature_deserializer(cls: Type[geojson.Feature], data: dict) -> geojson.Feat
     """
     return cls(
         type=data.get("type"),
-        geometry=geojson.geometry.Geometry(
+        geometry=Geometry(
             type=data["geometry"].get("type"), coordinates=data["geometry"].get("coordinates")
         ),
         properties=data.get("properties"),


### PR DESCRIPTION
The baseline customization at `eng/tools/emitter/gen/azure/azure-client-generator-core-alternate-type/specs/azure/clientgenerator/core/alternatetype/models/_patch.py` referenced `geojson.geometry.Geometry`, but `geojson` lacks type info, so pyright cannot resolve the `geometry` submodule attribute at the top level (`reportAttributeAccessIssue`).

Fix: import `Geometry` explicitly via `from geojson.geometry import Geometry` and call `Geometry(...)` directly. This unblocks pyright in downstream consumers (e.g. http-client-python tests) that copy this baseline via `resetBaselineFromSdkRepo()`.