### PR TITLE
[Cosmos] Set 4.14.7 release date

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.14.7 (Unreleased)
+### 4.14.7 (2026-05-14)
 
 #### Bugs Fixed
 * Fixed `SELECT VALUE` aggregation classification across partitions: booleans are no longer treated as numeric aggregates, non-aggregate numeric projections are no longer merged, and `MIN`/`MAX` detection is now correct. See [PR 46692](https://github.com/Azure/azure-sdk-for-python/pull/46692)


### PR DESCRIPTION
Set the azure-cosmos 4.14.7 entry in CHANGELOG.md from `(Unreleased)` to `(2026-05-14)` ahead of release.

No code changes — only the CHANGELOG header line is updated.