### PR TITLE
[breaking change tool] fix crash

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -119,6 +119,36 @@ class BreakingChangesTracker:
         self.check_parameter_ordering()  # not part of diff
         self.run_post_processing()
 
+    def is_client(self, module_name: Any, class_name: Any) -> bool:
+        """Determine whether a class should be treated as a client.
+
+        For non management-plane SDKs (module namespace does not start with
+        ``azure.mgmt.``) any class whose name ends with ``Client`` is treated
+        as a client.
+
+        For management-plane SDKs the class name must end with ``Client`` AND
+        its ``__init__`` must accept a parameter named ``credential``. This
+        avoids misclassifying helper classes such as ``ARMPollingClient`` or
+        similar that happen to end with ``Client``.
+        """
+        if isinstance(class_name, jsondiff.Symbol) or not isinstance(class_name, str):
+            return False
+        if not class_name.endswith("Client"):
+            return False
+        if not isinstance(module_name, str) or not module_name.startswith("azure.mgmt."):
+            return True
+        # Management-plane SDK: also require a "credential" parameter in __init__.
+        # The class definition may live in either the stable or current snapshot
+        # depending on whether the class is being added, removed, or modified.
+        for source in (self.current, self.stable):
+            class_info = source.get(module_name, {}).get("class_nodes", {}).get(class_name)
+            if not class_info:
+                continue
+            init_method = class_info.get("methods", {}).get("__init__", {})
+            if isinstance(init_method, dict) and "credential" in init_method.get("parameters", {}):
+                return True
+        return False
+
     def run_post_processing(self) -> None:
         # Remove duplicate reporting of changes that apply to both sync and async package components
         self.run_async_cleanup(self.breaking_changes)
@@ -581,7 +611,7 @@ class BreakingChangesTracker:
 
         for property in deleted_props:
             bc = None
-            if self._class_name.endswith("Client"):
+            if self.is_client(self._module_name, self._class_name):
                 property_type = self.stable[self._module_name]["class_nodes"][self._class_name]["properties"][property]["attr_type"]
                 # property_type is not always a string, such as client_side_validation which is a bool, so we need to check for strings
                 if property_type is not None and isinstance(property_type, str) and property_type.lower().endswith("operations"):
@@ -622,7 +652,7 @@ class BreakingChangesTracker:
                 deleted_classes = self.stable[self._module_name]["class_nodes"]
 
             for name in deleted_classes:
-                if name.endswith("Client"):
+                if self.is_client(self._module_name, name):
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT,
@@ -649,7 +679,7 @@ class BreakingChangesTracker:
                 methods_deleted = stable_methods_node
 
             for method in methods_deleted:
-                if self._class_name.endswith("Client"):
+                if self.is_client(self._module_name, self._class_name):
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_METHOD_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT_METHOD,

--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -34,40 +34,62 @@ class BreakingChangeType(str, Enum):
 
 
 class BreakingChangesTracker:
-    REMOVED_OR_RENAMED_CLIENT_MSG = "Deleted or renamed client `{}`"
-    REMOVED_OR_RENAMED_CLIENT_METHOD_MSG = "Deleted or renamed client method `{}.{}`"
-    REMOVED_OR_RENAMED_CLASS_MSG = "Deleted or renamed model `{}`"
-    REMOVED_OR_RENAMED_CLASS_METHOD_MSG = "Deleted or renamed method `{}.{}`"
-    REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = "Deleted or renamed function `{}`"
-    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = (
+    REMOVED_OR_RENAMED_CLIENT_MSG = \
+        "Deleted or renamed client `{}`"
+    REMOVED_OR_RENAMED_CLIENT_METHOD_MSG = \
+        "Deleted or renamed client method `{}.{}`"
+    REMOVED_OR_RENAMED_CLASS_MSG = \
+        "Deleted or renamed model `{}`"
+    REMOVED_OR_RENAMED_CLASS_METHOD_MSG = \
+        "Deleted or renamed method `{}.{}`"
+    REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = \
+        "Deleted or renamed function `{}`"
+    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = \
         "Method `{}.{}` deleted or renamed its parameter `{}` of kind `{}`"
-    )
-    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = (
+    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = \
         "Function `{}` deleted or renamed its parameter `{}` of kind `{}`"
-    )
-    ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = "Method `{}.{}` inserted a `{}` parameter `{}`"
-    ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = "Function `{}` inserted a `{}` parameter `{}`"
-    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = "Client `{}` deleted or renamed instance variable `{}`"
-    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = "Model `{}` deleted or renamed its instance variable `{}`"
-    REMOVED_OR_RENAMED_ENUM_VALUE_MSG = "Deleted or renamed enum value `{}.{}`"
-    CHANGED_PARAMETER_DEFAULT_VALUE_MSG = "Method `{}.{}` parameter `{}` changed default value from `{}` to `{}`"
-    CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = (
+    ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = \
+        "Method `{}.{}` inserted a `{}` parameter `{}`"
+    ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = \
+        "Function `{}` inserted a `{}` parameter `{}`"
+    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = \
+        "Client `{}` deleted or renamed instance variable `{}`"
+    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = \
+        "Model `{}` deleted or renamed its instance variable `{}`"
+    REMOVED_OR_RENAMED_ENUM_VALUE_MSG = \
+        "Deleted or renamed enum value `{}.{}`"
+    CHANGED_PARAMETER_DEFAULT_VALUE_MSG = \
+        "Method `{}.{}` parameter `{}` changed default value from `{}` to `{}`"
+    CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
         "Function `{}` parameter `{}` changed default value from `{}` to `{}`"
-    )
-    REMOVED_PARAMETER_DEFAULT_VALUE_MSG = "Method `{}.{}` removed default value `{}` from its parameter `{}`"
-    REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = "Function `{}` removed default value `{}` from its parameter `{}`"
-    CHANGED_PARAMETER_ORDERING_MSG = "Method `{}.{}` re-ordered its parameters from `{}` to `{}`"
-    CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = "Function `{}` re-ordered its parameters from `{}` to `{}`"
-    CHANGED_PARAMETER_KIND_MSG = "Method `{}.{}` changed its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = "Function `{}` changed its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_TYPE_MSG = "Method `{}.{}` changed type of its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG = "Function `{}` changed type of its parameter `{}` from `{}` to `{}`"
-    CHANGED_CLASS_FUNCTION_KIND_MSG = "Method `{}.{}` changed from `{}` to `{}`"
-    CHANGED_FUNCTION_KIND_MSG = "Changed function `{}` from `{}` to `{}`"
-    REMOVED_OR_RENAMED_MODULE_MSG = "Deleted or renamed module `{}`"
-    REMOVED_CLASS_FUNCTION_KWARGS_MSG = "Method `{}.{}` changed from accepting keyword arguments to not accepting them"
-    REMOVED_FUNCTION_KWARGS_MSG = "Function `{}` changed from accepting keyword arguments to not accepting them"
-    REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = "Deleted or renamed client operation group `{}.{}`"
+    REMOVED_PARAMETER_DEFAULT_VALUE_MSG = \
+        "Method `{}.{}` removed default value `{}` from its parameter `{}`"
+    REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
+        "Function `{}` removed default value `{}` from its parameter `{}`"
+    CHANGED_PARAMETER_ORDERING_MSG = \
+        "Method `{}.{}` re-ordered its parameters from `{}` to `{}`"
+    CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = \
+        "Function `{}` re-ordered its parameters from `{}` to `{}`"
+    CHANGED_PARAMETER_KIND_MSG = \
+        "Method `{}.{}` changed its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = \
+        "Function `{}` changed its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_TYPE_MSG = \
+        "Method `{}.{}` changed type of its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG = \
+        "Function `{}` changed type of its parameter `{}` from `{}` to `{}`"
+    CHANGED_CLASS_FUNCTION_KIND_MSG = \
+        "Method `{}.{}` changed from `{}` to `{}`"
+    CHANGED_FUNCTION_KIND_MSG = \
+        "Changed function `{}` from `{}` to `{}`"
+    REMOVED_OR_RENAMED_MODULE_MSG = \
+        "Deleted or renamed module `{}`"
+    REMOVED_CLASS_FUNCTION_KWARGS_MSG = \
+        "Method `{}.{}` changed from accepting keyword arguments to not accepting them"
+    REMOVED_FUNCTION_KWARGS_MSG = \
+        "Function `{}` changed from accepting keyword arguments to not accepting them"
+    REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = \
+        "Deleted or renamed client operation group `{}.{}`"
 
     def __init__(self, stable: Dict, current: Dict, package_name: str, **kwargs: Any) -> None:
         self.stable = stable
@@ -133,15 +155,12 @@ class BreakingChangesTracker:
         # Run user-defined post-processing checks
         for checker in self.post_processing_checkers:
             bc_list, fa_list = checker.run_check(
-                self.breaking_changes,
-                self.features_added,
-                diff=self.diff,
-                stable_nodes=self.stable,
-                current_nodes=self.current,
+                self.breaking_changes, self.features_added,
+                diff=self.diff, stable_nodes=self.stable, current_nodes=self.current
             )
             self.breaking_changes = bc_list
             self.features_added = fa_list
-
+        
     # Remove duplicate reporting of changes that apply to both sync and async package components
     def run_async_cleanup(self, changes_list: List) -> None:
         def _make_hashable(item):
@@ -165,7 +184,10 @@ class BreakingChangesTracker:
             if "aio" not in bc[2]:
                 non_aio_keys.add(_make_key(bc))
         # Keep only non-aio changes and aio changes that don't have a sync counterpart
-        changes_list[:] = [bc for bc in changes_list if "aio" not in bc[2] or _make_key(bc) not in non_aio_keys]
+        changes_list[:] = [
+            bc for bc in changes_list
+            if "aio" not in bc[2] or _make_key(bc) not in non_aio_keys
+        ]
 
     def run_breaking_change_diff_checks(self) -> None:
         for module_name, module in self.diff.items():
@@ -195,14 +217,7 @@ class BreakingChangesTracker:
                 for module_name, module_components in self.diff.items():
                     # If the module_name is a symbol, we'll skip it since we can't run class checks on it
                     if not isinstance(module_name, jsondiff.Symbol):
-                        changes_list.extend(
-                            checker.run_check(
-                                module_components.get("class_nodes", {}),
-                                self.stable,
-                                self.current,
-                                module_name=module_name,
-                            )
-                        )
+                        changes_list.extend(checker.run_check(module_components.get("class_nodes", {}), self.stable, self.current, module_name=module_name))
                         continue
             if checker.node_type == "function_or_method":
                 # If we are running a function or method checker, we need to run it on all functions and class methods in each module in the diff
@@ -212,24 +227,10 @@ class BreakingChangesTracker:
                         for class_name, class_components in module_components.get("class_nodes", {}).items():
                             # If the class_name is a symbol, we'll skip it since we can't run method checks on it
                             if not isinstance(class_name, jsondiff.Symbol):
-                                changes_list.extend(
-                                    checker.run_check(
-                                        class_components.get("methods", {}),
-                                        self.stable,
-                                        self.current,
-                                        module_name=module_name,
-                                        class_name=class_name,
-                                    )
-                                )
+                                changes_list.extend(checker.run_check(class_components.get("methods", {}), self.stable, self.current, module_name=module_name, class_name=class_name))
                                 continue
-                        changes_list.extend(
-                            checker.run_check(
-                                module_components.get("function_nodes", {}),
-                                self.stable,
-                                self.current,
-                                module_name=module_name,
-                            )
-                        )
+                        changes_list.extend(checker.run_check(module_components.get("function_nodes", {}), self.stable, self.current, module_name=module_name))
+
 
     def run_class_level_diff_checks(self, module: Dict) -> None:
         for class_name, class_components in module.get("class_nodes", {}).items():
@@ -247,9 +248,8 @@ class BreakingChangesTracker:
                 self._function_name = method_name
                 stable_methods_node = stable_class_nodes[self._class_name]["methods"]
                 current_methods_node = self.current[self._module_name]["class_nodes"][self._class_name]["methods"]
-                if self._function_name not in stable_methods_node and not isinstance(
-                    self._function_name, jsondiff.Symbol
-                ):
+                if self._function_name not in stable_methods_node and \
+                        not isinstance(self._function_name, jsondiff.Symbol):
                     continue  # this is a new method/additive change in current version so skip checks
 
                 method_deleted = self.check_class_method_removed_or_renamed(method_components, stable_methods_node)
@@ -271,9 +271,8 @@ class BreakingChangesTracker:
         for function_name, function_components in module.get("function_nodes", {}).items():
             self._function_name = function_name
             stable_function_nodes = self.stable[self._module_name]["function_nodes"]
-            if self._function_name not in stable_function_nodes and not isinstance(
-                self._function_name, jsondiff.Symbol
-            ):
+            if self._function_name not in stable_function_nodes and \
+                    not isinstance(self._function_name, jsondiff.Symbol):
                 continue  # this is a new function/additive change in current version so skip checks
 
             function_deleted = self.check_module_level_function_removed_or_renamed(function_components)
@@ -283,13 +282,17 @@ class BreakingChangesTracker:
             self.check_function_type_changed(function_components)
 
             stable_parameters_node = stable_function_nodes[self._function_name]["parameters"]
-            current_parameters_node = self.current[self._module_name]["function_nodes"][self._function_name][
-                "parameters"
-            ]
-            self.run_parameter_level_diff_checks(function_components, stable_parameters_node, current_parameters_node)
+            current_parameters_node = self.current[self._module_name]["function_nodes"][self._function_name]["parameters"]
+            self.run_parameter_level_diff_checks(
+                function_components,
+                stable_parameters_node,
+                current_parameters_node
+            )
 
     def run_parameter_level_diff_checks(
-        self, function_components: Dict, stable_parameters_node: Dict, current_parameters_node: Dict
+        self, function_components: Dict,
+        stable_parameters_node: Dict,
+        current_parameters_node: Dict
     ) -> None:
         for param_name, diff in function_components.get("parameters", {}).items():
             self._parameter_name = param_name
@@ -303,20 +306,33 @@ class BreakingChangesTracker:
                         diff_type,
                         stable_parameters_node,
                     )
-                    self.check_kwargs_removed(stable_parameters_node[diff_type]["param_type"], diff_type)
+                    self.check_kwargs_removed(
+                        stable_parameters_node[diff_type]["param_type"],
+                        diff_type
+                    )
                 elif self._parameter_name not in stable_parameters_node:
-                    self.check_positional_parameter_added(current_parameters_node[param_name])
+                    self.check_positional_parameter_added(
+                        current_parameters_node[param_name]
+                    )
                     break
                 elif diff_type == "default":
                     stable_default = stable_parameters_node[self._parameter_name]["default"]
-                    self.check_parameter_default_value_changed_or_added(diff[diff_type], stable_default)
-                    self.check_parameter_default_value_removed(diff[diff_type], stable_default)
+                    self.check_parameter_default_value_changed_or_added(
+                        diff[diff_type], stable_default
+                    )
+                    self.check_parameter_default_value_removed(
+                        diff[diff_type], stable_default
+                    )
                 elif diff_type == "param_type":
                     # Check if the parameter kind (positional vs keyword) has changed
