### PR TITLE
[Key Vault] Added API 2026-01-01-preview with EkmClient and EkmConnection

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0b1 (2026-05-27)
+## 4.8.0b1 (2026-05-29)
 
 ### Features Added
 

--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,26 +1,24 @@
 # Release History
 
-## 4.7.1 (Unreleased)
+## 4.8.0b1 (2026-05-27)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- Added support for service API version `2026-01-01-preview` [#46895](https://github.com/Azure/azure-sdk-for-python/pull/46895)
+- Added `KeyVaultEkmClient` for managing Managed HSM External Key Manager (EKM) connections. This new client exposes `get_ekm_connection`,
+  `create_ekm_connection`, `update_ekm_connection`, `delete_ekm_connection`, `get_ekm_certificate`, and `check_ekm_connection`.
+- Added `KeyVaultEkmConnection`, `KeyVaultEkmProxyClientCertificateInfo`, and `KeyVaultEkmProxyInfo` models supporting the EKM client.
 
 ### Other Changes
 
-## 4.7.0 (2026-05-18)
+- Python 3.9 is no longer supported. Please use Python version 3.10 or later.
+- Key Vault API version `2026-01-01-preview` is now the default.
+
+## 4.7.0 (2026-05-19)
 
 ### Features Added
 
 - Added support for service API version `2025-07-01` [#46716](https://github.com/Azure/azure-sdk-for-python/pull/46716)
-- Added `KeyVaultEkmClient` (sync and async) for managing Managed HSM External Key Manager
-  (EKM) connections via the `2026-01-01-preview` API. The new client exposes
-  `get_ekm_connection`, `create_ekm_connection`, `update_ekm_connection`,
-  `delete_ekm_connection`, `get_ekm_certificate`, and `check_ekm_connection`.
-- Added `KeyVaultEkmConnection`, `KeyVaultEkmProxyClientCertificateInfo`, and
-  `KeyVaultEkmProxyInfo` models supporting the EKM client.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -15,6 +15,12 @@
 ### Features Added
 
 - Added support for service API version `2025-07-01` [#46716](https://github.com/Azure/azure-sdk-for-python/pull/46716)
+- Added `KeyVaultEkmClient` (sync and async) for managing Managed HSM External Key Manager
+  (EKM) connections via the `2026-01-01-preview` API. The new client exposes
+  `get_ekm_connection`, `create_ekm_connection`, `update_ekm_connection`,
+  `delete_ekm_connection`, `get_ekm_certificate`, and `check_ekm_connection`.
+- Added `KeyVaultEkmConnection`, `KeyVaultEkmProxyClientCertificateInfo`, and
+  `KeyVaultEkmProxyInfo` models supporting the EKM client.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -219,8 +219,7 @@ role_definition = client.set_role_definition(scope=scope, role_name=role_name, p
 ```python
 new_permissions = [
     KeyVaultPermission(
-        data_actions=[KeyVaultDataAction.READ_HSM_KEY],
-        not_data_actions=[KeyVaultDataAction.CREATE_HSM_KEY]
+        data_actions=[KeyVaultDataAction.READ_HSM_KEY], not_data_actions=[KeyVaultDataAction.CREATE_HSM_KEY]
     )
 ]
 unique_definition_name = role_definition.name

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -42,7 +42,7 @@ authentication as demonstrated below.
 * An existing [Key Vault Managed HSM][managed_hsm]. If you need to create one, you can do so using the Azure CLI by following the steps in [this document][managed_hsm_cli].
 
 ### Authenticate the client
-In order to interact with the Azure Key Vault service, you will need an instance of either a [KeyVaultAccessControlClient](#create-a-keyvaultaccesscontrolclient) or [KeyVaultBackupClient](#create-a-keyvaultbackupclient), as well as a **vault url** (which you may see as "DNS Name" in the Azure Portal) and a credential object. This document demonstrates using a [DefaultAzureCredential][default_cred_ref], which is appropriate for most scenarios, including local development and production environments. We recommend using a [managed identity][managed_identity] for authentication in production environments.
+In order to interact with the Azure Key Vault service, you will need an instance of either a [KeyVaultAccessControlClient](#create-a-keyvaultaccesscontrolclient), [KeyVaultBackupClient](#create-a-keyvaultbackupclient), [KeyVaultSettingsClient](#create-a-keyvaultsettingsclient), or [KeyVaultEkmClient](#create-a-keyvaultekmclient) as well as a **vault url** (which you may see as "DNS Name" in the Azure Portal) and a credential object. This document demonstrates using a [DefaultAzureCredential][default_cred_ref], which is appropriate for most scenarios, including local development and production environments. We recommend using a [managed identity][managed_identity] for authentication in production environments.
 
 See [azure-identity][azure_identity] documentation for more information about other methods of authentication and their corresponding credential types.
 
@@ -109,6 +109,24 @@ client = KeyVaultSettingsClient(vault_url=MANAGED_HSM_URL, credential=credential
 
 > **NOTE:** For an asynchronous client, import `azure.keyvault.administration.aio`'s `KeyVaultSettingsClient` instead.
 
+#### Create a KeyVaultEkmClient
+After configuring your environment for the [DefaultAzureCredential][default_cred_ref] to use a suitable method of authentication, you can do the following to create an EKM client (replacing the value of `vault_url` with your Managed HSM's URL):
+
+<!-- SNIPPET:ekm_operations.create_a_ekm_client -->
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmClient
+
+MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+credential = DefaultAzureCredential()
+client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
+```
+
+<!-- END SNIPPET -->
+
+> **NOTE:** For an asynchronous client, import `azure.keyvault.administration.aio`'s `KeyVaultEkmClient` instead.
+
 ## Key concepts
 
 ### Role definition
@@ -140,6 +158,14 @@ A restore operation represents a long-running operation for both a full key and 
 ### KeyVaultSettingsClient
 
 A `KeyVaultSettingsClient` manages Managed HSM account settings.
+
+### KeyVaultEkmClient
+
+A `KeyVaultEkmClient` manages the Managed HSM's External Key Manager (EKM) connection.
+
+### EKM Connection
+
+An EKM connection represents the connection of an Azure Managed HSM resource with an external HSM.
 
 ## Examples
 This section contains code snippets covering common tasks:
@@ -193,7 +219,8 @@ role_definition = client.set_role_definition(scope=scope, role_name=role_name, p
 ```python
 new_permissions = [
     KeyVaultPermission(
-        data_actions=[KeyVaultDataAction.READ_HSM_KEY], not_data_actions=[KeyVaultDataAction.CREATE_HSM_KEY]
+        data_actions=[KeyVaultDataAction.READ_HSM_KEY],
+        not_data_actions=[KeyVaultDataAction.CREATE_HSM_KEY]
     )
 ]
 unique_definition_name = role_definition.name
@@ -413,6 +440,7 @@ Several samples are available in the Azure SDK for Python GitHub repository. The
 - [Create/update/delete role definitions and role assignments][access_control_operations_sample] ([async version][access_control_operations_async_sample])
 - [Full backup and restore][backup_operations_sample] ([async version][backup_operations_async_sample])
 - [List and update Key Vault settings][settings_operations_sample] ([async version][settings_operations_async_sample])
+- [Retrieve and manage EKM connections][ekm_operations_sample] ([async version][ekm_operations_async_sample])
 
 ###  Additional documentation
 For more extensive documentation on Azure Key Vault, see the [API reference documentation][reference_docs].
@@ -474,6 +502,8 @@ contact opencode@microsoft.com with any additional questions or comments.
 [sas_docs]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob/README.md#types-of-credentials
 [settings_operations_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
 [settings_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+[ekm_operations_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
+[ekm_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
 [storage_blob]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-blob/README.md
 [storage_explorer]: https://learn.microsoft.com/azure/vs-azure-tools-storage-manage-with-storage-explorer
 

--- a/sdk/keyvault/azure-keyvault-administration/_metadata.json
+++ b/sdk/keyvault/azure-keyvault-administration/_metadata.json
@@ -1,6 +1,6 @@
 {
-  "apiVersion": "2025-07-01",
+  "apiVersion": "2026-01-01-preview",
   "apiVersions": {
-    "KeyVault": "2025-07-01"
+    "KeyVault": "2026-01-01-preview"
   }
 }

--- a/sdk/keyvault/azure-keyvault-administration/apiview-properties.json
+++ b/sdk/keyvault/azure-keyvault-administration/apiview-properties.json
@@ -1,6 +1,9 @@
 {
     "CrossLanguagePackageId": "KeyVault",
     "CrossLanguageDefinitionId": {
+        "azure.keyvault.administration._generated.models.EkmConnection": "KeyVault.EkmConnection",
+        "azure.keyvault.administration._generated.models.EkmProxyClientCertificateInfo": "KeyVault.EkmProxyClientCertificateInfo",
+        "azure.keyvault.administration._generated.models.EkmProxyInfo": "KeyVault.EkmProxyInfo",
         "azure.keyvault.administration._generated.models.FullBackupOperation": "KeyVault.FullBackupOperation",
         "azure.keyvault.administration._generated.models.FullBackupOperationError": "KeyVault.FullBackupOperation.error.anonymous",
         "azure.keyvault.administration._generated.models.KeyVaultError": "KeyVaultError",
@@ -65,6 +68,18 @@
         "azure.keyvault.administration._generated.KeyVaultClient.get_setting": "KeyVault.getSetting",
         "azure.keyvault.administration._generated.aio.KeyVaultClient.get_setting": "KeyVault.getSetting",
         "azure.keyvault.administration._generated.KeyVaultClient.get_settings": "KeyVault.getSettings",
-        "azure.keyvault.administration._generated.aio.KeyVaultClient.get_settings": "KeyVault.getSettings"
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.get_settings": "KeyVault.getSettings",
+        "azure.keyvault.administration._generated.KeyVaultClient.get_ekm_connection": "KeyVault.getEkmConnection",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.get_ekm_connection": "KeyVault.getEkmConnection",
+        "azure.keyvault.administration._generated.KeyVaultClient.get_ekm_certificate": "KeyVault.getEkmCertificate",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.get_ekm_certificate": "KeyVault.getEkmCertificate",
+        "azure.keyvault.administration._generated.KeyVaultClient.check_ekm_connection": "KeyVault.checkEkmConnection",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.check_ekm_connection": "KeyVault.checkEkmConnection",
+        "azure.keyvault.administration._generated.KeyVaultClient.create_ekm_connection": "KeyVault.createEkmConnection",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.create_ekm_connection": "KeyVault.createEkmConnection",
+        "azure.keyvault.administration._generated.KeyVaultClient.update_ekm_connection": "KeyVault.updateEkmConnection",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.update_ekm_connection": "KeyVault.updateEkmConnection",
+        "azure.keyvault.administration._generated.KeyVaultClient.delete_ekm_connection": "KeyVault.deleteEkmConnection",
+        "azure.keyvault.administration._generated.aio.KeyVaultClient.delete_ekm_connection": "KeyVault.deleteEkmConnection"
     }
 }

--- a/sdk/keyvault/azure-keyvault-administration/apiview-properties.json
+++ b/sdk/keyvault/azure-keyvault-administration/apiview-properties.json
@@ -81,5 +81,6 @@
         "azure.keyvault.administration._generated.aio.KeyVaultClient.update_ekm_connection": "KeyVault.updateEkmConnection",
         "azure.keyvault.administration._generated.KeyVaultClient.delete_ekm_connection": "KeyVault.deleteEkmConnection",
         "azure.keyvault.administration._generated.aio.KeyVaultClient.delete_ekm_connection": "KeyVault.deleteEkmConnection"
-    }
+    },
+    "CrossLanguageVersion": "a3023239f547"
 }

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_007a803c2c"
+  "Tag": "python/keyvault/azure-keyvault-administration_a1cfcc06db"
 }

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_a1cfcc06db"
+  "Tag": "python/keyvault/azure-keyvault-administration_60fd5d77a0"
 }

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
@@ -4,10 +4,14 @@
 # ------------------------------------
 from ._access_control_client import KeyVaultAccessControlClient
 from ._backup_client import KeyVaultBackupClient
-from ._enums import KeyVaultRoleScope, KeyVaultDataAction, KeyVaultSettingType
+from ._ekm_client import KeyVaultEkmClient
+from ._enums import KeyVaultDataAction, KeyVaultRoleScope, KeyVaultSettingType
 from ._internal.client_base import ApiVersion
 from ._models import (
     KeyVaultBackupResult,
+    KeyVaultEkmConnection,
+    KeyVaultEkmProxyClientCertificateInfo,
+    KeyVaultEkmProxyInfo,
     KeyVaultPermission,
     KeyVaultRoleAssignment,
     KeyVaultRoleAssignmentProperties,
@@ -16,13 +20,16 @@ from ._models import (
 )
 from ._settings_client import KeyVaultSettingsClient
 
-
 __all__ = [
     "ApiVersion",
-    "KeyVaultBackupResult",
     "KeyVaultAccessControlClient",
     "KeyVaultBackupClient",
+    "KeyVaultBackupResult",
     "KeyVaultDataAction",
+    "KeyVaultEkmClient",
+    "KeyVaultEkmConnection",
+    "KeyVaultEkmProxyClientCertificateInfo",
+    "KeyVaultEkmProxyInfo",
     "KeyVaultPermission",
     "KeyVaultRoleAssignment",
     "KeyVaultRoleAssignmentProperties",

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_ekm_client.py
@@ -1,0 +1,114 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from typing import Any
+
+from azure.core.tracing.decorator import distributed_trace
+
+from ._internal import KeyVaultClientBase
+from ._models import KeyVaultEkmConnection, KeyVaultEkmProxyClientCertificateInfo, KeyVaultEkmProxyInfo
+
+
+class KeyVaultEkmClient(KeyVaultClientBase):
+    """Provides methods to manage Managed HSM External Key Manager (EKM) connections.
+
+    :param str vault_url: URL of the vault on which the client will operate. This is also called the vault's "DNS Name".
+        You should validate that this URL references a valid Key Vault or Managed HSM resource.
+        See https://aka.ms/azsdk/blog/vault-uri for details.
+    :param credential: An object which can provide an access token for the vault, such as a credential from
+        :mod:`azure.identity`
+    :type credential: ~azure.core.credentials.TokenCredential
+
+    :keyword api_version: Version of the service API to use. EKM operations require service API version
+        ``2026-01-01-preview`` or later.
+    :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str
+    :keyword bool verify_challenge_resource: Whether to verify the authentication challenge resource matches the Key
+        Vault or Managed HSM domain. Defaults to True.
+    """
+
+    # pylint:disable=protected-access
+
+    @distributed_trace
+    def get_ekm_connection(self, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Gets the configured EKM connection.
+
+        :returns: The configured EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.get_ekm_connection(**kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace
+    def create_ekm_connection(self, connection: KeyVaultEkmConnection, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Creates the EKM connection.
+
+        If an EKM connection already exists, this operation fails.
+
+        :param connection: The EKM connection to create.
+        :type connection: ~azure.keyvault.administration.KeyVaultEkmConnection
+
+        :returns: The created EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.create_ekm_connection(ekm_connection=connection._to_generated(), **kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace
+    def update_ekm_connection(self, connection: KeyVaultEkmConnection, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Updates the existing EKM connection.
+
+        If no EKM connection exists, this operation fails.
+
+        :param connection: The EKM connection to update.
+        :type connection: ~azure.keyvault.administration.KeyVaultEkmConnection
+
+        :returns: The updated EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.update_ekm_connection(ekm_connection=connection._to_generated(), **kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace
+    def delete_ekm_connection(  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
+        self, **kwargs: Any
+    ) -> KeyVaultEkmConnection:
+        """Deletes the existing EKM connection.
+
+        If no EKM connection exists, this operation fails.
+
+        :returns: The deleted EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.delete_ekm_connection(**kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace
+    def get_ekm_certificate(self, **kwargs: Any) -> KeyVaultEkmProxyClientCertificateInfo:
+        """Gets the EKM proxy client certificate information used to authenticate to the EKM proxy.
+
+        :returns: The EKM proxy client certificate information.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmProxyClientCertificateInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.get_ekm_certificate(**kwargs)
+        return KeyVaultEkmProxyClientCertificateInfo._from_generated(result)
+
+    @distributed_trace
+    def check_ekm_connection(self, **kwargs: Any) -> KeyVaultEkmProxyInfo:
+        """Checks the EKM connection by pinging the EKM proxy.
+
+        :returns: Information about the EKM proxy returned by the connectivity check.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmProxyInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = self._client.check_ekm_connection(**kwargs)
+        return KeyVaultEkmProxyInfo._from_generated(result)
+
+    def __enter__(self) -> "KeyVaultEkmClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_client.py
@@ -7,8 +7,8 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
+import sys
 from typing import Any, TYPE_CHECKING
-from typing_extensions import Self
 
 from azure.core import PipelineClient
 from azure.core.pipeline import policies
@@ -17,6 +17,11 @@ from azure.core.rest import HttpRequest, HttpResponse
 from ._configuration import KeyVaultClientConfiguration
 from ._utils.serialization import Deserializer, Serializer
 from .operations import RoleAssignmentsOperations, RoleDefinitionsOperations, _KeyVaultClientOperationsMixin
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self  # type: ignore
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -38,8 +43,9 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
     :keyword api_version: The API version to use for this operation. Known values are
-     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
-     value may result in unsupported behavior.
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     :keyword int polling_interval: Default waiting time between two polls for LRO operations if no
      Retry-After header is present.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_client.py
@@ -37,9 +37,9 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
+     value may result in unsupported behavior.
     :paramtype api_version: str
     :keyword int polling_interval: Default waiting time between two polls for LRO operations if no
      Retry-After header is present.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_configuration.py
@@ -27,14 +27,14 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
+     value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, vault_base_url: str, credential: "TokenCredential", **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-07-01")
+        api_version: str = kwargs.pop("api_version", "2026-01-01-preview")
 
         if vault_base_url is None:
             raise ValueError("Parameter 'vault_base_url' must not be None.")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_configuration.py
@@ -28,8 +28,9 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
     :keyword api_version: The API version to use for this operation. Known values are
-     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
-     value may result in unsupported behavior.
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_patch.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_patch.py
@@ -7,6 +7,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_utils/model_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_utils/model_base.py
@@ -23,13 +23,18 @@ from datetime import datetime, date, time, timedelta, timezone
 from json import JSONEncoder
 import xml.etree.ElementTree as ET
 from collections.abc import MutableMapping
-from typing_extensions import Self
 import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
 from azure.core.serialization import _Null
+
 from azure.core.rest import HttpResponse
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -585,6 +590,239 @@ def _create_value(rf: typing.Optional["_RestField"], value: typing.Any) -> typin
     return _serialize(value, rf._format)
 
 
+# ============================================================================
+# Fast-path scalar deserializer functions for rest_field(deserializer=...)
+# These are referenced from rest_field declarations to bypass the generic
+# _deserialize -> _deserialize_with_callable chain.
+# Only simple/primitive types — no models or container types.
+# ============================================================================
+
+
+def _xml_deser_str(value):
+    if isinstance(value, ET.Element):
+        return value.text or ""
+    return str(value) if value is not None else None
+
+
+def _xml_deser_int(value):
+    if isinstance(value, ET.Element):
+        return int(value.text) if value.text else None
+    return int(value) if value is not None else None
+
+
+def _xml_deser_float(value):
+    if isinstance(value, ET.Element):
+        return float(value.text) if value.text else None
+    return float(value) if value is not None else None
+
+
+def _xml_deser_bool(value):
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    if text in (True, False):
+        return text
+    return text.lower() == "true"
+
+
+# pylint: disable=docstring-missing-param
+def _xml_deser_bytes(value):
+    """Deserialize bytes from XML (base64)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_bytes(text)
+
+
+def _xml_deser_bytes_base64url(value):
+    """Deserialize bytes from XML (base64url)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_bytes_base64(text)
+
+
+def _xml_deser_datetime(value):
+    """Deserialize a datetime from XML (ISO 8601 / rfc3339)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_datetime(text)
+
+
+def _xml_deser_datetime_rfc7231(value):
+    """Deserialize a datetime from XML (RFC7231 format)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_datetime_rfc7231(text)
+
+
+def _xml_deser_datetime_unix_timestamp(value):
+    """Deserialize a datetime from XML (Unix timestamp)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_datetime_unix_timestamp(float(text))
+
+
+def _xml_deser_date(value):
+    """Deserialize a date from XML (ISO 8601)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_date(text)
+
+
+def _xml_deser_time(value):
+    """Deserialize a time from XML (ISO 8601)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_time(text)
+
+
+def _xml_deser_duration(value):
+    """Deserialize a timedelta from XML (ISO 8601 duration)."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_duration(text)
+
+
+def _xml_deser_decimal(value):
+    """Deserialize a Decimal from XML."""
+    if isinstance(value, ET.Element):
+        text = value.text
+    else:
+        text = value
+    if text is None:
+        return None
+    return _deserialize_decimal(text)
+
+
+def _xml_deser_enum_or_str(enum_cls, value):
+    """Deserialize a Union[EnumType, str] from XML."""
+    text = value.text if isinstance(value, ET.Element) else value
+    if text is None:
+        return None
+    try:
+        return enum_cls(text)
+    except ValueError:
+        return text
+
+
+def _extract_xml_model_type(rf_type):
+    """Extract the concrete Model class from a resolved rf._type partial chain.
+
+    Unwraps ``Optional[Model]`` and ``_deserialize_model(Model, ...)``
+    wrappers.  Only handles Model and Optional[Model] — other composite
+    types (List, Dict, Union, etc.) return None and fall through to the
+    generic ``_deserialize`` path at runtime.
+    """
+    if rf_type is None:
+        return None
+    if isinstance(rf_type, type) and _is_model(rf_type):
+        return rf_type
+    if not isinstance(rf_type, functools.partial):
+        return None
+    func = rf_type.func
+    args = rf_type.args
+    if func is _deserialize_with_optional and args:
+        return _extract_xml_model_type(args[0])
+    if func is _deserialize_model and args:
+        cls = args[0]
+        return cls if isinstance(cls, type) and _is_model(cls) else None
+    return None
+
+
+def _build_xml_field_plan(  # pylint: disable=docstring-missing-return, docstring-missing-rtype, unused-variable
+    cls, attr_to_rest_field: dict
+) -> list:
+    """Build a precomputed XML field plan for fast _init_from_xml iteration.
+
+    Called once per model class in __new__. Returns a list of tuples:
+        (rest_name, xml_name, kind, deser, rf_type, is_optional, items_name)
+
+    kind: 0=wrapped, 1=attribute, 2=unwrapped, 3=text
+
+    For Model and Optional[Model] fields that lack a scalar
+    ``_deserializer``, this function precomputes the Model class as the
+    deserializer so ``_init_from_xml`` can call ``ModelClass(element)``
+    directly instead of going through the expensive
+    ``_get_deserialize_callable_from_annotation`` chain at runtime.
+    """
+    model_meta = getattr(cls, "_xml", {})
+    model_ns = model_meta.get("ns") or model_meta.get("namespace")
+    plan = []
+
+    for rf in attr_to_rest_field.values():
+        prop_meta = getattr(rf, "_xml", {})
+        deser = rf._deserializer
+
+        xml_name = prop_meta.get("name", rf._rest_name)
+        xml_ns = _resolve_xml_ns(prop_meta, model_meta)
+        if xml_ns:
+            xml_name = "{" + xml_ns + "}" + xml_name
+
+        is_optional = rf._is_optional
+
+        # For Model / Optional[Model] fields without a scalar deserializer,
+        # precompute the Model class as the deserializer.
+        if deser is None and rf._type is not None:
+            model_cls = _extract_xml_model_type(rf._type)
+            if model_cls is not None:
+                deser = model_cls
+
+        if prop_meta.get("attribute", False):
+            plan.append((rf._rest_name, xml_name, 1, deser, rf._type, is_optional, None))
+        elif prop_meta.get("unwrapped", False):
+            items_name = prop_meta.get("itemsName")
+            if items_name:
+                items_ns = prop_meta.get("itemsNs")
+                if items_ns is not None:
+                    xml_ns = items_ns
+                if xml_ns:
+                    items_name = "{" + xml_ns + "}" + items_name
+            else:
+                items_name = xml_name
+            plan.append((rf._rest_name, xml_name, 2, deser, rf._type, is_optional, items_name))
+        elif prop_meta.get("text", False):
+            plan.append((rf._rest_name, xml_name, 3, deser, rf._type, is_optional, None))
+        else:
+            plan.append((rf._rest_name, xml_name, 0, deser, rf._type, is_optional, None))
+
+    return plan
+
+
+# pylint: enable=docstring-missing-param
 class Model(_MyMutableMapping):
     _is_model = True
     # label whether current class's _attr_to_rest_field has been calculated
@@ -595,11 +833,7 @@ class Model(_MyMutableMapping):
         class_name = self.__class__.__name__
         if len(args) > 1:
             raise TypeError(f"{class_name}.__init__() takes 2 positional arguments but {len(args) + 1} were given")
-        dict_to_pass = {
-            rest_field._rest_name: rest_field._default
-            for rest_field in self._attr_to_rest_field.values()
-            if rest_field._default is not _UNSET
-        }
+        dict_to_pass: dict[str, typing.Any] = {}
         if args:
             if isinstance(args[0], ET.Element):
                 dict_to_pass.update(self._init_from_xml(args[0]))
@@ -619,9 +853,19 @@ class Model(_MyMutableMapping):
                     if v is not None
                 }
             )
+        # Apply client default values for fields the caller didn't set so that
+        # defaults are part of `_data` and therefore included during serialization.
+        for rf in self._attr_to_rest_field.values():
+            if rf._default is _UNSET:
+                continue
+            if rf._rest_name in dict_to_pass:
+                continue
+            dict_to_pass[rf._rest_name] = _create_value(rf, rf._default)
         super().__init__(dict_to_pass)
 
-    def _init_from_xml(self, element: ET.Element) -> dict[str, typing.Any]:
+    def _init_from_xml(  # pylint: disable=too-many-branches, too-many-statements
+        self, element: ET.Element
+    ) -> dict[str, typing.Any]:
         """Deserialize an XML element into a dict mapping rest field names to values.
 
         :param ET.Element element: The XML element to deserialize from.
@@ -629,53 +873,89 @@ class Model(_MyMutableMapping):
         :rtype: dict
         """
         result: dict[str, typing.Any] = {}
-        model_meta = getattr(self, "_xml", {})
         existed_attr_keys: list[str] = []
 
-        for rf in self._attr_to_rest_field.values():
-            prop_meta = getattr(rf, "_xml", {})
-            xml_name = prop_meta.get("name", rf._rest_name)
-            xml_ns = _resolve_xml_ns(prop_meta, model_meta)
-            if xml_ns:
-                xml_name = "{" + xml_ns + "}" + xml_name
+        field_plan = getattr(self, "_xml_field_plan", None)
+        if field_plan:
+            for rest_name, xml_name, kind, deser, rf_type, is_optional, items_name in field_plan:
+                if kind == 0:  # wrapped element (most common)
+                    item = element.find(xml_name)
+                    if item is not None:
+                        existed_attr_keys.append(xml_name)
+                        if deser:
+                            result[rest_name] = deser(item)
+                        else:
+                            result[rest_name] = _deserialize(rf_type, item)
+                elif kind == 1:  # attribute
+                    attr_val = element.get(xml_name)
+                    if attr_val is not None:
+                        existed_attr_keys.append(xml_name)
+                        if deser:
+                            result[rest_name] = deser(attr_val)
+                        else:
+                            result[rest_name] = attr_val
+                elif kind == 2:  # unwrapped array
+                    items = element.findall(items_name)  # pyright: ignore
+                    if len(items) > 0:
+                        existed_attr_keys.append(items_name)
+                        if deser:
+                            result[rest_name] = deser(items)
+                        else:
+                            result[rest_name] = _deserialize(rf_type, items)
+                    elif not is_optional:
+                        existed_attr_keys.append(items_name)
+                        result[rest_name] = []
+                elif kind == 3:  # text
+                    if element.text is not None:
+                        if deser:
+                            result[rest_name] = deser(element.text)
+                        else:
+                            result[rest_name] = element.text
+        else:
+            model_meta = getattr(self, "_xml", {})
+            for rf in self._attr_to_rest_field.values():
+                prop_meta = getattr(rf, "_xml", {})
+                xml_name = prop_meta.get("name", rf._rest_name)
+                xml_ns = _resolve_xml_ns(prop_meta, model_meta)
+                if xml_ns:
+                    xml_name = "{" + xml_ns + "}" + xml_name
 
-            # attribute
-            if prop_meta.get("attribute", False) and element.get(xml_name) is not None:
-                existed_attr_keys.append(xml_name)
-                result[rf._rest_name] = _deserialize(rf._type, element.get(xml_name))
-                continue
-
-            # unwrapped element is array
-            if prop_meta.get("unwrapped", False):
-                # unwrapped array could either use prop items meta/prop meta
-                _items_name = prop_meta.get("itemsName")
-                if _items_name:
-                    xml_name = _items_name
-                    _items_ns = prop_meta.get("itemsNs")
-                    if _items_ns is not None:
-                        xml_ns = _items_ns
-                    if xml_ns:
-                        xml_name = "{" + xml_ns + "}" + xml_name
-                items = element.findall(xml_name)  # pyright: ignore
-                if len(items) > 0:
+                # attribute
+                if prop_meta.get("attribute", False) and element.get(xml_name) is not None:
                     existed_attr_keys.append(xml_name)
-                    result[rf._rest_name] = _deserialize(rf._type, items)
-                elif not rf._is_optional:
+                    result[rf._rest_name] = _deserialize(rf._type, element.get(xml_name))
+                    continue
+
+                # unwrapped element is array
+                if prop_meta.get("unwrapped", False):
+                    _items_name = prop_meta.get("itemsName")
+                    if _items_name:
+                        xml_name = _items_name
+                        _items_ns = prop_meta.get("itemsNs")
+                        if _items_ns is not None:
+                            xml_ns = _items_ns
+                        if xml_ns:
+                            xml_name = "{" + xml_ns + "}" + xml_name
+                    items = element.findall(xml_name)  # pyright: ignore
+                    if len(items) > 0:
+                        existed_attr_keys.append(xml_name)
+                        result[rf._rest_name] = _deserialize(rf._type, items)
+                    elif not rf._is_optional:
+                        existed_attr_keys.append(xml_name)
+                        result[rf._rest_name] = []
+                    continue
+
+                # text element is primitive type
+                if prop_meta.get("text", False):
+                    if element.text is not None:
+                        result[rf._rest_name] = _deserialize(rf._type, element.text)
+                    continue
+
+                # wrapped element could be normal property or array
+                item = element.find(xml_name)
+                if item is not None:
                     existed_attr_keys.append(xml_name)
-                    result[rf._rest_name] = []
-                continue
-
-            # text element is primitive type
-            if prop_meta.get("text", False):
-                if element.text is not None:
-                    result[rf._rest_name] = _deserialize(rf._type, element.text)
-                continue
-
-            # wrapped element could be normal property or array, it should only have one element
-            item = element.find(xml_name)
-            if item is not None:
-                existed_attr_keys.append(xml_name)
-                result[rf._rest_name] = _deserialize(rf._type, item)
+                    result[rf._rest_name] = _deserialize(rf._type, item)
 
         # rest thing is additional properties
         for e in element:
@@ -708,6 +988,9 @@ class Model(_MyMutableMapping):
                 if not rf._rest_name_input:
                     rf._rest_name_input = attr
             cls._attr_to_rest_field: dict[str, _RestField] = dict(attr_to_rest_field.items())
+            # Build XML field plan for fast _init_from_xml (only for XML models)
+            if getattr(cls, "_xml", None):
+                cls._xml_field_plan = _build_xml_field_plan(cls, attr_to_rest_field)
             cls._calculated.add(f"{cls.__module__}.{cls.__qualname__}")
 
         return super().__new__(cls)
@@ -1082,6 +1365,7 @@ class _RestField:
         format: typing.Optional[str] = None,
         is_multipart_file_input: bool = False,
         xml: typing.Optional[dict[str, typing.Any]] = None,
+        deserializer: typing.Optional[typing.Callable] = None,
     ):
         self._type = type
         self._rest_name_input = name
@@ -1094,6 +1378,7 @@ class _RestField:
         self._format = format
         self._is_multipart_file_input = is_multipart_file_input
         self._xml = xml if xml is not None else {}
+        self._deserializer = deserializer
 
     @property
     def _class_type(self) -> typing.Any:
@@ -1113,7 +1398,10 @@ class _RestField:
         # by this point, type and rest_name will have a value bc we default
         # them in __new__ of the Model class
         # Use _data.get() directly to avoid triggering __getitem__ which clears the cache
-        item = obj._data.get(self._rest_name)
+        item = obj._data.get(self._rest_name, _UNSET)
+        if item is _UNSET:
+            # Field not set by user; return the client default if one exists, otherwise None
+            return self._default if self._default is not _UNSET else None
         if item is None:
             return item
         if self._is_model:
@@ -1126,7 +1414,11 @@ class _RestField:
             # Return the value from _data directly (it's been deserialized in place)
             return obj._data.get(self._rest_name)
 
-        deserialized = _deserialize(self._type, _serialize(item, self._format), rf=self)
+        # Fast path: use _deserializer directly (avoids _serialize/_deserialize chain)
+        if self._deserializer:
+            deserialized = self._deserializer(item)
+        else:
+            deserialized = _deserialize(self._type, _serialize(item, self._format), rf=self)
 
         # For mutable types, store the deserialized value back in _data
         # so mutations directly affect _data
@@ -1172,6 +1464,7 @@ def rest_field(
     format: typing.Optional[str] = None,
     is_multipart_file_input: bool = False,
     xml: typing.Optional[dict[str, typing.Any]] = None,
+    deserializer: typing.Optional[typing.Callable] = None,
 ) -> typing.Any:
     return _RestField(
         name=name,
@@ -1181,6 +1474,7 @@ def rest_field(
         format=format,
         is_multipart_file_input=is_multipart_file_input,
         xml=xml,
+        deserializer=deserializer,
     )
 
 
@@ -1414,6 +1708,8 @@ def _deserialize_xml(
     value: str,
 ) -> typing.Any:
     element = ET.fromstring(value)  # nosec
+    if _is_model(deserializer):
+        return deserializer._deserialize(element, [])
     return _deserialize(deserializer, element)
 
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_utils/serialization.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/_utils/serialization.py
@@ -39,10 +39,14 @@ except ImportError:
 import xml.etree.ElementTree as ET
 
 import isodate  # type: ignore
-from typing_extensions import Self
 
 from azure.core.exceptions import DeserializationError, SerializationError
 from azure.core.serialization import NULL as CoreNull
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _BOM = codecs.BOM_UTF8.decode(encoding="utf-8")
 
@@ -1401,7 +1405,7 @@ class Deserializer:
         # Otherwise, result are unexpected
         self.additional_properties_detection = True
 
-    def __call__(self, target_obj, response_data, content_type=None):
+    def __call__(self, target_obj, response_data, content_type=None):  # pylint: disable=too-many-return-statements
         """Call the deserializer to process a REST response.
 
         :param str target_obj: Target data type to deserialize to.
@@ -1411,6 +1415,27 @@ class Deserializer:
         :return: Deserialized object.
         :rtype: object
         """
+        # Fast path for header deserialization: response_data is a plain str or None
+        # and target_obj is a simple scalar type. This avoids the expensive
+        # _unpack_content → _deserialize → _classify_target → deserialize_data chain.
+        if response_data is None:
+            return None
+        if target_obj == "str" and isinstance(response_data, str):
+            return response_data
+        if isinstance(response_data, str):
+            if target_obj == "int":
+                return int(response_data)
+            if target_obj == "bool":
+                if response_data in ("true", "1", "True"):
+                    return True
+                if response_data in ("false", "0", "False"):
+                    return False
+                return bool(response_data)
+            if target_obj == "rfc-1123":
+                return Deserializer.deserialize_rfc(response_data)
+            if target_obj == "bytearray":
+                return Deserializer.deserialize_bytearray(response_data)
+
         data = self._unpack_content(response_data, content_type)
         return self._deserialize(target_obj, data)
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_client.py
@@ -7,8 +7,8 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
+import sys
 from typing import Any, Awaitable, TYPE_CHECKING
-from typing_extensions import Self
 
 from azure.core import AsyncPipelineClient
 from azure.core.pipeline import policies
@@ -17,6 +17,11 @@ from azure.core.rest import AsyncHttpResponse, HttpRequest
 from .._utils.serialization import Deserializer, Serializer
 from ._configuration import KeyVaultClientConfiguration
 from .operations import RoleAssignmentsOperations, RoleDefinitionsOperations, _KeyVaultClientOperationsMixin
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self  # type: ignore
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
@@ -38,8 +43,9 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :keyword api_version: The API version to use for this operation. Known values are
-     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
-     value may result in unsupported behavior.
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     :keyword int polling_interval: Default waiting time between two polls for LRO operations if no
      Retry-After header is present.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_client.py
@@ -37,9 +37,9 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
+     value may result in unsupported behavior.
     :paramtype api_version: str
     :keyword int polling_interval: Default waiting time between two polls for LRO operations if no
      Retry-After header is present.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_configuration.py
@@ -27,14 +27,14 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
+     value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, vault_base_url: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-07-01")
+        api_version: str = kwargs.pop("api_version", "2026-01-01-preview")
 
         if vault_base_url is None:
             raise ValueError("Parameter 'vault_base_url' must not be None.")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_configuration.py
@@ -28,8 +28,9 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :keyword api_version: The API version to use for this operation. Known values are
-     "2026-01-01-preview". Default value is "2026-01-01-preview". Note that overriding this default
-     value may result in unsupported behavior.
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_patch.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/_patch.py
@@ -7,6 +7,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_operations.py
@@ -465,7 +465,10 @@ class RoleDefinitionsOperations:
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -897,7 +900,10 @@ class RoleAssignmentsOperations:
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_operations.py
@@ -38,9 +38,14 @@ from ..._utils.serialization import Deserializer, Serializer
 from ..._utils.utils import ClientMixinABC
 from ..._validation import api_version_validation
 from ...operations._operations import (
+    build_key_vault_check_ekm_connection_request,
+    build_key_vault_create_ekm_connection_request,
+    build_key_vault_delete_ekm_connection_request,
     build_key_vault_full_backup_request,
     build_key_vault_full_backup_status_request,
     build_key_vault_full_restore_operation_request,
+    build_key_vault_get_ekm_certificate_request,
+    build_key_vault_get_ekm_connection_request,
     build_key_vault_get_setting_request,
     build_key_vault_get_settings_request,
     build_key_vault_pre_full_backup_request,
@@ -48,6 +53,7 @@ from ...operations._operations import (
     build_key_vault_restore_status_request,
     build_key_vault_selective_key_restore_operation_request,
     build_key_vault_selective_key_restore_status_request,
+    build_key_vault_update_ekm_connection_request,
     build_key_vault_update_setting_request,
     build_role_assignments_create_request,
     build_role_assignments_delete_request,
@@ -934,7 +940,7 @@ class RoleAssignmentsOperations:
         return AsyncItemPaged(get_next, extract_data)
 
 
-class _KeyVaultClientOperationsMixin(
+class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
     ClientMixinABC[AsyncPipelineClient[HttpRequest, AsyncHttpResponse], KeyVaultClientConfiguration]
 ):
 
@@ -1221,7 +1227,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     async def _pre_full_backup_initial(
         self,
@@ -1362,7 +1368,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     async def begin_pre_full_backup(
         self,
@@ -1726,7 +1732,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     async def _pre_full_restore_operation_initial(
         self,
@@ -1867,7 +1873,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     async def begin_pre_full_restore_operation(
         self,
@@ -2534,6 +2540,585 @@ class _KeyVaultClientOperationsMixin(
             deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.SettingsListResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def get_ekm_connection(self, **kwargs: Any) -> _models.EkmConnection:
+        """Gets the EKM connection.
+
+        The External Key Manager (EKM) Get operation returns EKM connection. This operation requires
+        ekm/read permission.
+
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_get_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def get_ekm_certificate(self, **kwargs: Any) -> _models.EkmProxyClientCertificateInfo:
+        """Gets the EKM proxy client certificate.
+
+        The External Key Manager (EKM) Certificate Get operation returns Proxy client certificate. This
+        operation requires ekm/read permission.
+
+        :return: EkmProxyClientCertificateInfo. The EkmProxyClientCertificateInfo is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmProxyClientCertificateInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmProxyClientCertificateInfo] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_get_ekm_certificate_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmProxyClientCertificateInfo, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def check_ekm_connection(self, **kwargs: Any) -> _models.EkmProxyInfo:
+        """Checks the connectivity and authentication with the EKM proxy.
+
+        The External Key Manager (EKM) Check operation checks the connectivity and authentication with
+        the EKM proxy. This operation requires ekm/read permission.
+
+        :return: EkmProxyInfo. The EkmProxyInfo is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmProxyInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmProxyInfo] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_check_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmProxyInfo, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    async def create_ekm_connection(
+        self, ekm_connection: _models.EkmConnection, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def create_ekm_connection(
+        self, ekm_connection: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def create_ekm_connection(
+        self, ekm_connection: IO[bytes], *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "content_type", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def create_ekm_connection(
+        self, ekm_connection: Union[_models.EkmConnection, JSON, IO[bytes]], **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Is one of the following types:
+         EkmConnection, JSON, IO[bytes] Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection or JSON or
+         IO[bytes]
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(ekm_connection, (IOBase, bytes)):
+            _content = ekm_connection
+        else:
+            _content = json.dumps(ekm_connection, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_create_ekm_connection_request(
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    async def update_ekm_connection(
+        self, ekm_connection: _models.EkmConnection, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def update_ekm_connection(
+        self, ekm_connection: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def update_ekm_connection(
+        self, ekm_connection: IO[bytes], *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "content_type", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def update_ekm_connection(
+        self, ekm_connection: Union[_models.EkmConnection, JSON, IO[bytes]], **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Is one of the following types:
+         EkmConnection, JSON, IO[bytes] Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection or JSON or
+         IO[bytes]
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(ekm_connection, (IOBase, bytes)):
+            _content = ekm_connection
+        else:
+            _content = json.dumps(ekm_connection, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_update_ekm_connection_request(
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def delete_ekm_connection(self, **kwargs: Any) -> _models.EkmConnection:
+        """Deletes the EKM connection.
+
+        The External Key Manager (EKM) deletes the existing EKM connection. If the EKM connection does
+        not already exists, this operation fails. This operation requires ekm/delete permission.
+
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_delete_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
 
         if cls:
             return cls(pipeline_response, deserialized, {})  # type: ignore

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_patch.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/aio/operations/_patch.py
@@ -7,6 +7,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/__init__.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
 
 
 from ._models import (  # type: ignore
+    EkmConnection,
+    EkmProxyClientCertificateInfo,
+    EkmProxyInfo,
     FullBackupOperation,
     FullBackupOperationError,
     KeyVaultError,
@@ -50,6 +53,9 @@ from ._patch import *
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
+    "EkmConnection",
+    "EkmProxyClientCertificateInfo",
+    "EkmProxyInfo",
     "FullBackupOperation",
     "FullBackupOperationError",
     "KeyVaultError",

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/_models.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -14,6 +15,126 @@ from .._utils.model_base import Model as _Model, rest_field
 
 if TYPE_CHECKING:
     from .. import models as _models
+
+
+class EkmConnection(_Model):
+    """A EkmConnection model object.
+
+    :ivar host: EKM proxy FQDN (Fully Qualified Domain Name). Only allowed characters are a-z, A-Z,
+     0-9, hyphen (-), dot (.), and colon (:). Required.
+    :vartype host: str
+    :ivar path_prefix: Optional path prefix for the EKM proxy (if any).
+    :vartype path_prefix: str
+    :ivar server_ca_certificates: The root CA certificate chain that issued the proxy server's
+     certificate. An array of certificates in the certificate chain, each in DER format and base64
+     encoded. Required.
+    :vartype server_ca_certificates: list[bytes]
+    :ivar server_subject_common_name: The subject common name of the server certificate of EKM
+     Proxy.
+    :vartype server_subject_common_name: str
+    """
+
+    host: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """EKM proxy FQDN (Fully Qualified Domain Name). Only allowed characters are a-z, A-Z, 0-9, hyphen
+     (-), dot (.), and colon (:). Required."""
+    path_prefix: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """Optional path prefix for the EKM proxy (if any)."""
+    server_ca_certificates: list[bytes] = rest_field(
+        visibility=["read", "create", "update", "delete", "query"], format="base64"
+    )
+    """The root CA certificate chain that issued the proxy server's certificate. An array of
+     certificates in the certificate chain, each in DER format and base64 encoded. Required."""
+    server_subject_common_name: Optional[str] = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The subject common name of the server certificate of EKM Proxy."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        host: str,
+        server_ca_certificates: list[bytes],
+        path_prefix: Optional[str] = None,
+        server_subject_common_name: Optional[str] = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class EkmProxyClientCertificateInfo(_Model):
+    """EKM proxy client certificate information.
+
+    :ivar ca_certificates: The client root CA certificate chain to authenticate to the EKM proxy.
+     An array of certificates in the certificate chain, each in DER format and base64 encoded.
+     Required.
+    :vartype ca_certificates: list[bytes]
+    :ivar subject_common_name: The subject common name of the client certificate used to
+     authenticate to the EKM proxy. Required.
+    :vartype subject_common_name: str
+    """
+
+    ca_certificates: list[bytes] = rest_field(visibility=["read"], format="base64")
+    """The client root CA certificate chain to authenticate to the EKM proxy. An array of certificates
+     in the certificate chain, each in DER format and base64 encoded. Required."""
+    subject_common_name: str = rest_field(visibility=["read"])
+    """The subject common name of the client certificate used to authenticate to the EKM proxy.
+     Required."""
+
+
+class EkmProxyInfo(_Model):
+    """EKM proxy information.
+
+    :ivar api_version: The highest version of proxy interface API supported by the EKM Proxy.
+     Required.
+    :vartype api_version: str
+    :ivar proxy_vendor: The name of the proxy vendor. Required.
+    :vartype proxy_vendor: str
+    :ivar proxy_name: The name of the proxy product and its version. Required.
+    :vartype proxy_name: str
+    :ivar ekm_vendor: The name of the EKM vendor. Required.
+    :vartype ekm_vendor: str
+    :ivar ekm_product: The name of the EKM product and its version. Required.
+    :vartype ekm_product: str
+    """
+
+    api_version: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The highest version of proxy interface API supported by the EKM Proxy. Required."""
+    proxy_vendor: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The name of the proxy vendor. Required."""
+    proxy_name: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The name of the proxy product and its version. Required."""
+    ekm_vendor: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The name of the EKM vendor. Required."""
+    ekm_product: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The name of the EKM product and its version. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        api_version: str,
+        proxy_vendor: str,
+        proxy_name: str,
+        ekm_vendor: str,
+        ekm_product: str,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class FullBackupOperation(_Model):

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/_patch.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/models/_patch.py
@@ -7,6 +7,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_operations.py
@@ -51,7 +51,7 @@ def build_role_definitions_delete_request(scope: str, role_definition_name: str,
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -79,7 +79,7 @@ def build_role_definitions_create_or_update_request(  # pylint: disable=name-too
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -106,7 +106,7 @@ def build_role_definitions_get_request(scope: str, role_definition_name: str, **
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -131,7 +131,7 @@ def build_role_definitions_list_request(scope: str, *, filter: Optional[str] = N
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -157,7 +157,7 @@ def build_role_assignments_delete_request(scope: str, role_assignment_name: str,
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -183,7 +183,7 @@ def build_role_assignments_create_request(scope: str, role_assignment_name: str,
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -210,7 +210,7 @@ def build_role_assignments_get_request(scope: str, role_assignment_name: str, **
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -237,7 +237,7 @@ def build_role_assignments_list_for_scope_request(  # pylint: disable=name-too-l
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -265,7 +265,7 @@ def build_key_vault_full_backup_status_request(  # pylint: disable=name-too-long
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -290,7 +290,7 @@ def build_key_vault_full_backup_request(**kwargs: Any) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -312,7 +312,7 @@ def build_key_vault_pre_full_backup_request(**kwargs: Any) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -333,7 +333,7 @@ def build_key_vault_restore_status_request(job_id: str, **kwargs: Any) -> HttpRe
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -358,7 +358,7 @@ def build_key_vault_full_restore_operation_request(**kwargs: Any) -> HttpRequest
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -380,7 +380,7 @@ def build_key_vault_pre_full_restore_operation_request(**kwargs: Any) -> HttpReq
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -403,7 +403,7 @@ def build_key_vault_selective_key_restore_status_request(  # pylint: disable=nam
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -430,7 +430,7 @@ def build_key_vault_selective_key_restore_operation_request(  # pylint: disable=
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -457,7 +457,7 @@ def build_key_vault_update_setting_request(setting_name: str, **kwargs: Any) -> 
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -483,7 +483,7 @@ def build_key_vault_get_setting_request(setting_name: str, **kwargs: Any) -> Htt
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -507,7 +507,7 @@ def build_key_vault_get_settings_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -520,6 +520,126 @@ def build_key_vault_get_settings_request(**kwargs: Any) -> HttpRequest:
     _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
 
     return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_get_ekm_connection_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_get_ekm_certificate_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm/certificate"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_check_ekm_connection_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm/check"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_create_ekm_connection_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm/create"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_update_ekm_connection_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="PATCH", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_delete_ekm_connection_request(**kwargs: Any) -> HttpRequest:  # pylint: disable=name-too-long
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/ekm"
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
 
 
 class RoleDefinitionsOperations:
@@ -1388,7 +1508,7 @@ class RoleAssignmentsOperations:
         return ItemPaged(get_next, extract_data)
 
 
-class _KeyVaultClientOperationsMixin(
+class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
     ClientMixinABC[PipelineClient[HttpRequest, HttpResponse], KeyVaultClientConfiguration]
 ):
 
@@ -1674,7 +1794,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     def _pre_full_backup_initial(
         self,
@@ -1815,7 +1935,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     def begin_pre_full_backup(
         self,
@@ -2177,7 +2297,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     def _pre_full_restore_operation_initial(
         self,
@@ -2318,7 +2438,7 @@ class _KeyVaultClientOperationsMixin(
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["api_version", "content_type", "accept"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     def begin_pre_full_restore_operation(
         self,
@@ -2983,6 +3103,585 @@ class _KeyVaultClientOperationsMixin(
             deserialized = response.iter_bytes() if _decompress else response.iter_raw()
         else:
             deserialized = _deserialize(_models.SettingsListResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def get_ekm_connection(self, **kwargs: Any) -> _models.EkmConnection:
+        """Gets the EKM connection.
+
+        The External Key Manager (EKM) Get operation returns EKM connection. This operation requires
+        ekm/read permission.
+
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_get_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def get_ekm_certificate(self, **kwargs: Any) -> _models.EkmProxyClientCertificateInfo:
+        """Gets the EKM proxy client certificate.
+
+        The External Key Manager (EKM) Certificate Get operation returns Proxy client certificate. This
+        operation requires ekm/read permission.
+
+        :return: EkmProxyClientCertificateInfo. The EkmProxyClientCertificateInfo is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmProxyClientCertificateInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmProxyClientCertificateInfo] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_get_ekm_certificate_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmProxyClientCertificateInfo, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def check_ekm_connection(self, **kwargs: Any) -> _models.EkmProxyInfo:
+        """Checks the connectivity and authentication with the EKM proxy.
+
+        The External Key Manager (EKM) Check operation checks the connectivity and authentication with
+        the EKM proxy. This operation requires ekm/read permission.
+
+        :return: EkmProxyInfo. The EkmProxyInfo is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmProxyInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmProxyInfo] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_check_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmProxyInfo, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    def create_ekm_connection(
+        self, ekm_connection: _models.EkmConnection, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def create_ekm_connection(
+        self, ekm_connection: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def create_ekm_connection(
+        self, ekm_connection: IO[bytes], *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Required.
+        :type ekm_connection: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "content_type", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def create_ekm_connection(
+        self, ekm_connection: Union[_models.EkmConnection, JSON, IO[bytes]], **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Creates the EKM connection.
+
+        The External Key Manager (EKM) sets up the EKM connection. If the EKM connection already
+        exists, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to create. Is one of the following types:
+         EkmConnection, JSON, IO[bytes] Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection or JSON or
+         IO[bytes]
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(ekm_connection, (IOBase, bytes)):
+            _content = ekm_connection
+        else:
+            _content = json.dumps(ekm_connection, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_create_ekm_connection_request(
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    def update_ekm_connection(
+        self, ekm_connection: _models.EkmConnection, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def update_ekm_connection(
+        self, ekm_connection: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def update_ekm_connection(
+        self, ekm_connection: IO[bytes], *, content_type: str = "application/json", **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Required.
+        :type ekm_connection: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "content_type", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def update_ekm_connection(
+        self, ekm_connection: Union[_models.EkmConnection, JSON, IO[bytes]], **kwargs: Any
+    ) -> _models.EkmConnection:
+        """Updates the EKM connection.
+
+        The External Key Manager (EKM) updates the existing EKM connection. If the EKM connection does
+        not exist, this operation fails. This operation requires ekm/write permission.
+
+        :param ekm_connection: The ekmConnection to update. Is one of the following types:
+         EkmConnection, JSON, IO[bytes] Required.
+        :type ekm_connection: ~azure.keyvault.administration._generated.models.EkmConnection or JSON or
+         IO[bytes]
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(ekm_connection, (IOBase, bytes)):
+            _content = ekm_connection
+        else:
+            _content = json.dumps(ekm_connection, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_update_ekm_connection_request(
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["api_version", "accept"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def delete_ekm_connection(self, **kwargs: Any) -> _models.EkmConnection:
+        """Deletes the EKM connection.
+
+        The External Key Manager (EKM) deletes the existing EKM connection. If the EKM connection does
+        not already exists, this operation fails. This operation requires ekm/delete permission.
+
+        :return: EkmConnection. The EkmConnection is compatible with MutableMapping
+        :rtype: ~azure.keyvault.administration._generated.models.EkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.EkmConnection] = kwargs.pop("cls", None)
+
+        _request = build_key_vault_delete_ekm_connection_request(
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.EkmConnection, response.json())
 
         if cls:
             return cls(pipeline_response, deserialized, {})  # type: ignore

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_operations.py
@@ -1033,7 +1033,10 @@ class RoleDefinitionsOperations:
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -1465,7 +1468,10 @@ class RoleAssignmentsOperations:
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_patch.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_generated/operations/_patch.py
@@ -7,6 +7,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -24,6 +24,7 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Key Vault API versions supported by this package"""
 
     #: this is the default version
+    V2026_01_01_PREVIEW = "2026-01-01-preview"
     V2025_07_01 = "2025-07-01"
     V7_6 = "7.6"
     V7_5 = "7.5"
@@ -32,7 +33,7 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     V7_2 = "7.2"
 
 
-DEFAULT_VERSION = ApiVersion.V2025_07_01
+DEFAULT_VERSION = ApiVersion.V2026_01_01_PREVIEW
 
 _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge_cache.py
@@ -8,7 +8,6 @@ from urllib import parse
 
 from .http_challenge import HttpChallenge
 
-
 _cache: "Dict[str, HttpChallenge]" = {}
 _lock = threading.Lock()
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -2,12 +2,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from azure.core.rest import HttpResponse
 
 from ._enums import KeyVaultSettingType
 from ._generated.models import (
+    EkmConnection,
+    EkmProxyClientCertificateInfo,
+    EkmProxyInfo,
     FullBackupOperation,
     Permission,
     RoleAssignment,
@@ -234,3 +237,129 @@ class KeyVaultSetting(object):
     def _from_generated(cls, setting: Setting) -> "KeyVaultSetting":
         setting_type = KeyVaultSettingType.BOOLEAN if setting.type == "boolean" else setting.type
         return cls(name=setting.name, value=setting.value, setting_type=setting_type)
+
+
+class KeyVaultEkmConnection(object):
+    """An External Key Manager (EKM) connection.
+
+    :param str host: EKM proxy FQDN (Fully Qualified Domain Name). Only allowed characters are
+        ``a-z``, ``A-Z``, ``0-9``, hyphen (``-``), dot (``.``), and colon (``:``).
+    :param server_ca_certificates: The root CA certificate chain that issued the proxy server's
+        certificate. An array of certificates in the certificate chain, each in DER format and
+        base64 encoded.
+    :type server_ca_certificates: list[bytes]
+
+    :keyword str path_prefix: Optional path prefix for the EKM proxy (if any).
+    :keyword str server_subject_common_name: The subject common name of the server certificate of
+        the EKM proxy.
+
+    :ivar str host: EKM proxy FQDN.
+    :ivar list[bytes] server_ca_certificates: The root CA certificate chain that issued the proxy
+        server's certificate.
+    :ivar path_prefix: Optional path prefix for the EKM proxy (if any).
+    :vartype path_prefix: str or None
+    :ivar server_subject_common_name: The subject common name of the server certificate of the EKM
+        proxy.
+    :vartype server_subject_common_name: str or None
+    """
+
+    def __init__(
+        self,
+        host: str,
+        server_ca_certificates: List[bytes],
+        *,
+        path_prefix: Optional[str] = None,
+        server_subject_common_name: Optional[str] = None,
+    ) -> None:
+        self.host = host
+        self.server_ca_certificates = server_ca_certificates
+        self.path_prefix = path_prefix
+        self.server_subject_common_name = server_subject_common_name
+
+    def __repr__(self) -> str:
+        return f"KeyVaultEkmConnection<{self.host}>"
+
+    @classmethod
+    def _from_generated(cls, connection: EkmConnection) -> "KeyVaultEkmConnection":
+        return cls(
+            host=connection.host,
+            server_ca_certificates=connection.server_ca_certificates,
+            path_prefix=connection.path_prefix,
+            server_subject_common_name=connection.server_subject_common_name,
+        )
+
+    def _to_generated(self) -> EkmConnection:
+        return EkmConnection(
+            host=self.host,
+            server_ca_certificates=self.server_ca_certificates,
+            path_prefix=self.path_prefix,
+            server_subject_common_name=self.server_subject_common_name,
+        )
+
+
+class KeyVaultEkmProxyClientCertificateInfo(object):
+    """EKM proxy client certificate information.
+
+    :ivar ca_certificates: The client root CA certificate chain to authenticate to the EKM proxy.
+        An array of certificates in the certificate chain, each in DER format and base64 encoded.
+    :vartype ca_certificates: list[bytes] or None
+    :ivar subject_common_name: The subject common name of the client certificate used to
+        authenticate to the EKM proxy.
+    :vartype subject_common_name: str or None
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.ca_certificates: Optional[List[bytes]] = kwargs.get("ca_certificates")
+        self.subject_common_name: Optional[str] = kwargs.get("subject_common_name")
+
+    def __repr__(self) -> str:
+        return f"KeyVaultEkmProxyClientCertificateInfo<{self.subject_common_name}>"
+
+    @classmethod
+    def _from_generated(
+        cls, certificate_info: EkmProxyClientCertificateInfo
+    ) -> "KeyVaultEkmProxyClientCertificateInfo":
+        return cls(
+            ca_certificates=certificate_info.ca_certificates,
+            subject_common_name=certificate_info.subject_common_name,
+        )
+
+
+class KeyVaultEkmProxyInfo(object):
+    """EKM proxy information returned when checking an EKM connection.
+
+    :ivar api_version: The highest version of proxy interface API supported by the EKM proxy.
+    :vartype api_version: str or None
+    :ivar proxy_vendor: The name of the proxy vendor.
+    :vartype proxy_vendor: str or None
+    :ivar proxy_name: The name of the proxy product and its version.
+    :vartype proxy_name: str or None
+    :ivar ekm_vendor: The name of the EKM vendor.
+    :vartype ekm_vendor: str or None
+    :ivar ekm_product: The name of the EKM product and its version.
+    :vartype ekm_product: str or None
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.api_version: Optional[str] = kwargs.get("api_version")
+        self.proxy_vendor: Optional[str] = kwargs.get("proxy_vendor")
+        self.proxy_name: Optional[str] = kwargs.get("proxy_name")
+        self.ekm_vendor: Optional[str] = kwargs.get("ekm_vendor")
+        self.ekm_product: Optional[str] = kwargs.get("ekm_product")
+
+    def __repr__(self) -> str:
+        return (
+            f"KeyVaultEkmProxyInfo(api_version={self.api_version}, "
+            f"proxy_vendor={self.proxy_vendor}, proxy_name={self.proxy_name}, "
+            f"ekm_vendor={self.ekm_vendor}, ekm_product={self.ekm_product})"
+        )
+
+    @classmethod
+    def _from_generated(cls, proxy_info: EkmProxyInfo) -> "KeyVaultEkmProxyInfo":
+        return cls(
+            api_version=proxy_info.api_version,
+            proxy_vendor=proxy_info.proxy_vendor,
+            proxy_name=proxy_info.proxy_name,
+            ekm_vendor=proxy_info.ekm_vendor,
+            ekm_product=proxy_info.ekm_product,
+        )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.7.1"
+VERSION = "4.8.0b1"

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/__init__.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 from ._access_control_client import KeyVaultAccessControlClient
 from ._backup_client import KeyVaultBackupClient
+from ._ekm_client import KeyVaultEkmClient
 from ._settings_client import KeyVaultSettingsClient
 
-__all__ = ["KeyVaultAccessControlClient", "KeyVaultBackupClient", "KeyVaultSettingsClient"]
+__all__ = ["KeyVaultAccessControlClient", "KeyVaultBackupClient", "KeyVaultEkmClient", "KeyVaultSettingsClient"]

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/__init__.py
@@ -7,4 +7,9 @@ from ._backup_client import KeyVaultBackupClient
 from ._ekm_client import KeyVaultEkmClient
 from ._settings_client import KeyVaultSettingsClient
 
-__all__ = ["KeyVaultAccessControlClient", "KeyVaultBackupClient", "KeyVaultEkmClient", "KeyVaultSettingsClient"]
+__all__ = [
+    "KeyVaultAccessControlClient",
+    "KeyVaultBackupClient",
+    "KeyVaultEkmClient",
+    "KeyVaultSettingsClient",
+]

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_ekm_client.py
@@ -1,0 +1,114 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from typing import Any
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+
+from .._internal import AsyncKeyVaultClientBase
+from .._models import KeyVaultEkmConnection, KeyVaultEkmProxyClientCertificateInfo, KeyVaultEkmProxyInfo
+
+
+class KeyVaultEkmClient(AsyncKeyVaultClientBase):
+    """Provides methods to manage Managed HSM External Key Manager (EKM) connections.
+
+    :param str vault_url: URL of the vault on which the client will operate. This is also called the vault's "DNS Name".
+        You should validate that this URL references a valid Key Vault or Managed HSM resource.
+        See https://aka.ms/azsdk/blog/vault-uri for details.
+    :param credential: An object which can provide an access token for the vault, such as a credential from
+        :mod:`azure.identity.aio`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
+
+    :keyword api_version: Version of the service API to use. EKM operations require service API version
+        ``2026-01-01-preview`` or later.
+    :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str
+    :keyword bool verify_challenge_resource: Whether to verify the authentication challenge resource matches the Key
+        Vault or Managed HSM domain. Defaults to True.
+    """
+
+    # pylint:disable=protected-access
+
+    @distributed_trace_async
+    async def get_ekm_connection(self, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Gets the configured EKM connection.
+
+        :returns: The configured EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.get_ekm_connection(**kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace_async
+    async def create_ekm_connection(self, connection: KeyVaultEkmConnection, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Creates the EKM connection.
+
+        If an EKM connection already exists, this operation fails.
+
+        :param connection: The EKM connection to create.
+        :type connection: ~azure.keyvault.administration.KeyVaultEkmConnection
+
+        :returns: The created EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.create_ekm_connection(ekm_connection=connection._to_generated(), **kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace_async
+    async def update_ekm_connection(self, connection: KeyVaultEkmConnection, **kwargs: Any) -> KeyVaultEkmConnection:
+        """Updates the existing EKM connection.
+
+        If no EKM connection exists, this operation fails.
+
+        :param connection: The EKM connection to update.
+        :type connection: ~azure.keyvault.administration.KeyVaultEkmConnection
+
+        :returns: The updated EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.update_ekm_connection(ekm_connection=connection._to_generated(), **kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace_async
+    async def delete_ekm_connection(  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
+        self, **kwargs: Any
+    ) -> KeyVaultEkmConnection:
+        """Deletes the existing EKM connection.
+
+        If no EKM connection exists, this operation fails.
+
+        :returns: The deleted EKM connection.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmConnection
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.delete_ekm_connection(**kwargs)
+        return KeyVaultEkmConnection._from_generated(result)
+
+    @distributed_trace_async
+    async def get_ekm_certificate(self, **kwargs: Any) -> KeyVaultEkmProxyClientCertificateInfo:
+        """Gets the EKM proxy client certificate information used to authenticate to the EKM proxy.
+
+        :returns: The EKM proxy client certificate information.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmProxyClientCertificateInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.get_ekm_certificate(**kwargs)
+        return KeyVaultEkmProxyClientCertificateInfo._from_generated(result)
+
+    @distributed_trace_async
+    async def check_ekm_connection(self, **kwargs: Any) -> KeyVaultEkmProxyInfo:
+        """Checks the EKM connection by pinging the EKM proxy.
+
+        :returns: Information about the EKM proxy returned by the connectivity check.
+        :rtype: ~azure.keyvault.administration.KeyVaultEkmProxyInfo
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        result = await self._client.check_ekm_connection(**kwargs)
+        return KeyVaultEkmProxyInfo._from_generated(result)
+
+    async def __aenter__(self) -> "KeyVaultEkmClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
@@ -3,10 +3,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import os
-
-from azure.identity import DefaultAzureCredential
-from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnection
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
@@ -14,88 +10,105 @@ from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnecti
 #
 # 2. azure-keyvault-administration and azure-identity libraries (pip install these)
 #
-# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM, EKM_PROXY_HOST with the host of your EKM proxy,
+#    and CA_CERTIFICATE with the proxy server's certificate in DER format and base64 encoded.
 #
 # 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
 #    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 #
 # 5. An EKM (External Key Manager) proxy reachable from the Managed HSM. Replace the placeholder host
-#    and certificate bytes below with values that match your EKM proxy deployment. See
-#    https://learn.microsoft.com/azure/key-vault/managed-hsm/external-key-manager-overview for details.
+#    and certificate bytes below with values that match your EKM proxy deployment.
 #
-# Note: EKM operations are only available on the 2026-01-01-preview service API version. Pass
-# api_version="2026-01-01-preview" when constructing the client.
 # ----------------------------------------------------------------------------------------------------------
 # Sample - demonstrates Managed HSM External Key Manager (EKM) connection management
 #
-# 1. Get the EKM proxy client certificate (get_ekm_certificate)
+# 1. Create an EKM connection (create_ekm_connection)
 #
-# 2. Create an EKM connection (create_ekm_connection)
+# 2. Read the EKM connection (get_ekm_connection)
 #
-# 3. Read the EKM connection (get_ekm_connection)
+# 3. Get the EKM proxy client certificate (get_ekm_certificate)
 #
-# 4. Update the EKM connection (update_ekm_connection)
+# 4. Check an EKM connection (check_ekm_connection)
 #
-# 5. Check connectivity to the EKM proxy (check_ekm_connection)
+# 5. Update the EKM connection (update_ekm_connection)
 #
 # 6. Delete the EKM connection (delete_ekm_connection)
 # ----------------------------------------------------------------------------------------------------------
 
-MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-
-# Instantiate an EKM client. EKM operations require service API version 2026-01-01-preview.
+# Instantiate an EKM client that will be used to call the service.
 # Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+# [START create_a_ekm_client]
+import os
+import base64
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnection
+
+MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
+CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
+CA_CERTIFICATES = [CA_CERTIFICATE]
 credential = DefaultAzureCredential()
-client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential, api_version="2026-01-01-preview")
+client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
+# [END create_a_ekm_client]
 
-# 1. Inspect the EKM proxy client certificate the Managed HSM will present when contacting your EKM proxy.
-#    Use the subject common name and CA chain to provision the proxy to trust the HSM as a client.
-print("\n.. Get EKM proxy client certificate info")
-cert_info = client.get_ekm_certificate()
-print(f"Client subject common name: {cert_info.subject_common_name}")
-print(f"Client CA certificate count: {len(cert_info.ca_certificates or [])}")
-
-# 2. Create an EKM connection. Replace these placeholder values with the FQDN of your EKM proxy and the
-#    DER-encoded server CA certificate chain that issued its server certificate.
-ekm_proxy_host = "ekm.contoso.com"
-server_ca_chain = [b"\x30\x82\x01\x00"]  # Replace with your real DER-encoded CA certificate(s)
-
+# First, let's create an EKM connection
 print("\n.. Create EKM connection")
-new_connection = KeyVaultEkmConnection(
-    host=ekm_proxy_host,
-    server_ca_certificates=server_ca_chain,
-    path_prefix="/api",
-    server_subject_common_name=ekm_proxy_host,
+# [START create_ekm_connection]
+ekm_connection = KeyVaultEkmConnection(
+    host=EKM_PROXY_HOST,
+    server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
+    path_prefix="/api/v1",
 )
-created = client.create_ekm_connection(new_connection)
-print(f"EKM connection created for host: {created.host} (path_prefix={created.path_prefix})")
+created_ekm_connection = client.create_ekm_connection(connection=ekm_connection)
+print(f"EKM connection created with host: {created_ekm_connection.host}")
+# [END create_ekm_connection]
 
-# 3. Read the EKM connection back from the service.
+# Let's get the EKM connection we just created
 print("\n.. Get EKM connection")
-fetched = client.get_ekm_connection()
-print(f"Configured EKM host: {fetched.host}")
-
-# 4. Update the EKM connection (e.g., flip the path_prefix to a new API version).
-print("\n.. Update EKM connection path_prefix")
-updated_input = KeyVaultEkmConnection(
-    host=fetched.host,
-    server_ca_certificates=fetched.server_ca_certificates,
-    path_prefix="/v2",
-    server_subject_common_name=fetched.server_subject_common_name,
-)
-updated = client.update_ekm_connection(updated_input)
-print(f"Updated path_prefix to: {updated.path_prefix}")
-
-# 5. Check the connection by having the HSM ping the EKM proxy.
-print("\n.. Check EKM connection")
-proxy_info = client.check_ekm_connection()
+# [START get_ekm_connection]
+retrieved_ekm_connection = client.get_ekm_connection()
+print("Retrieved EKM connection with:")
+print(f"\tHost: {retrieved_ekm_connection.host}")
+print(f"\tPath prefix: {retrieved_ekm_connection.path_prefix}")
 print(
-    f"EKM proxy reachable: vendor={proxy_info.proxy_vendor}, name={proxy_info.proxy_name}, "
-    f"api_version={proxy_info.api_version}, ekm_vendor={proxy_info.ekm_vendor}, "
-    f"ekm_product={proxy_info.ekm_product}"
+    f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}"
 )
+# [END get_ekm_connection]
 
-# 6. Tear down the EKM connection.
+# Get the EKM certificate
+print("\n.. Get EKM certificate")
+# [START get_ekm_certificate]
+ekm_certificate = client.get_ekm_certificate()
+print(f"EKM certificate retrieved with subject: {ekm_certificate.subject_common_name}")
+# [END get_ekm_certificate]
+
+# Check the EKM connection status
+print("\n.. Check EKM connection")
+# [START check_ekm_connection]
+connection_status = client.check_ekm_connection()
+print("EKM connection status:")
+print(f"\tAPI Version: {connection_status.api_version}")
+print(f"\tProxy Vendor: {connection_status.proxy_vendor}")
+print(f"\tProxy Name: {connection_status.proxy_name}")
+print(f"\tEKM Vendor: {connection_status.ekm_vendor}")
+print(f"\tEKM Product: {connection_status.ekm_product}")
+# [END check_ekm_connection]
+
+# Update the EKM connection
+print("\n.. Update EKM connection")
+# [START update_ekm_connection]
+updated_ekm_connection = KeyVaultEkmConnection(
+    host="ekm-proxy-updated.contoso.com",
+    server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
+    path_prefix="/api/v2",
+)
+result = client.update_ekm_connection(connection=updated_ekm_connection)
+print(f"EKM connection updated with host: {result.host}")
+# [END update_ekm_connection]
+
+# Finally, let's delete the EKM connection
 print("\n.. Delete EKM connection")
-deleted = client.delete_ekm_connection()
-print(f"Deleted EKM connection for host: {deleted.host}")
+# [START delete_ekm_connection]
+deleted_ekm_connection = client.delete_ekm_connection()
+print("EKM connection deleted successfully")
+# [END delete_ekm_connection]

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
@@ -1,0 +1,101 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnection
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites:
+# 1. A managed HSM (https://learn.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli)
+#
+# 2. azure-keyvault-administration and azure-identity libraries (pip install these)
+#
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+#
+# 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
+#    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
+#
+# 5. An EKM (External Key Manager) proxy reachable from the Managed HSM. Replace the placeholder host
+#    and certificate bytes below with values that match your EKM proxy deployment. See
+#    https://learn.microsoft.com/azure/key-vault/managed-hsm/external-key-manager-overview for details.
+#
+# Note: EKM operations are only available on the 2026-01-01-preview service API version. Pass
+# api_version="2026-01-01-preview" when constructing the client.
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates Managed HSM External Key Manager (EKM) connection management
+#
+# 1. Get the EKM proxy client certificate (get_ekm_certificate)
+#
+# 2. Create an EKM connection (create_ekm_connection)
+#
+# 3. Read the EKM connection (get_ekm_connection)
+#
+# 4. Update the EKM connection (update_ekm_connection)
+#
+# 5. Check connectivity to the EKM proxy (check_ekm_connection)
+#
+# 6. Delete the EKM connection (delete_ekm_connection)
+# ----------------------------------------------------------------------------------------------------------
+
+MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+
+# Instantiate an EKM client. EKM operations require service API version 2026-01-01-preview.
+# Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+credential = DefaultAzureCredential()
+client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential, api_version="2026-01-01-preview")
+
+# 1. Inspect the EKM proxy client certificate the Managed HSM will present when contacting your EKM proxy.
+#    Use the subject common name and CA chain to provision the proxy to trust the HSM as a client.
+print("\n.. Get EKM proxy client certificate info")
+cert_info = client.get_ekm_certificate()
+print(f"Client subject common name: {cert_info.subject_common_name}")
+print(f"Client CA certificate count: {len(cert_info.ca_certificates or [])}")
+
+# 2. Create an EKM connection. Replace these placeholder values with the FQDN of your EKM proxy and the
+#    DER-encoded server CA certificate chain that issued its server certificate.
+ekm_proxy_host = "ekm.contoso.com"
+server_ca_chain = [b"\x30\x82\x01\x00"]  # Replace with your real DER-encoded CA certificate(s)
+
+print("\n.. Create EKM connection")
+new_connection = KeyVaultEkmConnection(
+    host=ekm_proxy_host,
+    server_ca_certificates=server_ca_chain,
+    path_prefix="/api",
+    server_subject_common_name=ekm_proxy_host,
+)
+created = client.create_ekm_connection(new_connection)
+print(f"EKM connection created for host: {created.host} (path_prefix={created.path_prefix})")
+
+# 3. Read the EKM connection back from the service.
+print("\n.. Get EKM connection")
+fetched = client.get_ekm_connection()
+print(f"Configured EKM host: {fetched.host}")
+
+# 4. Update the EKM connection (e.g., flip the path_prefix to a new API version).
+print("\n.. Update EKM connection path_prefix")
+updated_input = KeyVaultEkmConnection(
+    host=fetched.host,
+    server_ca_certificates=fetched.server_ca_certificates,
+    path_prefix="/v2",
+    server_subject_common_name=fetched.server_subject_common_name,
+)
+updated = client.update_ekm_connection(updated_input)
+print(f"Updated path_prefix to: {updated.path_prefix}")
+
+# 5. Check the connection by having the HSM ping the EKM proxy.
+print("\n.. Check EKM connection")
+proxy_info = client.check_ekm_connection()
+print(
+    f"EKM proxy reachable: vendor={proxy_info.proxy_vendor}, name={proxy_info.proxy_name}, "
+    f"api_version={proxy_info.api_version}, ekm_vendor={proxy_info.ekm_vendor}, "
+    f"ekm_product={proxy_info.ekm_product}"
+)
+
+# 6. Tear down the EKM connection.
+print("\n.. Delete EKM connection")
+deleted = client.delete_ekm_connection()
+print(f"Deleted EKM connection for host: {deleted.host}")

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations.py
@@ -3,6 +3,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import os
+import base64
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
@@ -38,15 +40,10 @@
 # Instantiate an EKM client that will be used to call the service.
 # Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
 # [START create_a_ekm_client]
-import os
-import base64
 from azure.identity import DefaultAzureCredential
-from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnection
+from azure.keyvault.administration import KeyVaultEkmClient
 
 MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
-CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
-CA_CERTIFICATES = [CA_CERTIFICATE]
 credential = DefaultAzureCredential()
 client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
 # [END create_a_ekm_client]
@@ -54,6 +51,11 @@ client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
 # First, let's create an EKM connection
 print("\n.. Create EKM connection")
 # [START create_ekm_connection]
+from azure.keyvault.administration import KeyVaultEkmConnection
+
+EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
+CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
+CA_CERTIFICATES = [CA_CERTIFICATE]
 ekm_connection = KeyVaultEkmConnection(
     host=EKM_PROXY_HOST,
     server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
@@ -70,9 +72,7 @@ retrieved_ekm_connection = client.get_ekm_connection()
 print("Retrieved EKM connection with:")
 print(f"\tHost: {retrieved_ekm_connection.host}")
 print(f"\tPath prefix: {retrieved_ekm_connection.path_prefix}")
-print(
-    f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}"
-)
+print(f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}")
 # [END get_ekm_connection]
 
 # Get the EKM certificate

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
@@ -3,12 +3,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import asyncio
-import os
-
-from azure.identity.aio import DefaultAzureCredential
-from azure.keyvault.administration import KeyVaultEkmConnection
-from azure.keyvault.administration.aio import KeyVaultEkmClient
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
@@ -16,83 +10,116 @@ from azure.keyvault.administration.aio import KeyVaultEkmClient
 #
 # 2. azure-keyvault-administration and azure-identity libraries (pip install these)
 #
-# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM, EKM_PROXY_HOST with the host of your EKM proxy,
+#    and CA_CERTIFICATE with the proxy server's certificate in DER format and base64 encoded.
 #
 # 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
 #    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 #
 # 5. An EKM (External Key Manager) proxy reachable from the Managed HSM. Replace the placeholder host
-#    and certificate bytes below with values that match your EKM proxy deployment. See
-#    https://learn.microsoft.com/azure/key-vault/managed-hsm/external-key-manager-overview for details.
+#    and certificate bytes below with values that match your EKM proxy deployment.
 #
-# Note: EKM operations are only available on the 2026-01-01-preview service API version. Pass
-# api_version="2026-01-01-preview" when constructing the client.
 # ----------------------------------------------------------------------------------------------------------
 # Sample - demonstrates Managed HSM External Key Manager (EKM) connection management
 #
-# 1. Get the EKM proxy client certificate (get_ekm_certificate)
+# 1. Create an EKM connection (create_ekm_connection)
 #
-# 2. Create an EKM connection (create_ekm_connection)
+# 2. Read the EKM connection (get_ekm_connection)
 #
-# 3. Read the EKM connection (get_ekm_connection)
+# 3. Get the EKM proxy client certificate (get_ekm_certificate)
 #
-# 4. Update the EKM connection (update_ekm_connection)
+# 4. Check an EKM connection (check_ekm_connection)
 #
-# 5. Check connectivity to the EKM proxy (check_ekm_connection)
+# 5. Update the EKM connection (update_ekm_connection)
 #
 # 6. Delete the EKM connection (delete_ekm_connection)
 # ----------------------------------------------------------------------------------------------------------
 
+# Instantiate an EKM client that will be used to call the service.
+# Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+# [START create_a_ekm_client]
+import os
+import base64
+import asyncio
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmConnection
+from azure.keyvault.administration.aio import KeyVaultEkmClient
+
 
 async def run_sample():
     MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-
+    EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
+    CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
+    CA_CERTIFICATES = [CA_CERTIFICATE]
     credential = DefaultAzureCredential()
-    client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential, api_version="2026-01-01-preview")
+    client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
+    # [END create_a_ekm_client]
 
-    print("\n.. Get EKM proxy client certificate info")
-    cert_info = await client.get_ekm_certificate()
-    print(f"Client subject common name: {cert_info.subject_common_name}")
-    print(f"Client CA certificate count: {len(cert_info.ca_certificates or [])}")
-
-    ekm_proxy_host = "ekm.contoso.com"
-    server_ca_chain = [b"\x30\x82\x01\x00"]  # Replace with your real DER-encoded CA certificate(s)
-
+    # First, let's create an EKM connection
     print("\n.. Create EKM connection")
-    new_connection = KeyVaultEkmConnection(
-        host=ekm_proxy_host,
-        server_ca_certificates=server_ca_chain,
-        path_prefix="/api",
-        server_subject_common_name=ekm_proxy_host,
+    # [START create_ekm_connection]
+    ekm_connection = KeyVaultEkmConnection(
+        host=EKM_PROXY_HOST,
+        server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
+        path_prefix="/api/v1",
     )
-    created = await client.create_ekm_connection(new_connection)
-    print(f"EKM connection created for host: {created.host} (path_prefix={created.path_prefix})")
+    created_ekm_connection = await client.create_ekm_connection(
+        connection=ekm_connection
+    )
+    print(f"EKM connection created with host: {created_ekm_connection.host}")
+    # [END create_ekm_connection]
 
+    # Let's get the EKM connection we just created
     print("\n.. Get EKM connection")
-    fetched = await client.get_ekm_connection()
-    print(f"Configured EKM host: {fetched.host}")
-
-    print("\n.. Update EKM connection path_prefix")
-    updated_input = KeyVaultEkmConnection(
-        host=fetched.host,
-        server_ca_certificates=fetched.server_ca_certificates,
-        path_prefix="/v2",
-        server_subject_common_name=fetched.server_subject_common_name,
-    )
-    updated = await client.update_ekm_connection(updated_input)
-    print(f"Updated path_prefix to: {updated.path_prefix}")
-
-    print("\n.. Check EKM connection")
-    proxy_info = await client.check_ekm_connection()
+    # [START get_ekm_connection]
+    retrieved_ekm_connection = await client.get_ekm_connection()
+    print("Retrieved EKM connection with:")
+    print(f"\tHost: {retrieved_ekm_connection.host}")
+    print(f"\tPath prefix: {retrieved_ekm_connection.path_prefix}")
     print(
-        f"EKM proxy reachable: vendor={proxy_info.proxy_vendor}, name={proxy_info.proxy_name}, "
-        f"api_version={proxy_info.api_version}, ekm_vendor={proxy_info.ekm_vendor}, "
-        f"ekm_product={proxy_info.ekm_product}"
+        f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}"
     )
+    # [END get_ekm_connection]
 
+    # Get the EKM certificate
+    print("\n.. Get EKM certificate")
+    # [START get_ekm_certificate]
+    ekm_certificate = await client.get_ekm_certificate()
+    print(
+        f"EKM certificate retrieved with subject: {ekm_certificate.subject_common_name}"
+    )
+    # [END get_ekm_certificate]
+
+    # Check the EKM connection status
+    print("\n.. Check EKM connection")
+    # [START check_ekm_connection]
+    connection_status = await client.check_ekm_connection()
+    print("EKM connection status:")
+    print(f"\tAPI Version: {connection_status.api_version}")
+    print(f"\tProxy Vendor: {connection_status.proxy_vendor}")
+    print(f"\tProxy Name: {connection_status.proxy_name}")
+    print(f"\tEKM Vendor: {connection_status.ekm_vendor}")
+    print(f"\tEKM Product: {connection_status.ekm_product}")
+    # [END check_ekm_connection]
+
+    # Update the EKM connection
+    print("\n.. Update EKM connection")
+    # [START update_ekm_connection]
+    updated_ekm_connection = KeyVaultEkmConnection(
+        host="ekm-proxy-updated.contoso.com",
+        server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
+        path_prefix="/api/v2",
+    )
+    result = await client.update_ekm_connection(connection=updated_ekm_connection)
+    print(f"EKM connection updated with host: {result.host}")
+    # [END update_ekm_connection]
+
+    # Finally, let's delete the EKM connection
     print("\n.. Delete EKM connection")
-    deleted = await client.delete_ekm_connection()
-    print(f"Deleted EKM connection for host: {deleted.host}")
+    # [START delete_ekm_connection]
+    deleted_ekm_connection = await client.delete_ekm_connection()
+    print("EKM connection deleted successfully")
+    # [END delete_ekm_connection]
 
     await client.close()
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
@@ -1,0 +1,102 @@
+# pylint: disable=line-too-long,useless-suppression
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import asyncio
+import os
+
+from azure.identity.aio import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmConnection
+from azure.keyvault.administration.aio import KeyVaultEkmClient
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites:
+# 1. A managed HSM (https://learn.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli)
+#
+# 2. azure-keyvault-administration and azure-identity libraries (pip install these)
+#
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+#
+# 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
+#    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
+#
+# 5. An EKM (External Key Manager) proxy reachable from the Managed HSM. Replace the placeholder host
+#    and certificate bytes below with values that match your EKM proxy deployment. See
+#    https://learn.microsoft.com/azure/key-vault/managed-hsm/external-key-manager-overview for details.
+#
+# Note: EKM operations are only available on the 2026-01-01-preview service API version. Pass
+# api_version="2026-01-01-preview" when constructing the client.
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates Managed HSM External Key Manager (EKM) connection management
+#
+# 1. Get the EKM proxy client certificate (get_ekm_certificate)
+#
+# 2. Create an EKM connection (create_ekm_connection)
+#
+# 3. Read the EKM connection (get_ekm_connection)
+#
+# 4. Update the EKM connection (update_ekm_connection)
+#
+# 5. Check connectivity to the EKM proxy (check_ekm_connection)
+#
+# 6. Delete the EKM connection (delete_ekm_connection)
+# ----------------------------------------------------------------------------------------------------------
+
+
+async def run_sample():
+    MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+
+    credential = DefaultAzureCredential()
+    client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential, api_version="2026-01-01-preview")
+
+    print("\n.. Get EKM proxy client certificate info")
+    cert_info = await client.get_ekm_certificate()
+    print(f"Client subject common name: {cert_info.subject_common_name}")
+    print(f"Client CA certificate count: {len(cert_info.ca_certificates or [])}")
+
+    ekm_proxy_host = "ekm.contoso.com"
+    server_ca_chain = [b"\x30\x82\x01\x00"]  # Replace with your real DER-encoded CA certificate(s)
+
+    print("\n.. Create EKM connection")
+    new_connection = KeyVaultEkmConnection(
+        host=ekm_proxy_host,
+        server_ca_certificates=server_ca_chain,
+        path_prefix="/api",
+        server_subject_common_name=ekm_proxy_host,
+    )
+    created = await client.create_ekm_connection(new_connection)
+    print(f"EKM connection created for host: {created.host} (path_prefix={created.path_prefix})")
+
+    print("\n.. Get EKM connection")
+    fetched = await client.get_ekm_connection()
+    print(f"Configured EKM host: {fetched.host}")
+
+    print("\n.. Update EKM connection path_prefix")
+    updated_input = KeyVaultEkmConnection(
+        host=fetched.host,
+        server_ca_certificates=fetched.server_ca_certificates,
+        path_prefix="/v2",
+        server_subject_common_name=fetched.server_subject_common_name,
+    )
+    updated = await client.update_ekm_connection(updated_input)
+    print(f"Updated path_prefix to: {updated.path_prefix}")
+
+    print("\n.. Check EKM connection")
+    proxy_info = await client.check_ekm_connection()
+    print(
+        f"EKM proxy reachable: vendor={proxy_info.proxy_vendor}, name={proxy_info.proxy_name}, "
+        f"api_version={proxy_info.api_version}, ekm_vendor={proxy_info.ekm_vendor}, "
+        f"ekm_product={proxy_info.ekm_product}"
+    )
+
+    print("\n.. Delete EKM connection")
+    deleted = await client.delete_ekm_connection()
+    print(f"Deleted EKM connection for host: {deleted.host}")
+
+    await client.close()
+    await credential.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_sample())

--- a/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/ekm_operations_async.py
@@ -3,6 +3,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import os
+import base64
+import asyncio
+
+from azure.identity.aio import DefaultAzureCredential
+from azure.keyvault.administration import KeyVaultEkmConnection
+from azure.keyvault.administration.aio import KeyVaultEkmClient
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
@@ -37,62 +44,41 @@
 
 # Instantiate an EKM client that will be used to call the service.
 # Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
-# [START create_a_ekm_client]
-import os
-import base64
-import asyncio
-from azure.identity import DefaultAzureCredential
-from azure.keyvault.administration import KeyVaultEkmConnection
-from azure.keyvault.administration.aio import KeyVaultEkmClient
 
 
 async def run_sample():
     MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-    EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
-    CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
-    CA_CERTIFICATES = [CA_CERTIFICATE]
     credential = DefaultAzureCredential()
     client = KeyVaultEkmClient(vault_url=MANAGED_HSM_URL, credential=credential)
-    # [END create_a_ekm_client]
 
     # First, let's create an EKM connection
     print("\n.. Create EKM connection")
-    # [START create_ekm_connection]
+    EKM_PROXY_HOST = os.environ["EKM_PROXY_HOST"]
+    CA_CERTIFICATE = os.environ["CA_CERTIFICATE"]
+    CA_CERTIFICATES = [CA_CERTIFICATE]
     ekm_connection = KeyVaultEkmConnection(
         host=EKM_PROXY_HOST,
         server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
         path_prefix="/api/v1",
     )
-    created_ekm_connection = await client.create_ekm_connection(
-        connection=ekm_connection
-    )
+    created_ekm_connection = await client.create_ekm_connection(connection=ekm_connection)
     print(f"EKM connection created with host: {created_ekm_connection.host}")
-    # [END create_ekm_connection]
 
     # Let's get the EKM connection we just created
     print("\n.. Get EKM connection")
-    # [START get_ekm_connection]
     retrieved_ekm_connection = await client.get_ekm_connection()
     print("Retrieved EKM connection with:")
     print(f"\tHost: {retrieved_ekm_connection.host}")
     print(f"\tPath prefix: {retrieved_ekm_connection.path_prefix}")
-    print(
-        f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}"
-    )
-    # [END get_ekm_connection]
+    print(f"\tServer subject common name: {retrieved_ekm_connection.server_subject_common_name}")
 
     # Get the EKM certificate
     print("\n.. Get EKM certificate")
-    # [START get_ekm_certificate]
     ekm_certificate = await client.get_ekm_certificate()
-    print(
-        f"EKM certificate retrieved with subject: {ekm_certificate.subject_common_name}"
-    )
-    # [END get_ekm_certificate]
+    print(f"EKM certificate retrieved with subject: {ekm_certificate.subject_common_name}")
 
     # Check the EKM connection status
     print("\n.. Check EKM connection")
-    # [START check_ekm_connection]
     connection_status = await client.check_ekm_connection()
     print("EKM connection status:")
     print(f"\tAPI Version: {connection_status.api_version}")
@@ -100,11 +86,9 @@ async def run_sample():
     print(f"\tProxy Name: {connection_status.proxy_name}")
     print(f"\tEKM Vendor: {connection_status.ekm_vendor}")
     print(f"\tEKM Product: {connection_status.ekm_product}")
-    # [END check_ekm_connection]
 
     # Update the EKM connection
     print("\n.. Update EKM connection")
-    # [START update_ekm_connection]
     updated_ekm_connection = KeyVaultEkmConnection(
         host="ekm-proxy-updated.contoso.com",
         server_ca_certificates=[base64.b64decode(cert) for cert in CA_CERTIFICATES],
@@ -112,14 +96,11 @@ async def run_sample():
     )
     result = await client.update_ekm_connection(connection=updated_ekm_connection)
     print(f"EKM connection updated with host: {result.host}")
-    # [END update_ekm_connection]
 
     # Finally, let's delete the EKM connection
     print("\n.. Delete EKM connection")
-    # [START delete_ekm_connection]
     deleted_ekm_connection = await client.delete_ekm_connection()
     print("EKM connection deleted successfully")
-    # [END delete_ekm_connection]
 
     await client.close()
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -38,7 +38,7 @@ setup(
     url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk",
     keywords="azure, azure sdk",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -11,7 +11,6 @@ import os
 import re
 from setuptools import setup, find_packages
 
-
 PACKAGE_NAME = "azure-keyvault-administration"
 PACKAGE_PPRINT_NAME = "Key Vault Administration"
 PACKAGE_NAMESPACE = "azure.keyvault.administration"
@@ -43,7 +42,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -69,5 +67,5 @@ setup(
         "azure-core>=1.38.0",
         "typing-extensions>=4.6.0",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -14,6 +14,8 @@ class BaseClientPreparer(AzureRecordedTestCase):
         hsm_playback_url = "https://managedhsmvaultname.managedhsm.azure.net"
         container_playback_uri = "https://storagename.blob.core.windows.net/container"
         playback_sas_token = "fake-sas"
+        playback_ekm_host = "fake-ekm-host"
+        playback_ekm_certificate = "fake-server-ca-certificate"
 
         if self.is_live:
             hsm = os.environ.get("AZURE_MANAGEDHSM_URL")
@@ -23,11 +25,15 @@ class BaseClientPreparer(AzureRecordedTestCase):
             self.container_uri = f"{storage_url.rstrip('/')}/{container_name}"
 
             self.sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN")
+            self.ekm_host = os.environ.get("EKM_PROXY_HOST")
+            self.ekm_certificate = os.environ.get("EKM_SERVER_CA_CERTIFICATE")
 
         else:
             self.managed_hsm_url = hsm_playback_url
             self.container_uri = container_playback_uri
             self.sas_token = playback_sas_token
+            self.ekm_host = playback_ekm_host
+            self.ekm_certificate = playback_ekm_certificate
 
         use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH", "false")
         use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
@@ -139,6 +145,8 @@ class KeyVaultEkmClientPreparer(BaseClientPreparer):
     def __call__(self, fn):
         async def _preparer(test_class, api_version, **kwargs):
             self._skip_if_not_configured(api_version)
+            kwargs["ekm_host"] = self.ekm_host
+            kwargs["ekm_certificate"] = self.ekm_certificate
             client = self.create_ekm_client(api_version=api_version, **kwargs)
 
             async with client:

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -133,3 +133,23 @@ class KeyVaultSettingsClientPreparer(BaseClientPreparer):
         return self.create_client_from_credential(
             KeyVaultSettingsClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
         )
+
+
+class KeyVaultEkmClientPreparer(BaseClientPreparer):
+    def __call__(self, fn):
+        async def _preparer(test_class, api_version, **kwargs):
+            self._skip_if_not_configured(api_version)
+            client = self.create_ekm_client(api_version=api_version, **kwargs)
+
+            async with client:
+                await fn(test_class, client, **kwargs)
+
+        return _preparer
+
+    def create_ekm_client(self, **kwargs):
+        from azure.keyvault.administration.aio import KeyVaultEkmClient
+
+        credential = self.get_credential(KeyVaultEkmClient, is_async=True)
+        return self.create_client_from_credential(
+            KeyVaultEkmClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
+        )

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -133,7 +133,7 @@ class KeyVaultSettingsClientPreparer(BaseClientPreparer):
         return self.create_client_from_credential(
             KeyVaultSettingsClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
         )
-
+    
 
 class KeyVaultEkmClientPreparer(BaseClientPreparer):
     def __call__(self, fn):

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -139,7 +139,7 @@ class KeyVaultSettingsClientPreparer(BaseClientPreparer):
         return self.create_client_from_credential(
             KeyVaultSettingsClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
         )
-    
+
 
 class KeyVaultEkmClientPreparer(BaseClientPreparer):
     def __call__(self, fn):

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -15,7 +15,7 @@ class BaseClientPreparer(AzureRecordedTestCase):
         container_playback_uri = "https://storagename.blob.core.windows.net/container"
         playback_sas_token = "fake-sas"
         playback_ekm_host = "fake-ekm-host"
-        playback_ekm_certificate = "fake-server-ca-certificate"
+        playback_ekm_certificate = "ZmFrZS1jZXJ0LWRhdGE="
 
         if self.is_live:
             hsm = os.environ.get("AZURE_MANAGEDHSM_URL")

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -16,6 +16,8 @@ class BaseClientPreparer(AzureRecordedTestCase):
         hsm_playback_url = "https://managedhsmvaultname.managedhsm.azure.net"
         container_playback_uri = "https://storagename.blob.core.windows.net/container"
         playback_sas_token = "fake-sas"
+        playback_ekm_host = "fake-ekm-host"
+        playback_server_ca_certificate = "fake-server-ca-certificate"
 
         if self.is_live:
             hsm = os.environ.get("AZURE_MANAGEDHSM_URL")
@@ -25,11 +27,15 @@ class BaseClientPreparer(AzureRecordedTestCase):
             self.container_uri = f"{storage_url.rstrip('/')}/{container_name}"
 
             self.sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN")
+            self.ekm_host = os.environ.get("EKM_PROXY_HOST")
+            self.ekm_certificate = os.environ.get("EKM_SERVER_CA_CERTIFICATE")
 
         else:
             self.managed_hsm_url = hsm_playback_url
             self.container_uri = container_playback_uri
             self.sas_token = playback_sas_token
+            self.ekm_host = playback_ekm_host
+            self.ekm_certificate = playback_server_ca_certificate
 
         use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH", "false")
         use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
@@ -156,6 +162,8 @@ class KeyVaultEkmClientPreparer(BaseClientPreparer):
     def __call__(self, fn):
         def _preparer(test_class, api_version, **kwargs):
             self._skip_if_not_configured(api_version)
+            kwargs["ekm_host"] = self.ekm_host
+            kwargs["ekm_certificate"] = self.ekm_certificate
             client = self.create_ekm_client(api_version=api_version, **kwargs)
 
             with client:

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -149,6 +149,29 @@ class KeyVaultSettingsClientPreparer(BaseClientPreparer):
         )
 
 
+class KeyVaultEkmClientPreparer(BaseClientPreparer):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+    def __call__(self, fn):
+        def _preparer(test_class, api_version, **kwargs):
+            self._skip_if_not_configured(api_version)
+            client = self.create_ekm_client(api_version=api_version, **kwargs)
+
+            with client:
+                fn(test_class, client, **kwargs)
+
+        return _preparer
+
+    def create_ekm_client(self, **kwargs):
+        from azure.keyvault.administration import KeyVaultEkmClient
+
+        credential = self.get_credential(KeyVaultEkmClient)
+        return self.create_client_from_credential(
+            KeyVaultEkmClient, credential=credential, vault_url=self.managed_hsm_url, **kwargs
+        )
+
+
 def get_decorator(**kwargs):
     """returns a test decorator for test parameterization"""
     versions = kwargs.pop("api_versions", None) or ApiVersion

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -17,7 +17,7 @@ class BaseClientPreparer(AzureRecordedTestCase):
         container_playback_uri = "https://storagename.blob.core.windows.net/container"
         playback_sas_token = "fake-sas"
         playback_ekm_host = "fake-ekm-host"
-        playback_server_ca_certificate = "fake-server-ca-certificate"
+        playback_server_ca_certificate = "ZmFrZS1jZXJ0LWRhdGE="
 
         if self.is_live:
             hsm = os.environ.get("AZURE_MANAGEDHSM_URL")

--- a/sdk/keyvault/azure-keyvault-administration/tests/conftest.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/conftest.py
@@ -32,6 +32,8 @@ def add_sanitizers(test_proxy):
     storage_url = os.environ.get("BLOB_STORAGE_URL", "https://Sanitized.blob.core.windows.net")
     client_id = os.environ.get("KEYVAULT_CLIENT_ID", "service-principal-id")
     sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN", "fake-sas")
+    ekm_host = os.environ.get("EKM_PROXY_HOST", "fake-ekm-host")
+    ekm_certificate = os.environ.get("EKM_SERVER_CA_CERTIFICATE", "fake-server-ca-certificate")
 
     add_general_string_sanitizer(target=azure_keyvault_url, value="https://Sanitized.vault.azure.net")
     add_general_string_sanitizer(target=keyvault_tenant_id, value="00000000-0000-0000-0000-000000000000")
@@ -40,6 +42,8 @@ def add_sanitizers(test_proxy):
     add_general_string_sanitizer(target=azure_attestation_uri, value="https://Sanitized.azurewebsites.net")
     add_general_string_sanitizer(target=storage_url, value="https://Sanitized.blob.core.windows.net")
     add_general_string_sanitizer(target=sas_token, value="fake-sas")
+    add_general_string_sanitizer(target=ekm_host, value="fake-ekm-host")
+    add_general_string_sanitizer(target=ekm_certificate, value="fake-server-ca-certificate")
     add_general_string_sanitizer(target=client_id, value="service-principal-id")
     # Sanitize API versions of `azure-keyvault-keys` requests
     add_uri_regex_sanitizer(

--- a/sdk/keyvault/azure-keyvault-administration/tests/conftest.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/conftest.py
@@ -33,7 +33,7 @@ def add_sanitizers(test_proxy):
     client_id = os.environ.get("KEYVAULT_CLIENT_ID", "service-principal-id")
     sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN", "fake-sas")
     ekm_host = os.environ.get("EKM_PROXY_HOST", "fake-ekm-host")
-    ekm_certificate = os.environ.get("EKM_SERVER_CA_CERTIFICATE", "fake-server-ca-certificate")
+    ekm_certificate = os.environ.get("EKM_SERVER_CA_CERTIFICATE", "ZmFrZS1jZXJ0LWRhdGE=")
 
     add_general_string_sanitizer(target=azure_keyvault_url, value="https://Sanitized.vault.azure.net")
     add_general_string_sanitizer(target=keyvault_tenant_id, value="00000000-0000-0000-0000-000000000000")
@@ -43,7 +43,7 @@ def add_sanitizers(test_proxy):
     add_general_string_sanitizer(target=storage_url, value="https://Sanitized.blob.core.windows.net")
     add_general_string_sanitizer(target=sas_token, value="fake-sas")
     add_general_string_sanitizer(target=ekm_host, value="fake-ekm-host")
-    add_general_string_sanitizer(target=ekm_certificate, value="fake-server-ca-certificate")
+    add_general_string_sanitizer(target=ekm_certificate, value="ZmFrZS1jZXJ0LWRhdGE=")
     add_general_string_sanitizer(target=client_id, value="service-principal-id")
     # Sanitize API versions of `azure-keyvault-keys` requests
     add_uri_regex_sanitizer(

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long,useless-suppression
 # ------------------------------------
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
@@ -2,156 +2,100 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+
+import base64
 import pytest
 
 from azure.core.exceptions import HttpResponseError
-from azure.keyvault.administration import (
-    KeyVaultEkmClient,
-    KeyVaultEkmConnection,
-    KeyVaultEkmProxyClientCertificateInfo,
-    KeyVaultEkmProxyInfo,
-)
-from azure.keyvault.administration._generated.models import EkmConnection as _GeneratedEkmConnection
+from azure.keyvault.administration import KeyVaultEkmClient, KeyVaultEkmConnection
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 
 from devtools_testutils import recorded_by_proxy
 
 from _shared.test_case import KeyVaultTestCase
 from _test_case import KeyVaultEkmClientPreparer, get_decorator
 
+only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
-# EKM operations are only available on the 2026-01-01-preview API version.
-ekm_api_versions = get_decorator(api_versions=["2026-01-01-preview"])
-
-# Minimal placeholder bytes; real ca certificates are PEM/DER chains pinned to your EKM proxy.
-_PROXY_CA_BYTES = b"\x30\x82\x01\x00"
+# Note: These tests require an EKM connection to be established with an EKM Sample Proxy.
 
 
-def _build_connection(host: str = "ekm.contoso.com") -> KeyVaultEkmConnection:
-    return KeyVaultEkmConnection(
-        host=host,
-        server_ca_certificates=[_PROXY_CA_BYTES],
-        path_prefix="/api",
-        server_subject_common_name="ekm.contoso.com",
-    )
-
-
-class TestEkmModels:
-    """Unit tests for EKM public model wrappers (no service interaction)."""
-
-    def test_ekm_connection_init_required_and_optional_fields(self):
-        connection = _build_connection()
-        assert connection.host == "ekm.contoso.com"
-        assert connection.server_ca_certificates == [_PROXY_CA_BYTES]
-        assert connection.path_prefix == "/api"
-        assert connection.server_subject_common_name == "ekm.contoso.com"
-
-    def test_ekm_connection_optional_fields_default_to_none(self):
-        connection = KeyVaultEkmConnection(host="h.example", server_ca_certificates=[_PROXY_CA_BYTES])
-        assert connection.path_prefix is None
-        assert connection.server_subject_common_name is None
-
-    def test_ekm_connection_repr_includes_host(self):
-        connection = _build_connection("repr.example.net")
-        assert "repr.example.net" in repr(connection)
-
-    def test_ekm_connection_round_trip_to_and_from_generated(self):
-        original = _build_connection()
-        generated = original._to_generated()
-        assert isinstance(generated, _GeneratedEkmConnection)
-        assert generated.host == original.host
-        assert generated.server_ca_certificates == original.server_ca_certificates
-        assert generated.path_prefix == original.path_prefix
-        assert generated.server_subject_common_name == original.server_subject_common_name
-
-        round_tripped = KeyVaultEkmConnection._from_generated(generated)
-        assert round_tripped.host == original.host
-        assert round_tripped.server_ca_certificates == original.server_ca_certificates
-        assert round_tripped.path_prefix == original.path_prefix
-        assert round_tripped.server_subject_common_name == original.server_subject_common_name
-
-    def test_ekm_proxy_client_certificate_info_kwargs(self):
-        info = KeyVaultEkmProxyClientCertificateInfo(
-            ca_certificates=[_PROXY_CA_BYTES], subject_common_name="ekm-client.contoso.com"
-        )
-        assert info.ca_certificates == [_PROXY_CA_BYTES]
-        assert info.subject_common_name == "ekm-client.contoso.com"
-        assert "ekm-client.contoso.com" in repr(info)
-
-    def test_ekm_proxy_info_kwargs(self):
-        info = KeyVaultEkmProxyInfo(
-            api_version="2.0", proxy_vendor="Contoso", proxy_name="ProxyX 1.2", ekm_vendor="Acme", ekm_product="HSM 9000"
-        )
-        assert info.api_version == "2.0"
-        assert info.proxy_vendor == "Contoso"
-        assert info.proxy_name == "ProxyX 1.2"
-        assert info.ekm_vendor == "Acme"
-        assert info.ekm_product == "HSM 9000"
-        rendered = repr(info)
-        assert "Contoso" in rendered and "Acme" in rendered
-
-
-class TestEkmClient(KeyVaultTestCase):
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
+class TestEkm(KeyVaultTestCase):
+    @pytest.mark.live_test_only
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultEkmClientPreparer()
     @recorded_by_proxy
-    def test_ekm_connection_lifecycle(self, client: KeyVaultEkmClient, **kwargs):
-        """Exercise create -> get -> update -> delete on an EKM connection."""
-        # Pre-condition: there should not be an existing EKM connection.
-        # If the recording was made against a clean HSM, delete is a no-op below.
+    def test_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
+        ekm_host = kwargs.pop("ekm_host")
+        server_ca_certificate = kwargs.pop("ekm_certificate")
+        if not server_ca_certificate or not ekm_host:
+            pytest.skip(
+                "EKM CA certificate is required for live tests. Please set the EKM_PROXY_HOST and EKM_SERVER_CA_CERTIFICATE environment variables."
+            )
+
+        # Cleanup
         try:
             client.delete_ekm_connection()
         except HttpResponseError:
             pass
 
-        # Create
-        created = client.create_ekm_connection(_build_connection())
-        assert isinstance(created, KeyVaultEkmConnection)
-        assert created.host == "ekm.contoso.com"
-        assert created.path_prefix == "/api"
+        # Create an EKM connection
+        ekm_connection = KeyVaultEkmConnection(
+            host=ekm_host,
+            server_ca_certificates=[base64.b64decode(server_ca_certificate)],
+            path_prefix="/api/v1",
+        )
+        created_ekm_connection = client.create_ekm_connection(connection=ekm_connection)
+        assert created_ekm_connection is not None
+        assert created_ekm_connection.host == ekm_host
+        assert created_ekm_connection.server_ca_certificates is not None
+        assert len(created_ekm_connection.server_ca_certificates) == 1
+        assert created_ekm_connection.path_prefix == ekm_connection.path_prefix
+        assert created_ekm_connection.server_subject_common_name == ekm_connection.server_subject_common_name
 
-        # Get
-        fetched = client.get_ekm_connection()
-        assert isinstance(fetched, KeyVaultEkmConnection)
-        assert fetched.host == created.host
-        assert fetched.path_prefix == created.path_prefix
+        # Get the EKM connection
+        retrieved_ekm_connection = client.get_ekm_connection()
+        assert retrieved_ekm_connection is not None
+        assert retrieved_ekm_connection.host == ekm_host
+        assert retrieved_ekm_connection.server_ca_certificates is not None
+        assert len(retrieved_ekm_connection.server_ca_certificates) == 1
+        assert retrieved_ekm_connection.path_prefix == ekm_connection.path_prefix
+        assert retrieved_ekm_connection.server_subject_common_name == created_ekm_connection.server_subject_common_name
 
-        # Update
-        updated_input = _build_connection()
-        updated_input.path_prefix = "/v2"
-        updated = client.update_ekm_connection(updated_input)
-        assert updated.path_prefix == "/v2"
+        # Get the EKM certificate
+        ekm_certificate = client.get_ekm_certificate()
+        assert ekm_certificate is not None
+        assert ekm_certificate.ca_certificates is not None
+        assert len(ekm_certificate.ca_certificates) == 1
 
-        # Delete
-        deleted = client.delete_ekm_connection()
-        assert isinstance(deleted, KeyVaultEkmConnection)
-        assert deleted.host == created.host
+        # Check the EKM connection status
+        connection_status = client.check_ekm_connection()
+        assert connection_status is not None
+        assert connection_status.api_version is not None
+        assert connection_status.proxy_vendor is not None
+        assert connection_status.proxy_name is not None
+        assert connection_status.ekm_vendor is not None
+        assert connection_status.ekm_product is not None
 
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
-    @KeyVaultEkmClientPreparer()
-    @recorded_by_proxy
-    def test_get_ekm_certificate(self, client: KeyVaultEkmClient, **kwargs):
-        """The EKM proxy client certificate info should always be retrievable."""
-        info = client.get_ekm_certificate()
-        assert isinstance(info, KeyVaultEkmProxyClientCertificateInfo)
-        # The service may return either populated certificate info or an empty payload
-        # depending on EKM provisioning state. Both are valid response shapes.
+        # Update the EKM connection
+        updated_ekm_connection = KeyVaultEkmConnection(
+            host=ekm_host,
+            server_ca_certificates=[base64.b64decode(server_ca_certificate)],
+            path_prefix="/api/v1",
+        )
+        result = client.update_ekm_connection(connection=updated_ekm_connection)
+        assert result is not None
+        assert result.host == updated_ekm_connection.host
+        assert result.server_ca_certificates is not None
+        assert len(result.server_ca_certificates) == 1
+        assert result.path_prefix == updated_ekm_connection.path_prefix
+        assert result.server_subject_common_name == updated_ekm_connection.server_subject_common_name
 
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
-    @KeyVaultEkmClientPreparer()
-    @recorded_by_proxy
-    def test_check_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
-        """Verify check_ekm_connection returns proxy info when an EKM proxy is reachable."""
-        try:
-            client.create_ekm_connection(_build_connection())
-        except HttpResponseError:
-            # An EKM connection may already exist from a previous test/recording
-            pass
-
-        try:
-            info = client.check_ekm_connection()
-            assert isinstance(info, KeyVaultEkmProxyInfo)
-        finally:
-            try:
-                client.delete_ekm_connection()
-            except HttpResponseError:
-                pass
+        # Delete the EKM connection
+        result = client.delete_ekm_connection()
+        assert result is not None
+        assert result.host == updated_ekm_connection.host
+        assert result.server_ca_certificates is not None
+        assert len(result.server_ca_certificates) == 1
+        assert result.path_prefix == updated_ekm_connection.path_prefix
+        assert result.server_subject_common_name == updated_ekm_connection.server_subject_common_name

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
@@ -1,0 +1,157 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import pytest
+
+from azure.core.exceptions import HttpResponseError
+from azure.keyvault.administration import (
+    KeyVaultEkmClient,
+    KeyVaultEkmConnection,
+    KeyVaultEkmProxyClientCertificateInfo,
+    KeyVaultEkmProxyInfo,
+)
+from azure.keyvault.administration._generated.models import EkmConnection as _GeneratedEkmConnection
+
+from devtools_testutils import recorded_by_proxy
+
+from _shared.test_case import KeyVaultTestCase
+from _test_case import KeyVaultEkmClientPreparer, get_decorator
+
+
+# EKM operations are only available on the 2026-01-01-preview API version.
+ekm_api_versions = get_decorator(api_versions=["2026-01-01-preview"])
+
+# Minimal placeholder bytes; real ca certificates are PEM/DER chains pinned to your EKM proxy.
+_PROXY_CA_BYTES = b"\x30\x82\x01\x00"
+
+
+def _build_connection(host: str = "ekm.contoso.com") -> KeyVaultEkmConnection:
+    return KeyVaultEkmConnection(
+        host=host,
+        server_ca_certificates=[_PROXY_CA_BYTES],
+        path_prefix="/api",
+        server_subject_common_name="ekm.contoso.com",
+    )
+
+
+class TestEkmModels:
+    """Unit tests for EKM public model wrappers (no service interaction)."""
+
+    def test_ekm_connection_init_required_and_optional_fields(self):
+        connection = _build_connection()
+        assert connection.host == "ekm.contoso.com"
+        assert connection.server_ca_certificates == [_PROXY_CA_BYTES]
+        assert connection.path_prefix == "/api"
+        assert connection.server_subject_common_name == "ekm.contoso.com"
+
+    def test_ekm_connection_optional_fields_default_to_none(self):
+        connection = KeyVaultEkmConnection(host="h.example", server_ca_certificates=[_PROXY_CA_BYTES])
+        assert connection.path_prefix is None
+        assert connection.server_subject_common_name is None
+
+    def test_ekm_connection_repr_includes_host(self):
+        connection = _build_connection("repr.example.net")
+        assert "repr.example.net" in repr(connection)
+
+    def test_ekm_connection_round_trip_to_and_from_generated(self):
+        original = _build_connection()
+        generated = original._to_generated()
+        assert isinstance(generated, _GeneratedEkmConnection)
+        assert generated.host == original.host
+        assert generated.server_ca_certificates == original.server_ca_certificates
+        assert generated.path_prefix == original.path_prefix
+        assert generated.server_subject_common_name == original.server_subject_common_name
+
+        round_tripped = KeyVaultEkmConnection._from_generated(generated)
+        assert round_tripped.host == original.host
+        assert round_tripped.server_ca_certificates == original.server_ca_certificates
+        assert round_tripped.path_prefix == original.path_prefix
+        assert round_tripped.server_subject_common_name == original.server_subject_common_name
+
+    def test_ekm_proxy_client_certificate_info_kwargs(self):
+        info = KeyVaultEkmProxyClientCertificateInfo(
+            ca_certificates=[_PROXY_CA_BYTES], subject_common_name="ekm-client.contoso.com"
+        )
+        assert info.ca_certificates == [_PROXY_CA_BYTES]
+        assert info.subject_common_name == "ekm-client.contoso.com"
+        assert "ekm-client.contoso.com" in repr(info)
+
+    def test_ekm_proxy_info_kwargs(self):
+        info = KeyVaultEkmProxyInfo(
+            api_version="2.0", proxy_vendor="Contoso", proxy_name="ProxyX 1.2", ekm_vendor="Acme", ekm_product="HSM 9000"
+        )
+        assert info.api_version == "2.0"
+        assert info.proxy_vendor == "Contoso"
+        assert info.proxy_name == "ProxyX 1.2"
+        assert info.ekm_vendor == "Acme"
+        assert info.ekm_product == "HSM 9000"
+        rendered = repr(info)
+        assert "Contoso" in rendered and "Acme" in rendered
+
+
+class TestEkmClient(KeyVaultTestCase):
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy
+    def test_ekm_connection_lifecycle(self, client: KeyVaultEkmClient, **kwargs):
+        """Exercise create -> get -> update -> delete on an EKM connection."""
+        # Pre-condition: there should not be an existing EKM connection.
+        # If the recording was made against a clean HSM, delete is a no-op below.
+        try:
+            client.delete_ekm_connection()
+        except HttpResponseError:
+            pass
+
+        # Create
+        created = client.create_ekm_connection(_build_connection())
+        assert isinstance(created, KeyVaultEkmConnection)
+        assert created.host == "ekm.contoso.com"
+        assert created.path_prefix == "/api"
+
+        # Get
+        fetched = client.get_ekm_connection()
+        assert isinstance(fetched, KeyVaultEkmConnection)
+        assert fetched.host == created.host
+        assert fetched.path_prefix == created.path_prefix
+
+        # Update
+        updated_input = _build_connection()
+        updated_input.path_prefix = "/v2"
+        updated = client.update_ekm_connection(updated_input)
+        assert updated.path_prefix == "/v2"
+
+        # Delete
+        deleted = client.delete_ekm_connection()
+        assert isinstance(deleted, KeyVaultEkmConnection)
+        assert deleted.host == created.host
+
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy
+    def test_get_ekm_certificate(self, client: KeyVaultEkmClient, **kwargs):
+        """The EKM proxy client certificate info should always be retrievable."""
+        info = client.get_ekm_certificate()
+        assert isinstance(info, KeyVaultEkmProxyClientCertificateInfo)
+        # The service may return either populated certificate info or an empty payload
+        # depending on EKM provisioning state. Both are valid response shapes.
+
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy
+    def test_check_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
+        """Verify check_ekm_connection returns proxy info when an EKM proxy is reachable."""
+        try:
+            client.create_ekm_connection(_build_connection())
+        except HttpResponseError:
+            # An EKM connection may already exist from a previous test/recording
+            pass
+
+        try:
+            info = client.check_ekm_connection()
+            assert isinstance(info, KeyVaultEkmProxyInfo)
+        finally:
+            try:
+                client.delete_ekm_connection()
+            except HttpResponseError:
+                pass

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client.py
@@ -22,7 +22,6 @@ only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
 
 class TestEkm(KeyVaultTestCase):
-    @pytest.mark.live_test_only
     @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultEkmClientPreparer()
     @recorded_by_proxy

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long,useless-suppression
 # ------------------------------------
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
@@ -2,15 +2,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+
+import base64
 import pytest
 
 from azure.core.exceptions import HttpResponseError
-from azure.keyvault.administration import (
-    KeyVaultEkmConnection,
-    KeyVaultEkmProxyClientCertificateInfo,
-    KeyVaultEkmProxyInfo,
-)
+from azure.keyvault.administration import KeyVaultEkmConnection
 from azure.keyvault.administration.aio import KeyVaultEkmClient
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 
 from devtools_testutils.aio import recorded_by_proxy_async
 
@@ -18,75 +17,88 @@ from _async_test_case import KeyVaultEkmClientPreparer
 from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
+only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
-ekm_api_versions = get_decorator(api_versions=["2026-01-01-preview"])
-
-_PROXY_CA_BYTES = b"\x30\x82\x01\x00"
-
-
-def _build_connection(host: str = "ekm.contoso.com") -> KeyVaultEkmConnection:
-    return KeyVaultEkmConnection(
-        host=host,
-        server_ca_certificates=[_PROXY_CA_BYTES],
-        path_prefix="/api",
-        server_subject_common_name="ekm.contoso.com",
-    )
+# Note: These tests require an EKM connection to be established with an EKM Sample Proxy.
 
 
-class TestEkmClient(KeyVaultTestCase):
+class TestEkm(KeyVaultTestCase):
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @pytest.mark.live_test_only
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultEkmClientPreparer()
     @recorded_by_proxy_async
-    async def test_ekm_connection_lifecycle(self, client: KeyVaultEkmClient, **kwargs):
-        """Exercise create -> get -> update -> delete on an EKM connection."""
+    async def test_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
+        ekm_host = kwargs.pop("ekm_host")
+        server_ca_certificate = kwargs.pop("ekm_certificate")
+        if not server_ca_certificate or not ekm_host:
+            pytest.skip(
+                "EKM CA certificate is required for live tests. Please set the EKM_PROXY_HOST and EKM_SERVER_CA_CERTIFICATE environment variables."
+            )
+
+        # Cleanup
         try:
             await client.delete_ekm_connection()
         except HttpResponseError:
             pass
 
-        created = await client.create_ekm_connection(_build_connection())
-        assert isinstance(created, KeyVaultEkmConnection)
-        assert created.host == "ekm.contoso.com"
-        assert created.path_prefix == "/api"
+        # Create an EKM connection
+        ekm_connection = KeyVaultEkmConnection(
+            host=ekm_host,
+            server_ca_certificates=[base64.b64decode(server_ca_certificate)],
+            path_prefix="/api/v1",
+        )
+        created_ekm_connection = await client.create_ekm_connection(connection=ekm_connection)
+        assert created_ekm_connection is not None
+        assert created_ekm_connection.host == ekm_host
+        assert created_ekm_connection.server_ca_certificates is not None
+        assert len(created_ekm_connection.server_ca_certificates) == 1
+        assert created_ekm_connection.path_prefix == ekm_connection.path_prefix
+        assert created_ekm_connection.server_subject_common_name == ekm_connection.server_subject_common_name
 
-        fetched = await client.get_ekm_connection()
-        assert isinstance(fetched, KeyVaultEkmConnection)
-        assert fetched.host == created.host
-        assert fetched.path_prefix == created.path_prefix
+        # Get the EKM connection
+        retrieved_ekm_connection = await client.get_ekm_connection()
+        assert retrieved_ekm_connection is not None
+        assert retrieved_ekm_connection.host == ekm_host
+        assert retrieved_ekm_connection.server_ca_certificates is not None
+        assert len(retrieved_ekm_connection.server_ca_certificates) == 1
+        assert retrieved_ekm_connection.path_prefix == ekm_connection.path_prefix
+        assert retrieved_ekm_connection.server_subject_common_name == created_ekm_connection.server_subject_common_name
 
-        updated_input = _build_connection()
-        updated_input.path_prefix = "/v2"
-        updated = await client.update_ekm_connection(updated_input)
-        assert updated.path_prefix == "/v2"
+        # Get the EKM certificate
+        ekm_certificate = await client.get_ekm_certificate()
+        assert ekm_certificate is not None
+        assert ekm_certificate.ca_certificates is not None
+        assert len(ekm_certificate.ca_certificates) == 1
 
-        deleted = await client.delete_ekm_connection()
-        assert isinstance(deleted, KeyVaultEkmConnection)
-        assert deleted.host == created.host
+        # Check the EKM connection status
+        connection_status = await client.check_ekm_connection()
+        assert connection_status is not None
+        assert connection_status.api_version is not None
+        assert connection_status.proxy_vendor is not None
+        assert connection_status.proxy_name is not None
+        assert connection_status.ekm_vendor is not None
+        assert connection_status.ekm_product is not None
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
-    @KeyVaultEkmClientPreparer()
-    @recorded_by_proxy_async
-    async def test_get_ekm_certificate(self, client: KeyVaultEkmClient, **kwargs):
-        info = await client.get_ekm_certificate()
-        assert isinstance(info, KeyVaultEkmProxyClientCertificateInfo)
+        # Update the EKM connection
+        updated_ekm_connection = KeyVaultEkmConnection(
+            host=ekm_host,
+            server_ca_certificates=[base64.b64decode(server_ca_certificate)],
+            path_prefix="/api/v1",
+        )
+        result = await client.update_ekm_connection(connection=updated_ekm_connection)
+        assert result is not None
+        assert result.host == updated_ekm_connection.host
+        assert result.server_ca_certificates is not None
+        assert len(result.server_ca_certificates) == 1
+        assert result.path_prefix == updated_ekm_connection.path_prefix
+        assert result.server_subject_common_name == updated_ekm_connection.server_subject_common_name
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", ekm_api_versions)
-    @KeyVaultEkmClientPreparer()
-    @recorded_by_proxy_async
-    async def test_check_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
-        try:
-            await client.create_ekm_connection(_build_connection())
-        except HttpResponseError:
-            pass
-
-        try:
-            info = await client.check_ekm_connection()
-            assert isinstance(info, KeyVaultEkmProxyInfo)
-        finally:
-            try:
-                await client.delete_ekm_connection()
-            except HttpResponseError:
-                pass
+        # Delete the EKM connection
+        result = await client.delete_ekm_connection()
+        assert result is not None
+        assert result.host == updated_ekm_connection.host
+        assert result.server_ca_certificates is not None
+        assert len(result.server_ca_certificates) == 1
+        assert result.path_prefix == updated_ekm_connection.path_prefix
+        assert result.server_subject_common_name == updated_ekm_connection.server_subject_common_name

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
@@ -1,0 +1,92 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import pytest
+
+from azure.core.exceptions import HttpResponseError
+from azure.keyvault.administration import (
+    KeyVaultEkmConnection,
+    KeyVaultEkmProxyClientCertificateInfo,
+    KeyVaultEkmProxyInfo,
+)
+from azure.keyvault.administration.aio import KeyVaultEkmClient
+
+from devtools_testutils.aio import recorded_by_proxy_async
+
+from _async_test_case import KeyVaultEkmClientPreparer
+from _test_case import get_decorator
+from _shared.test_case_async import KeyVaultTestCase
+
+
+ekm_api_versions = get_decorator(api_versions=["2026-01-01-preview"])
+
+_PROXY_CA_BYTES = b"\x30\x82\x01\x00"
+
+
+def _build_connection(host: str = "ekm.contoso.com") -> KeyVaultEkmConnection:
+    return KeyVaultEkmConnection(
+        host=host,
+        server_ca_certificates=[_PROXY_CA_BYTES],
+        path_prefix="/api",
+        server_subject_common_name="ekm.contoso.com",
+    )
+
+
+class TestEkmClient(KeyVaultTestCase):
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy_async
+    async def test_ekm_connection_lifecycle(self, client: KeyVaultEkmClient, **kwargs):
+        """Exercise create -> get -> update -> delete on an EKM connection."""
+        try:
+            await client.delete_ekm_connection()
+        except HttpResponseError:
+            pass
+
+        created = await client.create_ekm_connection(_build_connection())
+        assert isinstance(created, KeyVaultEkmConnection)
+        assert created.host == "ekm.contoso.com"
+        assert created.path_prefix == "/api"
+
+        fetched = await client.get_ekm_connection()
+        assert isinstance(fetched, KeyVaultEkmConnection)
+        assert fetched.host == created.host
+        assert fetched.path_prefix == created.path_prefix
+
+        updated_input = _build_connection()
+        updated_input.path_prefix = "/v2"
+        updated = await client.update_ekm_connection(updated_input)
+        assert updated.path_prefix == "/v2"
+
+        deleted = await client.delete_ekm_connection()
+        assert isinstance(deleted, KeyVaultEkmConnection)
+        assert deleted.host == created.host
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy_async
+    async def test_get_ekm_certificate(self, client: KeyVaultEkmClient, **kwargs):
+        info = await client.get_ekm_certificate()
+        assert isinstance(info, KeyVaultEkmProxyClientCertificateInfo)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version", ekm_api_versions)
+    @KeyVaultEkmClientPreparer()
+    @recorded_by_proxy_async
+    async def test_check_ekm_connection(self, client: KeyVaultEkmClient, **kwargs):
+        try:
+            await client.create_ekm_connection(_build_connection())
+        except HttpResponseError:
+            pass
+
+        try:
+            info = await client.check_ekm_connection()
+            assert isinstance(info, KeyVaultEkmProxyInfo)
+        finally:
+            try:
+                await client.delete_ekm_connection()
+            except HttpResponseError:
+                pass

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_ekm_client_async.py
@@ -25,7 +25,6 @@ only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
 class TestEkm(KeyVaultTestCase):
     @pytest.mark.asyncio
-    @pytest.mark.live_test_only
     @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultEkmClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/keyvault/azure-keyvault-administration/tsp-location.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/keyvault/data-plane/Administration
-commit: f6bd06be22baf3a18504ffef0f590230850953e5
+commit: 0aea5f5666b9d631d37074a2f9c9bd8ba0dd1eff
 repo: Azure/azure-rest-api-specs

--- a/sdk/keyvault/cspell.json
+++ b/sdk/keyvault/cspell.json
@@ -1,5 +1,6 @@
 {
     "ignoreWords": [
+        "keyvaultekmclient",
         "spiffe"
     ]
 }


### PR DESCRIPTION
# Description

- Added support for service API version `2026-01-01-preview` (https://github.com/Azure/azure-rest-api-specs/pull/40761)
- Added `KeyVaultEkmClient` for managing Managed HSM External Key Manager (EKM) connections. This new client exposes `get_ekm_connection`,  `create_ekm_connection`, `update_ekm_connection`, `delete_ekm_connection`, `get_ekm_certificate`, and `check_ekm_connection`.
- Added `KeyVaultEkmConnection`, `KeyVaultEkmProxyClientCertificateInfo`, and `KeyVaultEkmProxyInfo` models supporting the EKM client.
- Python 3.9 is no longer supported. Please use Python version 3.10 or later.
- Key Vault API version `2026-01-01-preview` is now the default.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
