### PR TITLE
Exporter release 1.0.0b52

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.0.0b52 (Unreleased)
+## 1.0.0b52 (2026-05-11)
 
 ### Features Added
+- Add ownership checks for storage directories
+  ([#46725](https://github.com/Azure/azure-sdk-for-python/pull/46725))
 - Add logger name to custom dimensions for Message, Exception and Event telemetry
   ([#46096](https://github.com/Azure/azure-sdk-for-python/pull/46096))
 - Add support for populating SDK version from distro and Microsoft OpenTelemetry distro environment variables

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b52 (2026-05-11)
+## 1.0.0b52 (2026-05-12)
 
 ### Features Added
 - Add ownership checks for storage directories


### PR DESCRIPTION
## 1.0.0b52 (2026-05-12)

### Features Added
- Add ownership checks for storage directories
  ([#46725](https://github.com/Azure/azure-sdk-for-python/pull/46725))
- Add logger name to custom dimensions for Message, Exception and Event telemetry
  ([#46096](https://github.com/Azure/azure-sdk-for-python/pull/46096))
- Add support for populating SDK version from distro and Microsoft OpenTelemetry distro environment variables
  ([#46613](https://github.com/Azure/azure-sdk-for-python/pull/46613))
- Add GenAI main-agent attribution processors to propagate `microsoft.gen_ai.main_agent.*` attributes
  across spans and log records in multi-agent systems per [spec](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/genai_main_agent_attribution.md)
  ([#46700](https://github.com/Azure/azure-sdk-for-python/pull/46700))

### Breaking Changes
- Dropped support for Python 3.9. This package now supports Python 3.10+. [Follows upstream otel dropping support](https://github.com/open-telemetry/opentelemetry-python/pull/5076)
  ([#46694](https://github.com/Azure/azure-sdk-for-python/pull/46694))

### Bugs Fixed
- Fix `success` field on HTTP request telemetry resolving to an integer instead of a boolean when no status code is present
  ([#46311](https://github.com/Azure/azure-sdk-for-python/pull/46311))

### Other Changes
- Skip the transient storage tests
  ([#46827](https://github.com/Azure/azure-sdk-for-python/pull/46827))