### PR TITLE
Add missing README.md files for typeddict test packages

### DIFF
--- a/eng/tools/azure-sdk-tools/emitter/generated/azure/client-naming-typeddict/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/azure/client-naming-typeddict/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-notdiscriminated-typeddict/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-notdiscriminated-typeddict/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-singlediscriminator-typeddict/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-singlediscriminator-typeddict/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-usage-typeddictonly/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/azure/typetest-model-usage-typeddictonly/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-notdiscriminated-typeddict/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-notdiscriminated-typeddict/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-singlediscriminator-typeddict/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-singlediscriminator-typeddict/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+

--- a/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-usage-typeddictonly/README.md
+++ b/eng/tools/azure-sdk-tools/emitter/generated/unbranded/typetest-model-usage-typeddictonly/README.md
@@ -1,0 +1,4 @@
+# ⚠️ TEST CODE — DO NOT INSTALL FROM PYPI
+
+This is not a published Azure SDK package; it exists only for testing purposes. Do not install from PyPI.
+


### PR DESCRIPTION
Adds README.md files to 7 typeddict test packages that were missing them, causing `test_readme_exists` CI failures in http-client-python.

Packages:
- azure/client-naming-typeddict
- azure/typetest-model-notdiscriminated-typeddict
- azure/typetest-model-singlediscriminator-typeddict
- azure/typetest-model-usage-typeddictonly
- unbranded/typetest-model-notdiscriminated-typeddict
- unbranded/typetest-model-singlediscriminator-typeddict
- unbranded/typetest-model-usage-typeddictonly