-                    self.check_parameter_type_changed(diff["param_type"], stable_parameters_node)
+                    self.check_parameter_type_changed(
+                        diff["param_type"], stable_parameters_node
+                    )
                 elif diff_type == "type":
                     # Check if the parameter type annotation has changed
-                    self.check_parameter_annotation_type_changed(diff["type"], stable_parameters_node)
+                    self.check_parameter_annotation_type_changed(
+                        diff["type"], stable_parameters_node
+                    )
 
     def check_kwargs_removed(self, param_type: str, param_name: str) -> None:
         if param_type == "var_keyword" and param_name == "kwargs":
@@ -324,16 +340,13 @@ class BreakingChangesTracker:
                 bc = (
                     self.REMOVED_CLASS_FUNCTION_KWARGS_MSG,
                     BreakingChangeType.REMOVED_FUNCTION_KWARGS,
-                    self._module_name,
-                    self._class_name,
-                    self._function_name,
+                    self._module_name, self._class_name, self._function_name
                 )
             else:
                 bc = (
                     self.REMOVED_FUNCTION_KWARGS_MSG,
                     BreakingChangeType.REMOVED_FUNCTION_KWARGS,
-                    self._module_name,
-                    self._function_name,
+                    self._module_name, self._function_name
                 )
             self.breaking_changes.append(bc)
 
@@ -346,13 +359,21 @@ class BreakingChangesTracker:
                 deleted_modules = self.stable
 
             for name in deleted_modules:
-                bc = (self.REMOVED_OR_RENAMED_MODULE_MSG, BreakingChangeType.REMOVED_OR_RENAMED_MODULE, name)
+                bc = (
+                    self.REMOVED_OR_RENAMED_MODULE_MSG,
+                    BreakingChangeType.REMOVED_OR_RENAMED_MODULE,
+                    name
+                )
                 self.breaking_changes.append(bc)
             return True
 
     def check_all_parameters_deleted(self, stable_parameters_node: Dict) -> Union[bool, None]:
         if isinstance(self._parameter_name, jsondiff.Symbol) and self._parameter_name.label == "replace":
-            self.check_positional_parameter_removed_or_renamed("positional_or_keyword", None, stable_parameters_node)
+            self.check_positional_parameter_removed_or_renamed(
+                "positional_or_keyword",
+                None,
+                stable_parameters_node
+            )
             return True
 
     def check_function_type_changed(self, function_components: Dict) -> None:
@@ -367,24 +388,15 @@ class BreakingChangesTracker:
             if self._class_name:
                 self.breaking_changes.append(
                     (
-                        self.CHANGED_CLASS_FUNCTION_KIND_MSG,
-                        BreakingChangeType.CHANGED_FUNCTION_KIND,
-                        self._module_name,
-                        self._class_name,
-                        self._function_name,
-                        original,
-                        change,
+                        self.CHANGED_CLASS_FUNCTION_KIND_MSG, BreakingChangeType.CHANGED_FUNCTION_KIND,
+                        self._module_name, self._class_name, self._function_name, original, change
                     )
                 )
             else:
                 self.breaking_changes.append(
                     (
-                        self.CHANGED_FUNCTION_KIND_MSG,
-                        BreakingChangeType.CHANGED_FUNCTION_KIND,
-                        self._module_name,
-                        self._function_name,
-                        original,
-                        change,
+                        self.CHANGED_FUNCTION_KIND_MSG, BreakingChangeType.CHANGED_FUNCTION_KIND,
+                        self._module_name, self._function_name, original, change
                     )
                 )
 
@@ -392,26 +404,17 @@ class BreakingChangesTracker:
         if self._class_name:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_KIND_MSG,
-                    BreakingChangeType.CHANGED_PARAMETER_KIND,
-                    self._module_name,
-                    self._class_name,
-                    self._function_name,
-                    self._parameter_name,
-                    stable_parameters_node[self._parameter_name]["param_type"],
-                    diff,
+                    self.CHANGED_PARAMETER_KIND_MSG, BreakingChangeType.CHANGED_PARAMETER_KIND,
+                    self._module_name, self._class_name, self._function_name, self._parameter_name,
+                    stable_parameters_node[self._parameter_name]["param_type"], diff
                 )
             )
         else:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG,
-                    BreakingChangeType.CHANGED_PARAMETER_KIND,
-                    self._module_name,
-                    self._function_name,
-                    self._parameter_name,
-                    stable_parameters_node[self._parameter_name]["param_type"],
-                    diff,
+                    self.CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG, BreakingChangeType.CHANGED_PARAMETER_KIND,
+                    self._module_name, self._function_name, self._parameter_name,
+                    stable_parameters_node[self._parameter_name]["param_type"], diff
                 )
             )
 
@@ -425,26 +428,17 @@ class BreakingChangesTracker:
         if self._class_name:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_TYPE_MSG,
-                    BreakingChangeType.CHANGED_PARAMETER_TYPE,
-                    self._module_name,
-                    self._class_name,
-                    self._function_name,
-                    self._parameter_name,
-                    display_stable,
-                    display_current,
+                    self.CHANGED_PARAMETER_TYPE_MSG, BreakingChangeType.CHANGED_PARAMETER_TYPE,
+                    self._module_name, self._class_name, self._function_name, self._parameter_name,
+                    display_stable, display_current
                 )
             )
         else:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG,
-                    BreakingChangeType.CHANGED_PARAMETER_TYPE,
-                    self._module_name,
-                    self._function_name,
-                    self._parameter_name,
-                    display_stable,
-                    display_current,
+                    self.CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG, BreakingChangeType.CHANGED_PARAMETER_TYPE,
+                    self._module_name, self._function_name, self._parameter_name,
+                    display_stable, display_current
                 )
             )
 
@@ -472,11 +466,7 @@ class BreakingChangesTracker:
                                     (
                                         self.CHANGED_PARAMETER_ORDERING_MSG,
                                         BreakingChangeType.CHANGED_PARAMETER_ORDERING,
-                                        module,
-                                        cls,
-                                        method,
-                                        list(stable_params),
-                                        list(current_params),
+                                        module, cls, method, list(stable_params), list(current_params)
                                     )
                                 )
                                 break
@@ -496,16 +486,14 @@ class BreakingChangesTracker:
                                 (
                                     self.CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG,
                                     BreakingChangeType.CHANGED_PARAMETER_ORDERING,
-                                    module,
-                                    func,
-                                    list(stable_params),
-                                    list(current_params),
+                                    module, func, list(stable_params), list(current_params)
                                 )
                             )
                             break
 
     def check_parameter_default_value_removed(
-        self, default: Union[str, None], stable_default: Union[str, None]
+        self, default: Union[str, None],
+        stable_default: Union[str, None]
     ) -> None:
         if stable_default is not None and default is None:
             if self._class_name:
@@ -513,11 +501,8 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_PARAMETER_DEFAULT_VALUE_MSG,
                         BreakingChangeType.REMOVED_PARAMETER_DEFAULT_VALUE,
-                        self._module_name,
-                        self._class_name,
-                        self._function_name,
-                        default,
-                        self._parameter_name,
+                        self._module_name, self._class_name, self._function_name,
+                        default, self._parameter_name
                     )
                 )
             else:
@@ -526,15 +511,13 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG,
                         BreakingChangeType.REMOVED_PARAMETER_DEFAULT_VALUE,
-                        self._module_name,
-                        self._function_name,
-                        default,
-                        self._parameter_name,
+                        self._module_name, self._function_name, default, self._parameter_name
                     )
                 )
 
     def check_parameter_default_value_changed_or_added(
-        self, default: Union[str, None], stable_default: Union[str, None]
+        self, default: Union[str, None],
+        stable_default: Union[str, None]
     ) -> None:
         if default is not None:  # a default was added in the current version
             if default != stable_default:
@@ -546,12 +529,8 @@ class BreakingChangesTracker:
                             (
                                 self.CHANGED_PARAMETER_DEFAULT_VALUE_MSG,
                                 BreakingChangeType.CHANGED_PARAMETER_DEFAULT_VALUE,
-                                self._module_name,
-                                self._class_name,
-                                self._function_name,
-                                self._parameter_name,
-                                stable_default,
-                                default,
+                                self._module_name, self._class_name, self._function_name,
+                                self._parameter_name, stable_default, default
                             )
                         )
                     else:
@@ -559,45 +538,35 @@ class BreakingChangesTracker:
                             (
                                 self.CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG,
                                 BreakingChangeType.CHANGED_PARAMETER_DEFAULT_VALUE,
-                                self._module_name,
-                                self._function_name,
-                                self._parameter_name,
-                                stable_default,
-                                default,
+                                self._module_name, self._function_name,
+                                self._parameter_name, stable_default, default
                             )
                         )
 
     def check_positional_parameter_added(self, current_parameters_node: Dict) -> None:
-        if (
-            current_parameters_node["param_type"] == "positional_or_keyword"
-            and current_parameters_node["default"] != "none"
-        ):
+        if current_parameters_node["param_type"] == "positional_or_keyword" and \
+                current_parameters_node["default"] != "none":
             if self._class_name:
                 self.breaking_changes.append(
                     (
-                        self.ADDED_POSITIONAL_PARAM_TO_METHOD_MSG,
-                        BreakingChangeType.ADDED_POSITIONAL_PARAM,
-                        self._module_name,
-                        self._class_name,
-                        self._function_name,
-                        current_parameters_node["param_type"],
-                        self._parameter_name,
+                        self.ADDED_POSITIONAL_PARAM_TO_METHOD_MSG, BreakingChangeType.ADDED_POSITIONAL_PARAM,
+                        self._module_name, self._class_name, self._function_name,
+                        current_parameters_node["param_type"], self._parameter_name
                     )
                 )
             else:
                 self.breaking_changes.append(
                     (
-                        self.ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG,
-                        BreakingChangeType.ADDED_POSITIONAL_PARAM,
-                        self._module_name,
-                        self._function_name,
-                        current_parameters_node["param_type"],
-                        self._parameter_name,
+                        self.ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG, BreakingChangeType.ADDED_POSITIONAL_PARAM,
+                        self._module_name, self._function_name,
+                        current_parameters_node["param_type"], self._parameter_name
                     )
                 )
 
     def check_positional_parameter_removed_or_renamed(
-        self, param_type: str, deleted: str, stable_parameters_node: Dict
+        self, param_type: str,
+        deleted: str,
+        stable_parameters_node: Dict
     ) -> None:
         if param_type != "positional_or_keyword":
             return
@@ -607,7 +576,8 @@ class BreakingChangesTracker:
         elif self._parameter_name.label == "replace":  # replace means all positional parameters were removed
             deleted_params = {
                 param_name: details
-                for param_name, details in stable_parameters_node.items()
+                for param_name, details
+                in stable_parameters_node.items()
                 if details["param_type"] == "positional_or_keyword"
             }
 
@@ -618,11 +588,7 @@ class BreakingChangesTracker:
                         (
                             self.REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG,
                             BreakingChangeType.REMOVED_OR_RENAMED_POSITIONAL_PARAM,
-                            self._module_name,
-                            self._class_name,
-                            self._function_name,
-                            deleted,
-                            param_type,
+                            self._module_name, self._class_name, self._function_name, deleted, param_type
                         )
                     )
                 else:
@@ -630,10 +596,7 @@ class BreakingChangesTracker:
                         (
                             self.REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG,
                             BreakingChangeType.REMOVED_OR_RENAMED_POSITIONAL_PARAM,
-                            self._module_name,
-                            self._function_name,
-                            deleted,
-                            param_type,
+                            self._module_name, self._function_name, deleted, param_type
                         )
                     )
 
@@ -649,51 +612,33 @@ class BreakingChangesTracker:
         for property in deleted_props:
             bc = None
             if self.is_client(self._module_name, self._class_name):
-                property_type = self.stable[self._module_name]["class_nodes"][self._class_name]["properties"][property][
-                    "attr_type"
-                ]
+                property_type = self.stable[self._module_name]["class_nodes"][self._class_name]["properties"][property]["attr_type"]
                 # property_type is not always a string, such as client_side_validation which is a bool, so we need to check for strings
-                if (
-                    property_type is not None
-                    and isinstance(property_type, str)
-                    and property_type.lower().endswith("operations")
-                ):
-                    bc = (
-                        self.REMOVED_OR_RENAMED_OPERATION_GROUP_MSG,
-                        BreakingChangeType.REMOVED_OR_RENAMED_OPERATION_GROUP,
-                        self._module_name,
-                        self._class_name,
-                        property,
-                    )
+                if property_type is not None and isinstance(property_type, str) and property_type.lower().endswith("operations"):
+                        bc = (
+                            self.REMOVED_OR_RENAMED_OPERATION_GROUP_MSG,
+                            BreakingChangeType.REMOVED_OR_RENAMED_OPERATION_GROUP,
+                            self._module_name, self._class_name, property
+                        )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE,
-                        self._module_name,
-                        self._class_name,
-                        property,
+                        self._module_name, self._class_name, property
                     )
             elif self.stable[self._module_name]["class_nodes"][self._class_name]["type"] == "Enum":
-                if (
-                    property.upper()
-                    not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]
-                    and property.lower()
-                    not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]
-                ):
+                if property.upper() not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"] \
+                    and property.lower() not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]:
                     bc = (
                         self.REMOVED_OR_RENAMED_ENUM_VALUE_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_ENUM_VALUE,
-                        self._module_name,
-                        self._class_name,
-                        property,
+                        self._module_name, self._class_name, property
                     )
             else:
                 bc = (
                     self.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG,
                     BreakingChangeType.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE,
-                    self._module_name,
-                    self._class_name,
-                    property,
+                    self._module_name, self._class_name, property
                 )
             if bc:
                 self.breaking_changes.append(bc)
@@ -711,21 +656,20 @@ class BreakingChangesTracker:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT,
-                        self._module_name,
-                        name,
+                        self._module_name, name
                     )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLASS_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLASS,
-                        self._module_name,
-                        name,
+                        self._module_name, name
                     )
                 self.breaking_changes.append(bc)
             return True
 
     def check_class_method_removed_or_renamed(
-        self, method_components: Dict, stable_methods_node: Dict
+        self, method_components: Dict,
+        stable_methods_node: Dict
     ) -> Union[bool, None]:
         if isinstance(self._function_name, jsondiff.Symbol):
             methods_deleted = []
@@ -739,17 +683,13 @@ class BreakingChangesTracker:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_METHOD_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT_METHOD,
-                        self._module_name,
-                        self._class_name,
-                        method,
+                        self._module_name, self._class_name, method
                     )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLASS_METHOD_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLASS_METHOD,
-                        self._module_name,
-                        self._class_name,
-                        method,
+                        self._module_name, self._class_name, method
                     )
                 self.breaking_changes.append(bc)
             return True
@@ -767,8 +707,7 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION,
-                        self._module_name,
-                        function,
+                        self._module_name, function
                     )
                 )
             return True
@@ -843,9 +782,8 @@ class BreakingChangesTracker:
             # For simple breaking changes reporting, prepend the change code to the message
             msg = f"({bc_type}): " + msg + "\n"
             formatted += msg.format(*args)
