### PR TITLE
feat: Detect model property type changes as breaking changes

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -28,6 +28,7 @@ class BreakingChangeType(str, Enum):
     CHANGED_PARAMETER_KIND = "ChangedParameterKind"
     CHANGED_PARAMETER_TYPE = "ChangedParameterType"
     CHANGED_FUNCTION_KIND = "ChangedFunctionKind"
+    CHANGED_CLASS_PROPERTY_TYPE = "ChangedClassPropertyType"
     REMOVED_OR_RENAMED_MODULE = "RemovedOrRenamedModule"
     REMOVED_FUNCTION_KWARGS = "RemovedFunctionKwargs"
     REMOVED_OR_RENAMED_OPERATION_GROUP = "RemovedOrRenamedOperationGroup"

--- a/scripts/breaking_changes_checker/checkers/changed_class_property_type_checker.py
+++ b/scripts/breaking_changes_checker/checkers/changed_class_property_type_checker.py
@@ -4,9 +4,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import sys
-import os
-sys.path.append(os.path.abspath("../../scripts/breaking_changes_checker"))
 from _models import CheckerType
 import jsondiff
 

--- a/scripts/breaking_changes_checker/checkers/changed_class_property_type_checker.py
+++ b/scripts/breaking_changes_checker/checkers/changed_class_property_type_checker.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import sys
+import os
+sys.path.append(os.path.abspath("../../scripts/breaking_changes_checker"))
+from _models import CheckerType
+import jsondiff
+
+
+class ChangedClassPropertyTypeChecker:
+    """Detect a change to a class property type annotation.
+    
+    This checker identifies when a model property changes its attr_type from one value
+    to another (e.g., Operation.display changed from OperationInfo to OperationDisplay).
+    It only emits when the property exists in both stable and current snapshots with
+    different attr_type values. Add/remove cases are handled by existing checkers.
+    """
+
+    node_type = CheckerType.CLASS
+    name = "ChangedClassPropertyType"
+    is_breaking = True
+    message = "Model `{}` changed type of property `{}` from `{}` to `{}`"
+
+    def run_check(self, diff, stable_nodes, current_nodes, **kwargs):
+        module_name = kwargs.get("module_name")
+        bc_list = []
+
+        # New module: nothing to compare against.
+        if module_name not in stable_nodes:
+            return bc_list
+
+        for class_name, class_components in diff.items():
+            # Skip removed/renamed class entries; those are handled by other checkers.
+            if isinstance(class_name, jsondiff.Symbol):
+                continue
+            
+            # Ensure class exists in both stable and current
+            if class_name not in stable_nodes[module_name].get("class_nodes", {}):
+                continue
+            if class_name not in current_nodes[module_name].get("class_nodes", {}):
+                continue
+
+            stable_class = stable_nodes[module_name]["class_nodes"][class_name]
+            current_class = current_nodes[module_name]["class_nodes"][class_name]
+
+            stable_properties = stable_class.get("properties", {})
+            current_properties = current_class.get("properties", {})
+
+            # Iterate over properties that exist in both stable and current
+            for prop_name in stable_properties.keys():
+                if prop_name not in current_properties:
+                    continue  # Property was removed, handled by existing checker
+
+                stable_prop = stable_properties[prop_name]
+                current_prop = current_properties[prop_name]
+
+                # Extract attr_type, handling dict and non-dict formats
+                stable_type = stable_prop.get("attr_type") if isinstance(stable_prop, dict) else stable_prop
+                current_type = current_prop.get("attr_type") if isinstance(current_prop, dict) else current_prop
+
+                # Only report if both have attr_type and they differ
+                if stable_type is None or current_type is None:
+                    continue
+                if stable_type == current_type:
+                    continue
+
+                # Emit breaking change
+                bc_list.append(
+                    (
+                        self.message, self.name, module_name, class_name, prop_name,
+                        stable_type, current_type,
+                    )
+                )
+
+        return bc_list

--- a/scripts/breaking_changes_checker/supported_checkers.py
+++ b/scripts/breaking_changes_checker/supported_checkers.py
@@ -8,12 +8,14 @@
 from checkers.removed_method_overloads_checker import RemovedMethodOverloadChecker
 from checkers.added_method_overloads_checker import AddedMethodOverloadChecker
 from checkers.changed_function_return_type_checker import ChangedFunctionReturnTypeChecker
+from checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
 from checkers.unflattened_models_checker import UnflattenedModelsChecker
 
 CHECKERS = [
     RemovedMethodOverloadChecker(),
     AddedMethodOverloadChecker(),
     ChangedFunctionReturnTypeChecker(),
+    ChangedClassPropertyTypeChecker(),
 ]
 
 POST_PROCESSING_CHECKERS = [

--- a/scripts/breaking_changes_checker/tests/test_breaking_changes.py
+++ b/scripts/breaking_changes_checker/tests/test_breaking_changes.py
@@ -993,6 +993,191 @@ def test_return_type_paged_iterable_equivalence_is_not_breaking():
         )
 
 
