### PR TITLE
[AI Projects] Fix code-based evaluator catalog sample: add missing data_mapping

### DIFF
--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_code_based_evaluators.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_code_based_evaluators.py
@@ -63,7 +63,7 @@ with (
                 "init_parameters": {
                     "required": ["deployment_name", "pass_threshold"],
                     "type": "object",
-                    "properties": {"deployment_name": {"type": "string"}, "pass_threshold": {"type": "string"}},
+                    "properties": {"deployment_name": {"type": "string"}, "pass_threshold": {"type": "number"}},
                 },
                 "metrics": {
                     "result": {
@@ -116,6 +116,7 @@ with (
             type="azure_ai_evaluator",
             name="my_custom_evaluator_code",
             evaluator_name="my_custom_evaluator_code",
+            data_mapping={"item": "{{item}}"},
             initialization_parameters={
                 "deployment_name": f"{model_deployment_name}",
                 "pass_threshold": 0.5,


### PR DESCRIPTION
### Fix code-based evaluator catalog sample

The sample `sample_eval_catalog_code_based_evaluators.py` currently fails at `client.evals.create(...)` with HTTP 400:

```
UserError / EvalValidationFailed
Code: MissingRequiredDataMapping
Target: group.testing_criteria[0].data_mapping
Message: Data mapping for required field 'item' is missing for evaluator 'my_custom_evaluator_code'.
```

#### Root cause

The evaluator's `data_schema` declares `"required": ["item"]` (the `grade(sample, item)` function expects the whole item object), but the `testing_criteria` entry omitted `data_mapping` entirely. The server validates that every field in `data_schema.required` has a corresponding mapping in the testing criterion.

For comparison, the working `sample_eval_catalog_prompt_based_evaluators.py` declares each field individually in `data_schema` and maps each one in `data_mapping`. The code-based sample needs to map the single required `item` field to the whole data-source item.

#### Fixes

1. **Add `data_mapping={"item": "{{item}}"}` to the testing criterion** — passes the entire data-source item to the evaluator's `item` parameter.
2. **Change `pass_threshold` type in `init_parameters.properties` from `"string"` to `"number"`** — the runtime value `0.5` is a float, not a string. After the data-mapping fix is in place, this would be the next validation failure.

#### Sample diff

```diff
-                    "properties": {"deployment_name": {"type": "string"}, "pass_threshold": {"type": "string"}},
+                    "properties": {"deployment_name": {"type": "string"}, "pass_threshold": {"type": "number"}},
...
         TestingCriterionAzureAIEvaluator(
             type="azure_ai_evaluator",
             name="my_custom_evaluator_code",
             evaluator_name="my_custom_evaluator_code",
+            data_mapping={"item": "{{item}}"},
             initialization_parameters={
                 "deployment_name": f"{model_deployment_name}",
                 "pass_threshold": 0.5,
             },
         )
```

#### Reproduction

Without this fix, running the sample with `azure-ai-projects==2.1.0` against an Azure AI Foundry project produces the 400 error shown above. With this fix, evaluation creation succeeds.

#### Scope

Sample-only change. No SDK source code, generated code, public surface, or tests are affected.
