### PR TITLE
Region normalization fix

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug where `CosmosClient` construction with AAD credentials would crash at startup if the semantic reranking inference endpoint environment variable was not set, even when semantic reranking was not being used. The inference service is now lazily initialized on first use. See [PR 46243](https://github.com/Azure/azure-sdk-for-python/pull/46243)
-* Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were matched case-sensitively and required exact spacing. See [PR 46792](https://github.com/Azure/azure-sdk-for-python/pull/46792)
+* Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were matched case-sensitively and required exact spacing. See [PR 46937](https://github.com/Azure/azure-sdk-for-python/pull/46937)
 
 #### Other Changes
 * Reduced per-client memory overhead when partition-level circuit breaker (PPCB) is enabled by sharing the partition key range routing map cache across CosmosClient instances connected to the same endpoint, and stripping unused fields from cached partition key ranges using compact PKRange namedtuples. See [PR 46297](https://github.com/Azure/azure-sdk-for-python/pull/46297)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug where `CosmosClient` construction with AAD credentials would crash at startup if the semantic reranking inference endpoint environment variable was not set, even when semantic reranking was not being used. The inference service is now lazily initialized on first use. See [PR 46243](https://github.com/Azure/azure-sdk-for-python/pull/46243)
+* Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were matched case-sensitively and required exact spacing. See [PR 46792](https://github.com/Azure/azure-sdk-for-python/pull/46792)
 
 #### Other Changes
 * Reduced per-client memory overhead when partition-level circuit breaker (PPCB) is enabled by sharing the partition key range routing map cache across CosmosClient instances connected to the same endpoint, and stripping unused fields from cached partition key ranges using compact PKRange namedtuples. See [PR 46297](https://github.com/Azure/azure-sdk-for-python/pull/46297)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug where `CosmosClient` construction with AAD credentials would crash at startup if the semantic reranking inference endpoint environment variable was not set, even when semantic reranking was not being used. The inference service is now lazily initialized on first use. See [PR 46243](https://github.com/Azure/azure-sdk-for-python/pull/46243)
-* Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were matched case-sensitively and required exact spacing. See [PR 46937](https://github.com/Azure/azure-sdk-for-python/pull/46937)
+* Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were not matched tolerantly for differences in case, whitespace, hyphens, and underscores. See [PR 46937](https://github.com/Azure/azure-sdk-for-python/pull/46937)
 
 #### Other Changes
 * Reduced per-client memory overhead when partition-level circuit breaker (PPCB) is enabled by sharing the partition key range routing map cache across CosmosClient instances connected to the same endpoint, and stripping unused fields from cached partition key ranges using compact PKRange namedtuples. See [PR 46297](https://github.com/Azure/azure-sdk-for-python/pull/46297)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
@@ -38,7 +38,7 @@ from .http_constants import ResourceType
 logger = logging.getLogger("azure.cosmos.LocationCache")
 
 
-def _normalize_region_name(region_name: str | None) -> str:
+def _normalize_region_name(region_name: Optional[str]) -> str:
     if region_name is None:
         return ""
     normalized = "".join(str(region_name).strip().lower().split())

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
@@ -37,10 +37,19 @@ from .http_constants import ResourceType
 
 logger = logging.getLogger("azure.cosmos.LocationCache")
 
+
+def _normalize_region_name(region_name: str | None) -> str:
+    if region_name is None:
+        return ""
+    normalized = "".join(str(region_name).strip().lower().split())
+    return normalized.replace("-", "").replace("_", "")
+
+
 class EndpointOperationType(object):
     NoneType = "None"
     ReadType = "Read"
     WriteType = "Write"
+
 
 class RegionalRoutingContext(object):
     def __init__(self, primary_endpoint: str):
@@ -57,6 +66,7 @@ class RegionalRoutingContext(object):
 
     def __str__(self):
         return "Primary: " + self.primary_endpoint
+
 
 def get_regional_routing_contexts_by_loc(new_locations: list[dict[str, str]]):
     # construct from previous object
@@ -82,13 +92,15 @@ def get_regional_routing_contexts_by_loc(new_locations: list[dict[str, str]]):
 
     return regional_routing_contexts_by_location, locations_by_endpoints, parsed_locations
 
+
 def _get_health_check_endpoints(regional_routing_contexts) -> Set[str]:
     # should use the endpoints in the order returned from gateway and only the ones specified in preferred locations
     preferred_endpoints = {context.get_primary() for context in regional_routing_contexts}
     return preferred_endpoints
 
+
 def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[RegionalRoutingContext],
-                                              location_name_by_endpoint: Mapping[str, str],
+                                              normalized_location_name_by_endpoint: Mapping[str, str],
                                               fall_back_regional_routing_context: RegionalRoutingContext,
                                               exclude_location_list: list[str],
                                               circuit_breaker_exclude_list: list[str],
@@ -108,8 +120,8 @@ def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[Re
 
     :param regional_routing_contexts: The initial list of regional contexts to filter.
     :type regional_routing_contexts: list[RegionalRoutingContext]
-    :param location_name_by_endpoint: A mapping from endpoint URL to location name.
-    :type location_name_by_endpoint: Mapping[str, str]
+    :param normalized_location_name_by_endpoint: A mapping from endpoint URL to normalized location name.
+    :type normalized_location_name_by_endpoint: Mapping[str, str]
     :param fall_back_regional_routing_context: The context to use as a fallback if all others are filtered out.
     :type fall_back_regional_routing_context: RegionalRoutingContext
     :param exclude_location_list: A list of location names to exclude, based on user configuration.
@@ -121,11 +133,17 @@ def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[Re
     :return: A filtered and reordered list of regional routing contexts.
     :rtype: list[RegionalRoutingContext]
     """
+    normalized_excluded_locations = {_normalize_region_name(location) for location in exclude_location_list}
+    normalized_circuit_breaker_locations = {
+        _normalize_region_name(location) for location in circuit_breaker_exclude_list
+    }
+
     # filter endpoints by excluded locations
     applicable_regional_routing_contexts = []
     user_excluded_regional_routing_contexts = []
     for regional_routing_context in regional_routing_contexts:
-        if location_name_by_endpoint.get(regional_routing_context.get_primary()) not in exclude_location_list:
+        normalized_location_name = normalized_location_name_by_endpoint.get(regional_routing_context.get_primary(), "")
+        if normalized_location_name not in normalized_excluded_locations:
             applicable_regional_routing_contexts.append(regional_routing_context)
         else:
             user_excluded_regional_routing_contexts.append(regional_routing_context)
@@ -134,7 +152,8 @@ def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[Re
     final_applicable_contexts = []
     circuit_breaker_excluded_contexts = []
     for regional_routing_context in applicable_regional_routing_contexts:
-        if location_name_by_endpoint.get(regional_routing_context.get_primary()) in circuit_breaker_exclude_list:
+        normalized_location_name = normalized_location_name_by_endpoint.get(regional_routing_context.get_primary(), "")
+        if normalized_location_name in normalized_circuit_breaker_locations:
             circuit_breaker_excluded_contexts.append(regional_routing_context)
         else:
             final_applicable_contexts.append(regional_routing_context)
@@ -151,6 +170,7 @@ def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[Re
         final_applicable_contexts.append(fall_back_regional_routing_context)
 
     return final_applicable_contexts
+
 
 class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many-instance-attributes
 
@@ -172,7 +192,14 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         self.account_locations_by_write_endpoints: dict[str, str] = {} # pylint: disable=name-too-long
         self.account_write_locations: list[str] = []
         self.account_read_locations: list[str] = []
+        self._read_locations_by_normalized: dict[str, RegionalRoutingContext] = {}
+        self._write_locations_by_normalized: dict[str, RegionalRoutingContext] = {}
+        self._normalized_location_by_read_endpoint: dict[str, str] = {}
+        self._normalized_location_by_write_endpoint: dict[str, str] = {}
+        self._normalized_name_by_read_location: dict[str, str] = {}
+        self._normalized_name_by_write_location: dict[str, str] = {}
         self.connection_policy: ConnectionPolicy = connection_policy
+        self._config_mismatch_warning_dedupe: set[tuple[str, tuple[str, ...], tuple[str, ...]]] = set()
 
     def get_write_regional_routing_contexts(self):
         return self.write_regional_routing_contexts
@@ -229,6 +256,38 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
 
         return excluded_locations
 
+    def _emit_config_mismatch_warning_once(
+            self,
+            configured_locations: list[str],
+            available_locations: list[str],
+            setting_name: str):
+        if not configured_locations:
+            return
+
+        available_by_normalized = {_normalize_region_name(location): location for location in available_locations}
+        unmatched_locations = [
+            location
+            for location in configured_locations
+            if _normalize_region_name(location) not in available_by_normalized
+        ]
+
+        if unmatched_locations:
+            dedupe_key = (
+                setting_name,
+                tuple(sorted(_normalize_region_name(location) for location in unmatched_locations)),
+                tuple(sorted(available_by_normalized.keys())),
+            )
+            if dedupe_key in self._config_mismatch_warning_dedupe:
+                return
+            self._config_mismatch_warning_dedupe.add(dedupe_key)
+
+            logger.warning(
+                "Ignoring %s entries that did not match account regions: %s. Available regions: %s",
+                setting_name,
+                unmatched_locations,
+                available_locations,
+            )
+
     def _get_applicable_read_regional_routing_contexts(self, request: RequestObject) -> list[RegionalRoutingContext]:
         # Get configured excluded locations
         excluded_locations = self._get_configured_excluded_locations(request)
@@ -237,7 +296,7 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         if excluded_locations or request.excluded_locations_circuit_breaker:
             return _get_applicable_regional_routing_contexts(
                 self.get_read_regional_routing_contexts(),
-                self.account_locations_by_read_endpoints,
+                self._normalized_location_by_read_endpoint,
                 self.get_write_regional_routing_contexts()[0],
                 excluded_locations,
                 request.excluded_locations_circuit_breaker or [],
@@ -254,7 +313,7 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         if excluded_locations or request.excluded_locations_circuit_breaker:
             return _get_applicable_regional_routing_contexts(
                 self.get_write_regional_routing_contexts(),
-                self.account_locations_by_write_endpoints,
+                self._normalized_location_by_write_endpoint,
                 self.default_regional_routing_context,
                 excluded_locations,
                 request.excluded_locations_circuit_breaker or [],
@@ -292,6 +351,8 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         ordered_locations = self.account_write_locations if is_write else self.account_read_locations
         all_contexts_by_loc = (self.account_write_regional_routing_contexts_by_location if is_write
                                else self.account_read_regional_routing_contexts_by_location)
+        normalized_name_by_location = (self._normalized_name_by_write_location if is_write
+                                       else self._normalized_name_by_read_location)
 
         # Safety check: if endpoint discovery is off or location cache isn't populated, fallback.
         if not self.connection_policy.EnableEndpointDiscovery or not ordered_locations:
@@ -309,14 +370,20 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         excluded_locations = self._get_configured_excluded_locations(request)
         circuit_breaker_excluded_locations = request.excluded_locations_circuit_breaker or []
 
+        normalized_excluded_locations = {_normalize_region_name(location) for location in excluded_locations}
+        normalized_circuit_breaker_locations = {
+            _normalize_region_name(location) for location in circuit_breaker_excluded_locations
+        }
+
         applicable_contexts = []
         circuit_breaker_contexts = []
         for loc_name in ordered_locations:
             if loc_name in all_contexts_by_loc:
                 context = all_contexts_by_loc[loc_name]
-                if loc_name in excluded_locations:
+                normalized_location_name = normalized_name_by_location.get(loc_name, "")
+                if normalized_location_name in normalized_excluded_locations:
                     continue  # Skip user-excluded locations
-                if loc_name in circuit_breaker_excluded_locations:
+                if normalized_location_name in normalized_circuit_breaker_locations:
                     circuit_breaker_contexts.append(context)
                 else:
                     applicable_contexts.append(context)
@@ -376,6 +443,11 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
 
     def should_refresh_endpoints(self):  # pylint: disable=too-many-return-statements
         most_preferred_location = self.effective_preferred_locations[0] if self.effective_preferred_locations else None
+        normalized_most_preferred_location = (
+            _normalize_region_name(most_preferred_location) if most_preferred_location else None
+        )
+        read_locations_by_normalized = self._read_locations_by_normalized
+        write_locations_by_normalized = self._write_locations_by_normalized
 
         # we should schedule refresh in background if we are unable to target the user's most preferredLocation.
         if self.connection_policy.EnableEndpointDiscovery:
@@ -383,18 +455,13 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
             should_refresh = (self.connection_policy.UseMultipleWriteLocations
                               and not self.enable_multiple_writable_locations)
 
-            if (most_preferred_location and most_preferred_location in
-                    self.account_read_regional_routing_contexts_by_location):
-                if (self.account_read_regional_routing_contexts_by_location
-                        and most_preferred_location in self.account_read_regional_routing_contexts_by_location):
-                    most_preferred_read_endpoint = (
-                        self.account_read_regional_routing_contexts_by_location)[most_preferred_location]
-                    if (most_preferred_read_endpoint and
-                            most_preferred_read_endpoint != self.read_regional_routing_contexts[0]):
-                        # For reads, we can always refresh in background as we can alternate to
-                        # other available read endpoints
-                        return True
-                else:
+            if (normalized_most_preferred_location and normalized_most_preferred_location in
+                    read_locations_by_normalized):
+                most_preferred_read_endpoint = read_locations_by_normalized[normalized_most_preferred_location]
+                if (most_preferred_read_endpoint and
+                        most_preferred_read_endpoint != self.read_regional_routing_contexts[0]):
+                    # For reads, we can always refresh in background as we can alternate to
+                    # other available read endpoints
                     return True
 
             if not self.can_use_multiple_write_locations():
@@ -405,10 +472,11 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
                     # we have an alternate write endpoint
                     return True
                 return should_refresh
-            if (most_preferred_location and
-                    most_preferred_location in self.account_write_regional_routing_contexts_by_location):
-                most_preferred_write_regional_endpoint = (
-                    self.account_write_regional_routing_contexts_by_location)[most_preferred_location]
+            if (normalized_most_preferred_location and
+                    normalized_most_preferred_location in write_locations_by_normalized):
+                most_preferred_write_regional_endpoint = write_locations_by_normalized[
+                    normalized_most_preferred_location
+                ]
                 if most_preferred_write_regional_endpoint:
                     should_refresh |= most_preferred_write_regional_endpoint != self.write_regional_routing_contexts[0]
                     return should_refresh
@@ -476,6 +544,32 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
                  self.account_locations_by_write_endpoints,
                  self.account_write_locations) = get_regional_routing_contexts_by_loc(write_locations)
 
+        # Cache normalized lookups once per topology refresh to avoid repeating work per request.
+        self._read_locations_by_normalized = {
+            _normalize_region_name(name): context
+            for name, context in self.account_read_regional_routing_contexts_by_location.items()
+        }
+        self._write_locations_by_normalized = {
+            _normalize_region_name(name): context
+            for name, context in self.account_write_regional_routing_contexts_by_location.items()
+        }
+        self._normalized_location_by_read_endpoint = {
+            endpoint: _normalize_region_name(name)
+            for endpoint, name in self.account_locations_by_read_endpoints.items()
+        }
+        self._normalized_location_by_write_endpoint = {
+            endpoint: _normalize_region_name(name)
+            for endpoint, name in self.account_locations_by_write_endpoints.items()
+        }
+        self._normalized_name_by_read_location = {
+            name: _normalize_region_name(name)
+            for name in self.account_read_regional_routing_contexts_by_location
+        }
+        self._normalized_name_by_write_location = {
+            name: _normalize_region_name(name)
+            for name in self.account_write_regional_routing_contexts_by_location
+        }
+
         # if preferred locations is empty and the default endpoint is a global endpoint,
         # we should use the read locations from gateway as effective preferred locations
         if self.connection_policy.PreferredLocations:
@@ -489,17 +583,40 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
             self.account_write_regional_routing_contexts_by_location,
             self.account_write_locations,
             EndpointOperationType.WriteType,
-            self.default_regional_routing_context
+            self.default_regional_routing_context,
+            self._write_locations_by_normalized,
         )
         self.read_regional_routing_contexts = self.get_preferred_regional_routing_contexts(
             self.account_read_regional_routing_contexts_by_location,
             self.account_read_locations,
             EndpointOperationType.ReadType,
-            self.write_regional_routing_contexts[0]
+            self.write_regional_routing_contexts[0],
+            self._read_locations_by_normalized,
         )
 
+        # Config-time visibility for misconfigured region names. Dedupe ensures periodic
+        # refreshes do not re-emit identical warnings; new mismatches still surface because
+        # the dedupe key includes the available account regions snapshot.
+        if self.connection_policy.PreferredLocations:
+            self._emit_config_mismatch_warning_once(
+                self.connection_policy.PreferredLocations,
+                self.account_read_locations or self.account_write_locations,
+                "preferred_locations",
+            )
+        if self.connection_policy.ExcludedLocations:
+            self._emit_config_mismatch_warning_once(
+                list(self.connection_policy.ExcludedLocations),
+                self.account_read_locations or self.account_write_locations,
+                "excluded_locations",
+            )
+
     def get_preferred_regional_routing_contexts(
-        self, endpoints_by_location, ordered_locations, expected_available_operation, fallback_endpoint
+        self,
+        endpoints_by_location,
+        ordered_locations,
+        expected_available_operation,
+        fallback_endpoint,
+        endpoints_by_normalized_location=None,
     ):
         regional_endpoints = []
         # if enableEndpointDiscovery is false, we always use the defaultEndpoint that
@@ -511,12 +628,18 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
             ):
                 unavailable_endpoints = []
                 if self.effective_preferred_locations:
+                    endpoints_by_normalized_location = endpoints_by_normalized_location or {
+                        _normalize_region_name(location): endpoint
+                        for location, endpoint in endpoints_by_location.items()
+                    }
+
                     # When client can not use multiple write locations, preferred locations
                     # list should only be used determining read endpoints order. If client
                     # can use multiple write locations, preferred locations list should be
                     # used for determining both read and write endpoints order.
                     for location in self.effective_preferred_locations:
-                        regional_endpoint = endpoints_by_location.get(location)
+                        normalized_location = _normalize_region_name(location)
+                        regional_endpoint = endpoints_by_normalized_location.get(normalized_location)
                         if regional_endpoint:
                             if self.is_endpoint_unavailable(regional_endpoint.get_primary(),
                                                             expected_available_operation):
@@ -593,8 +716,8 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
                 global_database_account_name = hostname_parts[0]
 
                 # Prepare the locational_database_account_name as contoso-eastus for location_name 'east us'
-                locational_database_account_name = global_database_account_name + "-" + location_name.replace(" ", "")
-                locational_database_account_name = locational_database_account_name.lower()
+                normalized_location_name = _normalize_region_name(location_name)
+                locational_database_account_name = global_database_account_name + "-" + normalized_location_name
 
                 # Replace 'contoso' with 'contoso-eastus' and return locational_endpoint
                 # as https://contoso-eastus.documents.azure.com:443/

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
@@ -38,6 +38,21 @@ from .http_constants import ResourceType
 logger = logging.getLogger("azure.cosmos.LocationCache")
 
 
+def _clean_location_list(locations: Optional[list[Optional[str]]]) -> list[str]:
+    """Drop ``None``/empty/whitespace-only entries from a location list.
+
+    We filter these out at every intake point because the region normalizer
+    turns ``None`` (and empty/whitespace input) into an empty string. If such
+    a value were allowed into an exclusion list, every endpoint that wasn't
+    found in our by-endpoint lookup map — which also returns an empty string
+    as its default — would compare equal to it and get silently excluded.
+    Stripping the bad inputs once, at the boundary, prevents that collision.
+    """
+    if not locations:
+        return []
+    return [loc for loc in locations if loc and str(loc).strip()]
+
+
 def _normalize_region_name(region_name: Optional[str]) -> str:
     if region_name is None:
         return ""
@@ -133,9 +148,10 @@ def _get_applicable_regional_routing_contexts(regional_routing_contexts: list[Re
     :return: A filtered and reordered list of regional routing contexts.
     :rtype: list[RegionalRoutingContext]
     """
-    normalized_excluded_locations = {_normalize_region_name(location) for location in exclude_location_list}
+    normalized_excluded_locations = {_normalize_region_name(location)
+                                     for location in _clean_location_list(exclude_location_list)}
     normalized_circuit_breaker_locations = {
-        _normalize_region_name(location) for location in circuit_breaker_exclude_list
+        _normalize_region_name(location) for location in _clean_location_list(circuit_breaker_exclude_list)
     }
 
     # filter endpoints by excluded locations
@@ -196,8 +212,6 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         self._write_locations_by_normalized: dict[str, RegionalRoutingContext] = {}
         self._normalized_location_by_read_endpoint: dict[str, str] = {}
         self._normalized_location_by_write_endpoint: dict[str, str] = {}
-        self._normalized_name_by_read_location: dict[str, str] = {}
-        self._normalized_name_by_write_location: dict[str, str] = {}
         self.connection_policy: ConnectionPolicy = connection_policy
         self._config_mismatch_warning_dedupe: set[tuple[str, tuple[str, ...], tuple[str, ...]]] = set()
 
@@ -254,13 +268,18 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
             else:
                 excluded_locations = []
 
-        return excluded_locations
+        # Strip None / empty / whitespace-only entries so they never reach the
+        # normalization layer (where they would collapse to "" and silently
+        # match unknown endpoints whose by-endpoint lookup also defaults to "").
+        return _clean_location_list(excluded_locations)
 
     def _emit_config_mismatch_warning_once(
             self,
             configured_locations: list[str],
             available_locations: list[str],
             setting_name: str):
+        configured_locations = _clean_location_list(configured_locations)
+        available_locations = _clean_location_list(available_locations)
         if not configured_locations:
             return
 
@@ -351,8 +370,6 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         ordered_locations = self.account_write_locations if is_write else self.account_read_locations
         all_contexts_by_loc = (self.account_write_regional_routing_contexts_by_location if is_write
                                else self.account_read_regional_routing_contexts_by_location)
-        normalized_name_by_location = (self._normalized_name_by_write_location if is_write
-                                       else self._normalized_name_by_read_location)
 
         # Safety check: if endpoint discovery is off or location cache isn't populated, fallback.
         if not self.connection_policy.EnableEndpointDiscovery or not ordered_locations:
@@ -368,7 +385,7 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
 
         # For reads or multi-write, filter locations by user and circuit-breaker exclusions.
         excluded_locations = self._get_configured_excluded_locations(request)
-        circuit_breaker_excluded_locations = request.excluded_locations_circuit_breaker or []
+        circuit_breaker_excluded_locations = _clean_location_list(request.excluded_locations_circuit_breaker)
 
         normalized_excluded_locations = {_normalize_region_name(location) for location in excluded_locations}
         normalized_circuit_breaker_locations = {
@@ -380,7 +397,7 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         for loc_name in ordered_locations:
             if loc_name in all_contexts_by_loc:
                 context = all_contexts_by_loc[loc_name]
-                normalized_location_name = normalized_name_by_location.get(loc_name, "")
+                normalized_location_name = _normalize_region_name(loc_name)
                 if normalized_location_name in normalized_excluded_locations:
                     continue  # Skip user-excluded locations
                 if normalized_location_name in normalized_circuit_breaker_locations:
@@ -560,14 +577,6 @@ class LocationCache(object):  # pylint: disable=too-many-public-methods,too-many
         self._normalized_location_by_write_endpoint = {
             endpoint: _normalize_region_name(name)
             for endpoint, name in self.account_locations_by_write_endpoints.items()
-        }
-        self._normalized_name_by_read_location = {
-            name: _normalize_region_name(name)
-            for name in self.account_read_regional_routing_contexts_by_location
-        }
-        self._normalized_name_by_write_location = {
-            name: _normalize_region_name(name)
-            for name in self.account_write_regional_routing_contexts_by_location
         }
 
         # if preferred locations is empty and the default endpoint is a global endpoint,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_location_cache.py
@@ -25,7 +25,7 @@ DatabaseAccount with multiple writable and readable locations.
 import collections
 import logging
 from typing import Optional
-from typing import Set, Mapping, OrderedDict
+from typing import Set, Mapping, OrderedDict, Sequence
 from urllib.parse import urlparse
 
 from . import documents, _base as base
@@ -38,7 +38,7 @@ from .http_constants import ResourceType
 logger = logging.getLogger("azure.cosmos.LocationCache")
 
 
-def _clean_location_list(locations: Optional[list[Optional[str]]]) -> list[str]:
+def _clean_location_list(locations: Optional[Sequence[Optional[str]]]) -> list[str]:
     """Drop ``None``/empty/whitespace-only entries from a location list.
 
     We filter these out at every intake point because the region normalizer
@@ -47,6 +47,14 @@ def _clean_location_list(locations: Optional[list[Optional[str]]]) -> list[str]:
     found in our by-endpoint lookup map — which also returns an empty string
     as its default — would compare equal to it and get silently excluded.
     Stripping the bad inputs once, at the boundary, prevents that collision.
+
+    :param locations: The raw location list to clean, or ``None``. May contain
+        ``None`` entries and empty/whitespace-only strings.
+    :type locations: Optional[Sequence[Optional[str]]]
+    :return: A new list containing only the non-empty, non-whitespace string
+        entries from ``locations``. Returns an empty list when ``locations``
+        is ``None`` or empty.
+    :rtype: list[str]
     """
     if not locations:
         return []
@@ -54,6 +62,43 @@ def _clean_location_list(locations: Optional[list[Optional[str]]]) -> list[str]:
 
 
 def _normalize_region_name(region_name: Optional[str]) -> str:
+    """Canonicalize a region name for equality comparison.
+
+    This is the single function every region-name comparison in this module
+    routes through (exclusion matching, preferred-location resolution, the
+    by-endpoint normalized lookup, the config-mismatch warning emitter, and
+    the most-preferred check in ``should_refresh_endpoints``). Two names
+    normalize to the same string iff the SDK treats them as the same region.
+
+    The rule, in plain terms:
+
+    - **Stripped:** outer and inner whitespace (via ``.strip()`` followed by
+      ``.split()`` / ``"".join(...)``), case (``.lower()``), and the two
+      separator characters customers commonly write — ``-`` and ``_``.
+    - **Preserved:** ASCII letters and **digits**. The digit invariant is the
+      load-bearing one: it is what keeps ``"East US"`` and ``"East US 2"``
+      distinct after normalization (``"eastus"`` vs ``"eastus2"``). Stripping
+      digits, even as part of a well-meaning cleanup, would silently collide
+      these regions and route each one's traffic to the other.
+    - **``None`` / empty / whitespace-only input maps to ``""``.** That empty
+      string is a sentinel that also appears as the default value of the
+      by-endpoint name lookup, so callers must filter such inputs out at the
+      configuration boundary with :func:`_clean_location_list` before they
+      reach this function. See that function's docstring for the collision
+      scenario.
+    - **Idempotent.** ``_normalize_region_name(_normalize_region_name(x)) ==
+      _normalize_region_name(x)`` for every ``x``. Defensive double-calls are
+      safe.
+
+    :param region_name: A region name to canonicalize, or ``None``. Customer
+        input (preferred/excluded locations) and account-side names from the
+        gateway both flow through here.
+    :type region_name: Optional[str]
+    :return: The canonicalized form, suitable for direct ``==`` / ``in``
+        comparison against other canonicalized names. Returns ``""`` for
+        ``None`` or whitespace-only input.
+    :rtype: str
+    """
     if region_name is None:
         return ""
     normalized = "".join(str(region_name).strip().lower().split())

--- a/sdk/cosmos/azure-cosmos/cspell.json
+++ b/sdk/cosmos/azure-cosmos/cspell.json
@@ -2,6 +2,7 @@
     "ignoreWords": [
         "hdrh",
         "hdrhistogram",
+        "dedupe",
         "perfdb",
         "perfresults",
         "pkrange",

--- a/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
@@ -39,6 +39,26 @@ def create_database_account(enable_multiple_writable_locations):
     return db_acc
 
 
+canonical_location1_name = "East US 2"
+canonical_location2_name = "West US 3"
+canonical_location1_endpoint = "https://eastus2.documents.azure.com"
+canonical_location2_endpoint = "https://westus3.documents.azure.com"
+
+
+def create_database_account_with_canonical_regions(enable_multiple_writable_locations):
+    db_acc = DatabaseAccount()
+    db_acc._WritableLocations = [
+        {"name": canonical_location1_name, "databaseAccountEndpoint": canonical_location1_endpoint},
+        {"name": canonical_location2_name, "databaseAccountEndpoint": canonical_location2_endpoint},
+    ]
+    db_acc._ReadableLocations = [
+        {"name": canonical_location1_name, "databaseAccountEndpoint": canonical_location1_endpoint},
+        {"name": canonical_location2_name, "databaseAccountEndpoint": canonical_location2_endpoint},
+    ]
+    db_acc._EnableMultipleWritableLocations = enable_multiple_writable_locations
+    return db_acc
+
+
 def refresh_location_cache(preferred_locations, use_multiple_write_locations, connection_policy=documents.ConnectionPolicy()):
     connection_policy.PreferredLocations = preferred_locations
     connection_policy.UseMultipleWriteLocations = use_multiple_write_locations
@@ -669,6 +689,111 @@ class TestLocationCache:
 
         assert read_after_second == [ctx.get_primary() for ctx in expected_read]
         assert write_after_second == [ctx.get_primary() for ctx in expected_write]
+
+    def test_resolve_endpoint_without_preferred_locations_supports_normalized_exclusions(self):
+        # This specifically exercises _resolve_endpoint_without_preferred_locations by
+        # setting use_preferred_locations=False.
+        lc = refresh_location_cache(
+            preferred_locations=[],
+            use_multiple_write_locations=True,
+        )
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+
+        write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)
+        write_request.use_preferred_locations = False
+        write_request.excluded_locations = ["east-us-2"]
+
+        assert lc.resolve_service_endpoint(write_request) == canonical_location2_endpoint
+
+        read_request = RequestObject(ResourceType.Document, _OperationType.Read, None)
+        read_request.use_preferred_locations = False
+        read_request.excluded_locations = ["west_us_3"]
+
+        assert lc.resolve_service_endpoint(read_request) == canonical_location1_endpoint
+
+    def test_preferred_locations_support_normalized_region_names(self):
+        # Preferred locations should match account region names even with case/spacing/separator variations.
+        lc = refresh_location_cache(["east-us-2", " west_us_3 "], True)
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+
+        write_contexts = lc.get_write_regional_routing_contexts()
+        read_contexts = lc.get_read_regional_routing_contexts()
+
+        assert write_contexts[0].get_primary() == canonical_location1_endpoint
+        assert write_contexts[1].get_primary() == canonical_location2_endpoint
+        assert read_contexts[0].get_primary() == canonical_location1_endpoint
+        assert read_contexts[1].get_primary() == canonical_location2_endpoint
+
+    def test_excluded_locations_support_normalized_region_names(self):
+        # Excluded locations should filter regions even when normalized names are used.
+        connection_policy = documents.ConnectionPolicy()
+        connection_policy.ExcludedLocations = ["east-us-2"]
+
+        lc = refresh_location_cache([canonical_location1_name, canonical_location2_name], True, connection_policy)
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+
+        read_request = RequestObject(ResourceType.Document, _OperationType.Read, None)
+        write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)
+        write_request.excluded_locations = ["west_us_3"]
+
+        assert lc.resolve_service_endpoint(read_request) == canonical_location2_endpoint
+        assert lc.resolve_service_endpoint(write_request) == canonical_location1_endpoint
+
+    def test_should_refresh_endpoints_handles_normalized_preferred_region(self):
+        # should_refresh_endpoints must match canonical region keys even when the
+        # customer's preferred location uses non-canonical spelling.
+        lc = refresh_location_cache(["east-us-2"], True)
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+
+        # Most-preferred is already the primary; no background refresh should be triggered.
+        assert lc.should_refresh_endpoints() is False
+
+    def test_get_locational_endpoint_normalizes_customer_region_string(self):
+        # GetLocationalEndpoint is used during bootstrap fallback with the customer-supplied
+        # preferred region string. It must produce the canonical regional URL for any
+        # accepted normalization variant.
+        default_endpoint_url = "https://contoso.documents.azure.com:443/"
+        expected_endpoint = "https://contoso-eastus2.documents.azure.com:443/"
+
+        for region_input in ("East US 2", "east us 2", "eastus2", "east-us-2", "east_us_2", " EastUs2 "):
+            assert LocationCache.GetLocationalEndpoint(default_endpoint_url, region_input) == expected_endpoint
+
+    def test_unmatched_excluded_locations_warning_is_deduped(self, caplog):
+        connection_policy = documents.ConnectionPolicy()
+        connection_policy.ExcludedLocations = ["unknown-region"]
+        lc = refresh_location_cache([canonical_location1_name], True, connection_policy)
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        with caplog.at_level("WARNING", logger="azure.cosmos.LocationCache"):
+            lc.perform_on_database_account_read(db_acc)
+            request = RequestObject(ResourceType.Document, _OperationType.Read, None)
+            lc.resolve_service_endpoint(request)
+            lc.resolve_service_endpoint(request)
+            # Simulate a periodic refresh with unchanged topology and config.
+            lc.perform_on_database_account_read(db_acc)
+
+        unmatched_logs = [
+            record for record in caplog.records
+            if "Ignoring excluded_locations entries" in record.getMessage()
+        ]
+        assert len(unmatched_logs) == 1
+
+    def test_unmatched_preferred_locations_warning_is_deduped(self, caplog):
+        with caplog.at_level("WARNING", logger="azure.cosmos.LocationCache"):
+            lc = refresh_location_cache(["unknown-region"], True)
+            db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+            lc.perform_on_database_account_read(db_acc)
+            # Simulate a periodic refresh with unchanged topology and config.
+            lc.perform_on_database_account_read(db_acc)
+
+        unmatched_logs = [
+            record for record in caplog.records
+            if "Ignoring preferred_locations entries" in record.getMessage()
+        ]
+        assert len(unmatched_logs) == 1
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
@@ -12,7 +12,7 @@ from azure.cosmos._service_request_retry_policy import ServiceRequestRetryPolicy
 
 from azure.cosmos.documents import DatabaseAccount, _OperationType
 from azure.cosmos.http_constants import ResourceType
-from azure.cosmos._location_cache import LocationCache
+from azure.cosmos._location_cache import LocationCache, _normalize_region_name
 from azure.cosmos._request_object import RequestObject
 
 default_endpoint = "https://default.documents.azure.com"
@@ -752,6 +752,30 @@ class TestLocationCache:
         # Most-preferred is already the primary; no background refresh should be triggered.
         assert lc.should_refresh_endpoints() is False
 
+    def test_should_refresh_endpoints_returns_true_for_normalized_non_primary(self):
+        # Companion to the False-branch test above: pins the True branch of
+        # should_refresh_endpoints() against a normalized preferred-location
+        # input. If normalization regresses on this path, the SDK silently
+        # stops scheduling background refreshes when the most-preferred
+        # region is no longer the primary — leaving customer traffic pinned
+        # to a region they tried to leave.
+        #
+        # Engineering the inequality: with two preferred regions
+        # ["east-us-2", "west-us-3"], the routing list normally puts East US 2
+        # first (primary == most-preferred → False). Marking East US 2's read
+        # endpoint unavailable promotes West US 3 to primary, but the
+        # normalized lookup for "east-us-2" still resolves to the East US 2
+        # context — which now != read_regional_routing_contexts[0], firing
+        # the True branch.
+        lc = refresh_location_cache(["east-us-2", "west-us-3"], True)
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+        lc.mark_endpoint_unavailable_for_read(canonical_location1_endpoint, refresh_cache=True)
+
+        # Sanity: primary is now West US 3, but most-preferred still normalizes to East US 2.
+        assert lc.read_regional_routing_contexts[0].get_primary() == canonical_location2_endpoint
+        assert lc.should_refresh_endpoints() is True
+
     def test_get_locational_endpoint_normalizes_customer_region_string(self):
         # GetLocationalEndpoint is used during bootstrap fallback with the customer-supplied
         # preferred region string. It must produce the canonical regional URL for any
@@ -794,6 +818,73 @@ class TestLocationCache:
             if "Ignoring preferred_locations entries" in record.getMessage()
         ]
         assert len(unmatched_logs) == 1
+
+    def test_excluded_locations_ignore_none_and_empty_entries(self):
+        # Defensive: None / "" / whitespace-only entries in excluded_locations must
+        # NOT collide with the "" sentinel produced by _normalize_region_name(None)
+        # and silently filter out unrelated endpoints. Behavior must equal the
+        # clean-list equivalent.
+        connection_policy = documents.ConnectionPolicy()
+        connection_policy.ExcludedLocations = [None, "", "  ", "east-us-2"]  # type: ignore[list-item]
+
+        lc = refresh_location_cache(
+            [canonical_location1_name, canonical_location2_name], True, connection_policy
+        )
+        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+        lc.perform_on_database_account_read(db_acc)
+
+        read_request = RequestObject(ResourceType.Document, _OperationType.Read, None)
+        write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)
+        # Mixed garbage on the request-level excluded list too.
+        write_request.excluded_locations = [None, "", "west_us_3"]  # type: ignore[list-item]
+
+        # East US 2 is excluded by the client list → reads route to the other region.
+        assert lc.resolve_service_endpoint(read_request) == canonical_location2_endpoint
+        # West US 3 is excluded on the request → writes route to East US 2.
+        assert lc.resolve_service_endpoint(write_request) == canonical_location1_endpoint
+
+
+class TestNormalizeRegionName:
+    """Pin down the safety invariants of `_normalize_region_name`.
+
+    The normalization rule must satisfy two opposing requirements:
+      1. Forgive cosmetic differences in user-supplied region names
+         (case, whitespace, hyphens, underscores) so that lookups
+         match the service-reported canonical names.
+      2. NEVER collapse two genuinely distinct Azure regions into
+         the same key — doing so would silently misroute traffic.
+         Prefix-sharing pairs like "East US" / "East US 2" are the
+         highest-risk case and are explicitly called out in the PR
+         description as the primary regression hazard.
+    """
+
+    # --- Collision-safety: distinct regions must stay distinct. ---
+    def test_does_not_collapse_prefix_sharing_regions(self):
+        assert _normalize_region_name("East US") != _normalize_region_name("East US 2")
+        assert _normalize_region_name("West US") != _normalize_region_name("West US 2")
+        assert _normalize_region_name("West US") != _normalize_region_name("West US 3")
+        assert _normalize_region_name("Central US") != _normalize_region_name("North Central US")
+        assert _normalize_region_name("Central US") != _normalize_region_name("South Central US")
+        assert _normalize_region_name("China East") != _normalize_region_name("China East 2")
+
+    # --- Positive normalization: cosmetic variants must collapse. ---
+    # These pin down that the function isn't a no-op — without them,
+    # a "fix" that just returned the input unchanged would still pass
+    # the collision-safety test above.
+    def test_collapses_case_and_whitespace_variants(self):
+        canonical = _normalize_region_name("East US 2")
+        assert _normalize_region_name("east us 2") == canonical
+        assert _normalize_region_name("EAST US 2") == canonical
+        assert _normalize_region_name("  East US 2  ") == canonical
+        assert _normalize_region_name("eastus2") == canonical
+        assert _normalize_region_name("east-us-2") == canonical
+        assert _normalize_region_name("east_us_2") == canonical
+
+    def test_handles_none_and_empty(self):
+        assert _normalize_region_name(None) == ""
+        assert _normalize_region_name("") == ""
+        assert _normalize_region_name("   ") == ""
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_location_cache.py
@@ -4,6 +4,7 @@
 import time
 import unittest
 import unittest.mock
+import logging
 from typing import Mapping, Any
 
 import pytest
@@ -712,11 +713,18 @@ class TestLocationCache:
 
         assert lc.resolve_service_endpoint(read_request) == canonical_location1_endpoint
 
-    def test_preferred_locations_support_normalized_region_names(self):
+    def test_preferred_locations_support_normalized_region_names(self, caplog):
         # Preferred locations should match account region names even with case/spacing/separator variations.
-        lc = refresh_location_cache(["east-us-2", " west_us_3 "], True)
-        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
-        lc.perform_on_database_account_read(db_acc)
+        # Also guards against drift between the two call sites that normalize region names:
+        # the routing path (get_preferred_regional_routing_contexts) and the diagnostic path
+        # (_emit_config_mismatch_warning_once). If they ever disagree on normalization, routing
+        # would still succeed while users got a misleading "did not match" warning.
+        with caplog.at_level(logging.WARNING):
+            lc = refresh_location_cache(["east-us-2", " west_us_3 "], True)
+            db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+            lc.perform_on_database_account_read(db_acc)
+
+        assert not [r for r in caplog.records if "did not match" in r.getMessage()]
 
         write_contexts = lc.get_write_regional_routing_contexts()
         read_contexts = lc.get_read_regional_routing_contexts()
@@ -726,14 +734,20 @@ class TestLocationCache:
         assert read_contexts[0].get_primary() == canonical_location1_endpoint
         assert read_contexts[1].get_primary() == canonical_location2_endpoint
 
-    def test_excluded_locations_support_normalized_region_names(self):
+    def test_excluded_locations_support_normalized_region_names(self, caplog):
         # Excluded locations should filter regions even when normalized names are used.
+        # Same divergence guard as the preferred-locations test: excluded_locations also flows
+        # through both the routing path and the diagnostic warning emitter, so a normalization
+        # mismatch between them would produce correct filtering plus a spurious warning.
         connection_policy = documents.ConnectionPolicy()
         connection_policy.ExcludedLocations = ["east-us-2"]
 
-        lc = refresh_location_cache([canonical_location1_name, canonical_location2_name], True, connection_policy)
-        db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
-        lc.perform_on_database_account_read(db_acc)
+        with caplog.at_level(logging.WARNING):
+            lc = refresh_location_cache([canonical_location1_name, canonical_location2_name], True, connection_policy)
+            db_acc = create_database_account_with_canonical_regions(enable_multiple_writable_locations=True)
+            lc.perform_on_database_account_read(db_acc)
+
+        assert not [r for r in caplog.records if "did not match" in r.getMessage()]
 
         read_request = RequestObject(ResourceType.Document, _OperationType.Read, None)
         write_request = RequestObject(ResourceType.Document, _OperationType.Create, None)


### PR DESCRIPTION
When a customer configures a Cosmos client, they pass region names as strings (preferred_locations, excluded_locations). The SDK previously did exact string comparisons against the canonical names returned by the account ("East US 2", "West US 3", ...). 
A small spelling difference — "eastus2", "east-us-2", "east_us_2" — silently failed to match, the entry was dropped, and the client could end up routing all traffic through the global endpoint instead of the regional pool.

What this change does:
Region matching is now tolerant of case, surrounding/internal whitespace, hyphens, and underscores.
Equivalent inputs all resolve to the same region:
"East US 2"
"east us 2"
"eastus2"
"EASTUS2"
"east-us-2"
"east_us_2"
" EastUs2 "

Anything beyond that (punctuation, digits, fuzzy matching) is intentionally not stripped — a more aggressive rule could collapse genuinely different regions like "East US" and "East US 2" into the same key and silently route to the wrong region. All client-supplied region-name strings — client-level preferred, client-level excluded, and request-level excluded  are normalized

The same matching rule is applied wherever the customer's region string is consumed. Previously some paths used exact-string comparisons; now they all share one normalization rule:

Routing: which region serves a request (preferred + excluded, client-level + per-request).
Refresh decision: whether to schedule a background refresh based on the most-preferred region.
Bootstrap fallback URL: when the global endpoint can't be reached at startup and the SDK constructs a regional URL from a preferred region.

Misconfigured region names now produce a visible warning that names the dropped entry and the regions that were available, emitted at config time — when account metadata is processed at startup and on each background refresh. 
There is no warning for per-request values as those happen thousands of times and its a lower blast radius. 

No public API change -  preferred_locations and excluded_locations remain plain list[str].

Behavior examples
Account regions: ["East US 2", "West US 3"]
| Customer input | Before | After |
|----------------|--------|-------|
| preferred_locations=["East US 2"] | routed to East US 2 | unchanged — routed to East US 2 |
| preferred_locations=["eastus2"] | dropped silently → fell back to global endpoint | routed to East US 2 |
| preferred_locations=["east-us-2", "west_us_3"] | both dropped silently → fell back to global endpoint | routed to East US 2 with West US 3 as secondary |
| excluded_locations=["eastus2"] | exclusion silently ignored | East US 2 actually excluded |
| preferred_locations=["eastus3"] (typo, not in account) | dropped silently | dropped, with a warning naming the unmatched entry and the regions that were available |
| Bootstrap fallback with preferred_locations=["east-us-2"] | constructed contoso-east-us-2.documents.azure.com (wrong host) | constructs contoso-eastus2.documents.azure.com |

Backwards compatibility:
If client config already uses the exact spelling Azure returns (e.g., "East US 2"), nothing changes
New Azure regions continue to work without an SDK upgrade; nothing in this change hardcodes a region list.

What this PR does not do:
Does not add a Regions constants surface. Adding a named-constant list of well-known regions would expand the public API surface area. Normalization plus a visible warning is enough to close the failure mode without touching the public surface today. Constants are therefore deferred to a later stable release as a separate, additive change.