-
+        
         formatted += f"\nFound {len(self.breaking_changes)} breaking changes.\n"
-        formatted += (
-            "\nSee aka.ms/azsdk/breaking-changes-tool to resolve " "any reported breaking changes or false positives.\n"
-        )
+        formatted += "\nSee aka.ms/azsdk/breaking-changes-tool to resolve " \
+                     "any reported breaking changes or false positives.\n"
         return formatted

--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -34,62 +34,40 @@ class BreakingChangeType(str, Enum):
 
 
 class BreakingChangesTracker:
-    REMOVED_OR_RENAMED_CLIENT_MSG = \
-        "Deleted or renamed client `{}`"
-    REMOVED_OR_RENAMED_CLIENT_METHOD_MSG = \
-        "Deleted or renamed client method `{}.{}`"
-    REMOVED_OR_RENAMED_CLASS_MSG = \
-        "Deleted or renamed model `{}`"
-    REMOVED_OR_RENAMED_CLASS_METHOD_MSG = \
-        "Deleted or renamed method `{}.{}`"
-    REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = \
-        "Deleted or renamed function `{}`"
-    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = \
+    REMOVED_OR_RENAMED_CLIENT_MSG = "Deleted or renamed client `{}`"
+    REMOVED_OR_RENAMED_CLIENT_METHOD_MSG = "Deleted or renamed client method `{}.{}`"
+    REMOVED_OR_RENAMED_CLASS_MSG = "Deleted or renamed model `{}`"
+    REMOVED_OR_RENAMED_CLASS_METHOD_MSG = "Deleted or renamed method `{}.{}`"
+    REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = "Deleted or renamed function `{}`"
+    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = (
         "Method `{}.{}` deleted or renamed its parameter `{}` of kind `{}`"
-    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = \
+    )
+    REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = (
         "Function `{}` deleted or renamed its parameter `{}` of kind `{}`"
-    ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = \
-        "Method `{}.{}` inserted a `{}` parameter `{}`"
-    ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = \
-        "Function `{}` inserted a `{}` parameter `{}`"
-    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = \
-        "Client `{}` deleted or renamed instance variable `{}`"
-    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = \
-        "Model `{}` deleted or renamed its instance variable `{}`"
-    REMOVED_OR_RENAMED_ENUM_VALUE_MSG = \
-        "Deleted or renamed enum value `{}.{}`"
-    CHANGED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "Method `{}.{}` parameter `{}` changed default value from `{}` to `{}`"
-    CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
+    )
+    ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = "Method `{}.{}` inserted a `{}` parameter `{}`"
+    ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = "Function `{}` inserted a `{}` parameter `{}`"
+    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = "Client `{}` deleted or renamed instance variable `{}`"
+    REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = "Model `{}` deleted or renamed its instance variable `{}`"
+    REMOVED_OR_RENAMED_ENUM_VALUE_MSG = "Deleted or renamed enum value `{}.{}`"
+    CHANGED_PARAMETER_DEFAULT_VALUE_MSG = "Method `{}.{}` parameter `{}` changed default value from `{}` to `{}`"
+    CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = (
         "Function `{}` parameter `{}` changed default value from `{}` to `{}`"
-    REMOVED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "Method `{}.{}` removed default value `{}` from its parameter `{}`"
-    REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
-        "Function `{}` removed default value `{}` from its parameter `{}`"
-    CHANGED_PARAMETER_ORDERING_MSG = \
-        "Method `{}.{}` re-ordered its parameters from `{}` to `{}`"
-    CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = \
-        "Function `{}` re-ordered its parameters from `{}` to `{}`"
-    CHANGED_PARAMETER_KIND_MSG = \
-        "Method `{}.{}` changed its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = \
-        "Function `{}` changed its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_TYPE_MSG = \
-        "Method `{}.{}` changed type of its parameter `{}` from `{}` to `{}`"
-    CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG = \
-        "Function `{}` changed type of its parameter `{}` from `{}` to `{}`"
-    CHANGED_CLASS_FUNCTION_KIND_MSG = \
-        "Method `{}.{}` changed from `{}` to `{}`"
-    CHANGED_FUNCTION_KIND_MSG = \
-        "Changed function `{}` from `{}` to `{}`"
-    REMOVED_OR_RENAMED_MODULE_MSG = \
-        "Deleted or renamed module `{}`"
-    REMOVED_CLASS_FUNCTION_KWARGS_MSG = \
-        "Method `{}.{}` changed from accepting keyword arguments to not accepting them"
-    REMOVED_FUNCTION_KWARGS_MSG = \
-        "Function `{}` changed from accepting keyword arguments to not accepting them"
-    REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = \
-        "Deleted or renamed client operation group `{}.{}`"
+    )
+    REMOVED_PARAMETER_DEFAULT_VALUE_MSG = "Method `{}.{}` removed default value `{}` from its parameter `{}`"
+    REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = "Function `{}` removed default value `{}` from its parameter `{}`"
+    CHANGED_PARAMETER_ORDERING_MSG = "Method `{}.{}` re-ordered its parameters from `{}` to `{}`"
+    CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = "Function `{}` re-ordered its parameters from `{}` to `{}`"
+    CHANGED_PARAMETER_KIND_MSG = "Method `{}.{}` changed its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = "Function `{}` changed its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_TYPE_MSG = "Method `{}.{}` changed type of its parameter `{}` from `{}` to `{}`"
+    CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG = "Function `{}` changed type of its parameter `{}` from `{}` to `{}`"
+    CHANGED_CLASS_FUNCTION_KIND_MSG = "Method `{}.{}` changed from `{}` to `{}`"
+    CHANGED_FUNCTION_KIND_MSG = "Changed function `{}` from `{}` to `{}`"
+    REMOVED_OR_RENAMED_MODULE_MSG = "Deleted or renamed module `{}`"
+    REMOVED_CLASS_FUNCTION_KWARGS_MSG = "Method `{}.{}` changed from accepting keyword arguments to not accepting them"
+    REMOVED_FUNCTION_KWARGS_MSG = "Function `{}` changed from accepting keyword arguments to not accepting them"
+    REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = "Deleted or renamed client operation group `{}.{}`"
 
     def __init__(self, stable: Dict, current: Dict, package_name: str, **kwargs: Any) -> None:
         self.stable = stable
@@ -155,12 +133,15 @@ class BreakingChangesTracker:
         # Run user-defined post-processing checks
         for checker in self.post_processing_checkers:
             bc_list, fa_list = checker.run_check(
-                self.breaking_changes, self.features_added,
-                diff=self.diff, stable_nodes=self.stable, current_nodes=self.current
+                self.breaking_changes,
+                self.features_added,
+                diff=self.diff,
+                stable_nodes=self.stable,
+                current_nodes=self.current,
             )
             self.breaking_changes = bc_list
             self.features_added = fa_list
-        
+
     # Remove duplicate reporting of changes that apply to both sync and async package components
     def run_async_cleanup(self, changes_list: List) -> None:
         def _make_hashable(item):
@@ -184,10 +165,7 @@ class BreakingChangesTracker:
             if "aio" not in bc[2]:
                 non_aio_keys.add(_make_key(bc))
         # Keep only non-aio changes and aio changes that don't have a sync counterpart
-        changes_list[:] = [
-            bc for bc in changes_list
-            if "aio" not in bc[2] or _make_key(bc) not in non_aio_keys
-        ]
+        changes_list[:] = [bc for bc in changes_list if "aio" not in bc[2] or _make_key(bc) not in non_aio_keys]
 
     def run_breaking_change_diff_checks(self) -> None:
         for module_name, module in self.diff.items():
@@ -217,7 +195,14 @@ class BreakingChangesTracker:
                 for module_name, module_components in self.diff.items():
                     # If the module_name is a symbol, we'll skip it since we can't run class checks on it
                     if not isinstance(module_name, jsondiff.Symbol):
-                        changes_list.extend(checker.run_check(module_components.get("class_nodes", {}), self.stable, self.current, module_name=module_name))
+                        changes_list.extend(
+                            checker.run_check(
+                                module_components.get("class_nodes", {}),
+                                self.stable,
+                                self.current,
+                                module_name=module_name,
+                            )
+                        )
                         continue
             if checker.node_type == "function_or_method":
                 # If we are running a function or method checker, we need to run it on all functions and class methods in each module in the diff
@@ -227,10 +212,24 @@ class BreakingChangesTracker:
                         for class_name, class_components in module_components.get("class_nodes", {}).items():
                             # If the class_name is a symbol, we'll skip it since we can't run method checks on it
                             if not isinstance(class_name, jsondiff.Symbol):
-                                changes_list.extend(checker.run_check(class_components.get("methods", {}), self.stable, self.current, module_name=module_name, class_name=class_name))
+                                changes_list.extend(
+                                    checker.run_check(
+                                        class_components.get("methods", {}),
+                                        self.stable,
+                                        self.current,
+                                        module_name=module_name,
+                                        class_name=class_name,
+                                    )
+                                )
                                 continue
-                        changes_list.extend(checker.run_check(module_components.get("function_nodes", {}), self.stable, self.current, module_name=module_name))
-
+                        changes_list.extend(
+                            checker.run_check(
+                                module_components.get("function_nodes", {}),
+                                self.stable,
+                                self.current,
+                                module_name=module_name,
+                            )
+                        )
 
     def run_class_level_diff_checks(self, module: Dict) -> None:
         for class_name, class_components in module.get("class_nodes", {}).items():
@@ -248,8 +247,9 @@ class BreakingChangesTracker:
                 self._function_name = method_name
                 stable_methods_node = stable_class_nodes[self._class_name]["methods"]
                 current_methods_node = self.current[self._module_name]["class_nodes"][self._class_name]["methods"]
-                if self._function_name not in stable_methods_node and \
-                        not isinstance(self._function_name, jsondiff.Symbol):
+                if self._function_name not in stable_methods_node and not isinstance(
+                    self._function_name, jsondiff.Symbol
+                ):
                     continue  # this is a new method/additive change in current version so skip checks
 
                 method_deleted = self.check_class_method_removed_or_renamed(method_components, stable_methods_node)
@@ -271,8 +271,9 @@ class BreakingChangesTracker:
         for function_name, function_components in module.get("function_nodes", {}).items():
             self._function_name = function_name
             stable_function_nodes = self.stable[self._module_name]["function_nodes"]
-            if self._function_name not in stable_function_nodes and \
-                    not isinstance(self._function_name, jsondiff.Symbol):
+            if self._function_name not in stable_function_nodes and not isinstance(
+                self._function_name, jsondiff.Symbol
+            ):
                 continue  # this is a new function/additive change in current version so skip checks
 
             function_deleted = self.check_module_level_function_removed_or_renamed(function_components)
@@ -282,17 +283,13 @@ class BreakingChangesTracker:
             self.check_function_type_changed(function_components)
 
             stable_parameters_node = stable_function_nodes[self._function_name]["parameters"]
-            current_parameters_node = self.current[self._module_name]["function_nodes"][self._function_name]["parameters"]
-            self.run_parameter_level_diff_checks(
-                function_components,
-                stable_parameters_node,
-                current_parameters_node
-            )
+            current_parameters_node = self.current[self._module_name]["function_nodes"][self._function_name][
+                "parameters"
+            ]
+            self.run_parameter_level_diff_checks(function_components, stable_parameters_node, current_parameters_node)
 
     def run_parameter_level_diff_checks(
-        self, function_components: Dict,
-        stable_parameters_node: Dict,
-        current_parameters_node: Dict
+        self, function_components: Dict, stable_parameters_node: Dict, current_parameters_node: Dict
     ) -> None:
         for param_name, diff in function_components.get("parameters", {}).items():
             self._parameter_name = param_name
@@ -306,33 +303,20 @@ class BreakingChangesTracker:
                         diff_type,
                         stable_parameters_node,
                     )
-                    self.check_kwargs_removed(
-                        stable_parameters_node[diff_type]["param_type"],
-                        diff_type
-                    )
+                    self.check_kwargs_removed(stable_parameters_node[diff_type]["param_type"], diff_type)
                 elif self._parameter_name not in stable_parameters_node:
-                    self.check_positional_parameter_added(
-                        current_parameters_node[param_name]
-                    )
+                    self.check_positional_parameter_added(current_parameters_node[param_name])
                     break
                 elif diff_type == "default":
                     stable_default = stable_parameters_node[self._parameter_name]["default"]
-                    self.check_parameter_default_value_changed_or_added(
-                        diff[diff_type], stable_default
-                    )
-                    self.check_parameter_default_value_removed(
-                        diff[diff_type], stable_default
-                    )
+                    self.check_parameter_default_value_changed_or_added(diff[diff_type], stable_default)
+                    self.check_parameter_default_value_removed(diff[diff_type], stable_default)
                 elif diff_type == "param_type":
                     # Check if the parameter kind (positional vs keyword) has changed
-                    self.check_parameter_type_changed(
-                        diff["param_type"], stable_parameters_node
-                    )
+                    self.check_parameter_type_changed(diff["param_type"], stable_parameters_node)
                 elif diff_type == "type":
                     # Check if the parameter type annotation has changed
-                    self.check_parameter_annotation_type_changed(
-                        diff["type"], stable_parameters_node
-                    )
+                    self.check_parameter_annotation_type_changed(diff["type"], stable_parameters_node)
 
     def check_kwargs_removed(self, param_type: str, param_name: str) -> None:
         if param_type == "var_keyword" and param_name == "kwargs":
@@ -340,13 +324,16 @@ class BreakingChangesTracker:
                 bc = (
                     self.REMOVED_CLASS_FUNCTION_KWARGS_MSG,
                     BreakingChangeType.REMOVED_FUNCTION_KWARGS,
-                    self._module_name, self._class_name, self._function_name
+                    self._module_name,
+                    self._class_name,
+                    self._function_name,
                 )
             else:
                 bc = (
                     self.REMOVED_FUNCTION_KWARGS_MSG,
                     BreakingChangeType.REMOVED_FUNCTION_KWARGS,
-                    self._module_name, self._function_name
+                    self._module_name,
+                    self._function_name,
                 )
             self.breaking_changes.append(bc)
 
@@ -359,21 +346,13 @@ class BreakingChangesTracker:
                 deleted_modules = self.stable
 
             for name in deleted_modules:
-                bc = (
-                    self.REMOVED_OR_RENAMED_MODULE_MSG,
-                    BreakingChangeType.REMOVED_OR_RENAMED_MODULE,
-                    name
-                )
+                bc = (self.REMOVED_OR_RENAMED_MODULE_MSG, BreakingChangeType.REMOVED_OR_RENAMED_MODULE, name)
                 self.breaking_changes.append(bc)
             return True
 
     def check_all_parameters_deleted(self, stable_parameters_node: Dict) -> Union[bool, None]:
         if isinstance(self._parameter_name, jsondiff.Symbol) and self._parameter_name.label == "replace":
-            self.check_positional_parameter_removed_or_renamed(
-                "positional_or_keyword",
-                None,
-                stable_parameters_node
-            )
+            self.check_positional_parameter_removed_or_renamed("positional_or_keyword", None, stable_parameters_node)
             return True
 
     def check_function_type_changed(self, function_components: Dict) -> None:
