### PR TITLE
Read for global feature sdkstats bitmap and add a 15 second delay timer

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.0.0b53 (Unreleased)
 
 ### Features Added
+- Read for global feature sdkstats bitmap and add a 15 second delay timer
+  ([#47031](https://github.com/Azure/azure-sdk-for-python/pull/47031))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -264,8 +264,8 @@ class LocalFileStorage:
             # Unix
             else:
                 open_flags = (
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # cspell:disable-line
-                )  # pylint: disable=no-member
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW  # pylint: disable=no-member  # cspell:disable-line
+                )
                 dir_fd = os.open(self._path, open_flags)
                 try:
                     dir_stat = os.fstat(dir_fd)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
@@ -280,7 +280,7 @@ class StatsbeatManager(metaclass=Singleton):
 
     def _cleanup(self, shutdown_meter_provider: bool = True) -> None:
         # Clean up resources with optional meter provider shutdown
-        if hasattr(self, '_warmup_timer') and self._warmup_timer:
+        if hasattr(self, "_warmup_timer") and self._warmup_timer:
             self._warmup_timer.cancel()
             self._warmup_timer = None
         if shutdown_meter_provider and self._meter_provider:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
@@ -24,6 +24,8 @@ from azure.monitor.opentelemetry.exporter._utils import Singleton
 
 logger = logging.getLogger(__name__)
 
+_STATSBEAT_INITIAL_EXPORT_WARMUP_SECONDS = 15  # 15 second warmup delay
+
 
 class StatsbeatConfig:
     """Configuration class for Statsbeat metrics collection."""
@@ -241,8 +243,8 @@ class StatsbeatManager(metaclass=Singleton):
                 config.distro_version,
             )
 
-            # Force initial flush and initialize non-initial metrics
-            self._meter_provider.force_flush()
+            # Schedule initial statsbeat flush after warmup delay to allow feature bits to settle.
+            self._schedule_initial_export_flush()
             self._metrics.init_non_initial_metrics()
 
             self._config = config
@@ -257,6 +259,22 @@ class StatsbeatManager(metaclass=Singleton):
             # Clean up on failure
             self._cleanup()
             return False
+
+    def _schedule_initial_export_flush(self) -> None:
+        def _flush() -> None:
+            meter_provider = self._meter_provider
+            if not self._initialized or meter_provider is None:
+                return
+            try:
+                meter_provider.force_flush()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(  # pylint: disable=do-not-log-exceptions-if-not-debug
+                    "Failed to force flush statsbeat after warmup: %s", e
+                )
+
+        timer = threading.Timer(_STATSBEAT_INITIAL_EXPORT_WARMUP_SECONDS, _flush)
+        timer.daemon = True
+        timer.start()
 
     def _cleanup(self, shutdown_meter_provider: bool = True) -> None:
         # Clean up resources with optional meter provider shutdown

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_manager.py
@@ -156,6 +156,7 @@ class StatsbeatManager(metaclass=Singleton):
         self._initialized: bool = False  # type: ignore
         self._metrics: Optional[_StatsbeatMetrics] = None  # type: ignore
         self._meter_provider: Optional[MeterProvider] = None  # type: ignore
+        self._warmup_timer: Optional[threading.Timer] = None
 
         # Set during first initialization, preserved in shutdown for potential re-initialization
         self._config: Optional[StatsbeatConfig] = None  # type: ignore
@@ -274,10 +275,14 @@ class StatsbeatManager(metaclass=Singleton):
 
         timer = threading.Timer(_STATSBEAT_INITIAL_EXPORT_WARMUP_SECONDS, _flush)
         timer.daemon = True
+        self._warmup_timer = timer
         timer.start()
 
     def _cleanup(self, shutdown_meter_provider: bool = True) -> None:
         # Clean up resources with optional meter provider shutdown
+        if hasattr(self, '_warmup_timer') and self._warmup_timer:
+            self._warmup_timer.cancel()
+            self._warmup_timer = None
         if shutdown_meter_provider and self._meter_provider:
             try:
                 self._meter_provider.shutdown()

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
@@ -20,6 +20,7 @@ _STATSBEAT_STATE = {
     "LIVE_METRICS_FEATURE_SET": False,
     "CUSTOMER_SDKSTATS_FEATURE_SET": False,
     "BROWSER_SDK_LOADER_FEATURE_SET": False,
+    "FEATURE_ATTRIBUTE_BITS": 0,
 }
 _STATSBEAT_STATE_LOCK = threading.Lock()
 _STATSBEAT_FAILURE_COUNT_THRESHOLD = 3
