### PR TITLE
[Storage] Cleanup and prepare content validation for merge to main

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_28cfcca089"
+  "Tag": "python/storage/azure-storage-blob_b09e37b521"
 }

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -36,7 +36,7 @@ from azure.storage.blob import (
     ImmutabilityPolicy,
     StandardBlobTier,
 )
-from azure.storage.blob._shared.policies import StorageContentValidation
+from azure.storage.blob._shared.validation import calculate_content_md5
 from azure.storage.blob.aio import BlobClient, BlobServiceClient
 
 

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -7,17 +7,17 @@
 from io import BytesIO
 
 import pytest
-from azure.core.exceptions import ResourceExistsError
-from azure.storage.blob import BlobBlock, BlobClient, BlobServiceClient, BlobType, ContainerClient
 from devtools_testutils import is_live, recorded_by_proxy
 from devtools_testutils.storage import (
     GenericTestProxyParametrize1,
     GenericTestProxyParametrize2,
     StorageRecordedTestCase,
 )
-
 from encryption_test_helper import KeyWrapper
 from settings.testcase import BlobPreparer
+
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobBlock, BlobClient, BlobServiceClient, BlobType, ContainerClient
 
 
 def assert_content_md5(request):

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -8,18 +8,12 @@ from io import BytesIO
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
-from azure.storage.blob import (
-    BlobBlock,
-    BlobClient,
-    BlobServiceClient,
-    BlobType,
-    ContainerClient
-)
+from azure.storage.blob import BlobBlock, BlobClient, BlobServiceClient, BlobType, ContainerClient
 from devtools_testutils import is_live, recorded_by_proxy
 from devtools_testutils.storage import (
     GenericTestProxyParametrize1,
     GenericTestProxyParametrize2,
-    StorageRecordedTestCase
+    StorageRecordedTestCase,
 )
 
 from encryption_test_helper import KeyWrapper
@@ -27,28 +21,37 @@ from settings.testcase import BlobPreparer
 
 
 def assert_content_md5(request):
-    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
-        assert request.http_request.headers.get('Content-MD5') is not None
+    if (
+        request.http_request.query.get("comp") in ("block", "page")
+        or request.http_request.headers.get("x-ms-blob-type") == "BlockBlob"
+    ):
+        assert request.http_request.headers.get("Content-MD5") is not None
 
 
 def assert_content_md5_get(response):
-    assert response.http_request.headers.get('x-ms-range-get-content-md5') == 'true'
-    assert response.http_response.headers.get('Content-MD5') is not None
+    assert response.http_request.headers.get("x-ms-range-get-content-md5") == "true"
+    assert response.http_response.headers.get("Content-MD5") is not None
 
 
 def assert_content_crc64(request):
-    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
-        assert request.http_request.headers.get('x-ms-content-crc64') is not None
+    if (
+        request.http_request.query.get("comp") in ("block", "page")
+        or request.http_request.headers.get("x-ms-blob-type") == "BlockBlob"
+    ):
+        assert request.http_request.headers.get("x-ms-content-crc64") is not None
 
 
 def assert_structured_message(request):
-    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
-        assert request.http_request.headers.get('x-ms-structured-body') is not None
+    if (
+        request.http_request.query.get("comp") in ("block", "page")
+        or request.http_request.headers.get("x-ms-blob-type") == "BlockBlob"
+    ):
+        assert request.http_request.headers.get("x-ms-structured-body") is not None
 
 
 def assert_structured_message_get(response):
-    assert response.http_request.headers.get('x-ms-structured-body') is not None
-    assert response.http_response.headers.get('x-ms-structured-body') is not None
+    assert response.http_request.headers.get("x-ms-structured-body") is not None
+    assert response.http_response.headers.get("x-ms-structured-body") is not None
 
 
 class TestIter:
@@ -68,7 +71,7 @@ class TestIter:
         if self.offset >= self.length:
             raise StopIteration
 
-        result = self.data[self.offset: self.offset + self.chunk_size]
+        result = self.data[self.offset : self.offset + self.chunk_size]
         self.offset += len(result)
         return result
 
@@ -80,7 +83,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
     def _setup(self, account_name):
         token_credential = self.get_credential(BlobServiceClient)
         self.bsc = BlobServiceClient(self.account_url(account_name, "blob"), token_credential, logging_enable=True)
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             self.container.create_container()
         except ResourceExistsError:
@@ -94,31 +97,32 @@ class TestStorageContentValidation(StorageRecordedTestCase):
                 pass
 
     def _get_blob_reference(self):
-        return self.get_resource_name('blob')
+        return self.get_resource_name("blob")
 
     @BlobPreparer()
     def test_encryption_blocked_crc64(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
 
-        kek = KeyWrapper('key1')
+        kek = KeyWrapper("key1")
         blob = BlobClient(
             self.account_url(storage_account_name, "blob"),
             "testing",
             "testing",
             credential=self.get_credential(BlobServiceClient),
             require_encryption=True,
-            encryption_version='2.0',
-            key_encryption_key=kek)
+            encryption_version="2.0",
+            key_encryption_key=kek,
+        )
 
         with pytest.raises(ValueError):