@@ -388,15 +367,24 @@ class BreakingChangesTracker:
             if self._class_name:
                 self.breaking_changes.append(
                     (
-                        self.CHANGED_CLASS_FUNCTION_KIND_MSG, BreakingChangeType.CHANGED_FUNCTION_KIND,
-                        self._module_name, self._class_name, self._function_name, original, change
+                        self.CHANGED_CLASS_FUNCTION_KIND_MSG,
+                        BreakingChangeType.CHANGED_FUNCTION_KIND,
+                        self._module_name,
+                        self._class_name,
+                        self._function_name,
+                        original,
+                        change,
                     )
                 )
             else:
                 self.breaking_changes.append(
                     (
-                        self.CHANGED_FUNCTION_KIND_MSG, BreakingChangeType.CHANGED_FUNCTION_KIND,
-                        self._module_name, self._function_name, original, change
+                        self.CHANGED_FUNCTION_KIND_MSG,
+                        BreakingChangeType.CHANGED_FUNCTION_KIND,
+                        self._module_name,
+                        self._function_name,
+                        original,
+                        change,
                     )
                 )
 
@@ -404,17 +392,26 @@ class BreakingChangesTracker:
         if self._class_name:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_KIND_MSG, BreakingChangeType.CHANGED_PARAMETER_KIND,
-                    self._module_name, self._class_name, self._function_name, self._parameter_name,
-                    stable_parameters_node[self._parameter_name]["param_type"], diff
+                    self.CHANGED_PARAMETER_KIND_MSG,
+                    BreakingChangeType.CHANGED_PARAMETER_KIND,
+                    self._module_name,
+                    self._class_name,
+                    self._function_name,
+                    self._parameter_name,
+                    stable_parameters_node[self._parameter_name]["param_type"],
+                    diff,
                 )
             )
         else:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG, BreakingChangeType.CHANGED_PARAMETER_KIND,
-                    self._module_name, self._function_name, self._parameter_name,
-                    stable_parameters_node[self._parameter_name]["param_type"], diff
+                    self.CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG,
+                    BreakingChangeType.CHANGED_PARAMETER_KIND,
+                    self._module_name,
+                    self._function_name,
+                    self._parameter_name,
+                    stable_parameters_node[self._parameter_name]["param_type"],
+                    diff,
                 )
             )
 
@@ -428,17 +425,26 @@ class BreakingChangesTracker:
         if self._class_name:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_TYPE_MSG, BreakingChangeType.CHANGED_PARAMETER_TYPE,
-                    self._module_name, self._class_name, self._function_name, self._parameter_name,
-                    display_stable, display_current
+                    self.CHANGED_PARAMETER_TYPE_MSG,
+                    BreakingChangeType.CHANGED_PARAMETER_TYPE,
+                    self._module_name,
+                    self._class_name,
+                    self._function_name,
+                    self._parameter_name,
+                    display_stable,
+                    display_current,
                 )
             )
         else:
             self.breaking_changes.append(
                 (
-                    self.CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG, BreakingChangeType.CHANGED_PARAMETER_TYPE,
-                    self._module_name, self._function_name, self._parameter_name,
-                    display_stable, display_current
+                    self.CHANGED_PARAMETER_TYPE_OF_FUNCTION_MSG,
+                    BreakingChangeType.CHANGED_PARAMETER_TYPE,
+                    self._module_name,
+                    self._function_name,
+                    self._parameter_name,
+                    display_stable,
+                    display_current,
                 )
             )
 
@@ -466,7 +472,11 @@ class BreakingChangesTracker:
                                     (
                                         self.CHANGED_PARAMETER_ORDERING_MSG,
                                         BreakingChangeType.CHANGED_PARAMETER_ORDERING,
-                                        module, cls, method, list(stable_params), list(current_params)
+                                        module,
+                                        cls,
+                                        method,
+                                        list(stable_params),
+                                        list(current_params),
                                     )
                                 )
                                 break
@@ -486,14 +496,16 @@ class BreakingChangesTracker:
                                 (
                                     self.CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG,
                                     BreakingChangeType.CHANGED_PARAMETER_ORDERING,
-                                    module, func, list(stable_params), list(current_params)
+                                    module,
+                                    func,
+                                    list(stable_params),
+                                    list(current_params),
                                 )
                             )
                             break
 
     def check_parameter_default_value_removed(
-        self, default: Union[str, None],
-        stable_default: Union[str, None]
+        self, default: Union[str, None], stable_default: Union[str, None]
     ) -> None:
         if stable_default is not None and default is None:
             if self._class_name:
@@ -501,8 +513,11 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_PARAMETER_DEFAULT_VALUE_MSG,
                         BreakingChangeType.REMOVED_PARAMETER_DEFAULT_VALUE,
-                        self._module_name, self._class_name, self._function_name,
-                        default, self._parameter_name
+                        self._module_name,
+                        self._class_name,
+                        self._function_name,
+                        default,
+                        self._parameter_name,
                     )
                 )
             else:
@@ -511,13 +526,15 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG,
                         BreakingChangeType.REMOVED_PARAMETER_DEFAULT_VALUE,
-                        self._module_name, self._function_name, default, self._parameter_name
+                        self._module_name,
+                        self._function_name,
+                        default,
+                        self._parameter_name,
                     )
                 )
 
     def check_parameter_default_value_changed_or_added(
-        self, default: Union[str, None],
-        stable_default: Union[str, None]
+        self, default: Union[str, None], stable_default: Union[str, None]
     ) -> None:
         if default is not None:  # a default was added in the current version
             if default != stable_default:
@@ -529,8 +546,12 @@ class BreakingChangesTracker:
                             (
                                 self.CHANGED_PARAMETER_DEFAULT_VALUE_MSG,
                                 BreakingChangeType.CHANGED_PARAMETER_DEFAULT_VALUE,
-                                self._module_name, self._class_name, self._function_name,
-                                self._parameter_name, stable_default, default
+                                self._module_name,
+                                self._class_name,
+                                self._function_name,
+                                self._parameter_name,
+                                stable_default,
+                                default,
                             )
                         )
                     else:
@@ -538,35 +559,45 @@ class BreakingChangesTracker:
                             (
                                 self.CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG,
                                 BreakingChangeType.CHANGED_PARAMETER_DEFAULT_VALUE,
-                                self._module_name, self._function_name,
-                                self._parameter_name, stable_default, default
+                                self._module_name,
+                                self._function_name,
+                                self._parameter_name,
+                                stable_default,
+                                default,
                             )
                         )
 
     def check_positional_parameter_added(self, current_parameters_node: Dict) -> None:
-        if current_parameters_node["param_type"] == "positional_or_keyword" and \
-                current_parameters_node["default"] != "none":
+        if (
+            current_parameters_node["param_type"] == "positional_or_keyword"
+            and current_parameters_node["default"] != "none"
+        ):
             if self._class_name:
                 self.breaking_changes.append(
                     (
-                        self.ADDED_POSITIONAL_PARAM_TO_METHOD_MSG, BreakingChangeType.ADDED_POSITIONAL_PARAM,
-                        self._module_name, self._class_name, self._function_name,
-                        current_parameters_node["param_type"], self._parameter_name
+                        self.ADDED_POSITIONAL_PARAM_TO_METHOD_MSG,
+                        BreakingChangeType.ADDED_POSITIONAL_PARAM,
+                        self._module_name,
+                        self._class_name,
+                        self._function_name,
+                        current_parameters_node["param_type"],
+                        self._parameter_name,
                     )
                 )
             else:
                 self.breaking_changes.append(
                     (
-                        self.ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG, BreakingChangeType.ADDED_POSITIONAL_PARAM,
-                        self._module_name, self._function_name,
-                        current_parameters_node["param_type"], self._parameter_name
+                        self.ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG,
+                        BreakingChangeType.ADDED_POSITIONAL_PARAM,
+                        self._module_name,
+                        self._function_name,
+                        current_parameters_node["param_type"],
+                        self._parameter_name,
                     )
                 )
 
     def check_positional_parameter_removed_or_renamed(
-        self, param_type: str,
-        deleted: str,
-        stable_parameters_node: Dict
+        self, param_type: str, deleted: str, stable_parameters_node: Dict
     ) -> None:
         if param_type != "positional_or_keyword":
             return
@@ -576,8 +607,7 @@ class BreakingChangesTracker:
         elif self._parameter_name.label == "replace":  # replace means all positional parameters were removed
             deleted_params = {
                 param_name: details
-                for param_name, details
-                in stable_parameters_node.items()
+                for param_name, details in stable_parameters_node.items()
                 if details["param_type"] == "positional_or_keyword"
             }
 
@@ -588,7 +618,11 @@ class BreakingChangesTracker:
                         (
                             self.REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG,
                             BreakingChangeType.REMOVED_OR_RENAMED_POSITIONAL_PARAM,
-                            self._module_name, self._class_name, self._function_name, deleted, param_type
+                            self._module_name,
+                            self._class_name,
+                            self._function_name,
+                            deleted,
+                            param_type,
                         )
                     )
                 else:
@@ -596,7 +630,10 @@ class BreakingChangesTracker:
                         (
                             self.REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG,
                             BreakingChangeType.REMOVED_OR_RENAMED_POSITIONAL_PARAM,
-                            self._module_name, self._function_name, deleted, param_type
+                            self._module_name,
+                            self._function_name,
+                            deleted,
+                            param_type,
                         )
                     )
 
@@ -612,33 +649,51 @@ class BreakingChangesTracker:
         for property in deleted_props:
             bc = None
             if self.is_client(self._module_name, self._class_name):
-                property_type = self.stable[self._module_name]["class_nodes"][self._class_name]["properties"][property]["attr_type"]
+                property_type = self.stable[self._module_name]["class_nodes"][self._class_name]["properties"][property][
+                    "attr_type"
+                ]
                 # property_type is not always a string, such as client_side_validation which is a bool, so we need to check for strings
-                if property_type is not None and isinstance(property_type, str) and property_type.lower().endswith("operations"):
-                        bc = (
-                            self.REMOVED_OR_RENAMED_OPERATION_GROUP_MSG,
-                            BreakingChangeType.REMOVED_OR_RENAMED_OPERATION_GROUP,
-                            self._module_name, self._class_name, property
-                        )
+                if (
+                    property_type is not None
+                    and isinstance(property_type, str)
+                    and property_type.lower().endswith("operations")
+                ):
+                    bc = (
+                        self.REMOVED_OR_RENAMED_OPERATION_GROUP_MSG,
+                        BreakingChangeType.REMOVED_OR_RENAMED_OPERATION_GROUP,
+                        self._module_name,
+                        self._class_name,
+                        property,
+                    )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE,
-                        self._module_name, self._class_name, property
+                        self._module_name,
+                        self._class_name,
+                        property,
                     )
             elif self.stable[self._module_name]["class_nodes"][self._class_name]["type"] == "Enum":
-                if property.upper() not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"] \
-                    and property.lower() not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]:
+                if (
+                    property.upper()
+                    not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]
+                    and property.lower()
+                    not in self.current[self._module_name]["class_nodes"][self._class_name]["properties"]
+                ):
                     bc = (
                         self.REMOVED_OR_RENAMED_ENUM_VALUE_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_ENUM_VALUE,
-                        self._module_name, self._class_name, property
+                        self._module_name,
+                        self._class_name,
+                        property,
                     )
             else:
                 bc = (
                     self.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG,
                     BreakingChangeType.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE,
-                    self._module_name, self._class_name, property
+                    self._module_name,
+                    self._class_name,
+                    property,
                 )
             if bc:
                 self.breaking_changes.append(bc)
@@ -656,20 +711,21 @@ class BreakingChangesTracker:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT,
-                        self._module_name, name
+                        self._module_name,
+                        name,
                     )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLASS_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLASS,
-                        self._module_name, name
+                        self._module_name,
+                        name,
                     )
                 self.breaking_changes.append(bc)
             return True
 
     def check_class_method_removed_or_renamed(
-        self, method_components: Dict,
-        stable_methods_node: Dict
+        self, method_components: Dict, stable_methods_node: Dict
     ) -> Union[bool, None]:
         if isinstance(self._function_name, jsondiff.Symbol):
             methods_deleted = []
@@ -683,13 +739,17 @@ class BreakingChangesTracker:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLIENT_METHOD_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLIENT_METHOD,
-                        self._module_name, self._class_name, method
+                        self._module_name,
+                        self._class_name,
+                        method,
                     )
                 else:
                     bc = (
                         self.REMOVED_OR_RENAMED_CLASS_METHOD_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_CLASS_METHOD,
-                        self._module_name, self._class_name, method
+                        self._module_name,
+                        self._class_name,
+                        method,
                     )
                 self.breaking_changes.append(bc)
             return True
@@ -707,7 +767,8 @@ class BreakingChangesTracker:
                     (
                         self.REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG,
                         BreakingChangeType.REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION,
-                        self._module_name, function
+                        self._module_name,
+                        function,
                     )
                 )
             return True
@@ -782,8 +843,9 @@ class BreakingChangesTracker:
             # For simple breaking changes reporting, prepend the change code to the message
             msg = f"({bc_type}): " + msg + "\n"
             formatted += msg.format(*args)
-        
+
         formatted += f"\nFound {len(self.breaking_changes)} breaking changes.\n"
-        formatted += "\nSee aka.ms/azsdk/breaking-changes-tool to resolve " \
-                     "any reported breaking changes or false positives.\n"
+        formatted += (
+            "\nSee aka.ms/azsdk/breaking-changes-tool to resolve " "any reported breaking changes or false positives.\n"
+        )
         return formatted

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 import jsondiff
 from breaking_changes_tracker import BreakingChangesTracker
 
+
 class ChangeType(str, Enum):
     ADDED_CLIENT = "AddedClient"
     ADDED_CLIENT_METHOD = "AddedClientMethod"
@@ -23,30 +24,19 @@ class ChangeType(str, Enum):
     ADDED_FUNCTION_PARAMETER = "AddedFunctionParameter"
     ADDED_OPERATION_GROUP = "AddedOperationGroup"
 
-class ChangelogTracker(BreakingChangesTracker):
-    ADDED_CLIENT_MSG = \
-        "Added client `{}`"
-    ADDED_CLIENT_METHOD_MSG = \
-        "Client `{}` added method `{}`"
-    ADDED_CLIENT_METHOD_PARAMETER_MSG = \
-        "Client `{}` added parameter `{}` in method `{}`"
-    ADDED_CLASS_MSG = \
-        "Added model `{}`"
-    ADDED_CLASS_METHOD_MSG = \
-        "Model `{}` added method `{}`"
-    ADDED_CLASS_METHOD_PARAMETER_MSG = \
-        "Model `{}` added parameter `{}` in method `{}`"
-    ADDED_FUNCTION_PARAMETER_MSG = \
-        "Function `{}` added parameter `{}`"
-    ADDED_CLASS_PROPERTY_MSG = \
-        "Model `{}` added property `{}`"
-    ADDED_ENUM_MSG = \
-        "Added enum `{}`"
-    ADDED_ENUM_MEMBER_MSG = \
-        "Enum `{}` added member `{}`"
-    ADDED_OPERATION_GROUP_MSG = \
-        "Client `{}` added operation group `{}`"
 