@@ -115,3 +116,12 @@ def get_statsbeat_browser_sdk_loader_feature_set():  # pylint: disable=name-too-
 def set_statsbeat_browser_sdk_loader_feature_set():  # pylint: disable=name-too-long
     with _STATSBEAT_STATE_LOCK:
         _STATSBEAT_STATE["BROWSER_SDK_LOADER_FEATURE_SET"] = True
+
+
+def get_statsbeat_feature_attribute_bits() -> int:
+    return int(_STATSBEAT_STATE["FEATURE_ATTRIBUTE_BITS"])
+
+
+def set_statsbeat_feature_attribute_bits(feature_bits: int) -> None:
+    with _STATSBEAT_STATE_LOCK:
+        _STATSBEAT_STATE["FEATURE_ATTRIBUTE_BITS"] = int(feature_bits)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -135,6 +135,8 @@ class _StatsbeatMetrics:
             _StatsbeatMetrics._COMMON_ATTRIBUTES["version"] = _get_version()
 
         self._ikey = instrumentation_key
+        if _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] is not None:
+            set_statsbeat_feature_attribute_bits(_StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"])
         self._feature = get_statsbeat_feature_attribute_bits()
         if not disable_offline_storage:
             self._feature |= _StatsbeatFeature.DISK_RETRY
@@ -267,6 +269,8 @@ class _StatsbeatMetrics:
             return observations
         # Feature metric
         # Check if any features were enabled during runtime
+        if _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] is not None:
+            set_statsbeat_feature_attribute_bits(_StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"])
         feature_bits = get_statsbeat_feature_attribute_bits()
         if feature_bits:
             self._feature |= feature_bits

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -133,7 +133,7 @@ class _StatsbeatMetrics:
             _StatsbeatMetrics._COMMON_ATTRIBUTES["version"] = _get_version()
 
         self._ikey = instrumentation_key
-        self._feature = _StatsbeatFeature.NONE
+        self._feature = _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] or _StatsbeatFeature.NONE
         if not disable_offline_storage:
             self._feature |= _StatsbeatFeature.DISK_RETRY
         if has_credential:
@@ -264,6 +264,10 @@ class _StatsbeatMetrics:
             return observations
         # Feature metric
         # Check if any features were enabled during runtime
+        feature_bits = int(_StatsbeatMetrics._FEATURE_ATTRIBUTES.get("feature") or 0)
+        if feature_bits:
+            self._feature |= feature_bits
+            _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
         if get_statsbeat_custom_events_feature_set():
             self._feature |= _StatsbeatFeature.CUSTOM_EVENTS_EXTENSION
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -33,6 +33,8 @@ from azure.monitor.opentelemetry.exporter._constants import (
 from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _REQUESTS_MAP_LOCK,
     _REQUESTS_MAP,
+    get_statsbeat_feature_attribute_bits,
+    set_statsbeat_feature_attribute_bits,
     get_statsbeat_live_metrics_feature_set,
     get_statsbeat_custom_events_feature_set,
     get_statsbeat_customer_sdkstats_feature_set,
@@ -133,7 +135,7 @@ class _StatsbeatMetrics:
             _StatsbeatMetrics._COMMON_ATTRIBUTES["version"] = _get_version()
 
         self._ikey = instrumentation_key
-        self._feature = _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] or _StatsbeatFeature.NONE
+        self._feature = get_statsbeat_feature_attribute_bits()
         if not disable_offline_storage:
             self._feature |= _StatsbeatFeature.DISK_RETRY
         if has_credential:
@@ -166,6 +168,7 @@ class _StatsbeatMetrics:
 
         _StatsbeatMetrics._NETWORK_ATTRIBUTES["host"] = _shorten_host(endpoint)
         _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+        set_statsbeat_feature_attribute_bits(self._feature)
         _StatsbeatMetrics._INSTRUMENTATION_ATTRIBUTES["feature"] = _utils.get_instrumentations()
 
         self._vm_retry = True  # True if we want to attempt to find if in VM