-            blob.upload_blob(b'123', validate_content='crc64')
+            blob.upload_blob(b"123", validate_content="crc64")
 
         # Needed for teardown
         self.container = None
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
-    @pytest.mark.parametrize('b', [True, 'auto','md5', 'crc64'])  # b: validate_content
+    @pytest.mark.parametrize("a", [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @pytest.mark.parametrize("b", [True, "auto", "md5", "crc64"])  # b: validate_content
     @GenericTestProxyParametrize2()
     @recorded_by_proxy
     def test_upload_blob(self, a, b, **kwargs):
@@ -126,30 +130,40 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if b in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if b in ("auto", "crc64") else assert_content_md5
 
         # Test supported data types
-        byte_data = b'abc' * 512
+        byte_data = b"abc" * 512
         str_data = "你好世界abcd" * 32
-        str_data_encoded = str_data.encode('utf-8')
+        str_data_encoded = str_data.encode("utf-8")
         byte_stream = BytesIO(byte_data)
         byte_iter = TestIter(byte_data)
         str_iter = TestIter(str_data)
 
         blob.upload_blob(byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
-        blob.upload_blob(str_data, blob_type=a, encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        blob.upload_blob(
+            str_data, blob_type=a, encoding="utf-8", validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert blob.download_blob().read() == str_data_encoded
         blob.upload_blob(byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
         blob.upload_blob(byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
-        blob.upload_blob(str_iter, blob_type=a, length=len(str_data_encoded), encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        blob.upload_blob(
+            str_iter,
+            blob_type=a,
+            length=len(str_data_encoded),
+            encoding="utf-8",
+            validate_content=b,
+            overwrite=True,
+            raw_request_hook=assert_method,
+        )
         assert blob.download_blob().read() == str_data_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
-    @pytest.mark.parametrize('b', [True, 'md5', 'crc64'])  # b: validate_content
+    @pytest.mark.parametrize("a", [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @pytest.mark.parametrize("b", [True, "md5", "crc64"])  # b: validate_content
     @GenericTestProxyParametrize2()
     @recorded_by_proxy
     def test_upload_blob_chunks(self, a, b, **kwargs):
@@ -160,54 +174,64 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.container._config.max_block_size = 512
         self.container._config.max_page_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if b == 'crc64' else assert_content_md5
+        assert_method = assert_content_crc64 if b == "crc64" else assert_content_md5
 
         # Test supported data types
-        byte_data = b'abc' * 512
+        byte_data = b"abc" * 512
         str_data = "你好世界abcd" * 32
-        str_data_encoded = str_data.encode('utf-8')
+        str_data_encoded = str_data.encode("utf-8")
         byte_stream = BytesIO(byte_data)
         byte_iter = TestIter(byte_data)
         str_iter = TestIter(str_data)
 
         blob.upload_blob(byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
-        blob.upload_blob(str_data, blob_type=a, encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        blob.upload_blob(
+            str_data, blob_type=a, encoding="utf-8", validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert blob.download_blob().read() == str_data_encoded
         blob.upload_blob(byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
         blob.upload_blob(byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
         assert blob.download_blob().read() == byte_data
-        blob.upload_blob(str_iter, blob_type=a, length=len(str_data_encoded), encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        blob.upload_blob(
+            str_iter,
+            blob_type=a,
+            length=len(str_data_encoded),
+            encoding="utf-8",
+            validate_content=b,
+            overwrite=True,
+            raw_request_hook=assert_method,
+        )
         assert blob.download_blob().read() == str_data_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_blob_substream(self, a, **kwargs):
         # Substream is disabled when using content validation so this will behave like regular upload (buffer)
         storage_account_name = kwargs.pop("storage_account_name")
-    
+
         self._setup(storage_account_name)
         self.container._config.max_single_put_size = 512
         self.container._config.max_block_size = 512
         self.container._config.min_large_block_upload_threshold = 1  # Set less than block size to enable substream
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
-    
-        data = b'abc' * 512 + b'abcde'
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
+
+        data = b"abc" * 512 + b"abcde"
         io = BytesIO(data)
-    
+
         # Act
         blob.upload_blob(io, validate_content=a, raw_request_hook=assert_method)
-    
+
         # Assert
         content = blob.download_blob()
         assert content.read() == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_stage_block(self, a, **kwargs):
@@ -215,28 +239,28 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
-        data2 = '你好世界' * 10
+        data1 = b"abc" * 512
+        data2 = "你好世界" * 10
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
-        blob.stage_block('1', data1, validate_content=a, raw_request_hook=assert_method)
-        blob.stage_block('2', data2, encoding='utf-8-sig', validate_content=a, raw_request_hook=assert_method)
-        blob.stage_block('3', generator(),  validate_content=a, raw_request_hook=assert_method)
-        blob.commit_block_list([BlobBlock('1'), BlobBlock('2'), BlobBlock('3')])
+        blob.stage_block("1", data1, validate_content=a, raw_request_hook=assert_method)
+        blob.stage_block("2", data2, encoding="utf-8-sig", validate_content=a, raw_request_hook=assert_method)
+        blob.stage_block("3", generator(), validate_content=a, raw_request_hook=assert_method)
+        blob.commit_block_list([BlobBlock("1"), BlobBlock("2"), BlobBlock("3")])
 
         # Assert
         content = blob.download_blob()
-        assert content.read() == data1 + data2.encode('utf-8-sig') + data1
+        assert content.read() == data1 + data2.encode("utf-8-sig") + data1
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_stage_block_streaming(self, a, **kwargs):
@@ -245,17 +269,17 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
-        blob.stage_block('1', BytesIO(content), validate_content=a, raw_request_hook=assert_method)
-        blob.commit_block_list([BlobBlock('1')])
+        blob.stage_block("1", BytesIO(content), validate_content=a, raw_request_hook=assert_method)
+        blob.commit_block_list([BlobBlock("1")])
 
         result = blob.download_blob()
         assert result.read() == content
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     def test_stage_block_streaming_large(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -263,21 +287,21 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
-        blob.stage_block('1', BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
-        blob.stage_block('2', BytesIO(data2), validate_content=a, raw_request_hook=assert_method)
-        blob.stage_block('3', BytesIO(data3), validate_content=a, raw_request_hook=assert_method)
-        blob.commit_block_list([BlobBlock('1'), BlobBlock('2'), BlobBlock('3')])
+        blob.stage_block("1", BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
+        blob.stage_block("2", BytesIO(data2), validate_content=a, raw_request_hook=assert_method)
+        blob.stage_block("3", BytesIO(data3), validate_content=a, raw_request_hook=assert_method)
+        blob.commit_block_list([BlobBlock("1"), BlobBlock("2"), BlobBlock("3")])
 
         result = blob.download_blob()
         assert result.read() == data1 + data2 + data3
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_append_block(self, a, **kwargs):
@@ -285,27 +309,27 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
-        data2 = '你好世界' * 10
+        data1 = b"abc" * 512
+        data2 = "你好世界" * 10
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         blob.create_append_blob()
         blob.append_block(data1, validate_content=a, raw_request_hook=assert_method)
-        blob.append_block(data2, encoding='utf-16', validate_content=a, raw_request_hook=assert_method)
+        blob.append_block(data2, encoding="utf-16", validate_content=a, raw_request_hook=assert_method)
         blob.append_block(generator(), validate_content=a, raw_request_hook=assert_method)
 
         content = blob.download_blob()
-        assert content.read() == data1 + data2.encode('utf-16') + data1
+        assert content.read() == data1 + data2.encode("utf-16") + data1
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_append_block_streaming(self, a, **kwargs):
@@ -314,8 +338,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         blob.create_append_blob()
         blob.append_block(BytesIO(content), validate_content=a, raw_request_hook=assert_method)
@@ -324,7 +348,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert result.read() == content
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     def test_append_block_streaming_large(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -332,10 +356,10 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         blob.create_append_blob()
         blob.append_block(BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
@@ -346,7 +370,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert result.read() == data1 + data2 + data3
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_page(self, a, **kwargs):
@@ -354,22 +378,29 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
+        data1 = b"abc" * 512
         data2 = "你好世界abcd" * 32
-        data2_encoded = data2.encode('utf-8')
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        data2_encoded = data2.encode("utf-8")
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         blob.create_page_blob(5 * 1024)
         blob.upload_page(data1, offset=0, length=len(data1), validate_content=a, raw_request_hook=assert_method)
-        blob.upload_page(data2, offset=len(data1), length=len(data2_encoded), encoding='utf-8', validate_content=a, raw_request_hook=assert_method)
+        blob.upload_page(
+            data2,
+            offset=len(data1),
+            length=len(data2_encoded),
+            encoding="utf-8",
+            validate_content=a,
+            raw_request_hook=assert_method,
+        )
 
         # Assert
         content = blob.download_blob(offset=0, length=len(data1) + len(data2_encoded))
         assert content.read() == data1 + data2_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_blob(self, a, **kwargs):
@@ -377,9 +408,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = blob.download_blob(validate_content=a, raw_response_hook=assert_method)
@@ -395,7 +426,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert stream.read() == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_blob_chunks(self, a, **kwargs):
@@ -405,9 +436,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = blob.download_blob(validate_content=a, raw_response_hook=assert_method)
@@ -418,7 +449,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         downloader.readinto(stream)
         stream.seek(0)
 
-        read_content = b''
+        read_content = b""
         downloader = blob.download_blob(validate_content=a, raw_response_hook=assert_method)
         for _ in range(len(data) // 100 + 1):
             read_content += downloader.read(100)
@@ -429,7 +460,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert read_content == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_blob_chunks_partial(self, a, **kwargs):
@@ -439,9 +470,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = blob.download_blob(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
@@ -465,22 +496,22 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         blob = self.container.get_blob_client(self._get_blob_reference())
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.container._config.max_chunk_get_size = 10 * 1024 * 1024
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         blob.upload_blob(data, overwrite=True, max_concurrency=5)
 
         # Act
-        downloader = blob.download_blob(validate_content='crc64', max_concurrency=5)
+        downloader = blob.download_blob(validate_content="crc64", max_concurrency=5)
         content = downloader.read()
 
-        downloader = blob.download_blob(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = blob.download_blob(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = downloader.read()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024: 30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_blob_chars(self, a, **kwargs):
@@ -490,18 +521,18 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
 
-        data = '你好世界' * 256  # 3 KiB
+        data = "你好世界" * 256  # 3 KiB
         blob = self.container.get_blob_client(self._get_blob_reference())
-        blob.upload_blob(data, encoding='utf-8', overwrite=True)
+        blob.upload_blob(data, encoding="utf-8", overwrite=True)
 
-        stream = blob.download_blob(encoding='utf-8', validate_content=a)
+        stream = blob.download_blob(encoding="utf-8", validate_content=a)
         assert stream.read() == data
 
-        stream = blob.download_blob(encoding='utf-8', validate_content=a)
+        stream = blob.download_blob(encoding="utf-8", validate_content=a)
         assert stream.read(chars=100000) == data
 
-        result = ''
-        stream = blob.download_blob(encoding='utf-8', validate_content=a)
+        result = ""
+        stream = blob.download_blob(encoding="utf-8", validate_content=a)
         for _ in range(4):
             chunk = stream.read(chars=100)
             result += chunk
@@ -511,7 +542,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert result == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_content_validation_with_retry(self, a, **kwargs):
@@ -525,22 +556,23 @@ class TestStorageContentValidation(StorageRecordedTestCase):
             retry_total=1,
             initial_backoff=0.1,
             increment_base=0.1,
-            logging_enable=True
+            logging_enable=True,
         )
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             self.container.create_container()
         except ResourceExistsError:
             pass
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
 
         # Determine the appropriate assert methods based on validation mode
-        upload_assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
-        download_assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        upload_assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
+        download_assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Test upload with retry
         upload_call_count = 0
+
         def upload_hook_fail_once(response):
             nonlocal upload_call_count
             upload_call_count += 1
@@ -555,6 +587,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         # Test download with retry
         download_call_count = 0
+
         def download_hook_fail_once(response):
             nonlocal download_call_count
             download_call_count += 1
@@ -569,7 +602,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_streaming_with_retry(self, a, **kwargs):
@@ -583,19 +616,20 @@ class TestStorageContentValidation(StorageRecordedTestCase):
             retry_total=1,
             initial_backoff=0.1,
             increment_base=0.1,
-            logging_enable=True
+            logging_enable=True,
         )
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             self.container.create_container()
         except ResourceExistsError:
             pass
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abc' * 512
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abc" * 512
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         call_count = 0
+
         def hook_fail_once(response):
             nonlocal call_count
             call_count += 1
@@ -605,9 +639,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
                 response.http_response.status_code = 408  # Request Timeout - triggers retry
 
         # Use stage_block to test structured message streaming
-        blob.stage_block('1', BytesIO(content), validate_content=a, raw_response_hook=hook_fail_once)
+        blob.stage_block("1", BytesIO(content), validate_content=a, raw_response_hook=hook_fail_once)
         assert call_count == 2  # Original + retry
-        
-        blob.commit_block_list([BlobBlock('1')])
+
+        blob.commit_block_list([BlobBlock("1")])
         result = blob.download_blob()
         assert result.read() == content

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
@@ -9,17 +9,13 @@ from io import BytesIO
 import pytest
 from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import BlobBlock, BlobType, ContainerClient as SyncContainerClient
-from azure.storage.blob.aio import (
-    BlobClient,
-    BlobServiceClient,
-    ContainerClient
-)
+from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 from devtools_testutils import is_live
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import (
     AsyncStorageRecordedTestCase,
     GenericTestProxyParametrize1,
-    GenericTestProxyParametrize2
+    GenericTestProxyParametrize2,
 )
 from encryption_test_helper import KeyWrapper
 from settings.testcase import BlobPreparer
@@ -30,7 +26,7 @@ from test_content_validation import (
     assert_content_md5_get,
     assert_structured_message,
     assert_structured_message_get,
-    TestIter
+    TestIter,
 )
 
 
@@ -41,7 +37,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
     async def _setup(self, account_name):
         token_credential = self.get_credential(BlobServiceClient, is_async=True)
         self.bsc = BlobServiceClient(self.account_url(account_name, "blob"), token_credential, logging_enable=True)
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             await self.container.create_container()
         except ResourceExistsError:
@@ -53,9 +49,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         # Use sync client as teardown_method must be sync
         if self.container:
             sync_credential = self.get_credential(SyncContainerClient, is_async=False)
-            sync_container = SyncContainerClient.from_container_url(
-                self.container.url,
-                credential=sync_credential)
+            sync_container = SyncContainerClient.from_container_url(self.container.url, credential=sync_credential)
 
             try:
                 sync_container.delete_container()
@@ -63,31 +57,32 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
                 pass
 
     def _get_blob_reference(self):
-        return self.get_resource_name('blob')
+        return self.get_resource_name("blob")
 
     @BlobPreparer()
     async def test_encryption_blocked_crc64(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
 
-        kek = KeyWrapper('key1')
+        kek = KeyWrapper("key1")
         blob = BlobClient(
             self.account_url(storage_account_name, "blob"),
             "testing",
             "testing",
             credential=self.get_credential(BlobServiceClient, is_async=True),
             require_encryption=True,
-            encryption_version='2.0',
-            key_encryption_key=kek)
+            encryption_version="2.0",
+            key_encryption_key=kek,
+        )
 
         with pytest.raises(ValueError):
-            await blob.upload_blob(b'123', validate_content='crc64')
+            await blob.upload_blob(b"123", validate_content="crc64")
 
         # Needed for teardown
         self.container = None
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
-    @pytest.mark.parametrize('b', [True, "auto", 'md5', 'crc64'])  # b: validate_content
+    @pytest.mark.parametrize("a", [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @pytest.mark.parametrize("b", [True, "auto", "md5", "crc64"])  # b: validate_content
     @GenericTestProxyParametrize2()
     @recorded_by_proxy_async
     async def test_upload_blob(self, a, b, **kwargs):
@@ -95,31 +90,47 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if b in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if b in ("auto", "crc64") else assert_content_md5
 
         # Test supported data types
-        byte_data = b'abc' * 512
+        byte_data = b"abc" * 512
         str_data = "你好世界abcd" * 32
-        str_data_encoded = str_data.encode('utf-8')
+        str_data_encoded = str_data.encode("utf-8")
         byte_stream = BytesIO(byte_data)
         byte_iter = TestIter(byte_data)
         str_iter = TestIter(str_data)
 
         # Act / Assert
-        await blob.upload_blob(byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(str_data, blob_type=a, encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            str_data, blob_type=a, encoding="utf-8", validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == str_data_encoded
-        await blob.upload_blob(byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(str_iter, blob_type=a, length=len(str_data_encoded), encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            str_iter,
+            blob_type=a,
+            length=len(str_data_encoded),
+            encoding="utf-8",
+            validate_content=b,
+            overwrite=True,
+            raw_request_hook=assert_method,
+        )
         assert await (await blob.download_blob()).read() == str_data_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
-    @pytest.mark.parametrize('b', [True, 'md5', 'crc64'])  # b: validate_content
+    @pytest.mark.parametrize("a", [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @pytest.mark.parametrize("b", [True, "md5", "crc64"])  # b: validate_content
     @GenericTestProxyParametrize2()
     @recorded_by_proxy_async
     async def test_upload_blob_chunks(self, a, b, **kwargs):
@@ -130,30 +141,46 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.container._config.max_block_size = 512
         self.container._config.max_page_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if b == 'crc64' else assert_content_md5
+        assert_method = assert_content_crc64 if b == "crc64" else assert_content_md5
 
         # Test supported data types
-        byte_data = b'abc' * 512
+        byte_data = b"abc" * 512
         str_data = "你好世界abcd" * 32
-        str_data_encoded = str_data.encode('utf-8')
+        str_data_encoded = str_data.encode("utf-8")
         byte_stream = BytesIO(byte_data)
         byte_iter = TestIter(byte_data)
         str_iter = TestIter(str_data)
 
         # Act / Assert
-        await blob.upload_blob(byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_data, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(str_data, blob_type=a, encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            str_data, blob_type=a, encoding="utf-8", validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == str_data_encoded
-        await blob.upload_blob(byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_stream, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            byte_iter, blob_type=a, validate_content=b, overwrite=True, raw_request_hook=assert_method
+        )
         assert await (await blob.download_blob()).read() == byte_data
-        await blob.upload_blob(str_iter, blob_type=a, length=len(str_data_encoded), encoding='utf-8', validate_content=b, overwrite=True, raw_request_hook=assert_method)
+        await blob.upload_blob(
+            str_iter,
+            blob_type=a,
+            length=len(str_data_encoded),
+            encoding="utf-8",
+            validate_content=b,
+            overwrite=True,
+            raw_request_hook=assert_method,
+        )
         assert await (await blob.download_blob()).read() == str_data_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_blob_substream(self, a, **kwargs):
@@ -165,9 +192,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.container._config.max_block_size = 512
         self.container._config.min_large_block_upload_threshold = 1  # Set less than block size to enable substream
         blob = self.container.get_blob_client(self._get_blob_reference())
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
 
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         io = BytesIO(data)
 
         # Act
@@ -178,7 +205,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.read() == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_stage_block(self, a, **kwargs):
@@ -186,29 +213,29 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
-        data2 = '你好世界' * 10
+        data1 = b"abc" * 512
+        data2 = "你好世界" * 10
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
-        await blob.stage_block('1', data1, validate_content=a, raw_request_hook=assert_method)
-        await blob.stage_block('2', data2, encoding='utf-8-sig', validate_content=a, raw_request_hook=assert_method)
-        await blob.stage_block('3', generator(), validate_content=a, raw_request_hook=assert_method)
-        await blob.commit_block_list([BlobBlock('1'), BlobBlock('2'), BlobBlock('3')])
+        await blob.stage_block("1", data1, validate_content=a, raw_request_hook=assert_method)
+        await blob.stage_block("2", data2, encoding="utf-8-sig", validate_content=a, raw_request_hook=assert_method)
+        await blob.stage_block("3", generator(), validate_content=a, raw_request_hook=assert_method)
+        await blob.commit_block_list([BlobBlock("1"), BlobBlock("2"), BlobBlock("3")])
 
         # Assert
         content = await blob.download_blob()
-        assert await content.read() == data1 + data2.encode('utf-8-sig') + data1
+        assert await content.read() == data1 + data2.encode("utf-8-sig") + data1
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_stage_block_streaming(self, a, **kwargs):
@@ -217,18 +244,18 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
-        await blob.stage_block('1', BytesIO(content), validate_content=a, raw_request_hook=assert_method)
-        await blob.commit_block_list([BlobBlock('1')])
+        await blob.stage_block("1", BytesIO(content), validate_content=a, raw_request_hook=assert_method)
+        await blob.commit_block_list([BlobBlock("1")])
 
         # Assert
         result = await blob.download_blob()
         assert await result.read() == content
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     async def test_stage_block_streaming_large(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -236,21 +263,21 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
-        await blob.stage_block('1', BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
-        await blob.stage_block('2', BytesIO(data2), validate_content=a, raw_request_hook=assert_method)
-        await blob.stage_block('3', BytesIO(data3), validate_content=a, raw_request_hook=assert_method)
-        await blob.commit_block_list([BlobBlock('1'), BlobBlock('2'), BlobBlock('3')])
+        await blob.stage_block("1", BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
+        await blob.stage_block("2", BytesIO(data2), validate_content=a, raw_request_hook=assert_method)
+        await blob.stage_block("3", BytesIO(data3), validate_content=a, raw_request_hook=assert_method)
+        await blob.commit_block_list([BlobBlock("1"), BlobBlock("2"), BlobBlock("3")])
 
         result = await blob.download_blob()
         assert await result.read() == data1 + data2 + data3
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_append_block(self, a, **kwargs):
@@ -258,29 +285,29 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
-        data2 = '你好世界' * 10
+        data1 = b"abc" * 512
+        data2 = "你好世界" * 10
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await blob.create_append_blob()
         await blob.append_block(data1, validate_content=a, raw_request_hook=assert_method)
-        await blob.append_block(data2, encoding='utf-16', validate_content=a, raw_request_hook=assert_method)
+        await blob.append_block(data2, encoding="utf-16", validate_content=a, raw_request_hook=assert_method)
         await blob.append_block(generator(), validate_content=a, raw_request_hook=assert_method)
 
         # Assert
         content = await blob.download_blob()
-        assert await content.readall() == data1 + data2.encode('utf-16') + data1
+        assert await content.readall() == data1 + data2.encode("utf-16") + data1
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_append_block_streaming(self, a, **kwargs):
@@ -289,8 +316,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         await blob.create_append_blob()
         await blob.append_block(BytesIO(content), validate_content=a, raw_request_hook=assert_method)
@@ -299,7 +326,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await result.read() == content
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     async def test_append_block_streaming_large(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
@@ -307,10 +334,10 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         await blob.create_append_blob()
         await blob.append_block(BytesIO(data1), validate_content=a, raw_request_hook=assert_method)
@@ -321,7 +348,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await result.read() == data1 + data2 + data3
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_page(self, a, **kwargs):
@@ -329,22 +356,29 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data1 = b'abc' * 512
+        data1 = b"abc" * 512
         data2 = "你好世界abcd" * 32
-        data2_encoded = data2.encode('utf-8')
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        data2_encoded = data2.encode("utf-8")
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await blob.create_page_blob(5 * 1024)
         await blob.upload_page(data1, offset=0, length=len(data1), validate_content=a, raw_request_hook=assert_method)
-        await blob.upload_page(data2, offset=len(data1), length=len(data2_encoded), encoding='utf-8', validate_content=a, raw_request_hook=assert_method)
+        await blob.upload_page(
+            data2,
+            offset=len(data1),
+            length=len(data2_encoded),
+            encoding="utf-8",
+            validate_content=a,
+            raw_request_hook=assert_method,
+        )
 
         # Assert
         content = await blob.download_blob(offset=0, length=len(data1) + len(data2_encoded))
         assert await content.read() == data1 + data2_encoded
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_blob(self, a, **kwargs):
@@ -352,9 +386,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         await blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = await blob.download_blob(validate_content=a, raw_response_hook=assert_method)
@@ -370,7 +404,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert stream.read() == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_blob_chunks(self, a, **kwargs):
@@ -380,9 +414,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = await blob.download_blob(validate_content=a, raw_response_hook=assert_method)
@@ -393,7 +427,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await downloader.readinto(stream)
         stream.seek(0)
 
-        read_content = b''
+        read_content = b""
         downloader = await blob.download_blob(validate_content=a, raw_response_hook=assert_method)
         for _ in range(len(data) // 100 + 1):
             read_content += await downloader.read(100)
@@ -404,7 +438,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert read_content == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_blob_chunks_partial(self, a, **kwargs):
@@ -414,16 +448,20 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await blob.upload_blob(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
-        downloader = await blob.download_blob(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
+        downloader = await blob.download_blob(
+            offset=10, length=1000, validate_content=a, raw_response_hook=assert_method
+        )
         content = await downloader.read()
 
         stream = BytesIO()
-        downloader = await blob.download_blob(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
+        downloader = await blob.download_blob(
+            offset=10, length=1000, validate_content=a, raw_response_hook=assert_method
+        )
         await downloader.readinto(stream)
         stream.seek(0)
 
@@ -440,22 +478,22 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         blob = self.container.get_blob_client(self._get_blob_reference())
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.container._config.max_chunk_get_size = 10 * 1024 * 1024
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         await blob.upload_blob(data, overwrite=True, max_concurrency=5)
 
         # Act
-        downloader = await blob.download_blob(validate_content='crc64', max_concurrency=5)
+        downloader = await blob.download_blob(validate_content="crc64", max_concurrency=5)
         content = await downloader.read()
 
-        downloader = await blob.download_blob(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = await blob.download_blob(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = await downloader.read()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024: 30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_blob_chars(self, a, **kwargs):
@@ -465,18 +503,18 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.container._config.max_single_get_size = 512
         self.container._config.max_chunk_get_size = 512
 
-        data = '你好世界' * 256  # 3 KiB
+        data = "你好世界" * 256  # 3 KiB
         blob = self.container.get_blob_client(self._get_blob_reference())
-        await blob.upload_blob(data, encoding='utf-8', overwrite=True)
+        await blob.upload_blob(data, encoding="utf-8", overwrite=True)
 
-        stream = await blob.download_blob(encoding='utf-8', validate_content=a)
+        stream = await blob.download_blob(encoding="utf-8", validate_content=a)
         assert await stream.read() == data
 
-        stream = await blob.download_blob(encoding='utf-8', validate_content=a)
+        stream = await blob.download_blob(encoding="utf-8", validate_content=a)
         assert await stream.read(chars=100000) == data
 
-        result = ''
-        stream = await blob.download_blob(encoding='utf-8', validate_content=a)
+        result = ""
+        stream = await blob.download_blob(encoding="utf-8", validate_content=a)
         for _ in range(4):
             chunk = await stream.read(chars=100)
             result += chunk
@@ -486,7 +524,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert result == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_content_validation_with_retry(self, a, **kwargs):
@@ -500,22 +538,23 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
             retry_total=1,
             initial_backoff=0.1,
             increment_base=0.1,
-            logging_enable=True
+            logging_enable=True,
         )
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             await self.container.create_container()
         except ResourceExistsError:
             pass
         blob = self.container.get_blob_client(self._get_blob_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
 
         # Determine the appropriate assert methods based on validation mode
-        upload_assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
-        download_assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        upload_assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
+        download_assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Test upload with retry
         upload_call_count = 0
+
         def upload_hook_fail_once(response):
             nonlocal upload_call_count
             upload_call_count += 1
@@ -530,6 +569,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         # Test download with retry
         download_call_count = 0
+
         def download_hook_fail_once(response):
             nonlocal download_call_count
             download_call_count += 1
@@ -544,7 +584,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert content == data
 
     @BlobPreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_streaming_with_retry(self, a, **kwargs):
@@ -558,20 +598,21 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
             retry_total=1,
             initial_backoff=0.1,
             increment_base=0.1,
-            logging_enable=True
+            logging_enable=True,
         )
-        self.container = self.bsc.get_container_client(self.get_resource_name('utcontainer'))
+        self.container = self.bsc.get_container_client(self.get_resource_name("utcontainer"))
         try:
             await self.container.create_container()
         except ResourceExistsError:
             pass
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abc' * 512
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abc" * 512
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Test stage_block streaming with retry
         call_count = 0
+
         def hook_fail_once(response):
             nonlocal call_count
             call_count += 1
@@ -581,9 +622,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
                 response.http_response.status_code = 408  # Request Timeout - triggers retry
 
         # Use stage_block to test structured message streaming
-        await blob.stage_block('1', BytesIO(content), validate_content=a, raw_response_hook=hook_fail_once)
+        await blob.stage_block("1", BytesIO(content), validate_content=a, raw_response_hook=hook_fail_once)
         assert call_count == 2  # Original + retry
-        
-        await blob.commit_block_list([BlobBlock('1')])
+
+        await blob.commit_block_list([BlobBlock("1")])
         result = await blob.download_blob()
         assert await result.read() == content

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
@@ -7,9 +7,6 @@
 from io import BytesIO
 
 import pytest
-from azure.core.exceptions import ResourceExistsError
-from azure.storage.blob import BlobBlock, BlobType, ContainerClient as SyncContainerClient
-from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 from devtools_testutils import is_live
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import (
@@ -19,7 +16,6 @@ from devtools_testutils.storage.aio import (
 )
 from encryption_test_helper import KeyWrapper
 from settings.testcase import BlobPreparer
-
 from test_content_validation import (
     assert_content_crc64,
     assert_content_md5,
@@ -28,6 +24,10 @@ from test_content_validation import (
     assert_structured_message_get,
     TestIter,
 )
+
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobBlock, BlobType, ContainerClient as SyncContainerClient
+from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -11,6 +11,8 @@ from io import BytesIO, UnsupportedOperation, SEEK_CUR, SEEK_END, SEEK_SET
 from typing import Iterator, List, Optional, Tuple, Union
 
 import pytest
+from test_helpers import NonSeekableStream
+
 from azure.storage.blob._shared.streams import (
     StructuredMessageConstants,
     StructuredMessageDecoder,
@@ -18,8 +20,6 @@ from azure.storage.blob._shared.streams import (
     StructuredMessageProperties,
 )
 from azure.storage.extensions import crc64
-
-from test_helpers import NonSeekableStream
 
 
 def _iter_bytes(data: bytes, chunk_size: int = 1024) -> Iterator[bytes]:
@@ -83,12 +83,12 @@ def _build_structured_message(
 
             segment_crc = None
             if StructuredMessageProperties.CRC64 in flags:
-                segment_crc = crc64.compute(segment_data, 0)
+                segment_crc = crc64.compute(segment_data, 0)  # pylint: disable=I1101
                 if i == invalidate_crc_segment:
                     segment_crc += 5
             _write_segment(i, segment_data, segment_crc, message)
 
-            message_crc = crc64.compute(segment_data, message_crc)
+            message_crc = crc64.compute(segment_data, message_crc)  # pylint: disable=I1101
 
     # Message footer
     if StructuredMessageProperties.CRC64 in flags:

--- a/sdk/storage/azure-storage-blob/tests/test_streams_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams_async.py
@@ -11,7 +11,6 @@ from io import BytesIO
 from typing import AsyncIterator, List, Optional, Tuple, Union
 
 import pytest
-import pytest_asyncio
 from azure.storage.blob._shared.streams import (
     StructuredMessageConstants,
     StructuredMessageProperties,
@@ -81,12 +80,12 @@ def _build_structured_message(
 
             segment_crc = None
             if StructuredMessageProperties.CRC64 in flags:
-                segment_crc = crc64.compute(segment_data, 0)
+                segment_crc = crc64.compute(segment_data, 0)  # pylint: disable=I1101
                 if i == invalidate_crc_segment:
                     segment_crc += 5
             _write_segment(i, segment_data, segment_crc, message)
 
-            message_crc = crc64.compute(segment_data, message_crc)
+            message_crc = crc64.compute(segment_data, message_crc)  # pylint: disable=I1101
 
     # Message footer
     if StructuredMessageProperties.CRC64 in flags:

--- a/sdk/storage/azure-storage-file-datalake/assets.json
+++ b/sdk/storage/azure-storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-datalake",
-  "Tag": "python/storage/azure-storage-file-datalake_c9ea6b56de"
+  "Tag": "python/storage/azure-storage-file-datalake_34be4c4176"
 }

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
@@ -7,11 +7,11 @@
 from io import BytesIO
 
 import pytest
-from azure.storage.filedatalake import DataLakeServiceClient
-
 from devtools_testutils import is_live, recorded_by_proxy
 from devtools_testutils.storage import GenericTestProxyParametrize1, StorageRecordedTestCase
 from settings.testcase import DataLakePreparer
+
+from azure.storage.filedatalake import DataLakeServiceClient
 
 
 def assert_content_md5(request):

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
@@ -7,9 +7,7 @@
 from io import BytesIO
 
 import pytest
-from azure.storage.filedatalake import (
-    DataLakeServiceClient
-)
+from azure.storage.filedatalake import DataLakeServiceClient
 
 from devtools_testutils import is_live, recorded_by_proxy
 from devtools_testutils.storage import GenericTestProxyParametrize1, StorageRecordedTestCase
@@ -17,35 +15,37 @@ from settings.testcase import DataLakePreparer
 
 
 def assert_content_md5(request):
-    if request.http_request.query.get('action') == 'append':
-        assert request.http_request.headers.get('Content-MD5') is not None
+    if request.http_request.query.get("action") == "append":
+        assert request.http_request.headers.get("Content-MD5") is not None
 
 
 def assert_content_md5_get(response):
-    assert response.http_request.headers.get('x-ms-range-get-content-md5') == 'true'
-    assert response.http_response.headers.get('Content-MD5') is not None
+    assert response.http_request.headers.get("x-ms-range-get-content-md5") == "true"
+    assert response.http_response.headers.get("Content-MD5") is not None
 
 
 def assert_content_crc64(request):
-    if request.http_request.query.get('action') == 'append':
-        assert request.http_request.headers.get('x-ms-content-crc64') is not None
+    if request.http_request.query.get("action") == "append":
+        assert request.http_request.headers.get("x-ms-content-crc64") is not None
 
 
 def assert_structured_message(request):
-    if request.http_request.query.get('action') == 'append':
-        assert request.http_request.headers.get('x-ms-structured-body') is not None
+    if request.http_request.query.get("action") == "append":
+        assert request.http_request.headers.get("x-ms-structured-body") is not None
 
 
 def assert_structured_message_get(response):
-    assert response.http_request.headers.get('x-ms-structured-body') is not None
-    assert response.http_response.headers.get('x-ms-structured-body') is not None
+    assert response.http_request.headers.get("x-ms-structured-body") is not None
+    assert response.http_response.headers.get("x-ms-structured-body") is not None
 
 
 class TestStorageContentValidation(StorageRecordedTestCase):
     def _setup(self, account_name):
         token_credential = self.get_credential(DataLakeServiceClient)
-        self.dsc = DataLakeServiceClient(self.account_url(account_name, "dfs"), credential=token_credential, logging_enable=True)
-        self.file_system = self.dsc.get_file_system_client(self.get_resource_name('filesystem'))
+        self.dsc = DataLakeServiceClient(
+            self.account_url(account_name, "dfs"), credential=token_credential, logging_enable=True
+        )
+        self.file_system = self.dsc.get_file_system_client(self.get_resource_name("filesystem"))
         self.file_system.create_file_system()
 
     def teardown_method(self, _):
@@ -56,10 +56,10 @@ class TestStorageContentValidation(StorageRecordedTestCase):
                 pass
 
     def _get_file_reference(self):
-        return self.get_resource_name('file')
+        return self.get_resource_name("file")
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_data(self, a, **kwargs):
@@ -67,8 +67,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         file.upload_data(data, overwrite=True, validate_content=a, raw_request_hook=assert_method)
@@ -78,7 +78,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_data_chunks(self, a, **kwargs):
@@ -86,8 +86,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abcde' * 512
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
+        data = b"abcde" * 512
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
 
         # Act
         file.upload_data(data, overwrite=True, validate_content=a, chunk_size=1024, raw_request_hook=assert_method)
@@ -97,7 +97,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_data_substream(self, a, **kwargs):
@@ -107,9 +107,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(datalake_storage_account_name)
         self.file_system._config.min_large_chunk_upload_threshold = 1  # Set less than chunk size to enable substream
         file = self.file_system.get_file_client(self._get_file_reference())
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
 
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         io = BytesIO(data)
 
         # Act
@@ -120,7 +120,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_append_data(self, a, **kwargs):
@@ -128,22 +128,22 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data1 = b'abcde' * 512
-        data2 = '你好世界' * 10
-        encoded2 = data2.encode('utf-8-sig')
+        data1 = b"abcde" * 512
+        data2 = "你好世界" * 10
+        encoded2 = data2.encode("utf-8-sig")
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         file.create_file()
         file.append_data(data1, 0, validate_content=a, raw_request_hook=assert_method)
-        file.append_data(data2, len(data1), encoding='utf-8-sig', validate_content=a, raw_request_hook=assert_method)
+        file.append_data(data2, len(data1), encoding="utf-8-sig", validate_content=a, raw_request_hook=assert_method)
         file.append_data(generator(), len(data1) + len(encoded2), validate_content=a, raw_request_hook=assert_method)
         file.flush_data(len(data1) + len(encoded2) + len(data1))
 
@@ -152,7 +152,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.read() == data1 + encoded2 + data1
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_append_data_streaming(self, a, **kwargs):
@@ -161,8 +161,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         file.create_file()
@@ -173,7 +173,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert result.read() == content
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     def test_append_data_streaming_large(self, a, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
@@ -181,16 +181,18 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         file.create_file()
         file.append_data(BytesIO(data1), 0, flush=True, validate_content=a, raw_request_hook=assert_method)
         file.append_data(BytesIO(data2), len(data1), flush=True, validate_content=a, raw_request_hook=assert_method)
-        file.append_data(BytesIO(data3), len(data1) + len(data2), flush=True, validate_content=a, raw_request_hook=assert_method)
+        file.append_data(
+            BytesIO(data3), len(data1) + len(data2), flush=True, validate_content=a, raw_request_hook=assert_method
+        )
         file.flush_data(len(data1) + len(data2) + len(data3))
 
         # Assert
@@ -198,7 +200,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert result.read() == data1 + data2 + data3
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file(self, a, **kwargs):
@@ -206,9 +208,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -224,7 +226,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert stream.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file_chunks(self, a, **kwargs):
@@ -234,9 +236,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.file_system._config.max_single_get_size = 512
         self.file_system._config.max_chunk_get_size = 512
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -258,7 +260,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert read_content == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file_chunks_partial(self, a, **kwargs):
@@ -268,9 +270,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.file_system._config.max_single_get_size = 512
         self.file_system._config.max_chunk_get_size = 512
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = file.download_file(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
@@ -294,16 +296,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         file = self.file_system.get_file_client(self._get_file_reference())
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.file_system._config.max_chunk_get_size = 10 * 1024 * 1024
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         file.upload_data(data, overwrite=True, max_concurrency=5)
 
         # Act
-        downloader = file.download_file(validate_content='crc64', max_concurrency=5)
+        downloader = file.download_file(validate_content="crc64", max_concurrency=5)
         content = downloader.read()
 
-        downloader = file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = downloader.read()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024:30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -53,7 +53,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         return self.get_resource_name("file")
 
     @DataLakePreparer()
-    @pytest.mark.parametrize("a", [True])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_data(self, a, **kwargs):

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -19,15 +19,17 @@ from test_content_validation import (
     assert_content_md5,
     assert_content_md5_get,
     assert_structured_message,
-    assert_structured_message_get
+    assert_structured_message_get,
 )
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
     async def _setup(self, account_name):
         token_credential = self.get_credential(DataLakeServiceClient, is_async=True)
-        self.dsc = DataLakeServiceClient(self.account_url(account_name, "dfs"), credential=token_credential, logging_enable=True)
-        self.file_system = self.dsc.get_file_system_client(self.get_resource_name('filesystem'))
+        self.dsc = DataLakeServiceClient(
+            self.account_url(account_name, "dfs"), credential=token_credential, logging_enable=True
+        )
+        self.file_system = self.dsc.get_file_system_client(self.get_resource_name("filesystem"))
         await self.file_system.create_file_system()
 
     def teardown_method(self, _):
@@ -39,7 +41,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
             sync_file_system = SyncFileSystemClient(
                 self.account_url(self.file_system.account_name, "dfs"),
                 self.file_system.file_system_name,
-                credential=sync_credential)
+                credential=sync_credential,
+            )
 
             try:
                 sync_file_system.delete_file_system()
@@ -47,10 +50,10 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
                 pass
 
     def _get_file_reference(self):
-        return self.get_resource_name('file')
-    
+        return self.get_resource_name("file")
+
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True])  # a: validate_content
+    @pytest.mark.parametrize("a", [True])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_data(self, a, **kwargs):
@@ -58,8 +61,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await file.upload_data(data, overwrite=True, validate_content=a, raw_request_hook=assert_method)
@@ -69,7 +72,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_data_chunks(self, a, **kwargs):
@@ -77,18 +80,20 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abcde' * 512
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
+        data = b"abcde" * 512
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
 
         # Act
-        await file.upload_data(data, overwrite=True, validate_content=a, chunk_size=1024, raw_request_hook=assert_method)
+        await file.upload_data(
+            data, overwrite=True, validate_content=a, chunk_size=1024, raw_request_hook=assert_method
+        )
 
         # Assert
         content = await file.download_file()
         assert await content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_data_substream(self, a, **kwargs):
@@ -98,9 +103,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(datalake_storage_account_name)
         self.file_system._config.min_large_chunk_upload_threshold = 1  # Set less than chunk size to enable substream
         file = self.file_system.get_file_client(self._get_file_reference())
-        assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
+        assert_method = assert_content_crc64 if a == "crc64" else assert_content_md5
 
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         io = BytesIO(data)
 
         # Act
@@ -111,7 +116,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_append_data(self, a, **kwargs):
@@ -119,23 +124,27 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data1 = b'abcde' * 512
-        data2 = '你好世界' * 10
-        encoded2 = data2.encode('utf-8-sig')
+        data1 = b"abcde" * 512
+        data2 = "你好世界" * 10
+        encoded2 = data2.encode("utf-8-sig")
 
         # An iterable with no length will be read into bytes and therefore will behave like
         # bytes when it comes to testing content validation.
         def generator():
             for i in range(0, len(data1), 500):
-                yield data1[i: i + 500]
+                yield data1[i : i + 500]
 
-        assert_method = assert_content_crc64 if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_content_crc64 if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await file.create_file()
         await file.append_data(data1, 0, validate_content=a, raw_request_hook=assert_method)
-        await file.append_data(data2, len(data1), encoding='utf-8-sig', validate_content=a, raw_request_hook=assert_method)
-        await file.append_data(generator(), len(data1) + len(encoded2), validate_content=a, raw_request_hook=assert_method)
+        await file.append_data(
+            data2, len(data1), encoding="utf-8-sig", validate_content=a, raw_request_hook=assert_method
+        )
+        await file.append_data(
+            generator(), len(data1) + len(encoded2), validate_content=a, raw_request_hook=assert_method
+        )
         await file.flush_data(len(data1) + len(encoded2) + len(data1))
 
         # Assert
@@ -143,7 +152,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.read() == data1 + encoded2 + data1
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_append_data_streaming(self, a, **kwargs):
@@ -152,8 +161,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
 
-        content = b'abcde' * 1030  # 5 KiB + 30
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        content = b"abcde" * 1030  # 5 KiB + 30
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         await file.create_file()
@@ -164,7 +173,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await result.read() == content
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @pytest.mark.live_test_only
     async def test_append_data_streaming_large(self, a, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
@@ -172,16 +181,20 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
 
-        data1 = b'abcde' * 1024 * 1024  # 5 MiB
-        data2 = b'12345' * 2 * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
-        data3 = b'12345678' * 8 * 1024 * 1024  # 64 MiB
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data1 = b"abcde" * 1024 * 1024  # 5 MiB
+        data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
+        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         await file.create_file()
         await file.append_data(BytesIO(data1), 0, flush=True, validate_content=a, raw_request_hook=assert_method)
-        await file.append_data(BytesIO(data2), len(data1), flush=True, validate_content=a, raw_request_hook=assert_method)
-        await file.append_data(BytesIO(data3), len(data1) + len(data2), flush=True, validate_content=a, raw_request_hook=assert_method)
+        await file.append_data(
+            BytesIO(data2), len(data1), flush=True, validate_content=a, raw_request_hook=assert_method
+        )
+        await file.append_data(
+            BytesIO(data3), len(data1) + len(data2), flush=True, validate_content=a, raw_request_hook=assert_method
+        )
         await file.flush_data(len(data1) + len(data2) + len(data3))
 
         # Assert
@@ -189,7 +202,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await result.read() == data1 + data2 + data3
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file(self, a, **kwargs):
@@ -197,9 +210,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(datalake_storage_account_name)
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         await file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -215,7 +228,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert stream.read() == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file_chunks(self, a, **kwargs):
@@ -225,9 +238,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.file_system._config.max_single_get_size = 512
         self.file_system._config.max_chunk_get_size = 512
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -249,7 +262,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert read_content == data
 
     @DataLakePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file_chunks_partial(self, a, **kwargs):
@@ -259,16 +272,20 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.file_system._config.max_single_get_size = 512
         self.file_system._config.max_chunk_get_size = 512
         file = self.file_system.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await file.upload_data(data, overwrite=True)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
-        downloader = await file.download_file(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
+        downloader = await file.download_file(
+            offset=10, length=1000, validate_content=a, raw_response_hook=assert_method
+        )
         content = await downloader.read()
 
         stream = BytesIO()
-        downloader = await file.download_file(offset=512, length=1024, validate_content=a, raw_response_hook=assert_method)
+        downloader = await file.download_file(
+            offset=512, length=1024, validate_content=a, raw_response_hook=assert_method
+        )
         await downloader.readinto(stream)
         stream.seek(0)
 
@@ -285,16 +302,16 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         file = self.file_system.get_file_client(self._get_file_reference())
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.file_system._config.max_chunk_get_size = 10 * 1024 * 1024
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         await file.upload_data(data, overwrite=True, max_concurrency=5)
 
         # Act
-        downloader = await file.download_file(validate_content='crc64', max_concurrency=5)
+        downloader = await file.download_file(validate_content="crc64", max_concurrency=5)
         content = await downloader.read()
 
-        downloader = await file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = await file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = await downloader.read()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024:30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -7,9 +7,6 @@
 from io import BytesIO
 
 import pytest
-from azure.storage.filedatalake import FileSystemClient as SyncFileSystemClient
-from azure.storage.filedatalake.aio import DataLakeServiceClient
-
 from devtools_testutils import is_live
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase, GenericTestProxyParametrize1
@@ -21,6 +18,9 @@ from test_content_validation import (
     assert_structured_message,
     assert_structured_message_get,
 )
+
+from azure.storage.filedatalake import FileSystemClient as SyncFileSystemClient
+from azure.storage.filedatalake.aio import DataLakeServiceClient
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
@@ -7,11 +7,11 @@
 from io import BytesIO
 
 import pytest
-from azure.storage.fileshare import ShareClient, ShareServiceClient
-
 from devtools_testutils import is_live, recorded_by_proxy
 from devtools_testutils.storage import GenericTestProxyParametrize1, StorageRecordedTestCase
 from settings.testcase import FileSharePreparer
+
+from azure.storage.fileshare import ShareClient, ShareServiceClient
 
 
 def assert_content_md5(request):

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
@@ -15,23 +15,23 @@ from settings.testcase import FileSharePreparer
 
 
 def assert_content_md5(request):
-    if request.http_request.query.get('comp') == 'range':
-        assert request.http_request.headers.get('Content-MD5') is not None
+    if request.http_request.query.get("comp") == "range":
+        assert request.http_request.headers.get("Content-MD5") is not None
 
 
 def assert_content_md5_get(response):
-    assert response.http_request.headers.get('x-ms-range-get-content-md5') == 'true'
-    assert response.http_response.headers.get('Content-MD5') is not None
+    assert response.http_request.headers.get("x-ms-range-get-content-md5") == "true"
+    assert response.http_response.headers.get("Content-MD5") is not None
 
 
 def assert_structured_message(request):
-    if request.http_request.query.get('comp') == 'range':
-        assert request.http_request.headers.get('x-ms-structured-body') is not None
+    if request.http_request.query.get("comp") == "range":
+        assert request.http_request.headers.get("x-ms-structured-body") is not None
 
 
 def assert_structured_message_get(response):
-    assert response.http_request.headers.get('x-ms-structured-body') is not None
-    assert response.http_response.headers.get('x-ms-structured-body') is not None
+    assert response.http_request.headers.get("x-ms-structured-body") is not None
+    assert response.http_response.headers.get("x-ms-structured-body") is not None
 
 
 class TestStorageContentValidation(StorageRecordedTestCase):
@@ -39,8 +39,13 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
     def _setup(self, account_name):
         token_credential = self.get_credential(ShareServiceClient)
-        self.ssc = ShareServiceClient(self.account_url(account_name, "file"), credential=token_credential, token_intent="backup", logging_enable=True)
-        self.share_client = self.ssc.get_share_client(self.get_resource_name('utshare'))
+        self.ssc = ShareServiceClient(
+            self.account_url(account_name, "file"),
+            credential=token_credential,
+            token_intent="backup",
+            logging_enable=True,
+        )
+        self.share_client = self.ssc.get_share_client(self.get_resource_name("utshare"))
         self.share_client.create_share()
 
     def teardown_method(self, _):
@@ -51,10 +56,10 @@ class TestStorageContentValidation(StorageRecordedTestCase):
                 pass
 
     def _get_file_reference(self):
-        return self.get_resource_name('file')
+        return self.get_resource_name("file")
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', ['auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", ["auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_create_file_with_data(self, a, **kwargs):
@@ -62,8 +67,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         file.create_file(len(data), data=data, validate_content=a, raw_request_hook=assert_method)
@@ -73,7 +78,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_file(self, a, **kwargs):
@@ -81,8 +86,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         file.upload_file(data, validate_content=a, raw_request_hook=assert_method)
@@ -92,7 +97,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_file_chunks(self, a, **kwargs):
@@ -101,8 +106,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         self.share_client._config.max_range_size = 1024
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abcde' * 512
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data = b"abcde" * 512
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         file.upload_file(data, validate_content=a, raw_request_hook=assert_method)
@@ -112,7 +117,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto','md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_range(self, a, **kwargs):
@@ -120,23 +125,25 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data1 = b'abcde' * 512
-        data2 = '你好世界' * 10
-        encoded2 = data2.encode('utf-16')
+        data1 = b"abcde" * 512
+        data2 = "你好世界" * 10
+        encoded2 = data2.encode("utf-16")
 
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
-    
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
+
         # Act
         file.create_file(len(data1) + len(encoded2))
         file.upload_range(data1, 0, len(data1), validate_content=a, raw_request_hook=assert_method)
-        file.upload_range(data2, len(data1), len(encoded2), encoding='utf-16', validate_content=a, raw_request_hook=assert_method)
+        file.upload_range(
+            data2, len(data1), len(encoded2), encoding="utf-16", validate_content=a, raw_request_hook=assert_method
+        )
 
         # Assert
         content = file.download_file()
         assert content.readall() == data1 + encoded2
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_upload_range_streaming(self, a, **kwargs):
@@ -145,8 +152,8 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
 
-        data = b'abcd' * 1030  # 4 KiB + 24
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data = b"abcd" * 1030  # 4 KiB + 24
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         file.create_file(len(data))
@@ -159,7 +166,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file(self, a, **kwargs):
@@ -167,9 +174,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         file.upload_file(data)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -185,7 +192,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert stream.read() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file_chunks(self, a, **kwargs):
@@ -195,9 +202,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.share_client._config.max_single_get_size = 512
         self.share_client._config.max_chunk_get_size = 512
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         file.upload_file(data)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -219,7 +226,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert read_content == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
     def test_download_file_chunks_partial(self, a, **kwargs):
@@ -229,9 +236,9 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self.share_client._config.max_single_get_size = 512
         self.share_client._config.max_chunk_get_size = 512
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         file.upload_file(data)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = file.download_file(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
@@ -255,16 +262,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.share_client._config.max_chunk_get_size = 5 * 1024 * 1024  # 5 MiB
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         file.upload_file(data, max_concurrency=5)
 
         # Act
-        downloader = file.download_file(validate_content='crc64', max_concurrency=5)
+        downloader = file.download_file(validate_content="crc64", max_concurrency=5)
         content = downloader.readall()
 
-        downloader = file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = downloader.readall()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024:30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
@@ -7,9 +7,6 @@
 from io import BytesIO
 
 import pytest
-from azure.storage.fileshare import ShareClient as SyncShareClient
-from azure.storage.fileshare.aio import ShareServiceClient
-
 from devtools_testutils import is_live
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase, GenericTestProxyParametrize1
@@ -20,6 +17,9 @@ from test_content_validation import (
     assert_structured_message,
     assert_structured_message_get,
 )
+
+from azure.storage.fileshare import ShareClient as SyncShareClient
+from azure.storage.fileshare.aio import ShareServiceClient
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
@@ -18,15 +18,20 @@ from test_content_validation import (
     assert_content_md5,
     assert_content_md5_get,
     assert_structured_message,
-    assert_structured_message_get
+    assert_structured_message_get,
 )
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
     async def _setup(self, account_name):
         token_credential = self.get_credential(ShareServiceClient, is_async=True)
-        self.ssc = ShareServiceClient(self.account_url(account_name, "file"), credential=token_credential, token_intent="backup", logging_enable=True)
-        self.share_client = self.ssc.get_share_client(self.get_resource_name('utshare'))
+        self.ssc = ShareServiceClient(
+            self.account_url(account_name, "file"),
+            credential=token_credential,
+            token_intent="backup",
+            logging_enable=True,
+        )
+        self.share_client = self.ssc.get_share_client(self.get_resource_name("utshare"))
         await self.share_client.create_share()
 
     def teardown_method(self, _):
@@ -38,17 +43,18 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
                 self.account_url(self.share_client.account_name, "file"),
                 self.share_client.share_name,
                 credential=sync_credential,
-                token_intent="backup")
+                token_intent="backup",
+            )
             try:
                 sync_share_client.delete_share()
             except:
                 pass
 
     def _get_file_reference(self):
-        return self.get_resource_name('file')
+        return self.get_resource_name("file")
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', ['auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", ["auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_create_file_with_data(self, a, **kwargs):
@@ -56,8 +62,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await file.create_file(len(data), data=data, validate_content=a, raw_request_hook=assert_method)
@@ -67,7 +73,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_file(self, a, **kwargs):
@@ -75,8 +81,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
+        data = b"abc" * 512
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await file.upload_file(data, validate_content=a, raw_request_hook=assert_method)
@@ -86,7 +92,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_file_chunks(self, a, **kwargs):
@@ -95,8 +101,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         self.share_client._config.max_range_size = 1024
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abcde' * 512
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data = b"abcde" * 512
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         await file.upload_file(data, validate_content=a, raw_request_hook=assert_method)
@@ -106,7 +112,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_range(self, a, **kwargs):
@@ -114,23 +120,25 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data1 = b'abcde' * 512
-        data2 = '你好世界' * 10
-        encoded2 = data2.encode('utf-16')
+        data1 = b"abcde" * 512
+        data2 = "你好世界" * 10
+        encoded2 = data2.encode("utf-16")
 
-        assert_method = assert_structured_message if a in ('auto', 'crc64') else assert_content_md5
+        assert_method = assert_structured_message if a in ("auto", "crc64") else assert_content_md5
 
         # Act
         await file.create_file(len(data1) + len(encoded2))
         await file.upload_range(data1, 0, len(data1), validate_content=a, raw_request_hook=assert_method)
-        await file.upload_range(data2, len(data1), len(encoded2), encoding='utf-16', validate_content=a, raw_request_hook=assert_method)
+        await file.upload_range(
+            data2, len(data1), len(encoded2), encoding="utf-16", validate_content=a, raw_request_hook=assert_method
+        )
 
         # Assert
         content = await file.download_file()
         assert await content.readall() == data1 + encoded2
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_upload_range_streaming(self, a, **kwargs):
@@ -139,8 +147,8 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
 
-        data = b'abcd' * 1030  # 4 KiB + 24
-        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+        data = b"abcd" * 1030  # 4 KiB + 24
+        assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act
         await file.create_file(len(data))
@@ -153,7 +161,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert await content.readall() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'auto', 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "auto", "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file(self, a, **kwargs):
@@ -161,9 +169,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name)
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512
+        data = b"abc" * 512
         await file.upload_file(data)
-        assert_method = assert_structured_message_get if a in ('auto', 'crc64') else assert_content_md5_get
+        assert_method = assert_structured_message_get if a in ("auto", "crc64") else assert_content_md5_get
 
         # Act
         downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -179,7 +187,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert stream.read() == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file_chunks(self, a, **kwargs):
@@ -189,9 +197,9 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.share_client._config.max_single_get_size = 512
         self.share_client._config.max_chunk_get_size = 512
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await file.upload_file(data)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
         downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
@@ -213,7 +221,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         assert read_content == data
 
     @FileSharePreparer()
-    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.parametrize("a", [True, "md5", "crc64"])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
     async def test_download_file_chunks_partial(self, a, **kwargs):
@@ -223,16 +231,20 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         self.share_client._config.max_single_get_size = 512
         self.share_client._config.max_chunk_get_size = 512
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abc' * 512 + b'abcde'
+        data = b"abc" * 512 + b"abcde"
         await file.upload_file(data)
-        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+        assert_method = assert_structured_message_get if a == "crc64" else assert_content_md5_get
 
         # Act
-        downloader = await file.download_file(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
+        downloader = await file.download_file(
+            offset=10, length=1000, validate_content=a, raw_response_hook=assert_method
+        )
         content = await downloader.readall()
 
         stream = BytesIO()
-        downloader = await file.download_file(offset=512, length=1024, validate_content=a, raw_response_hook=assert_method)
+        downloader = await file.download_file(
+            offset=512, length=1024, validate_content=a, raw_response_hook=assert_method
+        )
         await downloader.readinto(stream)
         stream.seek(0)
 
@@ -249,16 +261,16 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         # The service will use 4 MiB for structured message chunk size, so make chunk size larger
         self.share_client._config.max_chunk_get_size = 5 * 1024 * 1024  # 5 MiB
         file = self.share_client.get_file_client(self._get_file_reference())
-        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        data = b"abcde" * 30 * 1024 * 1024 + b"abcde"  # 150 MiB + 5
         await file.upload_file(data, max_concurrency=5)
 
         # Act
-        downloader = await file.download_file(validate_content='crc64', max_concurrency=5)
+        downloader = await file.download_file(validate_content="crc64", max_concurrency=5)
         content = await downloader.readall()
 
-        downloader = await file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content='crc64')
+        downloader = await file.download_file(offset=5 * 1024 * 1024, length=25 * 1024 * 1024, validate_content="crc64")
         partial = await downloader.readall()
 
         # Assert
         assert content == data
-        assert partial == data[5 * 1024 * 1024:30 * 1024 * 1024]
+        assert partial == data[5 * 1024 * 1024 : 30 * 1024 * 1024]


### PR DESCRIPTION
This change runs black and next-pylint on the content validation test files as well as fixes some minor issues and re-records blob and datalake tests.