### PR TITLE
ci(azure-sdk-tools): declare contents: read

### DIFF
--- a/.github/workflows/azure-sdk-tools.yml
+++ b/.github/workflows/azure-sdk-tools.yml
@@ -8,6 +8,9 @@ on:
       - "eng/tools/azure-sdk-tools/**"
       - ".github/workflows/azure-sdk-tools.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every other workflow in `.github/workflows/` here already declares a top-level permissions block. `azure-sdk-tools.yml` is the one outlier.

The job only checks out the tree and runs pytest, black, and an azpysdk command-discovery script against `eng/tools/azure-sdk-tools`. No GitHub API writes. Adding `permissions: contents: read` aligns it with the existing pattern (see `event.yml` using `permissions: {}`, `post-apiview.yml` using `contents: read + pull-requests: write`, etc.).

YAML re-parsed locally. No behavior change.