### PR TITLE
Distro release 1.8.8

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.8.8 (Unreleased)
+## 1.8.8 (2026-05-14)
 
 ### Features Added
 - Move `AZURE_MONITOR_DISTRO_VERSION` env var assignment before exporter imports
@@ -14,8 +14,6 @@
 ### Breaking Changes
 - Dropped support for Python 3.9. This package now supports Python 3.10+. [Follows upstream otel dropping support](https://github.com/open-telemetry/opentelemetry-python/pull/5076)
   ([#46695](https://github.com/Azure/azure-sdk-for-python/pull/46695))
-
-### Bugs Fixed
 
 ### Other Changes
 - Remove deprecated events packages.


### PR DESCRIPTION
## 1.8.8 (2026-05-14)

### Features Added
- Move `AZURE_MONITOR_DISTRO_VERSION` env var assignment before exporter imports
  ([#46869](https://github.com/Azure/azure-sdk-for-python/pull/46869))
- Set `AZURE_MONITOR_DISTRO_VERSION` environment variable to pass distro version to the exporter
  ([#46666](https://github.com/Azure/azure-sdk-for-python/pull/46666))
- Register GenAI main-agent attribution processors to automatically propagate
  `microsoft.gen_ai.main_agent.*` attributes in multi-agent GenAI systems per [spec](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/genai_main_agent_attribution.md)
  ([#46703](https://github.com/Azure/azure-sdk-for-python/pull/46703))

### Breaking Changes
- Dropped support for Python 3.9. This package now supports Python 3.10+. [Follows upstream otel dropping support](https://github.com/open-telemetry/opentelemetry-python/pull/5076)
  ([#46695](https://github.com/Azure/azure-sdk-for-python/pull/46695))

### Other Changes
- Remove deprecated events packages.
  ([#45684](https://github.com/Azure/azure-sdk-for-python/pull/45684))