+class ChangelogTracker(BreakingChangesTracker):
+    ADDED_CLIENT_MSG = "Added client `{}`"
+    ADDED_CLIENT_METHOD_MSG = "Client `{}` added method `{}`"
+    ADDED_CLIENT_METHOD_PARAMETER_MSG = "Client `{}` added parameter `{}` in method `{}`"
+    ADDED_CLASS_MSG = "Added model `{}`"
+    ADDED_CLASS_METHOD_MSG = "Model `{}` added method `{}`"
+    ADDED_CLASS_METHOD_PARAMETER_MSG = "Model `{}` added parameter `{}` in method `{}`"
+    ADDED_FUNCTION_PARAMETER_MSG = "Function `{}` added parameter `{}`"
+    ADDED_CLASS_PROPERTY_MSG = "Model `{}` added property `{}`"
+    ADDED_ENUM_MSG = "Added enum `{}`"
+    ADDED_ENUM_MEMBER_MSG = "Enum `{}` added member `{}`"
+    ADDED_OPERATION_GROUP_MSG = "Client `{}` added operation group `{}`"
 
     def __init__(self, stable: Dict, current: Dict, package_name: str, **kwargs: Any) -> None:
         super().__init__(stable, current, package_name, **kwargs)
@@ -73,27 +63,15 @@ class ChangelogTracker(BreakingChangesTracker):
                 if self.class_name not in stable_class_nodes:
                     if self.is_client(self.module_name, self.class_name):
                         # This is a new client
-                        fa = (
-                            self.ADDED_CLIENT_MSG,
-                            ChangeType.ADDED_CLIENT,
-                            self.module_name, class_name
-                        )
+                        fa = (self.ADDED_CLIENT_MSG, ChangeType.ADDED_CLIENT, self.module_name, class_name)
                         self.features_added.append(fa)
                     elif class_components.get("type", None) == "Enum":
                         # This is a new enum
-                        fa = (
-                            self.ADDED_ENUM_MSG,
-                            ChangeType.ADDED_ENUM,
-                            self.module_name, class_name
-                        )
+                        fa = (self.ADDED_ENUM_MSG, ChangeType.ADDED_ENUM, self.module_name, class_name)
                         self.features_added.append(fa)
                     else:
                         # This is a new class
-                        fa = (
-                            self.ADDED_CLASS_MSG,
-                            ChangeType.ADDED_CLASS,
-                            self.module_name, class_name
-                        )
+                        fa = (self.ADDED_CLASS_MSG, ChangeType.ADDED_CLASS, self.module_name, class_name)
                         self.features_added.append(fa)
                 else:
                     # Check existing class for new methods
@@ -107,7 +85,9 @@ class ChangelogTracker(BreakingChangesTracker):
                                     fa = (
                                         self.ADDED_CLIENT_METHOD_MSG,
                                         ChangeType.ADDED_CLIENT_METHOD,
-                                        self.module_name, self.class_name, method_name
+                                        self.module_name,
+                                        self.class_name,
+                                        method_name,
                                     )
                                     self.features_added.append(fa)
                                 else:
@@ -115,50 +95,59 @@ class ChangelogTracker(BreakingChangesTracker):
                                     fa = (
                                         self.ADDED_CLASS_METHOD_MSG,
                                         ChangeType.ADDED_CLASS_METHOD,
-                                        self.module_name, class_name, method_name
+                                        self.module_name,
+                                        class_name,
+                                        method_name,
                                     )
                                     self.features_added.append(fa)
                             else:
                                 # Check existing methods for new parameters
                                 stable_parameters_node = stable_methods_node[self.function_name]["parameters"]
-                                current_parameters_node = self.current[self.module_name]["class_nodes"][self.class_name]["methods"][self.function_name]["parameters"]
+                                current_parameters_node = self.current[self.module_name]["class_nodes"][
+                                    self.class_name
+                                ]["methods"][self.function_name]["parameters"]
                                 for param_name, param_components in method_components.get("parameters", {}).items():
                                     self.parameter_name = param_name
-                                    if self.parameter_name not in stable_parameters_node and \
-                                            not isinstance(self.parameter_name, jsondiff.Symbol):
+                                    if self.parameter_name not in stable_parameters_node and not isinstance(
+                                        self.parameter_name, jsondiff.Symbol
+                                    ):
                                         if self.function_name == "__init__":
                                             # If this is a new class property skip reporting it here and let the class properties check handle it.
                                             # This is because we'll get multiple reports for the same new property if it's a parameter in __init__
                                             # and a class level attribute.
                                             if self.parameter_name in class_components.get("properties", {}).keys():
                                                 continue
-                                        self.check_non_positional_parameter_added(
-                                            current_parameters_node[param_name]
-                                        )
+                                        self.check_non_positional_parameter_added(current_parameters_node[param_name])
                     stable_property_node = stable_class_nodes[self.class_name]["properties"]
                     for property_name, property_components in class_components.get("properties", {}).items():
-                        if property_name not in stable_property_node and \
-                                not isinstance(property_name, jsondiff.Symbol):
+                        if property_name not in stable_property_node and not isinstance(property_name, jsondiff.Symbol):
                             fa = (
-                                    self.ADDED_CLASS_PROPERTY_MSG,
-                                    ChangeType.ADDED_CLASS_PROPERTY,
-                                    self.module_name, class_name, property_name
-                                )
+                                self.ADDED_CLASS_PROPERTY_MSG,
+                                ChangeType.ADDED_CLASS_PROPERTY,
+                                self.module_name,
+                                class_name,
+                                property_name,
+                            )
                             if self.is_client(self.module_name, self.class_name):
-                                if property_components["attr_type"] is not None and property_components["attr_type"].lower().endswith("operations"):
+                                if property_components["attr_type"] is not None and property_components[
+                                    "attr_type"
+                                ].lower().endswith("operations"):
                                     fa = (
                                         self.ADDED_OPERATION_GROUP_MSG,
                                         ChangeType.ADDED_OPERATION_GROUP,
-                                        self.module_name, self.class_name, property_name
+                                        self.module_name,
+                                        self.class_name,
+                                        property_name,
                                     )
                             if stable_class_nodes[self.class_name]["type"] == "Enum":
                                 fa = (
                                     self.ADDED_ENUM_MEMBER_MSG,
                                     ChangeType.ADDED_ENUM_MEMBER,
-                                    self.module_name, class_name, property_name
+                                    self.module_name,
+                                    class_name,
+                                    property_name,
                                 )
                             self.features_added.append(fa)
-
 
     def check_non_positional_parameter_added(self, current_parameters_node: Dict) -> None:
         if current_parameters_node["param_type"] != "positional_or_keyword":
@@ -166,37 +155,48 @@ class ChangelogTracker(BreakingChangesTracker):
                 if self.is_client(self.module_name, self.class_name):
                     self.features_added.append(
                         (
-                            self.ADDED_CLIENT_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLIENT_METHOD_PARAMETER,
-                            self.module_name, self.class_name, self.parameter_name, self.function_name
+                            self.ADDED_CLIENT_METHOD_PARAMETER_MSG,
+                            ChangeType.ADDED_CLIENT_METHOD_PARAMETER,
+                            self.module_name,
+                            self.class_name,
+                            self.parameter_name,
+                            self.function_name,
                         )
                     )
                 else:
                     self.features_added.append(
                         (
-                            self.ADDED_CLASS_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLASS_METHOD_PARAMETER,
-                            self.module_name, self.class_name, self.parameter_name, self.function_name
+                            self.ADDED_CLASS_METHOD_PARAMETER_MSG,
+                            ChangeType.ADDED_CLASS_METHOD_PARAMETER,
+                            self.module_name,
+                            self.class_name,
+                            self.parameter_name,
+                            self.function_name,
                         )
                     )
             else:
                 self.features_added.append(
                     (
-                        self.ADDED_FUNCTION_PARAMETER_MSG, ChangeType.ADDED_FUNCTION_PARAMETER,
-                        self.module_name, self.function_name, self.parameter_name
+                        self.ADDED_FUNCTION_PARAMETER_MSG,
+                        ChangeType.ADDED_FUNCTION_PARAMETER,
+                        self.module_name,
+                        self.function_name,
+                        self.parameter_name,
                     )
                 )
-
 
     def report_changes(self) -> None:
         ignore_changes = self.ignore if self.ignore else {}
         self.get_reportable_changes(ignore_changes, self.breaking_changes)
         self.get_reportable_changes(ignore_changes, self.features_added)
+
         # Code borrowed and modified from the previous change log tool
         def _build_md(content: list, title: str, buffer: list):
             buffer.append(title)
             buffer.append("")
             for _, bc in enumerate(content):
                 # Extract the message, skip the change type and the module name
-                msg, _, _,*args = bc
+                msg, _, _, *args = bc
                 buffer.append("  - " + msg.format(*args))
             buffer.append("")
             return buffer
@@ -206,7 +206,7 @@ class ChangelogTracker(BreakingChangesTracker):
             _build_md(self.features_added, "### Features Added", buffer)
         if self.breaking_changes:
             _build_md(self.breaking_changes, "### Breaking Changes", buffer)
-        content =  "\n".join(buffer).strip()
+        content = "\n".join(buffer).strip()
 
         content = "===== changelog start =====\n" + content + "\n===== changelog end =====\n"
         return content

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 import jsondiff
 from breaking_changes_tracker import BreakingChangesTracker
 
-
 class ChangeType(str, Enum):
     ADDED_CLIENT = "AddedClient"
     ADDED_CLIENT_METHOD = "AddedClientMethod"
@@ -24,19 +23,30 @@ class ChangeType(str, Enum):
     ADDED_FUNCTION_PARAMETER = "AddedFunctionParameter"
     ADDED_OPERATION_GROUP = "AddedOperationGroup"
 
-
 class ChangelogTracker(BreakingChangesTracker):
-    ADDED_CLIENT_MSG = "Added client `{}`"
-    ADDED_CLIENT_METHOD_MSG = "Client `{}` added method `{}`"
-    ADDED_CLIENT_METHOD_PARAMETER_MSG = "Client `{}` added parameter `{}` in method `{}`"
-    ADDED_CLASS_MSG = "Added model `{}`"
-    ADDED_CLASS_METHOD_MSG = "Model `{}` added method `{}`"
-    ADDED_CLASS_METHOD_PARAMETER_MSG = "Model `{}` added parameter `{}` in method `{}`"
-    ADDED_FUNCTION_PARAMETER_MSG = "Function `{}` added parameter `{}`"
-    ADDED_CLASS_PROPERTY_MSG = "Model `{}` added property `{}`"
-    ADDED_ENUM_MSG = "Added enum `{}`"
-    ADDED_ENUM_MEMBER_MSG = "Enum `{}` added member `{}`"
-    ADDED_OPERATION_GROUP_MSG = "Client `{}` added operation group `{}`"
+    ADDED_CLIENT_MSG = \
+        "Added client `{}`"
+    ADDED_CLIENT_METHOD_MSG = \
+        "Client `{}` added method `{}`"
+    ADDED_CLIENT_METHOD_PARAMETER_MSG = \
+        "Client `{}` added parameter `{}` in method `{}`"
+    ADDED_CLASS_MSG = \
+        "Added model `{}`"
+    ADDED_CLASS_METHOD_MSG = \
+        "Model `{}` added method `{}`"
+    ADDED_CLASS_METHOD_PARAMETER_MSG = \
+        "Model `{}` added parameter `{}` in method `{}`"
+    ADDED_FUNCTION_PARAMETER_MSG = \
+        "Function `{}` added parameter `{}`"
+    ADDED_CLASS_PROPERTY_MSG = \
+        "Model `{}` added property `{}`"
+    ADDED_ENUM_MSG = \
+        "Added enum `{}`"
+    ADDED_ENUM_MEMBER_MSG = \
+        "Enum `{}` added member `{}`"
+    ADDED_OPERATION_GROUP_MSG = \
+        "Client `{}` added operation group `{}`"
+
 
     def __init__(self, stable: Dict, current: Dict, package_name: str, **kwargs: Any) -> None:
         super().__init__(stable, current, package_name, **kwargs)
@@ -63,15 +73,27 @@ class ChangelogTracker(BreakingChangesTracker):
                 if self.class_name not in stable_class_nodes:
                     if self.is_client(self.module_name, self.class_name):
                         # This is a new client
-                        fa = (self.ADDED_CLIENT_MSG, ChangeType.ADDED_CLIENT, self.module_name, class_name)
+                        fa = (
+                            self.ADDED_CLIENT_MSG,
+                            ChangeType.ADDED_CLIENT,
+                            self.module_name, class_name
+                        )
                         self.features_added.append(fa)
                     elif class_components.get("type", None) == "Enum":
                         # This is a new enum
-                        fa = (self.ADDED_ENUM_MSG, ChangeType.ADDED_ENUM, self.module_name, class_name)
+                        fa = (
+                            self.ADDED_ENUM_MSG,
+                            ChangeType.ADDED_ENUM,
+                            self.module_name, class_name
+                        )
                         self.features_added.append(fa)
                     else:
                         # This is a new class
-                        fa = (self.ADDED_CLASS_MSG, ChangeType.ADDED_CLASS, self.module_name, class_name)
+                        fa = (
+                            self.ADDED_CLASS_MSG,
+                            ChangeType.ADDED_CLASS,
+                            self.module_name, class_name
+                        )
                         self.features_added.append(fa)
                 else:
                     # Check existing class for new methods
@@ -85,9 +107,7 @@ class ChangelogTracker(BreakingChangesTracker):
                                     fa = (
                                         self.ADDED_CLIENT_METHOD_MSG,
                                         ChangeType.ADDED_CLIENT_METHOD,
-                                        self.module_name,
-                                        self.class_name,
-                                        method_name,
+                                        self.module_name, self.class_name, method_name
                                     )
                                     self.features_added.append(fa)
                                 else:
@@ -95,59 +115,50 @@ class ChangelogTracker(BreakingChangesTracker):
                                     fa = (
                                         self.ADDED_CLASS_METHOD_MSG,
                                         ChangeType.ADDED_CLASS_METHOD,
-                                        self.module_name,
-                                        class_name,
-                                        method_name,
+                                        self.module_name, class_name, method_name
                                     )
                                     self.features_added.append(fa)
                             else:
                                 # Check existing methods for new parameters
                                 stable_parameters_node = stable_methods_node[self.function_name]["parameters"]
-                                current_parameters_node = self.current[self.module_name]["class_nodes"][
-                                    self.class_name
-                                ]["methods"][self.function_name]["parameters"]
+                                current_parameters_node = self.current[self.module_name]["class_nodes"][self.class_name]["methods"][self.function_name]["parameters"]
                                 for param_name, param_components in method_components.get("parameters", {}).items():
                                     self.parameter_name = param_name
-                                    if self.parameter_name not in stable_parameters_node and not isinstance(
-                                        self.parameter_name, jsondiff.Symbol
-                                    ):
+                                    if self.parameter_name not in stable_parameters_node and \
+                                            not isinstance(self.parameter_name, jsondiff.Symbol):
                                         if self.function_name == "__init__":
                                             # If this is a new class property skip reporting it here and let the class properties check handle it.
                                             # This is because we'll get multiple reports for the same new property if it's a parameter in __init__
                                             # and a class level attribute.
                                             if self.parameter_name in class_components.get("properties", {}).keys():
                                                 continue