@@ -264,22 +267,27 @@ class _StatsbeatMetrics:
             return observations
         # Feature metric
         # Check if any features were enabled during runtime
-        feature_bits = int(_StatsbeatMetrics._FEATURE_ATTRIBUTES.get("feature") or 0)
+        feature_bits = get_statsbeat_feature_attribute_bits()
         if feature_bits:
             self._feature |= feature_bits
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+            set_statsbeat_feature_attribute_bits(self._feature)
         if get_statsbeat_custom_events_feature_set():
             self._feature |= _StatsbeatFeature.CUSTOM_EVENTS_EXTENSION
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+            set_statsbeat_feature_attribute_bits(self._feature)
         if get_statsbeat_live_metrics_feature_set():
             self._feature |= _StatsbeatFeature.LIVE_METRICS
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+            set_statsbeat_feature_attribute_bits(self._feature)
         if get_statsbeat_customer_sdkstats_feature_set():
             self._feature |= _StatsbeatFeature.CUSTOMER_SDKSTATS
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+            set_statsbeat_feature_attribute_bits(self._feature)
         if get_statsbeat_browser_sdk_loader_feature_set():
             self._feature |= _StatsbeatFeature.BROWSER_SDK_LOADER
             _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = self._feature
+            set_statsbeat_feature_attribute_bits(self._feature)
 
         # Don't send observation if no features enabled
         if self._feature is not _StatsbeatFeature.NONE:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_manager.py
@@ -270,6 +270,8 @@ class TestStatsbeatManager(unittest.TestCase):
             self.manager._metrics = None
         if hasattr(self.manager, "_meter_provider"):
             self.manager._meter_provider = None
+        if hasattr(self.manager, "_warmup_timer"):
+            self.manager._warmup_timer = None
 
     def tearDown(self):
         """Clean up after tests."""
@@ -673,6 +675,8 @@ class TestStatsbeatManager(unittest.TestCase):
         self.manager._initialized = True
         mock_meter_provider = Mock()
         self.manager._meter_provider = mock_meter_provider
+        mock_timer = Mock()
+        self.manager._warmup_timer = mock_timer
         self.manager._metrics = Mock()
         config_mock = Mock()
         self.manager._config = config_mock
@@ -682,8 +686,10 @@ class TestStatsbeatManager(unittest.TestCase):
         self.assertFalse(self.manager._initialized)
         self.assertIsNone(self.manager._meter_provider)
         self.assertIsNone(self.manager._metrics)
+        self.assertIsNone(self.manager._warmup_timer)
         # Config is intact for potential re-initialization
         self.assertEqual(self.manager._config, config_mock)
+        mock_timer.cancel.assert_called_once()
         mock_meter_provider.shutdown.assert_called_once()
 
     def test_cleanup_without_shutdown(self):
@@ -692,6 +698,8 @@ class TestStatsbeatManager(unittest.TestCase):
         self.manager._initialized = True
         mock_meter_provider = Mock()
         self.manager._meter_provider = mock_meter_provider
+        mock_timer = Mock()
+        self.manager._warmup_timer = mock_timer
         self.manager._metrics = Mock()
         config_mock = Mock()
         self.manager._config = config_mock
@@ -701,8 +709,10 @@ class TestStatsbeatManager(unittest.TestCase):
         self.assertFalse(self.manager._initialized)
         self.assertIsNone(self.manager._meter_provider)
         self.assertIsNone(self.manager._metrics)
+        self.assertIsNone(self.manager._warmup_timer)
         # Config is intact for potential re-initialization
         self.assertEqual(self.manager._config, config_mock)
+        mock_timer.cancel.assert_called_once()
         mock_meter_provider.shutdown.assert_not_called()
 
     def test_cleanup_meter_provider_exception(self):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_manager.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_manager.py
