### PR TITLE
Skip cibuildwheel for dev-requirement wheels with C extensions

### DIFF
--- a/eng/tools/azure-sdk-tools/ci_tools/build.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/build.py
@@ -218,11 +218,21 @@ def build_packages(
 
 
 def create_package(
-    setup_directory_or_file: str, dest_folder: str, enable_wheel: bool = True, enable_sdist: bool = True
+    setup_directory_or_file: str,
+    dest_folder: str,
+    enable_wheel: bool = True,
+    enable_sdist: bool = True,
+    use_cibuildwheel: bool = True,
 ):
     """
     Uses the invoking python executable to build a wheel and sdist file given a setup.py or setup.py directory. Outputs
     into a distribution directory and defaults to the value of get_artifact_directory().
+
+    When ``use_cibuildwheel`` is False, packages with C extension modules are built with the
+    invoking Python via ``setup.py bdist_wheel`` instead of ``cibuildwheel``. This is the
+    appropriate choice when the wheel is only consumed by the current venv (e.g. dev-requirement
+    installs in CI), since ``cibuildwheel`` otherwise downloads a fresh CPython from nuget.org
+    which is not reachable from all CI agents.
     """
 
     dist = get_artifact_directory(dest_folder)
@@ -263,7 +273,7 @@ def create_package(
         )
     else:
         if enable_wheel:
-            if setup_parsed.ext_modules:
+            if setup_parsed.ext_modules and use_cibuildwheel:
                 run_logged(
                     [sys.executable, "-m", "cibuildwheel", "--output-dir", dist],
                     cwd=setup_parsed.folder,

--- a/eng/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -350,7 +350,12 @@ def build_whl_for_req(req: str, package_path: str, wheel_dir: Optional[str]) -> 
                     os.mkdir(temp_dir)
 
             logging.info("Building wheel for package {}".format(parsed.name))
-            create_package(req_pkg_path, temp_dir, enable_sdist=False)
+            # ``cibuildwheel`` is intended for producing release artifacts that span multiple
+            # Python versions; it downloads its own CPython from nuget.org which is not
+            # reachable from all CI agents. For dev-requirements builds the wheel only needs
+            # to install into the current venv, so opt out of ``cibuildwheel`` here and let
+            # ``setup.py bdist_wheel`` run with the invoking Python.
+            create_package(req_pkg_path, temp_dir, enable_sdist=False, use_cibuildwheel=False)
 
             whl_path = os.path.join(temp_dir, find_whl(temp_dir, parsed.name, parsed.version))
 


### PR DESCRIPTION
## Problem

The internal storage SDK pipeline fails on every PR that touches a package whose `dev_requirements.txt` includes `azure-storage-extensions` (e.g. `azure-storage-queue`, `azure-storage-blob`, `azure-storage-file-datalake`).

The failure occurs in `dispatch_checks.py` → `replace_dev_reqs` → `build_whl_for_req` → `create_package`. Because `azure-storage-extensions` defines a `crc64` C extension module, `create_package` routes the wheel build through `cibuildwheel`. On Windows, `cibuildwheel` downloads its own CPython from `api.nuget.org` via NuGet, but the internal 1ES pool agents block outbound to `api.nuget.org` (DNS returns RFC-5737 sinkhole `192.0.2.9` and the firewall denies the connection):

```
Unable to load the service index for source https://api.nuget.org/v3/index.json.
  An error occurred while sending the request.
  Unable to connect to the remote server
  An attempt was made to access a socket in a way forbidden by its access permissions 192.0.2.9:443
```

## Fix

`cibuildwheel` is designed for producing release artifacts that span multiple Python versions and ABIs. For dev-requirement builds, the wheel only needs to install into the **current** test venv with the **current** Python — so the cibuildwheel-driven download of an isolated CPython is unnecessary.

This PR adds a `use_cibuildwheel` parameter to `create_package` (defaulting to `True` so release builds keep using cibuildwheel) and has `build_whl_for_req` (the dev-requirements path) pass `use_cibuildwheel=False`. When the flag is off and the package has `ext_modules`, the build falls through to `setup.py bdist_wheel` with the invoking Python, which works fine in-venv and needs no nuget.org access.

## Impact

- **Release pipeline (`build_packages`):** unchanged — still produces the abi3 wheel for `azure-storage-extensions` via cibuildwheel on the public-CI agent that can reach nuget.org.
- **Dev-requirements installs (`build_whl_for_req`):** now build the local ext-module package with the invoking Python — no nuget download, works on the internal 1ES pool.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
