### PR TITLE
[Identity] Add suppression comments

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -94,7 +94,7 @@ _Cert = NamedTuple("_Cert", [("pem_bytes", bytes), ("private_key", "Any"), ("fin
 def load_pem_certificate(certificate_data: bytes, password: Optional[bytes] = None) -> _Cert:
     private_key = serialization.load_pem_private_key(certificate_data, password, backend=default_backend())
     cert = x509.load_pem_x509_certificate(certificate_data, default_backend())
-    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
+    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec # CodeQL [SM02167] only used as a thumbprint/identifier
     return _Cert(certificate_data, private_key, fingerprint)
 
 
@@ -120,7 +120,7 @@ def load_pkcs12_certificate(certificate_data: bytes, password: Optional[bytes] =
     pem_sections = [key_bytes] + [c.public_bytes(Encoding.PEM) for c in [cert] + additional_certs]
     pem_bytes = b"".join(pem_sections)
 
-    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
+    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec # CodeQL [SM02167] only used as a thumbprint/identifier
 
     return _Cert(pem_bytes, private_key, fingerprint)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aadclient_certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aadclient_certificate.py
@@ -25,7 +25,7 @@ class AadClientCertificate:
         self._private_key = private_key
 
         cert = x509.load_pem_x509_certificate(pem_bytes, default_backend())
-        fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
+        fingerprint = cert.fingerprint(hashes.SHA1())  # nosec # CodeQL [SM02167] only used as a thumbprint/identifier
         sha256_fingerprint = cert.fingerprint(hashes.SHA256())
         self._thumbprint = base64.urlsafe_b64encode(fingerprint).decode("utf-8")
         self._sha256_thumbprint = base64.urlsafe_b64encode(sha256_fingerprint).decode("utf-8")


### PR DESCRIPTION
Some CodeQL comments were added for SHA1 lines. This is still needed for backwards compatibility and for certain scenarios like ADFS. SHA1 is only used for certificate thumbprints and is not considered a security vulnerability. In most cases, SHA256 would be used in any case.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/46198