### PR TITLE
doc: add breaking change rule for renamed model/enum

### DIFF
--- a/doc/dev/mgmt/sdk-breaking-changes-guide.md
+++ b/doc/dev/mgmt/sdk-breaking-changes-guide.md
@@ -328,3 +328,53 @@ Removal of a property and addition of a corresponding property with `_property` 
 **Impact**: Users need to update property access to use the `_property` suffix (e.g., `.values` to `.values_property`, `.keys` to `.keys_property`, `.items` to `.items_property`).
 
 **Resolution**: Accept these breaking changes.
+
+## 13. Renamed Model or Enum
+
+**Changelog Pattern**:
+
+Entries showing a model or enum has been renamed:
+
+```md
+- Renamed model `OldModelName` to `NewModelName`
+- Renamed enum `OldEnumName` to `NewEnumName`
+```
+
+**Reason**: TypeSpec may produce different model or enum names than Swagger (for example, due to namespace changes or naming convention differences).
+
+**Spec Pattern**:
+
+Find the type definition by examining the new name from the changelog entry:
+
+```tsp
+model NewModelName {
+  ...
+}
+
+union NewEnumName {
+  string,
+  ...
+}
+```
+
+**Resolution**:
+
+Use `@clientName` to restore the original name from the removal entry:
+
+```tsp
+@@clientName(NewModelName, "OldModelName", "python");
+@@clientName(NewEnumName, "OldEnumName", "python");
+```
+
+**Note**: Some renamed models are defined in common types (e.g., `Azure.ResourceManager.CommonTypes`) rather than the current service's TypeSpec. In that case, you may not find the type definition in the local spec — import the relevant library and reference the type by its fully qualified name. For example:
+
+```tsp
+import "@azure-tools/typespec-azure-resource-manager";
+...
+
+@@clientName(
+  Azure.ResourceManager.CommonTypes.OperationDisplay,
+  "OperationInfo",
+  "python"
+);
+```


### PR DESCRIPTION
Adds rule 13 to the TypeSpec migration breaking-changes guide covering the `Renamed model` / `Renamed enum` changelog patterns, with `@clientName` as the mitigation. Includes a note that some renamed models live in common-type libraries (e.g. `Azure.ResourceManager.CommonTypes`) and need to be referenced by fully qualified name.