@@ -366,9 +366,16 @@ class TestStatsbeatManager(unittest.TestCase):
     @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.PeriodicExportingMetricReader")
     @patch("azure.monitor.opentelemetry.exporter.export.metrics._exporter.AzureMonitorMetricExporter")
     @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager._StatsbeatMetrics")
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.threading.Timer")
     @patch("azure.monitor.opentelemetry.exporter.statsbeat._state.is_statsbeat_enabled")
     def test_initialize_success(
-        self, mock_is_enabled, mock_statsbeat_metrics, mock_exporter_class, mock_reader_class, mock_meter_provider_class
+        self,
+        mock_is_enabled,
+        mock_timer_class,
+        mock_statsbeat_metrics,
+        mock_exporter_class,
+        mock_reader_class,
+        mock_meter_provider_class,
     ):
         """Test successful initialization."""
         mock_is_enabled.return_value = True
@@ -388,6 +395,7 @@ class TestStatsbeatManager(unittest.TestCase):
         # Mock the statsbeat metrics
         mock_metrics = Mock()
         mock_statsbeat_metrics.return_value = mock_metrics
+        mock_timer_class.return_value = Mock()
 
         config = self._create_valid_config()
 
@@ -404,8 +412,46 @@ class TestStatsbeatManager(unittest.TestCase):
         mock_reader_class.assert_called_once()
         mock_meter_provider_class.assert_called_once()
         mock_statsbeat_metrics.assert_called_once()
-        mock_meter_provider.force_flush.assert_called_once()
+        mock_timer_class.assert_called_once()
+        mock_timer_class.return_value.start.assert_called_once()
+        mock_meter_provider.force_flush.assert_not_called()
         mock_metrics.init_non_initial_metrics.assert_called_once()
+
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.threading.Timer")
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.MeterProvider")
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.PeriodicExportingMetricReader")
+    @patch("azure.monitor.opentelemetry.exporter.export.metrics._exporter.AzureMonitorMetricExporter")
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager._StatsbeatMetrics")
+    @patch("azure.monitor.opentelemetry.exporter.statsbeat._state.is_statsbeat_enabled")
+    def test_initialize_with_delay_schedules_non_blocking_flush(
+        self,
+        mock_is_enabled,
+        mock_statsbeat_metrics,
+        mock_exporter_class,
+        mock_reader_class,
+        mock_meter_provider_class,
+        mock_timer_class,
+    ):
+        """Test delayed initial statsbeat flush is scheduled asynchronously."""
+        mock_is_enabled.return_value = True
+
+        mock_exporter_class.return_value = Mock()
+        mock_reader_class.return_value = Mock()
+        mock_meter_provider = Mock()
+        mock_meter_provider_class.return_value = mock_meter_provider
+        mock_metrics = Mock()
+        mock_statsbeat_metrics.return_value = mock_metrics
+
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        result = self.manager.initialize(self._create_valid_config())
+
+        self.assertTrue(result)
+        mock_timer_class.assert_called_once()
+        self.assertEqual(mock_timer_class.call_args[0][0], 15)
+        mock_timer.start.assert_called_once()
+        mock_meter_provider.force_flush.assert_not_called()
 
     @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.MeterProvider")
     @patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.PeriodicExportingMetricReader")

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_metrics.py
@@ -24,6 +24,8 @@ from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _REQUESTS_MAP,
     _STATSBEAT_STATE,
     _STATSBEAT_STATE_LOCK,
+    get_statsbeat_feature_attribute_bits,
+    set_statsbeat_feature_attribute_bits,
 )
 from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
     _shorten_host,
@@ -87,6 +89,7 @@ class TestStatsbeatMetrics(unittest.TestCase):
             _STATSBEAT_STATE["CUSTOM_EVENTS_FEATURE_SET"] = False
             _STATSBEAT_STATE["LIVE_METRICS_FEATURE_SET"] = False
             _STATSBEAT_STATE["CUSTOMER_SDKSTATS_FEATURE_SET"] = False
+            _STATSBEAT_STATE["FEATURE_ATTRIBUTE_BITS"] = 0
 
         _StatsbeatMetrics._COMMON_ATTRIBUTES = dict(_StatsbeatMetrics_COMMON_ATTRS)
         _StatsbeatMetrics._NETWORK_ATTRIBUTES = dict(_StatsbeatMetrics_NETWORK_ATTRS)
@@ -125,6 +128,14 @@ class TestStatsbeatMetrics(unittest.TestCase):
         self.assertTrue(isinstance(metric._feature_metric, ObservableGauge))
         self.assertEqual(metric._attach_metric.name, _ATTACH_METRIC_NAME[0])
         self.assertEqual(metric._feature_metric.name, _FEATURE_METRIC_NAME[0])