-                                        self.check_non_positional_parameter_added(current_parameters_node[param_name])
+                                        self.check_non_positional_parameter_added(
+                                            current_parameters_node[param_name]
+                                        )
                     stable_property_node = stable_class_nodes[self.class_name]["properties"]
                     for property_name, property_components in class_components.get("properties", {}).items():
-                        if property_name not in stable_property_node and not isinstance(property_name, jsondiff.Symbol):
+                        if property_name not in stable_property_node and \
+                                not isinstance(property_name, jsondiff.Symbol):
                             fa = (
-                                self.ADDED_CLASS_PROPERTY_MSG,
-                                ChangeType.ADDED_CLASS_PROPERTY,
-                                self.module_name,
-                                class_name,
-                                property_name,
-                            )
+                                    self.ADDED_CLASS_PROPERTY_MSG,
+                                    ChangeType.ADDED_CLASS_PROPERTY,
+                                    self.module_name, class_name, property_name
+                                )
                             if self.is_client(self.module_name, self.class_name):
-                                if property_components["attr_type"] is not None and property_components[
-                                    "attr_type"
-                                ].lower().endswith("operations"):
+                                if property_components["attr_type"] is not None and property_components["attr_type"].lower().endswith("operations"):
                                     fa = (
                                         self.ADDED_OPERATION_GROUP_MSG,
                                         ChangeType.ADDED_OPERATION_GROUP,
-                                        self.module_name,
-                                        self.class_name,
-                                        property_name,
+                                        self.module_name, self.class_name, property_name
                                     )
                             if stable_class_nodes[self.class_name]["type"] == "Enum":
                                 fa = (
                                     self.ADDED_ENUM_MEMBER_MSG,
                                     ChangeType.ADDED_ENUM_MEMBER,
-                                    self.module_name,
-                                    class_name,
-                                    property_name,
+                                    self.module_name, class_name, property_name
                                 )
                             self.features_added.append(fa)
+
 
     def check_non_positional_parameter_added(self, current_parameters_node: Dict) -> None:
         if current_parameters_node["param_type"] != "positional_or_keyword":
@@ -155,48 +166,37 @@ class ChangelogTracker(BreakingChangesTracker):
                 if self.is_client(self.module_name, self.class_name):
                     self.features_added.append(
                         (
-                            self.ADDED_CLIENT_METHOD_PARAMETER_MSG,
-                            ChangeType.ADDED_CLIENT_METHOD_PARAMETER,
-                            self.module_name,
-                            self.class_name,
-                            self.parameter_name,
-                            self.function_name,
+                            self.ADDED_CLIENT_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLIENT_METHOD_PARAMETER,
+                            self.module_name, self.class_name, self.parameter_name, self.function_name
                         )
                     )
                 else:
                     self.features_added.append(
                         (
-                            self.ADDED_CLASS_METHOD_PARAMETER_MSG,
-                            ChangeType.ADDED_CLASS_METHOD_PARAMETER,
-                            self.module_name,
-                            self.class_name,
-                            self.parameter_name,
-                            self.function_name,
+                            self.ADDED_CLASS_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLASS_METHOD_PARAMETER,
+                            self.module_name, self.class_name, self.parameter_name, self.function_name
                         )
                     )
             else:
                 self.features_added.append(
                     (
-                        self.ADDED_FUNCTION_PARAMETER_MSG,
-                        ChangeType.ADDED_FUNCTION_PARAMETER,
-                        self.module_name,
-                        self.function_name,
-                        self.parameter_name,
+                        self.ADDED_FUNCTION_PARAMETER_MSG, ChangeType.ADDED_FUNCTION_PARAMETER,
+                        self.module_name, self.function_name, self.parameter_name
                     )
                 )
+
 
     def report_changes(self) -> None:
         ignore_changes = self.ignore if self.ignore else {}
         self.get_reportable_changes(ignore_changes, self.breaking_changes)
         self.get_reportable_changes(ignore_changes, self.features_added)
-
         # Code borrowed and modified from the previous change log tool
         def _build_md(content: list, title: str, buffer: list):
             buffer.append(title)
             buffer.append("")
             for _, bc in enumerate(content):
                 # Extract the message, skip the change type and the module name
-                msg, _, _, *args = bc
+                msg, _, _,*args = bc
                 buffer.append("  - " + msg.format(*args))
             buffer.append("")
             return buffer
@@ -206,7 +206,7 @@ class ChangelogTracker(BreakingChangesTracker):
             _build_md(self.features_added, "### Features Added", buffer)
         if self.breaking_changes:
             _build_md(self.breaking_changes, "### Breaking Changes", buffer)
-        content = "\n".join(buffer).strip()
+        content =  "\n".join(buffer).strip()
 
         content = "===== changelog start =====\n" + content + "\n===== changelog end =====\n"
         return content

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -68,7 +68,7 @@ class ChangelogTracker(BreakingChangesTracker):
             stable_class_nodes = self.stable[self.module_name]["class_nodes"]
             if not isinstance(class_name, jsondiff.Symbol):
                 if self.class_name not in stable_class_nodes:
-                    if self.class_name.endswith("Client"):
+                    if self.is_client(self.module_name, self.class_name):
                         # This is a new client
                         fa = (
                             self.ADDED_CLIENT_MSG,
@@ -99,7 +99,7 @@ class ChangelogTracker(BreakingChangesTracker):
                         self.function_name = method_name
                         if not isinstance(self.function_name, jsondiff.Symbol):
                             if self.function_name not in stable_methods_node:
-                                if self.class_name.endswith("Client"):
+                                if self.is_client(self.module_name, self.class_name):
                                     # This is a new client method
                                     fa = (
                                         self.ADDED_CLIENT_METHOD_MSG,
@@ -141,7 +141,7 @@ class ChangelogTracker(BreakingChangesTracker):
                                     ChangeType.ADDED_CLASS_PROPERTY,
                                     self.module_name, class_name, property_name
                                 )
-                            if self.class_name.endswith("Client"):
+                            if self.is_client(self.module_name, self.class_name):
                                 if property_components["attr_type"] is not None and property_components["attr_type"].lower().endswith("operations"):
                                     fa = (
                                         self.ADDED_OPERATION_GROUP_MSG,

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -13,6 +13,7 @@ from breaking_changes_tracker import BreakingChangesTracker
 class ChangeType(str, Enum):
     ADDED_CLIENT = "AddedClient"
     ADDED_CLIENT_METHOD = "AddedClientMethod"
+    ADDED_CLIENT_METHOD_PARAMETER = "AddedClientMethodParameter"
     ADDED_CLASS = "AddedClass"
     ADDED_CLASS_METHOD = "AddedClassMethod"
     ADDED_CLASS_METHOD_PARAMETER = "AddedClassMethodParameter"
@@ -27,6 +28,8 @@ class ChangelogTracker(BreakingChangesTracker):
         "Added client `{}`"
     ADDED_CLIENT_METHOD_MSG = \
         "Client `{}` added method `{}`"
+    ADDED_CLIENT_METHOD_PARAMETER_MSG = \
+        "Client `{}` added parameter `{}` in method `{}`"
     ADDED_CLASS_MSG = \
         "Added model `{}`"
     ADDED_CLASS_METHOD_MSG = \
@@ -160,12 +163,20 @@ class ChangelogTracker(BreakingChangesTracker):
     def check_non_positional_parameter_added(self, current_parameters_node: Dict) -> None:
         if current_parameters_node["param_type"] != "positional_or_keyword":
             if self.class_name:
-                self.features_added.append(
-                    (
-                        self.ADDED_CLASS_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLASS_METHOD_PARAMETER,
-                        self.module_name, self.class_name, self.parameter_name, self.function_name
+                if self.is_client(self.module_name, self.class_name):
+                    self.features_added.append(
+                        (
+                            self.ADDED_CLIENT_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLIENT_METHOD_PARAMETER,
+                            self.module_name, self.class_name, self.parameter_name, self.function_name
+                        )
                     )
-                )
+                else:
+                    self.features_added.append(
+                        (
+                            self.ADDED_CLASS_METHOD_PARAMETER_MSG, ChangeType.ADDED_CLASS_METHOD_PARAMETER,
+                            self.module_name, self.class_name, self.parameter_name, self.function_name
+                        )
+                    )
             else:
                 self.features_added.append(
                     (

--- a/scripts/breaking_changes_checker/tests/data/expected_apimanagement_5_6b1_changelog.txt
+++ b/scripts/breaking_changes_checker/tests/data/expected_apimanagement_5_6b1_changelog.txt
@@ -1,6 +1,6 @@
 ### Features Added
 
-  - Model `ApiManagementClient` added parameter `cloud_setting` in method `__init__`
+  - Client `ApiManagementClient` added parameter `cloud_setting` in method `__init__`
   - Client `ApiManagementClient` added method `send_request`
   - Client `ApiManagementClient` added operation group `api_tool`
   - Client `ApiManagementClient` added operation group `api_gateway_hostname_binding`

--- a/scripts/breaking_changes_checker/tests/data/expected_peering_b1_b2_changelog.txt
+++ b/scripts/breaking_changes_checker/tests/data/expected_peering_b1_b2_changelog.txt
@@ -1,6 +1,6 @@
 ### Features Added
 
-  - Model `PeeringManagementClient` added parameter `cloud_setting` in method `__init__`
+  - Client `PeeringManagementClient` added parameter `cloud_setting` in method `__init__`
   - Client `PeeringManagementClient` added method `send_request`
   - Model `CdnPeeringPrefix` added property `system_data`
   - Model `ConnectionMonitorTest` added property `system_data`

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -24,13 +24,9 @@ from breaking_changes_checker.detect_breaking_changes import test_compare_report
 
 
 def test_changelog_flag():
-    with open(
-        os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "stable.json"), "r"
-    ) as fd:
+    with open(os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "stable.json"), "r") as fd:
         stable = json.load(fd)
-    with open(
-        os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "current.json"), "r"
-    ) as fd:
+    with open(os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "current.json"), "r") as fd:
         current = json.load(fd)
 
     bc = ChangelogTracker(stable, current, "azure-ai-contentsafety")
@@ -39,8 +35,7 @@ def test_changelog_flag():
     assert len(bc.features_added) > 0
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLIENT_METHOD_MSG
-    assert args == ["azure.ai.contentsafety", "BlocklistClient", "new_blocklist_client_method"]
-
+    assert args == ['azure.ai.contentsafety', 'BlocklistClient', 'new_blocklist_client_method']
 
 def test_new_class_property_added():
     # Testing reporting on class level property added
@@ -53,8 +48,8 @@ def test_new_class_property_added():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str",
-                    },
+                        "new_class_att": "str"
+                    }
                 },
             }
         }
@@ -69,7 +64,7 @@ def test_new_class_property_added():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -81,7 +76,7 @@ def test_new_class_property_added():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
-    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att"]
+    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att']
 
 
 def test_async_cleanup_check():
@@ -94,8 +89,8 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str",
-                    },
+                        "new_class_att": "str"
+                    }
                 },
             }
         },
@@ -107,11 +102,11 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str",
-                    },
+                        "new_class_att": "str"
+                    }
                 },
             }
-        },
+        }
     }
 
     current = {
@@ -123,8 +118,8 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_property": "str",
-                    },
+                        "new_property": "str"
+                    }
                 },
             }
         },
@@ -136,11 +131,11 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_property": "str",
-                    },
+                        "new_property": "str"
+                    }
                 },
             }
-        },
+        }
     }
 
     bc = ChangelogTracker(stable, current, "azure-mgmt-contentsafety")
@@ -166,18 +161,27 @@ def test_new_class_property_added_init():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "new_class_att": {"default": None, "param_type": "keyword_only"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "new_class_att": {
+                                    "default": None,
+                                    "param_type": "keyword_only"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str",
-                    },
+                        "new_class_att": "str"
+                    }
                 },
             }
         }
@@ -191,17 +195,26 @@ def test_new_class_property_added_init():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "new_class_att": {"default": None, "param_type": "keyword_only"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "new_class_att": {
+                                    "default": None,
+                                    "param_type": "keyword_only"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -213,7 +226,7 @@ def test_new_class_property_added_init():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
-    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att"]
+    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att']
 
 
 def test_new_class_property_added_init_only():
@@ -225,17 +238,26 @@ def test_new_class_property_added_init_only():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "new_class_att": {"default": None, "param_type": "keyword_only"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "new_class_att": {
+                                    "default": None,
+                                    "param_type": "keyword_only"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -248,16 +270,22 @@ def test_new_class_property_added_init_only():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -269,7 +297,7 @@ def test_new_class_property_added_init_only():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
-    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att", "__init__"]
+    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att', '__init__']
 
 
 def test_new_class_method_parameter_added():
@@ -281,22 +309,34 @@ def test_new_class_method_parameter_added():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                         "foo": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "bar": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "bar": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             }
-                        },
+                        }
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -309,22 +349,31 @@ def test_new_class_method_parameter_added():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
-                                "kwargs": {"default": None, "param_type": "var_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
+                                "kwargs": {
+                                    "default": None,
+                                    "param_type": "var_keyword"
+                                }
                             },
-                            "is_async": False,
+                            "is_async": False
                         },
                         "foo": {
                             "parameters": {
-                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "self": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                },
                             },
-                            "is_async": False,
-                        },
+                            "is_async": False
+                        }
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    },
+                    }
                 },
             }
         }
@@ -336,7 +385,7 @@ def test_new_class_method_parameter_added():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
-    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "bar", "foo"]
+    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'bar', 'foo']
 
 
 @pytest.mark.skip(reason="We need to regenerate the code reports for these tests and update the expected results")
