### PR TITLE
Remove pypy 3.9 from azure-storage-extensions build matrix

### DIFF
--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -17,7 +17,7 @@ suppressed_skip_warnings = ["*"]
 requires = ["setuptools", "wheel"]
 
 [tool.cibuildwheel]
-build = ["cp39*", "pp39*", "pp310*", "pp311*"]
+build = ["cp39*", "pp310*", "pp311*"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 test-skip = "*-macosx_arm64"


### PR DESCRIPTION
storage live tests failing due to `cibuildwheel` image not having PyPy 3.9

removing pp39 from the `pyproject.toml` since we're going to be dropping support for 3.9 anyway repo-wide
(related to https://github.com/Azure/azure-sdk-for-python/issues/47064 )