+
+    def test_statsbeat_feature_attribute_bits_getter_default(self):
+        self.assertEqual(get_statsbeat_feature_attribute_bits(), 0)
+
+    def test_statsbeat_feature_attribute_bits_setter_and_getter(self):
+        feature_bits = _StatsbeatFeature.DISK_RETRY | _StatsbeatFeature.LIVE_METRICS
+        set_statsbeat_feature_attribute_bits(feature_bits)
+        self.assertEqual(get_statsbeat_feature_attribute_bits(), feature_bits)
 
     @mock.patch("azure.monitor.opentelemetry.exporter._utils._is_attach_enabled")
     def test_statsbeat_metric_init_attach_enabled(self, attach_mock):
@@ -717,6 +728,7 @@ class TestStatsbeatMetrics(unittest.TestCase):
         )
         metric._feature = _StatsbeatFeature.NONE
         _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = _StatsbeatFeature.NONE
+        set_statsbeat_feature_attribute_bits(_StatsbeatFeature.NONE)
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
         attributes.update(_StatsbeatMetrics._INSTRUMENTATION_ATTRIBUTES)
         self.assertEqual(attributes["type"], _FEATURE_TYPES.INSTRUMENTATION)
@@ -749,6 +761,7 @@ class TestStatsbeatMetrics(unittest.TestCase):
         )
         metric._feature = _StatsbeatFeature.NONE
         _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = _StatsbeatFeature.NONE
+        set_statsbeat_feature_attribute_bits(_StatsbeatFeature.NONE)
         self.assertEqual(_StatsbeatMetrics._INSTRUMENTATION_ATTRIBUTES["feature"], 0)
         with mock.patch("azure.monitor.opentelemetry.exporter._utils.get_instrumentations") as instrumentations:
             instrumentations.return_value = 0

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_metrics.py
@@ -716,6 +716,7 @@ class TestStatsbeatMetrics(unittest.TestCase):
             False,
         )
         metric._feature = _StatsbeatFeature.NONE
+        _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = _StatsbeatFeature.NONE
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
         attributes.update(_StatsbeatMetrics._INSTRUMENTATION_ATTRIBUTES)
         self.assertEqual(attributes["type"], _FEATURE_TYPES.INSTRUMENTATION)
@@ -747,6 +748,7 @@ class TestStatsbeatMetrics(unittest.TestCase):
             False,
         )
         metric._feature = _StatsbeatFeature.NONE
+        _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = _StatsbeatFeature.NONE
         self.assertEqual(_StatsbeatMetrics._INSTRUMENTATION_ATTRIBUTES["feature"], 0)
         with mock.patch("azure.monitor.opentelemetry.exporter._utils.get_instrumentations") as instrumentations:
             instrumentations.return_value = 0

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
@@ -10,7 +10,7 @@ from azure.monitor.opentelemetry.exporter._constants import (
 )
 from azure.monitor.opentelemetry.exporter.statsbeat import StatsbeatConfig, _statsbeat
 from azure.monitor.opentelemetry.exporter.statsbeat._manager import StatsbeatManager
-from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import _StatsbeatFeature
+from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import _StatsbeatFeature, _StatsbeatMetrics
 from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _STATSBEAT_STATE,
     _STATSBEAT_STATE_LOCK,
@@ -23,6 +23,8 @@ from azure.monitor.opentelemetry.exporter._constants import (
 )
 
 # cSpell:disable
+
+_StatsbeatMetrics_FEATURE_ATTRIBUTES = dict(_StatsbeatMetrics._FEATURE_ATTRIBUTES)
 
 
 # pylint: disable=protected-access, unused-argument
@@ -41,6 +43,7 @@ class TestStatsbeat(unittest.TestCase):
             _STATSBEAT_STATE["CUSTOM_EVENTS_FEATURE_SET"] = False
             _STATSBEAT_STATE["LIVE_METRICS_FEATURE_SET"] = False
             _STATSBEAT_STATE["CUSTOMER_SDKSTATS_FEATURE_SET"] = False
