### PR TITLE
Prepare azure-ai-agentserver-responses 1.0.0b7 release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b7 (Unreleased)
+## 1.0.0b7 (2026-05-22)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0b7 (Unreleased)
+
+### Features Added
+
+- Added MCP output item builder enhancements for hosted MCP relay scenarios: `ResponseEventStream.add_output_item_mcp_call()` now supports caller-supplied item IDs, and MCP call `emit_done()` supports optional `output` and `error` payloads for canonical `mcp_call` persistence and replay.
+
 ## 1.0.0b6 (2026-05-21)
 
 ### Features Added

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.0.0b6"
+VERSION = "1.0.0b7"


### PR DESCRIPTION

# Description

This pull request prepares the next release of azure-ai-agentserver-responses so downstream dependencies can consume changes merged after 1.0.0b6.

Changes included:
- Bump package version from 1.0.0b6 to 1.0.0b7.
- Add a 1.0.0b7 (2026-05-22) section in CHANGELOG.md with notes for MCP builder enhancements.
- This release prep is needed because PR #46985 merged after the 1.0.0b6 release.

Relevant issues and PRs:
- https://github.com/Azure/azure-sdk-for-python/pull/46985

# All SDK Contribution checklist:
- [x] **The pull request does not introduce breaking changes**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the contribution guidelines:** https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, see this page: https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