+def test_changed_class_property_type():
+    """Model property type change should be reported as a breaking change."""
+    stable = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationInfo",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationDisplay",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+
+    EXPECTED = [
+        "(ChangedClassPropertyType): Model `Operation` changed type of property `display` from `OperationInfo` to `OperationDisplay`",
+    ]
+
+    from breaking_changes_checker.checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
+    bc = BreakingChangesTracker(
+        stable, current, "azure-contoso",
+        checkers=[ChangedClassPropertyTypeChecker()],
+    )
+    bc.run_checks()
+
+    changes = normalize_breaking_changes_report(bc.report_changes())
+    expected_msg = format_breaking_changes(EXPECTED)
+    assert len(bc.breaking_changes) == len(EXPECTED)
+    assert changes == expected_msg
+
+
+def test_changed_class_property_type_not_reported_when_property_added():
+    """Property added only (not in stable) should not trigger property type change detection."""
+    stable = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {}
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationDisplay",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+
+    from breaking_changes_checker.checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
+    bc = BreakingChangesTracker(
+        stable, current, "azure-contoso",
+        checkers=[ChangedClassPropertyTypeChecker()],
+    )
+    bc.run_checks()
+
+    # No breaking changes expected for property that only exists in current
+    assert len(bc.breaking_changes) == 0
+
+
+def test_changed_class_property_type_not_reported_when_property_removed():
+    """Property removed only (not in current) should not trigger property type change detection."""
+    stable = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationInfo",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {}
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+
+    from breaking_changes_checker.checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
+    bc = BreakingChangesTracker(
+        stable, current, "azure-contoso",
+        checkers=[ChangedClassPropertyTypeChecker()],
+    )
+    bc.run_checks()
+
+    # No breaking changes expected from the property type change checker for property that only exists in stable
+    # Filter to only look at ChangedClassPropertyType changes
+    property_type_changes = [bc for bc in bc.breaking_changes if bc[1] == BreakingChangeType.CHANGED_CLASS_PROPERTY_TYPE]
+    assert len(property_type_changes) == 0
+
+
+def test_changed_class_property_type_not_reported_when_unchanged():
+    """Property type unchanged should not be reported."""
+    stable = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationInfo",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationInfo",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+
+    from breaking_changes_checker.checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
+    bc = BreakingChangesTracker(
+        stable, current, "azure-contoso",
+        checkers=[ChangedClassPropertyTypeChecker()],
+    )
+    bc.run_checks()
+
+    # No breaking changes expected for unchanged property
+    assert len(bc.breaking_changes) == 0
+
+
+
 def test_create_function_report_scopes_return_type_to_owner_class():
     """End-to-end check that `create_function_report` captures the right return
     annotation when multiple functions/methods in the same module share a name.

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -940,3 +940,60 @@ def test_added_keyword_only_param_to_model_method_still_reported_as_class():
     assert msg == ChangelogTracker.ADDED_CLASS_METHOD_PARAMETER_MSG
     assert args == ["azure.contoso", "ContosoModel", "extra", "do_something"]
 
+
+def test_changelog_class_property_type_changed():
+    """Verify that class property type changes are reported in changelog output."""
+    stable = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationInfo",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+    current = {
+        "azure.contoso": {
+            "class_nodes": {
+                "Operation": {
+                    "type": "Model",
+                    "methods": {},
+                    "properties": {
+                        "display": {
+                            "attr_type": "OperationDisplay",
+                        }
+                    }
+                }
+            },
+            "function_nodes": {},
+        }
+    }
+
+    from breaking_changes_checker.checkers.changed_class_property_type_checker import ChangedClassPropertyTypeChecker
+    bc = ChangelogTracker(
+        stable, current, "azure-contoso",
+        checkers=[ChangedClassPropertyTypeChecker()],
+    )
+    bc.run_checks()
+
+    # Should have one breaking change for property type change
+    assert len(bc.breaking_changes) == 1
+    msg, change_type, *args = bc.breaking_changes[0]
+    assert change_type == "ChangedClassPropertyType"
+    assert args == ["azure.contoso", "Operation", "display", "OperationInfo", "OperationDisplay"]
+    
+    # Verify it appears in the report with proper formatting
+    report = bc.report_changes()
+    assert "Model `Operation` changed type of property `display`" in report
+    assert "OperationInfo" in report
+    assert "OperationDisplay" in report
+
+
+


### PR DESCRIPTION
## Description

Add support for detecting model property type changes as breaking changes in the Azure SDK for Python breaking changes checker.

## Problem

The breaking changes checker previously could only detect property additions, deletions, and renames. When a property's type annotation changed (e.g., `Operation.display` changed from `OperationInfo` to `OperationDisplay`), this breaking change was not reported.

## Solution

Implement a pluggable `ChangedClassPropertyTypeChecker` that detects when a class property's `attr_type` differs between stable and current versions.

### Changes Made

1. **New Checker**: `scripts/breaking_changes_checker/checkers/changed_class_property_type_checker.py`
   - Detects property type changes in model classes
   - Only reports when property exists in both stable and current versions with different `attr_type` values
   - Follows existing pluggable checker pattern

2. **Breaking Change Type**: Added `CHANGED_CLASS_PROPERTY_TYPE` to `BreakingChangeType` enum in `breaking_changes_tracker.py`

3. **Registration**: Registered `ChangedClassPropertyTypeChecker` in `supported_checkers.py` CHECKERS list

4. **Tests**: Added comprehensive test coverage:
   - `test_changed_class_property_type`: Positive case (type change detected)
   - `test_changed_class_property_type_not_reported_when_property_added`: Property added only (not reported)
   - `test_changed_class_property_type_not_reported_when_property_removed`: Property removed only (not reported)
   - `test_changed_class_property_type_not_reported_when_unchanged`: Type unchanged (not reported)
   - `test_changelog_class_property_type_changed`: Changelog integration test

## Testing

✅ All 5 new tests pass
✅ All 23 existing breaking changes tests pass
✅ All 22 existing changelog tests pass
✅ Zero regressions

## Example Output

When a property type changes, the checker now reports:
```
(ChangedClassPropertyType): Model `Operation` changed type of property `display` from `OperationInfo` to `OperationDisplay`
```

This will appear in the changelog output under the "### Breaking Changes" section.

## Related Issues

Resolves the detection gap for property type changes that was previously missed by the breaking changes checker tool.