+        _StatsbeatMetrics._FEATURE_ATTRIBUTES = dict(_StatsbeatMetrics_FEATURE_ATTRIBUTES)
 
     def tearDown(self):
         """Clean up after tests."""
@@ -56,7 +59,10 @@ class TestStatsbeat(unittest.TestCase):
     @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.MeterProvider")
     @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.PeriodicExportingMetricReader")
     @mock.patch("azure.monitor.opentelemetry.exporter.AzureMonitorMetricExporter")
-    def test_collect_statsbeat_metrics(self, mock_exporter, mock_reader, mock_meter_provider, mock_statsbeat_metrics):
+    @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.threading.Timer")
+    def test_collect_statsbeat_metrics(
+        self, mock_timer_class, mock_exporter, mock_reader, mock_meter_provider, mock_statsbeat_metrics
+    ):
         """Test that collect_statsbeat_metrics properly initializes statsbeat collection."""
         # Arrange
         exporter = mock.Mock()
@@ -78,6 +84,9 @@ class TestStatsbeat(unittest.TestCase):
         flush_mock = mock.Mock()
         mock_meter_provider_instance.force_flush = flush_mock
 
+        mock_timer = mock.Mock()
+        mock_timer_class.return_value = mock_timer
+
         mock_statsbeat_metrics_instance = mock.Mock()
         mock_statsbeat_metrics.return_value = mock_statsbeat_metrics_instance
 
@@ -86,6 +95,10 @@ class TestStatsbeat(unittest.TestCase):
 
         # Act
         _statsbeat.collect_statsbeat_metrics(exporter)
+
+        # Simulate warmup timer callback execution.
+        timer_callback = mock_timer_class.call_args[0][1]
+        timer_callback()
 
         # Assert - verify manager is initialized
         self.assertTrue(manager._initialized)
@@ -329,8 +342,15 @@ class TestStatsbeat(unittest.TestCase):
     @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.MeterProvider")
     @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.PeriodicExportingMetricReader")
     @mock.patch("azure.monitor.opentelemetry.exporter.export.metrics._exporter.AzureMonitorMetricExporter")
+    @mock.patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.threading.Timer")
     def test_collect_statsbeat_metrics_exists(
-        self, mock_exporter, mock_reader, mock_meter_provider, mock_statsbeat_metrics, mock_get_manager
+        self,
+        mock_timer_class,
+        mock_exporter,
+        mock_reader,
+        mock_meter_provider,
+        mock_statsbeat_metrics,
+        mock_get_manager,
     ):
         """Test that collect_statsbeat_metrics reuses existing configuration when called multiple times with same config."""  # pylint: disable=line-too-long
         # Arrange
@@ -353,6 +373,9 @@ class TestStatsbeat(unittest.TestCase):
         flush_mock = mock.Mock()
         mock_meter_provider_instance.force_flush = flush_mock
 
+        mock_timer = mock.Mock()
+        mock_timer_class.return_value = mock_timer
+
         mock_statsbeat_metrics_instance = mock.Mock()
         mock_statsbeat_metrics.return_value = mock_statsbeat_metrics_instance
 
@@ -362,6 +385,8 @@ class TestStatsbeat(unittest.TestCase):
 
         # Act - Initialize first time
         _statsbeat.collect_statsbeat_metrics(exporter)
+        timer_callback = mock_timer_class.call_args[0][1]
+        timer_callback()
         first_metrics = manager._metrics
         self.assertTrue(manager._initialized)
         self.assertEqual(first_metrics, mock_statsbeat_metrics_instance)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
@@ -43,6 +43,7 @@ class TestStatsbeat(unittest.TestCase):
             _STATSBEAT_STATE["CUSTOM_EVENTS_FEATURE_SET"] = False
             _STATSBEAT_STATE["LIVE_METRICS_FEATURE_SET"] = False
             _STATSBEAT_STATE["CUSTOMER_SDKSTATS_FEATURE_SET"] = False
+            _STATSBEAT_STATE["FEATURE_ATTRIBUTE_BITS"] = 0
         _StatsbeatMetrics._FEATURE_ATTRIBUTES = dict(_StatsbeatMetrics_FEATURE_ATTRIBUTES)
 
     def tearDown(self):


### PR DESCRIPTION
**TODO** Since we have live metrics on by default now, we should track when it has been disabled instead.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