@@ -355,7 +404,17 @@ def test_pass_custom_reports_changelog(capsys):
 def test_added_operation_group():
     stable = {
         "azure.contoso": {
-            "class_nodes": {"ContosoClient": {"type": None, "methods": {}, "properties": {"bar": {"attr_type": "str"}}}}
+            "class_nodes": {
+                "ContosoClient": {
+                    "type": None,
+                    "methods": {},
+                    "properties": {
+                        "bar": {
+                            "attr_type": "str"
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -366,10 +425,16 @@ def test_added_operation_group():
                     "type": None,
                     "methods": {},
                     "properties": {
-                        "bar": {"attr_type": "str"},
-                        "foo": {"attr_type": "DeviceGroupsOperations"},
-                        "zip": {"attr_type": "bool"},
-                    },
+                        "bar": {
+                            "attr_type": "str"
+                        },
+                        "foo": {
+                            "attr_type": "DeviceGroupsOperations"
+                        },
+                        "zip": {
+                            "attr_type": "bool"
+                        }
+                    }
                 }
             }
         }
@@ -381,7 +446,7 @@ def test_added_operation_group():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_OPERATION_GROUP_MSG
-    assert args == ["azure.contoso", "ContosoClient", "foo"]
+    assert args == ['azure.contoso', 'ContosoClient', 'foo']
     msg, _, *args = bc.features_added[1]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
 
@@ -389,7 +454,17 @@ def test_added_operation_group():
 def test_ignore_changes():
     stable = {
         "azure.contoso": {
-            "class_nodes": {"ContosoClient": {"type": None, "methods": {}, "properties": {"bar": {"attr_type": "str"}}}}
+            "class_nodes": {
+                "ContosoClient": {
+                    "type": None,
+                    "methods": {},
+                    "properties": {
+                        "bar": {
+                            "attr_type": "str"
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -400,16 +475,24 @@ def test_ignore_changes():
                     "type": None,
                     "methods": {},
                     "properties": {
-                        "bar": {"attr_type": "str"},
-                        "foo": {"attr_type": "DeviceGroupsOperations"},
-                        "zip": {"attr_type": "bool"},
-                    },
+                        "bar": {
+                            "attr_type": "str"
+                        },
+                        "foo": {
+                            "attr_type": "DeviceGroupsOperations"
+                        },
+                        "zip": {
+                            "attr_type": "bool"
+                        }
+                    }
                 }
             }
         }
     }
 
-    IGNORE = {"azure-contoso": [("AddedOperationGroup", "*", "ContosoClient", "foo")]}
+    IGNORE = {
+        "azure-contoso": [("AddedOperationGroup", "*", "ContosoClient", "foo")]
+    }
     bc = ChangelogTracker(stable, current, "azure-contoso", ignore=IGNORE)
     bc.run_checks()
     bc.report_changes()
@@ -433,13 +516,7 @@ def test_async_features_added_cleanup():
 
     assert len(ct.features_added) == 2
     assert ct.features_added[0] == ("Message", "AddedClient", "azure.contoso", "FooClient", "foo")
-    assert ct.features_added[1] == (
-        "Message",
-        "AddedClassMethod",
-        "azure.contoso",
-        "FooClient",
-        "from_connection_string",
-    )
+    assert ct.features_added[1] == ("Message", "AddedClassMethod", "azure.contoso", "FooClient", "from_connection_string")
 
 
 def test_new_enum_added():
@@ -452,7 +529,7 @@ def test_new_enum_added():
                     "properties": {
                         "a": "a",
                         "b": "b",
-                    },
+                    }
                 },
                 "ManagerEnum": {
                     "type": "Enum",
@@ -460,7 +537,7 @@ def test_new_enum_added():
                     "properties": {
                         "foo": "foo",
                         "bar": "bar",
-                    },
+                    }
                 },
             }
         }
@@ -474,7 +551,7 @@ def test_new_enum_added():
                     "methods": {},
                     "properties": {
                         "foo": "foo",
-                    },
+                    }
                 },
             }
         }
@@ -486,10 +563,10 @@ def test_new_enum_added():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_ENUM_MEMBER_MSG
-    assert args == ["azure.contoso.widgetmanager", "ManagerEnum", "bar"]
+    assert args == ['azure.contoso.widgetmanager', 'ManagerEnum', 'bar']
     msg, _, *args = bc.features_added[1]
     assert msg == ChangelogTracker.ADDED_ENUM_MSG
-    assert args == ["azure.contoso.widgetmanager", "WidgetEnum"]
+    assert args == ['azure.contoso.widgetmanager', 'WidgetEnum']
 
 
 def test_added_overload():
@@ -500,7 +577,12 @@ def test_added_overload():
                     "properties": {},
                     "methods": {
                         "one": {
-                            "parameters": {"testing": {"default": None, "param_type": "positional_or_keyword"}},
+                            "parameters": {
+                                "testing": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                }
+                            },
                             "is_async": True,
                             "overloads": [
                                 {
@@ -508,39 +590,48 @@ def test_added_overload():
                                         "testing": {
                                             "type": "Test",
                                             "default": None,
-                                            "param_type": "positional_or_keyword",
+                                            "param_type": "positional_or_keyword"
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": "TestResult",
+                                    "return_type": "TestResult"
                                 },
                                 {
                                     "parameters": {
                                         "testing": {
                                             "type": "JSON",
                                             "default": None,
-                                            "param_type": "positional_or_keyword",
+                                            "param_type": "positional_or_keyword"
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": None,
-                                },
-                            ],
+                                    "return_type": None
+                                }
+                            ]
                         },
                         "two": {
-                            "parameters": {"testing2": {"default": None, "param_type": "positional_or_keyword"}},
+                            "parameters": {
+                                "testing2": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                }
+                            },
                             "is_async": True,
                             "overloads": [
                                 {
                                     "parameters": {
-                                        "foo": {"type": "JSON", "default": None, "param_type": "positional_or_keyword"}
+                                        "foo": {
+                                            "type": "JSON",
+                                            "default": None,
+                                            "param_type": "positional_or_keyword"
+                                        }
                                     },
                                     "is_async": True,
-                                    "return_type": None,
+                                    "return_type": None
                                 }
-                            ],
+                            ]
                         },
-                    },
+                    }
                 }
             }
         }
@@ -553,7 +644,12 @@ def test_added_overload():
                     "properties": {},
                     "methods": {
                         "one": {
-                            "parameters": {"testing": {"default": None, "param_type": "positional_or_keyword"}},
+                            "parameters": {
+                                "testing": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                }
+                            },
                             "is_async": True,
                             "overloads": [
                                 {
@@ -561,20 +657,25 @@ def test_added_overload():
                                         "testing": {
                                             "type": "JSON",
                                             "default": None,
-                                            "param_type": "positional_or_keyword",
+                                            "param_type": "positional_or_keyword"
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": None,
+                                    "return_type": None
                                 }
-                            ],
+                            ]
                         },
                         "two": {
-                            "parameters": {"testing2": {"default": None, "param_type": "positional_or_keyword"}},
+                            "parameters": {
+                                "testing2": {
+                                    "default": None,
+                                    "param_type": "positional_or_keyword"
+                                }
+                            },
                             "is_async": True,
-                            "overloads": [],
+                            "overloads": []
                         },
-                    },
+                    }
                 }
             }
         }
@@ -586,21 +687,17 @@ def test_added_overload():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == AddedMethodOverloadChecker.message["default"]
-    assert args == ["azure.contoso", "class_name", "one", "def one(testing: Test) -> TestResult"]
+    assert args == ['azure.contoso', 'class_name', 'one', 'def one(testing: Test) -> TestResult']
     msg, _, *args = bc.features_added[1]
     assert msg == AddedMethodOverloadChecker.message["default"]
-    assert args == ["azure.contoso", "class_name", "two", "def two(foo: JSON)"]
+    assert args == ['azure.contoso', 'class_name', 'two', 'def two(foo: JSON)']
 
 
 def test_compare_reports_with_absolute_paths(capsys):
     """Verify test_compare_reports accepts absolute paths for source/target reports."""
     tests_dir = os.path.dirname(__file__)
-    source_report = os.path.abspath(
-        os.path.join(tests_dir, "examples", "code-reports", "content-safety", "stable.json")
-    )
-    target_report = os.path.abspath(
-        os.path.join(tests_dir, "examples", "code-reports", "content-safety", "current.json")
-    )
+    source_report = os.path.abspath(os.path.join(tests_dir, "examples", "code-reports", "content-safety", "stable.json"))
+    target_report = os.path.abspath(os.path.join(tests_dir, "examples", "code-reports", "content-safety", "current.json"))
     pkg_dir = tests_dir  # pkg_dir must exist and is still used (e.g., for package_name and cleanup); its value is independent of using absolute report paths
 
     # Should not raise; changelog=True means no SystemExit(1) even if breaking changes exist
@@ -842,3 +939,4 @@ def test_added_keyword_only_param_to_model_method_still_reported_as_class():
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
     assert args == ["azure.contoso", "ContosoModel", "extra", "do_something"]
+

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -706,3 +706,150 @@ def test_compare_reports_with_absolute_paths(capsys):
     captured = capsys.readouterr()
     assert "===== changelog start =====" in captured.out
     assert "===== changelog end =====" in captured.out
+
+
+def _make_client_class_node(has_credential: bool):
+    init_params = {
+        "self": {"default": None, "param_type": "positional_or_keyword"},
+        "endpoint": {"default": None, "param_type": "positional_or_keyword"},
+    }
+    if has_credential:
+        init_params["credential"] = {"default": None, "param_type": "positional_or_keyword"}
+    return {
+        "type": None,
+        "methods": {
+            "__init__": {
+                "parameters": init_params,
+                "is_async": False,
+            }
+        },
+        "properties": {},
+    }
+
+
+def test_is_client_non_mgmt_sdk():
+    # For non-mgmt SDKs, any class ending with "Client" is considered a client
+    # regardless of whether __init__ has a "credential" parameter.
+    stable = {"azure.contoso": {"class_nodes": {}}}
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "ContosoClient": _make_client_class_node(has_credential=False),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-contoso")
+    assert bc.is_client("azure.contoso", "ContosoClient") is True
+
+
+def test_is_client_mgmt_sdk_with_credential():
+    # For mgmt SDKs, the class name must end with "Client" AND __init__ must
+    # accept a "credential" parameter.
+    stable = {"azure.mgmt.contoso": {"class_nodes": {}}}
+    current = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                "ContosoMgmtClient": _make_client_class_node(has_credential=True),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-mgmt-contoso")
+    assert bc.is_client("azure.mgmt.contoso", "ContosoMgmtClient") is True
+
+
+def test_is_client_mgmt_sdk_without_credential():
+    # A class in a mgmt namespace whose __init__ does not accept a "credential"
+    # parameter (e.g. ARMPollingClient) should NOT be treated as a client.
+    stable = {"azure.mgmt.contoso": {"class_nodes": {}}}
+    current = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                "ARMPollingClient": _make_client_class_node(has_credential=False),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-mgmt-contoso")
+    assert bc.is_client("azure.mgmt.contoso", "ARMPollingClient") is False
+
+
+def test_is_client_non_client_suffix():
+    # Classes whose name does not end with "Client" are never clients.
+    stable = {"azure.contoso": {"class_nodes": {}}}
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "ContosoModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-contoso")
+    assert bc.is_client("azure.contoso", "ContosoModel") is False
+
+
+def test_added_client_mgmt_sdk_with_credential_reported_as_client():
+    # Adding a mgmt client whose __init__ takes a "credential" parameter
+    # should be reported as a new client.
+    existing = {"Existing": {"type": None, "methods": {}, "properties": {}}}
+    stable = {"azure.mgmt.contoso": {"class_nodes": dict(existing)}}
+    current = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                **existing,
+                "ContosoMgmtClient": _make_client_class_node(has_credential=True),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-mgmt-contoso")
+    bc.run_checks()
+
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLIENT_MSG
+    assert args == ["azure.mgmt.contoso", "ContosoMgmtClient"]
+
+
+def test_added_client_mgmt_sdk_without_credential_reported_as_class():
+    # Adding a mgmt class ending with "Client" but lacking the "credential"
+    # parameter (e.g. ARMPollingClient) should be reported as a new model/class,
+    # NOT as a new client.
+    existing = {"Existing": {"type": None, "methods": {}, "properties": {}}}
+    stable = {"azure.mgmt.contoso": {"class_nodes": dict(existing)}}
+    current = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                **existing,
+                "ARMPollingClient": _make_client_class_node(has_credential=False),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-mgmt-contoso")
+    bc.run_checks()
+
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLASS_MSG
+    assert args == ["azure.mgmt.contoso", "ARMPollingClient"]
+
+
+def test_added_client_non_mgmt_sdk_reported_as_client():
+    # For non-mgmt SDKs, a class ending with "Client" is always reported as
+    # a new client, even if no "credential" parameter exists.
+    existing = {"Existing": {"type": None, "methods": {}, "properties": {}}}
+    stable = {"azure.contoso": {"class_nodes": dict(existing)}}
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                **existing,
+                "ContosoClient": _make_client_class_node(has_credential=False),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-contoso")
+    bc.run_checks()
+
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLIENT_MSG
+    assert args == ["azure.contoso", "ContosoClient"]
+
+

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -853,3 +853,92 @@ def test_added_client_non_mgmt_sdk_reported_as_client():
     assert args == ["azure.contoso", "ContosoClient"]
 
 
+def _make_client_with_init_kwarg(extra_kwargs=None):
+    params = {
+        "self": {"default": None, "param_type": "positional_or_keyword"},
+        "endpoint": {"default": None, "param_type": "positional_or_keyword"},
+        "credential": {"default": None, "param_type": "positional_or_keyword"},
+    }
+    if extra_kwargs:
+        params.update(extra_kwargs)
+    return {
+        "type": None,
+        "methods": {
+            "__init__": {
+                "parameters": params,
+                "is_async": False,
+            }
+        },
+        "properties": {},
+    }
+
+
+def test_added_keyword_only_param_to_mgmt_client_init_reported_as_client():
+    # Adding a keyword-only parameter to a mgmt client's __init__ should be
+    # reported using the client message, not the model/class message.
+    stable = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                "ContosoMgmtClient": _make_client_with_init_kwarg(),
+            }
+        }
+    }
+    current = {
+        "azure.mgmt.contoso": {
+            "class_nodes": {
+                "ContosoMgmtClient": _make_client_with_init_kwarg(
+                    {"cloud_setting": {"default": None, "param_type": "keyword_only"}}
+                ),
+            }
+        }
+    }
+    bc = ChangelogTracker(stable, current, "azure-mgmt-contoso")
+    bc.run_checks()
+
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLIENT_METHOD_PARAMETER_MSG
+    assert args == ["azure.mgmt.contoso", "ContosoMgmtClient", "cloud_setting", "__init__"]
+
+
+def test_added_keyword_only_param_to_model_method_still_reported_as_class():
+    # Adding a keyword-only parameter to a non-client class method should
+    # still be reported using the model/class message.
+    model_node = {
+        "type": None,
+        "methods": {
+            "do_something": {
+                "parameters": {
+                    "self": {"default": None, "param_type": "positional_or_keyword"},
+                },
+                "is_async": False,
+            }
+        },
+        "properties": {},
+    }
+    model_node_updated = {
+        "type": None,
+        "methods": {
+            "do_something": {
+                "parameters": {
+                    "self": {"default": None, "param_type": "positional_or_keyword"},
+                    "extra": {"default": None, "param_type": "keyword_only"},
+                },
+                "is_async": False,
+            }
+        },
+        "properties": {},
+    }
+    stable = {"azure.contoso": {"class_nodes": {"ContosoModel": model_node}}}
+    current = {"azure.contoso": {"class_nodes": {"ContosoModel": model_node_updated}}}
+
+    bc = ChangelogTracker(stable, current, "azure-contoso")
+    bc.run_checks()
+
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
+    assert args == ["azure.contoso", "ContosoModel", "extra", "do_something"]
+
+
+

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -24,9 +24,13 @@ from breaking_changes_checker.detect_breaking_changes import test_compare_report
 
 
 def test_changelog_flag():
-    with open(os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "stable.json"), "r") as fd:
+    with open(
+        os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "stable.json"), "r"
+    ) as fd:
         stable = json.load(fd)
