### PR TITLE
Don't require `approval` on publish phase of namereserve pipeline

### DIFF
--- a/eng/pipelines/templates/stages/publish-namereserve-package.yml
+++ b/eng/pipelines/templates/stages/publish-namereserve-package.yml
@@ -40,7 +40,7 @@ extends:
       jobs:
         - deployment: PublishPackage
           displayName: "Publish to PyPI"
-          environment: package-publish
+          environment: none
 
           variables:
             PUBLISHDIRECTORY: "$(Pipeline.Workspace)/esrp-release/"


### PR DESCRIPTION
If we've gotten there, we intend it.