### PR TITLE
[Storage] Drop cp39 from azure-storage-extensions cibuildwheel matrix

### DIFF
--- a/sdk/storage/azure-storage-extensions/CHANGELOG.md
+++ b/sdk/storage/azure-storage-extensions/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 0.1.0 (Unreleased)
 
 Initial release.
+
+### Other Changes
+
+- Minimum supported Python version is now 3.10.

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -17,7 +17,7 @@ suppressed_skip_warnings = ["*"]
 requires = ["setuptools", "wheel"]
 
 [tool.cibuildwheel]
-build = ["cp39*", "pp310*", "pp311*"]
+build = ["cp310*", "pp310*", "pp311*"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 test-skip = "*-macosx_arm64"

--- a/sdk/storage/azure-storage-extensions/setup.py
+++ b/sdk/storage/azure-storage-extensions/setup.py
@@ -41,7 +41,6 @@ setup(
         'Programming Language :: Python',
         "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -50,7 +49,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     zip_safe=False,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     ext_package='azure.storage.extensions',
     ext_modules=[
         Extension(


### PR DESCRIPTION
## Why

CI builds of `azure-storage-extensions` are failing in the `cp39-manylinux_x86_64` leg of `cibuildwheel`. Inside the manylinux2014 container, `pip` cannot reach `pypi.org` to fetch the PEP-517 build dependency `setuptools` — every retry hits `ConnectTimeoutError(... 'Connection to pypi.org timed out. (connect timeout=15)')`, and the wheel build aborts before the package is ever compiled.

This blocks downstream packages (e.g. `azure-storage-blob`) whose `dev_requirements.txt` includeth `azure-storage-extensions`.

## What

Drop `cp39*` from the `cibuildwheel` build matrix. Because the C extension is built as an **abi3** wheel (`py_limited_api=True`, `bdist_wheel_abi3` in `setup.py`), one wheel from cp310+ covers Python 3.10 and above. There is no longer any need to spin up the cp39 manylinux2014 container.

To keep the metadata honest with the new build floor:
- Removed the `Programming Language :: Python :: 3.9` classifier.
- Bumped `python_requires` from `>=3.9` to `>=3.10`.
- Noted the minimum-version bump in `CHANGELOG.md`.

## Notes for reviewers

- The package is unreleased (`0.1.0 (Unreleased)`), so dropping 3.9 here hath no impact on already-shipped consumers.
- pp310/pp311 PyPy targets are unchanged.