-    with open(os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "current.json"), "r") as fd:
+    with open(
+        os.path.join(os.path.dirname(__file__), "examples", "code-reports", "content-safety", "current.json"), "r"
+    ) as fd:
         current = json.load(fd)
 
     bc = ChangelogTracker(stable, current, "azure-ai-contentsafety")
@@ -35,7 +39,8 @@ def test_changelog_flag():
     assert len(bc.features_added) > 0
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLIENT_METHOD_MSG
-    assert args == ['azure.ai.contentsafety', 'BlocklistClient', 'new_blocklist_client_method']
+    assert args == ["azure.ai.contentsafety", "BlocklistClient", "new_blocklist_client_method"]
+
 
 def test_new_class_property_added():
     # Testing reporting on class level property added
@@ -48,8 +53,8 @@ def test_new_class_property_added():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str"
-                    }
+                        "new_class_att": "str",
+                    },
                 },
             }
         }
@@ -64,7 +69,7 @@ def test_new_class_property_added():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -76,7 +81,7 @@ def test_new_class_property_added():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
-    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att']
+    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att"]
 
 
 def test_async_cleanup_check():
@@ -89,8 +94,8 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str"
-                    }
+                        "new_class_att": "str",
+                    },
                 },
             }
         },
@@ -102,11 +107,11 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str"
-                    }
+                        "new_class_att": "str",
+                    },
                 },
             }
-        }
+        },
     }
 
     current = {
@@ -118,8 +123,8 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_property": "str"
-                    }
+                        "new_property": "str",
+                    },
                 },
             }
         },
@@ -131,11 +136,11 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_property": "str"
-                    }
+                        "new_property": "str",
+                    },
                 },
             }
-        }
+        },
     }
 
     bc = ChangelogTracker(stable, current, "azure-mgmt-contentsafety")
@@ -161,27 +166,18 @@ def test_new_class_property_added_init():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "new_class_att": {
-                                    "default": None,
-                                    "param_type": "keyword_only"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "new_class_att": {"default": None, "param_type": "keyword_only"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                        "new_class_att": "str"
-                    }
+                        "new_class_att": "str",
+                    },
                 },
             }
         }
@@ -195,26 +191,17 @@ def test_new_class_property_added_init():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "new_class_att": {
-                                    "default": None,
-                                    "param_type": "keyword_only"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "new_class_att": {"default": None, "param_type": "keyword_only"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -226,7 +213,7 @@ def test_new_class_property_added_init():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
-    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att']
+    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att"]
 
 
 def test_new_class_property_added_init_only():
@@ -238,26 +225,17 @@ def test_new_class_property_added_init_only():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "new_class_att": {
-                                    "default": None,
-                                    "param_type": "keyword_only"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "new_class_att": {"default": None, "param_type": "keyword_only"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -270,22 +248,16 @@ def test_new_class_property_added_init_only():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -297,7 +269,7 @@ def test_new_class_property_added_init_only():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
-    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att', '__init__']
+    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "new_class_att", "__init__"]
 
 
 def test_new_class_method_parameter_added():
@@ -309,34 +281,22 @@ def test_new_class_method_parameter_added():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                         "foo": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "bar": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "bar": {"default": None, "param_type": "var_keyword"},
                             }
-                        }
+                        },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -349,31 +309,22 @@ def test_new_class_method_parameter_added():
                     "methods": {
                         "__init__": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
-                                "kwargs": {
-                                    "default": None,
-                                    "param_type": "var_keyword"
-                                }
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
+                                "kwargs": {"default": None, "param_type": "var_keyword"},
                             },
-                            "is_async": False
+                            "is_async": False,
                         },
                         "foo": {
                             "parameters": {
-                                "self": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                },
+                                "self": {"default": None, "param_type": "positional_or_keyword"},
                             },
-                            "is_async": False
-                        }
+                            "is_async": False,
+                        },
                     },
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
-                    }
+                    },
                 },
             }
         }
@@ -385,7 +336,7 @@ def test_new_class_method_parameter_added():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
-    assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'bar', 'foo']
+    assert args == ["azure.ai.contentsafety", "AnalyzeTextResult", "bar", "foo"]
 
 
 @pytest.mark.skip(reason="We need to regenerate the code reports for these tests and update the expected results")
@@ -404,17 +355,7 @@ def test_pass_custom_reports_changelog(capsys):
 def test_added_operation_group():
     stable = {
         "azure.contoso": {
-            "class_nodes": {
-                "ContosoClient": {
-                    "type": None,
-                    "methods": {},
-                    "properties": {
-                        "bar": {
-                            "attr_type": "str"
-                        }
-                    }
-                }
-            }
+            "class_nodes": {"ContosoClient": {"type": None, "methods": {}, "properties": {"bar": {"attr_type": "str"}}}}
         }
     }
 
@@ -425,16 +366,10 @@ def test_added_operation_group():
                     "type": None,
                     "methods": {},
                     "properties": {
-                        "bar": {
-                            "attr_type": "str"
-                        },
-                        "foo": {
-                            "attr_type": "DeviceGroupsOperations"
-                        },
-                        "zip": {
-                            "attr_type": "bool"
-                        }
-                    }
+                        "bar": {"attr_type": "str"},
+                        "foo": {"attr_type": "DeviceGroupsOperations"},
+                        "zip": {"attr_type": "bool"},
+                    },
                 }
             }
         }
@@ -446,7 +381,7 @@ def test_added_operation_group():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_OPERATION_GROUP_MSG
-    assert args == ['azure.contoso', 'ContosoClient', 'foo']
+    assert args == ["azure.contoso", "ContosoClient", "foo"]
     msg, _, *args = bc.features_added[1]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
 
@@ -454,17 +389,7 @@ def test_added_operation_group():
 def test_ignore_changes():
     stable = {
         "azure.contoso": {
-            "class_nodes": {
-                "ContosoClient": {
-                    "type": None,
-                    "methods": {},
-                    "properties": {
-                        "bar": {
-                            "attr_type": "str"
-                        }
-                    }
-                }
-            }
+            "class_nodes": {"ContosoClient": {"type": None, "methods": {}, "properties": {"bar": {"attr_type": "str"}}}}
         }
     }
 
@@ -475,24 +400,16 @@ def test_ignore_changes():
                     "type": None,
                     "methods": {},
                     "properties": {
-                        "bar": {
-                            "attr_type": "str"
-                        },
-                        "foo": {
-                            "attr_type": "DeviceGroupsOperations"
-                        },
-                        "zip": {
-                            "attr_type": "bool"
-                        }
-                    }
+                        "bar": {"attr_type": "str"},
+                        "foo": {"attr_type": "DeviceGroupsOperations"},
+                        "zip": {"attr_type": "bool"},
+                    },
                 }
             }
         }
     }
 
-    IGNORE = {
-        "azure-contoso": [("AddedOperationGroup", "*", "ContosoClient", "foo")]
-    }
+    IGNORE = {"azure-contoso": [("AddedOperationGroup", "*", "ContosoClient", "foo")]}
     bc = ChangelogTracker(stable, current, "azure-contoso", ignore=IGNORE)
     bc.run_checks()
     bc.report_changes()
@@ -516,7 +433,13 @@ def test_async_features_added_cleanup():
 
     assert len(ct.features_added) == 2
     assert ct.features_added[0] == ("Message", "AddedClient", "azure.contoso", "FooClient", "foo")
-    assert ct.features_added[1] == ("Message", "AddedClassMethod", "azure.contoso", "FooClient", "from_connection_string")
+    assert ct.features_added[1] == (
+        "Message",
+        "AddedClassMethod",
+        "azure.contoso",
+        "FooClient",
+        "from_connection_string",
+    )
 
 
 def test_new_enum_added():
@@ -529,7 +452,7 @@ def test_new_enum_added():
                     "properties": {
                         "a": "a",
                         "b": "b",
-                    }
+                    },
                 },
                 "ManagerEnum": {
                     "type": "Enum",
@@ -537,7 +460,7 @@ def test_new_enum_added():
                     "properties": {
                         "foo": "foo",
                         "bar": "bar",
-                    }
+                    },
                 },
             }
         }
@@ -551,7 +474,7 @@ def test_new_enum_added():
                     "methods": {},
                     "properties": {
                         "foo": "foo",
-                    }
+                    },
                 },
             }
         }
@@ -563,10 +486,10 @@ def test_new_enum_added():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_ENUM_MEMBER_MSG
-    assert args == ['azure.contoso.widgetmanager', 'ManagerEnum', 'bar']
+    assert args == ["azure.contoso.widgetmanager", "ManagerEnum", "bar"]
     msg, _, *args = bc.features_added[1]
     assert msg == ChangelogTracker.ADDED_ENUM_MSG
-    assert args == ['azure.contoso.widgetmanager', 'WidgetEnum']
+    assert args == ["azure.contoso.widgetmanager", "WidgetEnum"]
 
 
 def test_added_overload():
@@ -577,12 +500,7 @@ def test_added_overload():
                     "properties": {},
                     "methods": {
                         "one": {
-                            "parameters": {
-                                "testing": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                }
-                            },
+                            "parameters": {"testing": {"default": None, "param_type": "positional_or_keyword"}},
                             "is_async": True,
                             "overloads": [
                                 {
@@ -590,48 +508,39 @@ def test_added_overload():
                                         "testing": {
                                             "type": "Test",
                                             "default": None,
-                                            "param_type": "positional_or_keyword"
+                                            "param_type": "positional_or_keyword",
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": "TestResult"
+                                    "return_type": "TestResult",
                                 },
                                 {
                                     "parameters": {
                                         "testing": {
                                             "type": "JSON",
                                             "default": None,
-                                            "param_type": "positional_or_keyword"
+                                            "param_type": "positional_or_keyword",
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": None
-                                }
-                            ]
+                                    "return_type": None,
+                                },
+                            ],
                         },
                         "two": {
-                            "parameters": {
-                                "testing2": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                }
-                            },
+                            "parameters": {"testing2": {"default": None, "param_type": "positional_or_keyword"}},
                             "is_async": True,
                             "overloads": [
                                 {
                                     "parameters": {
-                                        "foo": {
-                                            "type": "JSON",
-                                            "default": None,
-                                            "param_type": "positional_or_keyword"
-                                        }
+                                        "foo": {"type": "JSON", "default": None, "param_type": "positional_or_keyword"}
                                     },
                                     "is_async": True,
-                                    "return_type": None
+                                    "return_type": None,
                                 }
-                            ]
+                            ],
                         },
-                    }
+                    },
                 }
             }
         }
@@ -644,12 +553,7 @@ def test_added_overload():
                     "properties": {},
                     "methods": {
                         "one": {
-                            "parameters": {
-                                "testing": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                }
-                            },
+                            "parameters": {"testing": {"default": None, "param_type": "positional_or_keyword"}},
                             "is_async": True,
                             "overloads": [
                                 {
@@ -657,25 +561,20 @@ def test_added_overload():
                                         "testing": {
                                             "type": "JSON",
                                             "default": None,
-                                            "param_type": "positional_or_keyword"
+                                            "param_type": "positional_or_keyword",
                                         }
                                     },
                                     "is_async": True,
-                                    "return_type": None
+                                    "return_type": None,
                                 }
-                            ]
+                            ],
                         },
                         "two": {
-                            "parameters": {
-                                "testing2": {
-                                    "default": None,
-                                    "param_type": "positional_or_keyword"
-                                }
-                            },
+                            "parameters": {"testing2": {"default": None, "param_type": "positional_or_keyword"}},
                             "is_async": True,
-                            "overloads": []
+                            "overloads": [],
                         },
-                    }
+                    },
                 }
             }
         }
@@ -687,17 +586,21 @@ def test_added_overload():
     assert len(bc.features_added) == 2
     msg, _, *args = bc.features_added[0]
     assert msg == AddedMethodOverloadChecker.message["default"]
-    assert args == ['azure.contoso', 'class_name', 'one', 'def one(testing: Test) -> TestResult']
+    assert args == ["azure.contoso", "class_name", "one", "def one(testing: Test) -> TestResult"]
     msg, _, *args = bc.features_added[1]
     assert msg == AddedMethodOverloadChecker.message["default"]
-    assert args == ['azure.contoso', 'class_name', 'two', 'def two(foo: JSON)']
+    assert args == ["azure.contoso", "class_name", "two", "def two(foo: JSON)"]
 
 
 def test_compare_reports_with_absolute_paths(capsys):
     """Verify test_compare_reports accepts absolute paths for source/target reports."""
     tests_dir = os.path.dirname(__file__)
-    source_report = os.path.abspath(os.path.join(tests_dir, "examples", "code-reports", "content-safety", "stable.json"))
-    target_report = os.path.abspath(os.path.join(tests_dir, "examples", "code-reports", "content-safety", "current.json"))
+    source_report = os.path.abspath(
+        os.path.join(tests_dir, "examples", "code-reports", "content-safety", "stable.json")
+    )
+    target_report = os.path.abspath(
+        os.path.join(tests_dir, "examples", "code-reports", "content-safety", "current.json")
+    )
     pkg_dir = tests_dir  # pkg_dir must exist and is still used (e.g., for package_name and cleanup); its value is independent of using absolute report paths
 
     # Should not raise; changelog=True means no SystemExit(1) even if breaking changes exist
@@ -939,6 +842,3 @@ def test_added_keyword_only_param_to_model_method_still_reported_as_class():
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
     assert args == ["azure.contoso", "ContosoModel", "extra", "do_something"]
-
-
-


### PR DESCRIPTION
## Context

tool crash when generate changelog for azure-mgmt-eventgrid: 
<img width="1113" height="84" alt="image" src="https://github.com/user-attachments/assets/0ea4d30b-94fe-4410-a11f-be3a163ae1a2" />

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6268338&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=2545

## Summary

Fixes incorrect changelog reporting in the breaking-changes/changelog tool when a class name happens to end with `Client` but is not actually a service client (e.g. `ARMPollingClient` in mgmt SDKs), and when keyword-only parameters are added to a client''s `__init__`.

## Changes

- Added `BreakingChangesTracker.is_client(module_name, class_name)` helper:
  - Non-mgmt SDKs (namespace not starting with `azure.mgmt.`): keep old logic — class name ends with `Client`.
  - Mgmt-plane SDKs (namespace starts with `azure.mgmt.`): class name ends with `Client` **and** its `__init__` accepts a `credential` parameter.
- Replaced all six `endswith("Client")` checks across `breaking_changes_tracker.py` and `changelog_tracker.py` with `is_client(...)`.
- Added `ADDED_CLIENT_METHOD_PARAMETER` change type / message and routed `check_non_positional_parameter_added` through `is_client`, so adding a kwarg to a client constructor is now reported as ``Client `X` added parameter `y` in method `__init__``` instead of ``Model `X` added parameter ...``.

## Tests

Added unit + integration tests in `tests/test_changelog.py` covering:
- `is_client` for non-mgmt vs mgmt namespaces, with/without `credential`, and non-`Client` suffix.
- New client/class added in mgmt vs non-mgmt namespace produces correct message.
- Keyword-only param added to mgmt client `__init__` produces client message; same change on a model still produces class message.

All 34 tests pass (`pytest tests/test_changelog.py tests/test_breaking_changes.py`).
