### PR TITLE
Untyped ValueError/AssertionError bug

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bugs Fixed
 * Fixed bug where `CosmosClient` construction with AAD credentials would crash at startup if the semantic reranking inference endpoint environment variable was not set, even when semantic reranking was not being used. The inference service is now lazily initialized on first use. See [PR 46243](https://github.com/Azure/azure-sdk-for-python/pull/46243)
 * Fixed bug where region names in `preferred_locations` and `excluded_locations` (client-level and per-request) were not matched tolerantly for differences in case, whitespace, hyphens, and underscores. See [PR 46937](https://github.com/Azure/azure-sdk-for-python/pull/46937)
+* Fixed bug where a `ValueError("Ranges overlap")` or an `AssertionError("code bug: returned overlapping ranges ... is empty")` from the partition key range cache could escape to the caller when the `/pkranges` response contained a transiently inconsistent snapshot (overlap or gap). See [PR 47091](https://github.com/Azure/azure-sdk-for-python/pull/47091)
 
 #### Other Changes
 * Reduced per-client memory overhead when partition-level circuit breaker (PPCB) is enabled by sharing the partition key range routing map cache across CosmosClient instances connected to the same endpoint, and stripping unused fields from cached partition key ranges using compact PKRange namedtuples. See [PR 46297](https://github.com/Azure/azure-sdk-for-python/pull/46297)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -334,6 +334,14 @@ def _has_read_retryable_headers(request_headers):
         return True
     return False
 
+def _is_read_retryable_request(request, request_params: Optional[RequestObject] = None):
+    if request and _has_read_retryable_headers(request.headers):
+        return True
+    if request_params and _OperationType.IsReadOnlyOperation(request_params.operation_type):
+        # Fallback for flows where operation headers are absent but request metadata is available.
+        return True
+    return False
+
 def _has_database_account_header(request_headers):
     if request_headers.get(HttpHeaders.ThinClientProxyResourceType) == ResourceType.DatabaseAccount:
         return True
@@ -354,13 +362,17 @@ def _handle_service_request_retries(
         raise exception
 
 def _handle_service_response_retries(request, client, response_retry_policy, exception, *args):
-    if request and (_has_read_retryable_headers(request.headers) or (args and (is_write_retryable(args[0], client) or
-                            client._global_endpoint_manager.is_per_partition_automatic_failover_applicable(args[0])))):
+    request_params = args[0] if args else None
+    if request and (_is_read_retryable_request(request, request_params) or (request_params is not None and (
+            is_write_retryable(request_params, client) or
+            client._global_endpoint_manager.is_per_partition_automatic_failover_applicable(request_params)))):
         # we resolve the request endpoint to the next preferred region
         # once we are out of preferred regions we stop retrying
         retry_policy = response_retry_policy
         if not retry_policy.ShouldRetry():
-            if args and args[0].should_clear_session_token_on_session_read_failure and client.session:
+            if (request_params is not None
+                    and request_params.should_clear_session_token_on_session_read_failure
+                    and client.session):
                 client.session.clear_session_token(client.last_response_headers)
             raise exception
     else:
@@ -444,7 +456,7 @@ class ConnectionRetryPolicy(RetryPolicy):
             except ServiceResponseError as err:
                 retry_error = err
                 # Only read operations can be safely retried with ServiceResponseError
-                if (not _has_read_retryable_headers(request.http_request.headers) or
+                if (not _is_read_retryable_request(request.http_request, request_params) or
                         _has_database_account_header(request.http_request.headers) or
                         request_params.healthy_tentative_location):
                     raise err
@@ -466,7 +478,7 @@ class ConnectionRetryPolicy(RetryPolicy):
                 if (_has_database_account_header(request.http_request.headers) or
                         request_params.healthy_tentative_location):
                     raise err
-                if _has_read_retryable_headers(request.http_request.headers) and retry_settings['read'] > 0:
+                if _is_read_retryable_request(request.http_request, request_params) and retry_settings['read'] > 0:
                     _record_failure_if_request_not_cancelled(request_params, global_endpoint_manager, None)
                     retry_active = self.increment(retry_settings, response=request, error=err)
                     if retry_active:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
@@ -28,10 +28,16 @@ to both code paths simultaneously.
 """
 
 import logging
+import random
 from typing import Any, Dict, List, Optional, Tuple
 
 from .. import _base, http_constants
-from .collection_routing_map import CollectionRoutingMap, _build_routing_map_from_ranges
+from ..exceptions import CosmosHttpResponseError
+from .collection_routing_map import (
+    CollectionRoutingMap,
+    _build_routing_map_from_ranges,
+    _OverlapDetected,  # noqa: F401  # re-exported for sync/async provider modules and tests
+)
 from . import routing_range
 from .routing_range import (
     PKRange,
@@ -43,6 +49,114 @@ from .routing_range import (
 logger = logging.getLogger(__name__)
 
 PAGE_SIZE_CHANGE_FEED = "-1"  # Return all available changes
+
+# Number of times the full-load path will re-fetch ``/pkranges`` when the
+# builder reports an overlap (``_OverlapDetected``). Overlap on the full-load
+# path is treated as a transient gateway inconsistency, so a small fixed
+# retry budget with backoff is preferred over surfacing immediately. After
+# this many attempts the caller surfaces a transient HTTP 503 so the
+# upstream retry policy can take over.
+#
+# Defined here (rather than in each provider module) so the sync and async
+# providers cannot drift on the retry budget — both import the same constant.
+_OVERLAP_RETRY_MAX_ATTEMPTS = 3
+# Initial backoff between overlap retries; doubles each attempt. Worst-case
+# total sleep under the budget above is ~3.5s (0.5 + 1.0 + 2.0).
+_OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS = 0.5
+
+
+def _jittered_backoff(backoff_seconds: float) -> float:
+    """Return a uniformly-jittered backoff in the range ``[0, backoff_seconds]``.
+
+    Implements the "full jitter" strategy: the actual sleep is drawn uniformly
+    from zero to the full deterministic backoff. This decorrelates concurrent
+    retriers (for example, multiple Cosmos clients running inside a single
+    PySpark process that all hit the same gateway node on the same bad
+    ``/pkranges`` snapshot at the same instant) so they do not retry in
+    lockstep and re-collide on the same gateway node.
+
+    The worst-case sleep per attempt is unchanged (still bounded by the
+    deterministic backoff), so the documented retry-budget contract still
+    holds; the expected per-attempt sleep is half of it.
+    """
+    return random.uniform(0, backoff_seconds)
+
+
+def _handle_overlap_retry_decision(
+    *,
+    overlap_attempt_count: int,
+    collection_link: str,
+    logger: logging.Logger,  # pylint: disable=redefined-outer-name
+) -> float:
+    """Decide what to do after the full-load builder reported an overlap.
+
+    Centralises the sync/async-identical retry policy. Returns the number of
+    seconds the caller should sleep before the next attempt. Raises
+    :class:`CosmosHttpResponseError` (HTTP 503) when the attempt budget has
+    been exhausted; the caller's existing retry policy then handles it as
+    a transient error.
+
+    The returned sleep duration is jittered (see :func:`_jittered_backoff`)
+    so concurrent retriers do not retry in lockstep. The deterministic
+    backoff schedule (0.5s -> 1.0s -> 2.0s, doubling) defines the *upper
+    bound* of each attempt's sleep; the actual sleep is drawn uniformly
+    from ``[0, that upper bound]``.
+
+    The caller is responsible for the actual sleep (sync ``time.sleep`` or
+    ``await asyncio.sleep``). Keeping the sleep at the call site is what
+    lets this helper stay free of concurrency-runtime assumptions — the
+    only line that has to differ between the sync and async providers.
+
+    :param int overlap_attempt_count: Number of overlap attempts made so far,
+        including the one that just failed. Pass ``1`` after the first failure,
+        ``2`` after the second, etc.
+    :param str collection_link: Used in log messages and the 503 error body
+        so the caller knows which collection ran out of budget.
+    :param logging.Logger logger: Caller's module-level logger, so messages
+        appear under the right ``azure.cosmos._routing.*`` namespace.
+    :return: Jittered backoff seconds to sleep before retrying. Guaranteed
+        to be in ``[0, deterministic_backoff_for_attempt]``.
+    :rtype: float
+    :raises CosmosHttpResponseError: When ``overlap_attempt_count`` has reached
+        ``_OVERLAP_RETRY_MAX_ATTEMPTS``. Status code is 503 so the upstream
+        retry policy classifies it as transient.
+    """
+    if overlap_attempt_count >= _OVERLAP_RETRY_MAX_ATTEMPTS:
+        logger.error(
+            "Full-load routing-map fetch for collection '%s' detected "
+            "overlapping partition key ranges on every one of %d attempt(s). "
+            "Surfacing as transient HTTP 503 so the caller's retry policy "
+            "can take over.",
+            collection_link,
+            overlap_attempt_count,
+        )
+        raise CosmosHttpResponseError(
+            status_code=http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+            message=(
+                "Failed to build routing map for collection '{}': "
+                "overlapping partition key ranges persisted across {} "
+                "full-load attempt(s). Surfaced as a retryable transient "
+                "error so the upstream retry policy can take over, rather "
+                "than allowing the underlying ValueError to escape as a "
+                "fatal crash."
+            ).format(collection_link, overlap_attempt_count),
+        )
+
+    deterministic_backoff = (
+        _OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS * (2 ** (overlap_attempt_count - 1))
+    )
+    jittered_backoff = _jittered_backoff(deterministic_backoff)
+    logger.warning(
+        "Full-load routing-map fetch for collection '%s' detected overlapping "
+        "partition key ranges (attempt %d/%d). Sleeping %.2fs (jittered from "
+        "upper bound %.2fs) and retrying.",
+        collection_link,
+        overlap_attempt_count,
+        _OVERLAP_RETRY_MAX_ATTEMPTS,
+        jittered_backoff,
+        deterministic_backoff,
+    )
+    return jittered_backoff
 
 
 def is_cache_unchanged_since_previous(
@@ -257,7 +371,32 @@ def process_fetched_ranges(
 
         unresolved = next_unresolved
 
-    result = previous_routing_map.try_combine(range_tuples, effective_etag)
+    try:
+        result = previous_routing_map.try_combine(range_tuples, effective_etag)
+    except ValueError as overlap_error:
+        # ``try_combine`` validates the merged map via
+        # ``CollectionRoutingMap.is_complete_set_of_range`` and raises
+        # ``ValueError("Ranges overlap: ...")`` if the merge produces a
+        # self-contradictory tiling. This can happen during the incremental
+        # path when the delta contains a range whose key span overlaps an
+        # existing cached range without either side declaring the other a
+        # parent.
+        #
+        # We must NOT let this ``ValueError`` escape: the cache layer above
+        # treats a ``None`` routing map as "no ranges" and would convert
+        # the bare exception into a silent empty-result return at
+        # ``get_overlapping_ranges``. Convert to ``_IncrementalMergeFailed``
+        # so the caller's existing retry loop retries the incremental fetch
+        # once and then falls back to the full-load path, which has its own
+        # ``_OverlapDetected`` handler with retry+backoff and surfaces a
+        # transient HTTP 503 if the inconsistency persists.
+        logger.warning(
+            "Incremental merge for collection '%s' produced overlapping ranges: %s. "
+            "Converting to _IncrementalMergeFailed so the caller retries / "
+            "falls back to a full refresh.",
+            collection_link, str(overlap_error),
+        )
+        raise _IncrementalMergeFailed() from overlap_error
     if not result:
         logger.warning(
             "Incremental merge resulted in incomplete routing map for "

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
@@ -33,11 +33,16 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .. import _base, http_constants
 from ..exceptions import CosmosHttpResponseError
-from .collection_routing_map import (
+# ``_OverlapDetected`` and ``_GapDetected`` are imported (but not referenced
+# inside this module) so that provider modules and tests can import them from
+# this single module instead of reaching into ``collection_routing_map``
+# directly. Pylint reports ``unused-import`` on the ``from`` line as a whole
+# (not on the individual names), so the disable must live on that line.
+from .collection_routing_map import (  # pylint: disable=unused-import
     CollectionRoutingMap,
     _build_routing_map_from_ranges,
-    _OverlapDetected,  # noqa: F401  # re-exported for provider modules and tests
-    _GapDetected,  # noqa: F401  # re-exported for provider modules and tests
+    _OverlapDetected,
+    _GapDetected,
 )
 from . import routing_range
 from .routing_range import (

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
@@ -55,21 +55,90 @@ PAGE_SIZE_CHANGE_FEED = "-1"  # Return all available changes
 
 # Retry budget for transient ``/pkranges`` snapshot inconsistencies (overlap
 # or gap) before the caller surfaces a 503. Shared by sync and async providers.
-_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 3
-# Initial backoff (seconds) before the next retry; doubles each attempt and
-# is jittered uniformly in ``[0, upper_bound]``. With MAX_ATTEMPTS=3 the
-# worst-case cumulative sleep is 0 + 0.1 + 0.2 = 0.3s per surfaced 503.
-_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS = 0.1
+#
+# Total attempts the fetch loop will make before raising 503. With the
+# schedule below, 4 attempts means up to 3 sleeps: worst-case cumulative
+# blocking time is 1.4s (0.2 + 0.4 + 0.8), expected ~0.775s when all three
+# retries occur (sum of per-attempt midpoints of the floored uniform).
+_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 4
+
+# Initial deterministic upper bound (seconds) for the first retry sleep.
+# Doubled each attempt and clamped at ``_TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS``.
+# At 0.2s the median sleep on attempt 1 lands in the same window in which
+# /pkranges gateway-snapshot inconsistencies typically converge (tens to a
+# few hundred ms), so attempt 2 is much more likely to see fresh state.
+_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS = 0.2
+
+# Hard cap on the deterministic upper bound for any single retry sleep.
+# Forward-protection: if ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` ever
+# grows, exponential growth alone cannot block the calling thread for more
+# than this many seconds inside a single sleep. Independent of the per-call
+# budget -- this caps *one* sleep, not the cumulative.
+_TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS = 2.0
+
+# Floor (seconds) for the jittered sleep. Below this, gateway /pkranges
+# state has not had time to begin converging, so a retry would burn an
+# attempt with no benefit. Applied as ``min(MIN, upper / 4)`` so the floor
+# never dominates the jitter range on small upper bounds (i.e. attempt 1).
+_TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS = 0.05
 
 
-def _jittered_backoff(backoff_seconds: float) -> float:
-    """Return a uniformly-distributed sleep in ``[0, backoff_seconds]``.
+def _deterministic_backoff_for_attempt(attempt: int) -> float:
+    """Return the deterministic exponential upper bound for ``attempt``.
 
-    :param float backoff_seconds: Non-negative upper bound for the backoff.
-    :return: A random sleep value in ``[0, backoff_seconds]``.
+    The schedule is ``INITIAL * 2^(attempt - 1)``, clamped at
+    ``_TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS``. ``attempt`` is
+    1-indexed (i.e. ``attempt=1`` is the first retry after the first
+    failure).
+
+    Extracted as a single source of truth so the test suite can derive
+    expected bounds from the same formula the production code uses rather
+    than re-encoding the constants. A regression that changes either the
+    base or the doubling factor now fails one test, not many.
+
+    :param int attempt: 1-indexed retry attempt number.
+    :return: The deterministic upper bound (seconds) for this attempt's sleep.
     :rtype: float
     """
-    return random.uniform(0, backoff_seconds)
+    raw = _TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1))
+    return min(raw, _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS)
+
+
+def _jittered_backoff(deterministic_upper: float) -> float:
+    """Return a floored-full-jitter sleep in ``[floor, deterministic_upper]``.
+
+    ``floor = min(_TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS, deterministic_upper / 4)``
+
+    This is the hybrid jitter strategy chosen for ``/pkranges`` snapshot
+    retries:
+
+    * The **non-zero floor** eliminates the near-zero-sleep tail of pure
+      full jitter. The failure mode here is state propagation on the
+      gateway, not contention -- a retry that fires within a few ms of
+      the previous one will see the same stale snapshot and burn an
+      attempt for nothing.
+    * The **uniform distribution over** ``[floor, upper]`` preserves the
+      bulk of full jitter's fleet-wide herd dispersion. Using an additive
+      form (``uniform(floor, upper)``) rather than ``max(floor, uniform(0,
+      upper))`` avoids creating a probability spike at exactly ``floor``,
+      which would itself form a micro-herd at scale.
+    * The ``upper / 4`` clamp on the floor guarantees the jitter range is
+      always at least 75% of the deterministic upper, so the floor never
+      collapses the smallest attempts into a near-constant wait.
+
+    :param float deterministic_upper: Non-negative upper bound for the
+        sleep (typically produced by :func:`_deterministic_backoff_for_attempt`).
+    :return: A random sleep value in ``[floor, deterministic_upper]``, or
+        ``0.0`` when ``deterministic_upper`` is non-positive.
+    :rtype: float
+    """
+    if deterministic_upper <= 0:
+        return 0.0
+    floor = min(
+        _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS,
+        deterministic_upper / 4,
+    )
+    return random.uniform(floor, deterministic_upper)
 
 
 def _handle_transient_snapshot_retry_decision(
@@ -88,7 +157,8 @@ def _handle_transient_snapshot_retry_decision(
         one. Pass ``1`` after the first failure.
     :keyword str collection_link: Used in log messages and the 503 body.
     :keyword logging.Logger logger: Caller's module-level logger.
-    :return: Jittered backoff seconds in ``[0, deterministic_upper_bound]``.
+    :return: Floored-full-jitter backoff seconds in
+        ``[floor, deterministic_upper_bound]``.
     :rtype: float
     :raises CosmosHttpResponseError: When the retry budget is exhausted.
     """
@@ -107,9 +177,7 @@ def _handle_transient_snapshot_retry_decision(
             ).format(collection_link, retry_attempt_count),
         )
 
-    deterministic_backoff = (
-        _TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS * (2 ** (retry_attempt_count - 1))
-    )
+    deterministic_backoff = _deterministic_backoff_for_attempt(retry_attempt_count)
     jittered_backoff = _jittered_backoff(deterministic_backoff)
     logger.warning(
         "Routing-map fetch for collection '%s' returned overlapping or "

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
@@ -33,11 +33,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .. import _base, http_constants
 from ..exceptions import CosmosHttpResponseError
-# ``_OverlapDetected`` and ``_GapDetected`` are imported (but not referenced
-# inside this module) so that provider modules and tests can import them from
-# this single module instead of reaching into ``collection_routing_map``
-# directly. Pylint reports ``unused-import`` on the ``from`` line as a whole
-# (not on the individual names), so the disable must live on that line.
+# Re-exported here so provider modules and tests import these from one place
+# rather than reaching into ``collection_routing_map`` directly.
 from .collection_routing_map import (  # pylint: disable=unused-import
     CollectionRoutingMap,
     _build_routing_map_from_ranges,
@@ -56,28 +53,20 @@ logger = logging.getLogger(__name__)
 
 PAGE_SIZE_CHANGE_FEED = "-1"  # Return all available changes
 
-# Maximum retry attempts for transient full-load /pkranges inconsistencies
-# (overlap OR gap) before surfacing a transient HTTP 503. Centralised here so
-# the sync and async providers share one source of truth.
+# Retry budget for transient ``/pkranges`` snapshot inconsistencies (overlap
+# or gap) before the caller surfaces a 503. Shared by sync and async providers.
 _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 3
-# Initial backoff between inconsistency retries; doubles each attempt. With
-# ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 3``, attempt 3 raises 503 before
-# sleeping, so only the post-attempt-1 and post-attempt-2 backoffs are slept --
-# deterministic worst case is the sum of the first two schedule entries
-# (``_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS`` and that value
-# doubled); expected wall time is half of that under full jitter.
-_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS = 0.5
+# Initial backoff (seconds) before the next retry; doubles each attempt and
+# is jittered uniformly in ``[0, upper_bound]``. With MAX_ATTEMPTS=3 the
+# worst-case cumulative sleep is 0 + 0.1 + 0.2 = 0.3s per surfaced 503.
+_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS = 0.1
 
 
 def _jittered_backoff(backoff_seconds: float) -> float:
-    """Return a uniformly-jittered backoff in the range ``[0, backoff_seconds]``.
+    """Return a uniformly-distributed sleep in ``[0, backoff_seconds]``.
 
-    Implements the "full jitter" strategy so concurrent retriers in different
-    processes do not retry in lockstep against the same gateway node.
-
-    :param float backoff_seconds: Deterministic upper bound for the backoff,
-        in seconds. Must be non-negative.
-    :return: A uniformly-distributed sleep value in ``[0, backoff_seconds]``.
+    :param float backoff_seconds: Non-negative upper bound for the backoff.
+    :return: A random sleep value in ``[0, backoff_seconds]``.
     :rtype: float
     """
     return random.uniform(0, backoff_seconds)
@@ -89,44 +78,32 @@ def _handle_transient_snapshot_retry_decision(
     collection_link: str,
     logger: logging.Logger,  # pylint: disable=redefined-outer-name
 ) -> float:
-    """Decide what to do after the full-load builder reported a transient
-    snapshot inconsistency (overlap or gap).
+    """Return the next backoff to sleep, or raise 503 once the budget is exhausted.
 
-    Returns a jittered backoff for the caller to sleep before the next
-    attempt; raises :class:`CosmosHttpResponseError` (HTTP 503) once
-    ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` is reached. Under the default
-    budget the final attempt raises 503 before sleeping, so only the first
-    ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS - 1`` attempts produce a sleep
-    (deterministic upper bounds doubling from
-    ``_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS``). The caller
-    performs the actual sleep (``time.sleep`` vs ``await asyncio.sleep``),
-    which is the only line that differs between the sync and async
-    providers.
+    Called after the routing-map builder reports a transient overlap or gap.
+    The caller performs the actual sleep (``time.sleep`` vs ``await
+    asyncio.sleep``) -- the only line that differs between sync and async.
 
-    :keyword int retry_attempt_count: Attempts so far, including the one
-        that just failed. Pass ``1`` after the first failure.
+    :keyword int retry_attempt_count: Attempts so far, including the failed
+        one. Pass ``1`` after the first failure.
     :keyword str collection_link: Used in log messages and the 503 body.
     :keyword logging.Logger logger: Caller's module-level logger.
     :return: Jittered backoff seconds in ``[0, deterministic_upper_bound]``.
     :rtype: float
-    :raises CosmosHttpResponseError: When the attempt budget is exhausted.
+    :raises CosmosHttpResponseError: When the retry budget is exhausted.
     """
     if retry_attempt_count >= _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS:
         logger.error(
-            "Full-load routing-map fetch for collection '%s' detected a "
-            "transient snapshot inconsistency (overlap or gap) on every "
-            "one of %d attempt(s). Surfacing as transient HTTP 503 so the "
-            "caller's retry policy can take over.",
+            "Routing-map fetch for collection '%s' returned overlapping or "
+            "gapped ranges on %d attempt(s). Surfacing as HTTP 503.",
             collection_link,
             retry_attempt_count,
         )
         raise CosmosHttpResponseError(
             status_code=http_constants.StatusCodes.SERVICE_UNAVAILABLE,
             message=(
-                "Failed to build routing map for collection '{}': transient "
-                "snapshot inconsistency (overlap or gap) persisted across {} "
-                "full-load attempt(s). Surfaced as a retryable transient "
-                "error so the upstream retry policy can take over."
+                "Routing-map fetch for collection '{}' returned overlapping "
+                "or gapped ranges on {} attempt(s)."
             ).format(collection_link, retry_attempt_count),
         )
 
@@ -135,14 +112,12 @@ def _handle_transient_snapshot_retry_decision(
     )
     jittered_backoff = _jittered_backoff(deterministic_backoff)
     logger.warning(
-        "Full-load routing-map fetch for collection '%s' detected a transient "
-        "snapshot inconsistency (overlap or gap) (attempt %d/%d). Sleeping "
-        "%.2fs (jittered from upper bound %.2fs) and retrying.",
+        "Routing-map fetch for collection '%s' returned overlapping or "
+        "gapped ranges (attempt %d/%d). Sleeping %.2fs and retrying.",
         collection_link,
         retry_attempt_count,
         _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
         jittered_backoff,
-        deterministic_backoff,
     )
     return jittered_backoff
 
@@ -362,19 +337,15 @@ def process_fetched_ranges(
     try:
         result = previous_routing_map.try_combine(range_tuples, effective_etag)
     except ValueError as overlap_error:
-        # Convert the overlap ``ValueError`` from ``try_combine`` into
-        # ``_IncrementalMergeFailed`` so the caller retries the incremental
-        # fetch and ultimately falls back to the full-load path (which has
-        # its own ``_OverlapDetected`` retry + 503 safety net). Narrow to
-        # the literal ``"Ranges overlap"`` prefix (kept stable in
-        # ``is_complete_set_of_range`` and pinned by the regression tests)
-        # so any future unrelated ``ValueError`` surfaces as a real bug.
+        # Convert the overlap ``ValueError`` to ``_IncrementalMergeFailed`` so
+        # the caller retries and falls back to a full refresh. Narrow the
+        # match to the ``"Ranges overlap"`` prefix so any unrelated
+        # ``ValueError`` still surfaces as a real bug.
         if not str(overlap_error).startswith("Ranges overlap"):
             raise
         logger.warning(
             "Incremental merge for collection '%s' produced overlapping ranges: %s. "
-            "Converting to _IncrementalMergeFailed so the caller retries / "
-            "falls back to a full refresh.",
+            "Falling back to a full refresh.",
             collection_link, str(overlap_error),
         )
         raise _IncrementalMergeFailed() from overlap_error

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/_routing_map_provider_common.py
@@ -36,7 +36,8 @@ from ..exceptions import CosmosHttpResponseError
 from .collection_routing_map import (
     CollectionRoutingMap,
     _build_routing_map_from_ranges,
-    _OverlapDetected,  # noqa: F401  # re-exported for sync/async provider modules and tests
+    _OverlapDetected,  # noqa: F401  # re-exported for provider modules and tests
+    _GapDetected,  # noqa: F401  # re-exported for provider modules and tests
 )
 from . import routing_range
 from .routing_range import (
@@ -50,113 +51,97 @@ logger = logging.getLogger(__name__)
 
 PAGE_SIZE_CHANGE_FEED = "-1"  # Return all available changes
 
-# Number of times the full-load path will re-fetch ``/pkranges`` when the
-# builder reports an overlap (``_OverlapDetected``). Overlap on the full-load
-# path is treated as a transient gateway inconsistency, so a small fixed
-# retry budget with backoff is preferred over surfacing immediately. After
-# this many attempts the caller surfaces a transient HTTP 503 so the
-# upstream retry policy can take over.
-#
-# Defined here (rather than in each provider module) so the sync and async
-# providers cannot drift on the retry budget — both import the same constant.
-_OVERLAP_RETRY_MAX_ATTEMPTS = 3
-# Initial backoff between overlap retries; doubles each attempt. Worst-case
-# total sleep under the budget above is ~3.5s (0.5 + 1.0 + 2.0).
-_OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS = 0.5
+# Maximum retry attempts for transient full-load /pkranges inconsistencies
+# (overlap OR gap) before surfacing a transient HTTP 503. Centralised here so
+# the sync and async providers share one source of truth.
+_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 3
+# Initial backoff between inconsistency retries; doubles each attempt. With
+# ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 3``, attempt 3 raises 503 before
+# sleeping, so only the post-attempt-1 and post-attempt-2 backoffs are slept --
+# deterministic worst case is the sum of the first two schedule entries
+# (``_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS`` and that value
+# doubled); expected wall time is half of that under full jitter.
+_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS = 0.5
 
 
 def _jittered_backoff(backoff_seconds: float) -> float:
     """Return a uniformly-jittered backoff in the range ``[0, backoff_seconds]``.
 
-    Implements the "full jitter" strategy: the actual sleep is drawn uniformly
-    from zero to the full deterministic backoff. This decorrelates concurrent
-    retriers (for example, multiple Cosmos clients running inside a single
-    PySpark process that all hit the same gateway node on the same bad
-    ``/pkranges`` snapshot at the same instant) so they do not retry in
-    lockstep and re-collide on the same gateway node.
+    Implements the "full jitter" strategy so concurrent retriers in different
+    processes do not retry in lockstep against the same gateway node.
 
-    The worst-case sleep per attempt is unchanged (still bounded by the
-    deterministic backoff), so the documented retry-budget contract still
-    holds; the expected per-attempt sleep is half of it.
+    :param float backoff_seconds: Deterministic upper bound for the backoff,
+        in seconds. Must be non-negative.
+    :return: A uniformly-distributed sleep value in ``[0, backoff_seconds]``.
+    :rtype: float
     """
     return random.uniform(0, backoff_seconds)
 
 
-def _handle_overlap_retry_decision(
+def _handle_transient_snapshot_retry_decision(
     *,
-    overlap_attempt_count: int,
+    retry_attempt_count: int,
     collection_link: str,
     logger: logging.Logger,  # pylint: disable=redefined-outer-name
 ) -> float:
-    """Decide what to do after the full-load builder reported an overlap.
+    """Decide what to do after the full-load builder reported a transient
+    snapshot inconsistency (overlap or gap).
 
-    Centralises the sync/async-identical retry policy. Returns the number of
-    seconds the caller should sleep before the next attempt. Raises
-    :class:`CosmosHttpResponseError` (HTTP 503) when the attempt budget has
-    been exhausted; the caller's existing retry policy then handles it as
-    a transient error.
+    Returns a jittered backoff for the caller to sleep before the next
+    attempt; raises :class:`CosmosHttpResponseError` (HTTP 503) once
+    ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` is reached. Under the default
+    budget the final attempt raises 503 before sleeping, so only the first
+    ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS - 1`` attempts produce a sleep
+    (deterministic upper bounds doubling from
+    ``_TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS``). The caller
+    performs the actual sleep (``time.sleep`` vs ``await asyncio.sleep``),
+    which is the only line that differs between the sync and async
+    providers.
 
-    The returned sleep duration is jittered (see :func:`_jittered_backoff`)
-    so concurrent retriers do not retry in lockstep. The deterministic
-    backoff schedule (0.5s -> 1.0s -> 2.0s, doubling) defines the *upper
-    bound* of each attempt's sleep; the actual sleep is drawn uniformly
-    from ``[0, that upper bound]``.
-
-    The caller is responsible for the actual sleep (sync ``time.sleep`` or
-    ``await asyncio.sleep``). Keeping the sleep at the call site is what
-    lets this helper stay free of concurrency-runtime assumptions — the
-    only line that has to differ between the sync and async providers.
-
-    :param int overlap_attempt_count: Number of overlap attempts made so far,
-        including the one that just failed. Pass ``1`` after the first failure,
-        ``2`` after the second, etc.
-    :param str collection_link: Used in log messages and the 503 error body
-        so the caller knows which collection ran out of budget.
-    :param logging.Logger logger: Caller's module-level logger, so messages
-        appear under the right ``azure.cosmos._routing.*`` namespace.
-    :return: Jittered backoff seconds to sleep before retrying. Guaranteed
-        to be in ``[0, deterministic_backoff_for_attempt]``.
+    :keyword int retry_attempt_count: Attempts so far, including the one
+        that just failed. Pass ``1`` after the first failure.
+    :keyword str collection_link: Used in log messages and the 503 body.
+    :keyword logging.Logger logger: Caller's module-level logger.
+    :return: Jittered backoff seconds in ``[0, deterministic_upper_bound]``.
     :rtype: float
-    :raises CosmosHttpResponseError: When ``overlap_attempt_count`` has reached
-        ``_OVERLAP_RETRY_MAX_ATTEMPTS``. Status code is 503 so the upstream
-        retry policy classifies it as transient.
+    :raises CosmosHttpResponseError: When the attempt budget is exhausted.
     """
-    if overlap_attempt_count >= _OVERLAP_RETRY_MAX_ATTEMPTS:
+    if retry_attempt_count >= _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS:
         logger.error(
-            "Full-load routing-map fetch for collection '%s' detected "
-            "overlapping partition key ranges on every one of %d attempt(s). "
-            "Surfacing as transient HTTP 503 so the caller's retry policy "
-            "can take over.",
+            "Full-load routing-map fetch for collection '%s' detected a "
+            "transient snapshot inconsistency (overlap or gap) on every "
+            "one of %d attempt(s). Surfacing as transient HTTP 503 so the "
+            "caller's retry policy can take over.",
             collection_link,
-            overlap_attempt_count,
+            retry_attempt_count,
         )
         raise CosmosHttpResponseError(
             status_code=http_constants.StatusCodes.SERVICE_UNAVAILABLE,
             message=(
-                "Failed to build routing map for collection '{}': "
-                "overlapping partition key ranges persisted across {} "
+                "Failed to build routing map for collection '{}': transient "
+                "snapshot inconsistency (overlap or gap) persisted across {} "
                 "full-load attempt(s). Surfaced as a retryable transient "
-                "error so the upstream retry policy can take over, rather "
-                "than allowing the underlying ValueError to escape as a "
-                "fatal crash."
-            ).format(collection_link, overlap_attempt_count),
+                "error so the upstream retry policy can take over."
+            ).format(collection_link, retry_attempt_count),
         )
 
     deterministic_backoff = (
-        _OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS * (2 ** (overlap_attempt_count - 1))
+        _TRANSIENT_SNAPSHOT_RETRY_INITIAL_BACKOFF_SECONDS * (2 ** (retry_attempt_count - 1))
     )
     jittered_backoff = _jittered_backoff(deterministic_backoff)
     logger.warning(
-        "Full-load routing-map fetch for collection '%s' detected overlapping "
-        "partition key ranges (attempt %d/%d). Sleeping %.2fs (jittered from "
-        "upper bound %.2fs) and retrying.",
+        "Full-load routing-map fetch for collection '%s' detected a transient "
+        "snapshot inconsistency (overlap or gap) (attempt %d/%d). Sleeping "
+        "%.2fs (jittered from upper bound %.2fs) and retrying.",
         collection_link,
-        overlap_attempt_count,
-        _OVERLAP_RETRY_MAX_ATTEMPTS,
+        retry_attempt_count,
+        _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
         jittered_backoff,
         deterministic_backoff,
     )
     return jittered_backoff
+
+
 
 
 def is_cache_unchanged_since_previous(
@@ -263,7 +248,7 @@ def _resolve_endpoint(client: Any) -> str:
 
 
 class _IncrementalMergeFailed(Exception):
-    """Sentinel raised by :func:`process_fetched_ranges` when the
+    """Private exception type raised by :func:`process_fetched_ranges` when the
     incremental update cannot resolve all partition key ranges.
 
     The caller decides how to recover: retry the incremental fetch
@@ -276,7 +261,7 @@ def process_fetched_ranges(
     collection_id: str,
     collection_link: str,
     new_etag: Optional[str],
-) -> Optional[CollectionRoutingMap]:
+) -> CollectionRoutingMap:
     """Turn raw PK-range results into a :class:`CollectionRoutingMap`.
 
     Handles both initial-load (when *previous_routing_map* is ``None``)
@@ -291,10 +276,8 @@ def process_fetched_ranges(
     :param str collection_id: The ID of the collection.
     :param str collection_link: The link to the collection.
     :param str new_etag: The ETag from the change feed response, or ``None``.
-    :return: The new/updated routing map, or ``None`` when an
-        initial load yields no ranges.
+    :return: The new/updated routing map.
     :rtype: ~azure.cosmos._routing.collection_routing_map.CollectionRoutingMap
-        or None
     :raises _IncrementalMergeFailed: When the incremental path cannot
         resolve all ranges.  The caller catches this and either retries
         the incremental fetch or falls back to a full refresh.
@@ -374,22 +357,15 @@ def process_fetched_ranges(
     try:
         result = previous_routing_map.try_combine(range_tuples, effective_etag)
     except ValueError as overlap_error:
-        # ``try_combine`` validates the merged map via
-        # ``CollectionRoutingMap.is_complete_set_of_range`` and raises
-        # ``ValueError("Ranges overlap: ...")`` if the merge produces a
-        # self-contradictory tiling. This can happen during the incremental
-        # path when the delta contains a range whose key span overlaps an
-        # existing cached range without either side declaring the other a
-        # parent.
-        #
-        # We must NOT let this ``ValueError`` escape: the cache layer above
-        # treats a ``None`` routing map as "no ranges" and would convert
-        # the bare exception into a silent empty-result return at
-        # ``get_overlapping_ranges``. Convert to ``_IncrementalMergeFailed``
-        # so the caller's existing retry loop retries the incremental fetch
-        # once and then falls back to the full-load path, which has its own
-        # ``_OverlapDetected`` handler with retry+backoff and surfaces a
-        # transient HTTP 503 if the inconsistency persists.
+        # Convert the overlap ``ValueError`` from ``try_combine`` into
+        # ``_IncrementalMergeFailed`` so the caller retries the incremental
+        # fetch and ultimately falls back to the full-load path (which has
+        # its own ``_OverlapDetected`` retry + 503 safety net). Narrow to
+        # the literal ``"Ranges overlap"`` prefix (kept stable in
+        # ``is_complete_set_of_range`` and pinned by the regression tests)
+        # so any future unrelated ``ValueError`` surfaces as a real bug.
+        if not str(overlap_error).startswith("Ranges overlap"):
+            raise
         logger.warning(
             "Incremental merge for collection '%s' produced overlapping ranges: %s. "
             "Converting to _IncrementalMergeFailed so the caller retries / "

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -419,12 +419,8 @@ class PartitionKeyRangeCache(object):
 
                 raise
             except (_OverlapDetected, _GapDetected):
-                # Reset ``current_previous_map`` to ``None`` so the next
-                # iteration runs the full-load path: we do not want to keep
-                # retrying an incremental fetch against the same inconsistent
-                # base. ``_handle_transient_snapshot_retry_decision`` returns
-                # the backoff or raises a 503 once the attempt budget is
-                # exhausted.
+                # Reset to ``None`` so the next attempt runs a full refresh
+                # instead of merging onto the same inconsistent base.
                 inconsistency_attempt_count += 1
                 backoff = _handle_transient_snapshot_retry_decision(
                     retry_attempt_count=inconsistency_attempt_count,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -312,9 +312,12 @@ class PartitionKeyRangeCache(object):
                     **kwargs
                 )
 
-                # Update the cache.
-                if new_routing_map:
-                    self._collection_routing_map_by_item[collection_id] = new_routing_map
+                # ``_fetch_routing_map`` always returns a populated
+                # ``CollectionRoutingMap`` on success and raises otherwise --
+                # No defensive None-check needed; one
+                # would only mask a future regression by silently leaving
+                # the cache empty instead of surfacing the failure.
+                self._collection_routing_map_by_item[collection_id] = new_routing_map
 
             return self._collection_routing_map_by_item.get(collection_id)
 
@@ -326,7 +329,7 @@ class PartitionKeyRangeCache(object):
             previous_routing_map: Optional[CollectionRoutingMap],
             feed_options: Optional[Dict[str, Any]],
             **kwargs
-    ) -> Optional[CollectionRoutingMap]:
+    ) -> CollectionRoutingMap:
         """Fetches or updates the routing map using an incremental change feed.
 
         This method handles both the initial loading of a collection's routing
@@ -336,15 +339,26 @@ class PartitionKeyRangeCache(object):
         of inconsistencies during an incremental update, it automatically falls
         back to a full refresh.
 
+        Always returns a populated :class:`CollectionRoutingMap` on success.
+        Failure modes raise an exception rather than returning ``None``:
+        ``CosmosHttpResponseError`` for the underlying network call (including
+        the transient HTTP 503 raised once the snapshot-inconsistency retry
+        budget is exhausted), or the internal ``_IncrementalMergeFailed``
+        signal when the incremental-merge path cannot make progress and there
+        is no previous map to fall back on.
+
         :param str collection_link: The link to the collection.
         :param str collection_id: The ID of the collection.
         :param previous_routing_map: The last known routing map for incremental updates.
         :type previous_routing_map: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap or None
         :param feed_options: Options for the change feed request.
         :type feed_options: dict or None
-        :return: The updated or newly created CollectionRoutingMap, or None if the update fails.
-        :rtype: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap or None
-        :raises CosmosHttpResponseError: If the underlying request to fetch ranges fails.
+        :return: The updated or newly created CollectionRoutingMap.
+        :rtype: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap
+        :raises CosmosHttpResponseError: If the underlying ``/pkranges`` fetch
+            fails, or if every snapshot-inconsistency retry exhausts the
+            budget (surfaced as HTTP 503 so the upstream retry policy can
+            take over).
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -38,6 +38,9 @@ from .._routing_map_provider_common import (
     determine_refresh_action,
     get_smart_overlapping_ranges,
     _IncrementalMergeFailed,
+    _OverlapDetected,
+    _OVERLAP_RETRY_MAX_ATTEMPTS,  # noqa: F401  # re-exported for tests
+    _handle_overlap_retry_decision,
 )
 
 
@@ -103,6 +106,10 @@ logger = logging.getLogger(__name__)
 # Number of extra incremental attempts after an incomplete incremental merge
 # before falling back to a full routing-map refresh.
 _INCOMPLETE_ROUTING_MAP_MAX_RETRIES = 1
+
+# Overlap-retry budget and backoff live in ``_routing_map_provider_common`` so
+# the sync and async providers cannot drift on them. ``_OVERLAP_RETRY_MAX_ATTEMPTS``
+# is re-exported through this module for test imports.
 class PartitionKeyRangeCache(object):
     """
     PartitionKeyRangeCache provides list of effective partition key ranges for a
@@ -343,6 +350,7 @@ class PartitionKeyRangeCache(object):
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0
+        overlap_attempt_count = 0
 
         while True:
             request_kwargs = dict(kwargs)
@@ -398,6 +406,24 @@ class PartitionKeyRangeCache(object):
                     continue
 
                 raise
+            except _OverlapDetected:
+                # The full-load builder reported overlapping ranges. Apply
+                # the retry-on-overlap policy: ``_handle_overlap_retry_decision``
+                # either returns a backoff to sleep or raises ``CosmosHttpResponseError``
+                # (503) when the attempt budget is exhausted. Reset
+                # ``current_previous_map`` to ``None`` so the next iteration
+                # runs the full-load path regardless of which path tripped
+                # the overlap — we do not want to keep retrying an incremental
+                # fetch against the same inconsistent base.
+                overlap_attempt_count += 1
+                backoff = _handle_overlap_retry_decision(
+                    overlap_attempt_count=overlap_attempt_count,
+                    collection_link=collection_link,
+                    logger=logger,
+                )
+                await asyncio.sleep(backoff)
+                current_previous_map = None
+                continue
 
     async def get_range_by_partition_key_range_id(
             self,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -91,13 +91,22 @@ _shared_cache_refcounts: Dict[str, int] = {}
 # independent set of module-level dicts and its own ``_shared_cache_lock`` —
 # state is NOT shared between the sync and async modules. A sync and an async
 # ``CosmosClient`` targeting the same endpoint maintain separate routing-map
-# caches. Using a ``threading.Lock`` (not an ``asyncio.Lock``) is also
+# caches. Using a ``threading.RLock`` (not an ``asyncio.Lock``) is also
 # essential for correctness across multiple event loops in the same process:
 # an ``asyncio.Lock`` binds to the loop that first acquires it. The critical
 # sections this lock guards are pure dict reads/writes — never await, never
 # network I/O — so a brief threading-lock acquisition from a coroutine is
-# safe and does not block the event loop in any meaningful way.
-_shared_cache_lock = threading.Lock()
+# safe and does not block the event loop in any meaningful way. ``RLock`` is
+# required (not ``Lock``) because ``__init__`` holds this lock while
+# indexing into ``_shared_routing_map_cache``, and that indexing can
+# synchronously trigger GC of an older ``PartitionKeyRangeCache`` instance
+# on the same thread (e.g. when ``client`` is a ``MagicMock`` whose
+# ``_mock_set_magics`` drops prior child-mock references; the same shape
+# can fire in production any time GC collects a prior instance during a new
+# instance's ``__init__``). GC runs ``__del__`` -> ``release()``, which
+# re-acquires this same lock on the same thread; with a non-reentrant
+# ``Lock`` that re-acquisition would deadlock.
+_shared_cache_lock = threading.RLock()
 
 
 # pylint: disable=protected-access

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -97,13 +97,9 @@ _shared_cache_refcounts: Dict[str, int] = {}
 # threading-lock acquisition from a coroutine does not meaningfully block
 # the event loop.
 #
-# Reentrant (``RLock``) because the dict operations inside ``__init__``'s
-# critical section can trigger cyclic GC at a CPython allocation safe-point.
-# If a ``PartitionKeyRangeCache`` participates in a reference cycle (e.g.
-# ``self._document_client`` -> ... -> ``self``), GC may sweep an unreachable
-# cycle on the same thread, run ``__del__`` -> ``release()``, and re-acquire
-# this lock. A plain ``Lock`` would deadlock; an ``RLock`` permits the
-# re-entry.
+# Reentrant (``RLock``) to tolerate same-thread re-entry (for example
+# ``__del__`` -> ``release()``) if future refactors add allocation points
+# inside this critical section.
 _shared_cache_lock = threading.RLock()
 
 
@@ -135,25 +131,29 @@ class PartitionKeyRangeCache(object):
         self._endpoint = _resolve_endpoint(client)
         self._released = False
 
-        # Share routing map cache, per-collection asyncio locks, and the
-        # per-endpoint meta-lock that guards the per-collection-lock dict
-        # across all clients with the same endpoint. Refcount lets us evict
-        # the entry when the last sharing client releases it (see ``release``).
+        # Share routing map cache, per-collection asyncio locks, and the lock
+        # that protects lock creation across clients for this endpoint.
+        # Defaults are allocated before locking so this block stays dict-only.
+        new_routing_map: Dict[str, CollectionRoutingMap] = {}
+        new_collection_locks: Dict[tuple, asyncio.Lock] = {}
+        new_locks_lock = threading.Lock()
+
         with _shared_cache_lock:
-            # See ``_shared_cache_lock`` module-level comment: the dict ops
-            # below can re-enter this lock via cyclic GC -> ``__del__`` ->
-            # ``release()`` on the same thread, which is why the lock is an
-            # ``RLock``. If this block is ever refactored to move dict ops
-            # outside the lock, revisit whether ``RLock`` is still required.
-            if self._endpoint not in _shared_routing_map_cache:
-                _shared_routing_map_cache[self._endpoint] = {}
-                _shared_collection_locks[self._endpoint] = {}
-                _shared_locks_locks[self._endpoint] = threading.Lock()
-                _shared_cache_refcounts[self._endpoint] = 0
-            _shared_cache_refcounts[self._endpoint] += 1
-            self._collection_routing_map_by_item = _shared_routing_map_cache[self._endpoint]
-            self._collection_locks: Dict[tuple, asyncio.Lock] = _shared_collection_locks[self._endpoint]
-            self._locks_lock: threading.Lock = _shared_locks_locks[self._endpoint]
+            # ``setdefault`` preserves existing endpoint entries.
+            routing_map = _shared_routing_map_cache.setdefault(
+                self._endpoint, new_routing_map)
+            collection_locks = _shared_collection_locks.setdefault(
+                self._endpoint, new_collection_locks)
+            locks_lock = _shared_locks_locks.setdefault(
+                self._endpoint, new_locks_lock)
+            # Preserve existing refcount instead of reinitializing.
+            _shared_cache_refcounts[self._endpoint] = (
+                _shared_cache_refcounts.get(self._endpoint, 0) + 1
+            )
+
+            self._collection_routing_map_by_item = routing_map
+            self._collection_locks: Dict[tuple, asyncio.Lock] = collection_locks
+            self._locks_lock: threading.Lock = locks_lock
 
     def clear_cache(self):
         """Clear the shared routing map cache for this endpoint.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -86,26 +86,24 @@ _shared_locks_locks: Dict[str, threading.Lock] = {}
 # count — it only wipes routing-map contents.
 _shared_cache_refcounts: Dict[str, int] = {}
 
-# Process-wide lock guarding the four dicts above for *this* (async) module.
-# Note: the sync module ``_routing/routing_map_provider.py`` defines its own
-# independent set of module-level dicts and its own ``_shared_cache_lock`` —
-# state is NOT shared between the sync and async modules. A sync and an async
-# ``CosmosClient`` targeting the same endpoint maintain separate routing-map
-# caches. Using a ``threading.RLock`` (not an ``asyncio.Lock``) is also
-# essential for correctness across multiple event loops in the same process:
-# an ``asyncio.Lock`` binds to the loop that first acquires it. The critical
-# sections this lock guards are pure dict reads/writes — never await, never
-# network I/O — so a brief threading-lock acquisition from a coroutine is
-# safe and does not block the event loop in any meaningful way. ``RLock`` is
-# required (not ``Lock``) because ``__init__`` holds this lock while
-# indexing into ``_shared_routing_map_cache``, and that indexing can
-# synchronously trigger GC of an older ``PartitionKeyRangeCache`` instance
-# on the same thread (e.g. when ``client`` is a ``MagicMock`` whose
-# ``_mock_set_magics`` drops prior child-mock references; the same shape
-# can fire in production any time GC collects a prior instance during a new
-# instance's ``__init__``). GC runs ``__del__`` -> ``release()``, which
-# re-acquires this same lock on the same thread; with a non-reentrant
-# ``Lock`` that re-acquisition would deadlock.
+# Process-wide lock guarding the four dicts above. The sync module
+# (``_routing/routing_map_provider.py``) has its own independent set, so
+# sync and async clients targeting the same endpoint do not share state.
+#
+# A ``threading`` lock (not ``asyncio.Lock``) is used because an
+# ``asyncio.Lock`` binds to the loop that first acquires it, which breaks
+# across multiple event loops in the same process. The critical sections
+# are pure dict reads/writes with no await and no network I/O, so a brief
+# threading-lock acquisition from a coroutine does not meaningfully block
+# the event loop.
+#
+# Reentrant (``RLock``) because the dict operations inside ``__init__``'s
+# critical section can trigger cyclic GC at a CPython allocation safe-point.
+# If a ``PartitionKeyRangeCache`` participates in a reference cycle (e.g.
+# ``self._document_client`` -> ... -> ``self``), GC may sweep an unreachable
+# cycle on the same thread, run ``__del__`` -> ``release()``, and re-acquire
+# this lock. A plain ``Lock`` would deadlock; an ``RLock`` permits the
+# re-entry.
 _shared_cache_lock = threading.RLock()
 
 
@@ -142,6 +140,11 @@ class PartitionKeyRangeCache(object):
         # across all clients with the same endpoint. Refcount lets us evict
         # the entry when the last sharing client releases it (see ``release``).
         with _shared_cache_lock:
+            # See ``_shared_cache_lock`` module-level comment: the dict ops
+            # below can re-enter this lock via cyclic GC -> ``__del__`` ->
+            # ``release()`` on the same thread, which is why the lock is an
+            # ``RLock``. If this block is ever refactored to move dict ops
+            # outside the lock, revisit whether ``RLock`` is still required.
             if self._endpoint not in _shared_routing_map_cache:
                 _shared_routing_map_cache[self._endpoint] = {}
                 _shared_collection_locks[self._endpoint] = {}

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/aio/routing_map_provider.py
@@ -39,8 +39,8 @@ from .._routing_map_provider_common import (
     get_smart_overlapping_ranges,
     _IncrementalMergeFailed,
     _OverlapDetected,
-    _OVERLAP_RETRY_MAX_ATTEMPTS,  # noqa: F401  # re-exported for tests
-    _handle_overlap_retry_decision,
+    _GapDetected,
+    _handle_transient_snapshot_retry_decision,
 )
 
 
@@ -107,9 +107,7 @@ logger = logging.getLogger(__name__)
 # before falling back to a full routing-map refresh.
 _INCOMPLETE_ROUTING_MAP_MAX_RETRIES = 1
 
-# Overlap-retry budget and backoff live in ``_routing_map_provider_common`` so
-# the sync and async providers cannot drift on them. ``_OVERLAP_RETRY_MAX_ATTEMPTS``
-# is re-exported through this module for test imports.
+
 class PartitionKeyRangeCache(object):
     """
     PartitionKeyRangeCache provides list of effective partition key ranges for a
@@ -350,7 +348,7 @@ class PartitionKeyRangeCache(object):
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0
-        overlap_attempt_count = 0
+        inconsistency_attempt_count = 0
 
         while True:
             request_kwargs = dict(kwargs)
@@ -406,18 +404,16 @@ class PartitionKeyRangeCache(object):
                     continue
 
                 raise
-            except _OverlapDetected:
-                # The full-load builder reported overlapping ranges. Apply
-                # the retry-on-overlap policy: ``_handle_overlap_retry_decision``
-                # either returns a backoff to sleep or raises ``CosmosHttpResponseError``
-                # (503) when the attempt budget is exhausted. Reset
-                # ``current_previous_map`` to ``None`` so the next iteration
-                # runs the full-load path regardless of which path tripped
-                # the overlap — we do not want to keep retrying an incremental
-                # fetch against the same inconsistent base.
-                overlap_attempt_count += 1
-                backoff = _handle_overlap_retry_decision(
-                    overlap_attempt_count=overlap_attempt_count,
+            except (_OverlapDetected, _GapDetected):
+                # Reset ``current_previous_map`` to ``None`` so the next
+                # iteration runs the full-load path: we do not want to keep
+                # retrying an incremental fetch against the same inconsistent
+                # base. ``_handle_transient_snapshot_retry_decision`` returns
+                # the backoff or raises a 503 once the attempt budget is
+                # exhausted.
+                inconsistency_attempt_count += 1
+                backoff = _handle_transient_snapshot_retry_decision(
+                    retry_attempt_count=inconsistency_attempt_count,
                     collection_link=collection_link,
                     logger=logger,
                 )

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
@@ -31,26 +31,30 @@ from azure.cosmos._routing.routing_range import PartitionKeyRange, PKRange
 
 
 class _OverlapDetected(Exception):
-    """Sentinel raised by :func:`_build_routing_map_from_ranges` when the
-    ``/pkranges`` response contains overlapping ranges that the SDK cannot
-    reconcile from a single snapshot.
+    """Raised by :func:`_build_routing_map_from_ranges` to signal that the
+    gateway returned a ``/pkranges`` snapshot with overlapping ranges.
 
-    Distinct from a plain ``ValueError`` so the caller can identify the
-    overlap case explicitly and apply the retry-on-overlap policy instead
-    of treating it as a fatal programmer error. Overlap on this path is
-    expected to be transient (a paginated ``/pkranges`` response that is
-    not snapshot-isolated across gateway nodes), so a short retry budget
-    with backoff is sufficient.
+    Intentionally NOT a ``ValueError`` subclass: cache-layer code historically
+    catches ``ValueError`` broadly, so a plain ``ValueError`` would be
+    silently swallowed and surface later as an empty result from
+    ``get_overlapping_ranges``. Each provider's ``_fetch_routing_map``
+    catches this type explicitly and applies the retry-on-overlap policy.
+    """
 
-    The caller (``_fetch_routing_map`` on both sync and async cache
-    providers) catches this sentinel, sleeps briefly, and retries the
-    fetch. After a small number of failed retries it surfaces a typed
-    transient HTTP error so the upstream retry policy can take over. The
-    sentinel is intentionally not allowed to escape to the query layer
-    as a bare ``ValueError`` — that path would otherwise convert into a
-    silent empty-result return at ``get_overlapping_ranges`` (which
-    treats a ``None`` routing map as "no ranges"), masking the failure
-    as a correctness bug.
+
+class _GapDetected(Exception):
+    """Raised by :func:`_build_routing_map_from_ranges` to signal that the
+    gateway returned a ``/pkranges`` snapshot with a hole in the key space
+    (i.e. one range's upper bound is strictly less than the next range's
+    lower bound, leaving some keys uncovered).
+
+    Same root cause as :class:`_OverlapDetected` -- a transient gateway
+    snapshot served mid-propagation -- but the opposite symptom. Today
+    this case escapes as ``AssertionError("code bug: returned overlapping
+    ranges ... is empty")`` from ``SmartRoutingMapProvider``'s generator
+    when the downstream query tries to use the empty result. Caught
+    alongside ``_OverlapDetected`` and given the same bounded retry +
+    typed HTTP 503 treatment so the upstream retry policy can absorb it.
     """
 
 # pylint: disable=line-too-long
@@ -305,15 +309,14 @@ def _build_routing_map_from_ranges(
     new_etag,
     collection_link: str,
     _logger
-) -> Optional['CollectionRoutingMap']:
+) -> 'CollectionRoutingMap':
     """Build a complete routing map from a full load of partition key ranges.
 
     Filters out parent (gone) ranges and validates that the remaining ranges
-    form a complete, gap-free partition key space. Returns None if the ranges
-    are incomplete (gap), and raises ``_OverlapDetected`` if the ranges
-    overlap — the caller is expected to retry the fetch on the overlap case,
-    since overlap on the full-load path is treated as a transient gateway
-    inconsistency rather than a permanent input error.
+    form a complete, gap-free partition key space. Raises ``_OverlapDetected``
+    when the ranges overlap and ``_GapDetected`` when they have a gap; both
+    are transient gateway-snapshot inconsistencies the caller is expected to
+    retry.
 
     This is shared between the sync and async PartitionKeyRangeCache to avoid
     code duplication — the logic is purely synchronous.
@@ -323,22 +326,22 @@ def _build_routing_map_from_ranges(
     :param str new_etag: The ETag from the change feed response.
     :param str collection_link: The collection link, used for log messages.
     :param logging.Logger _logger: Logger instance for error reporting.
-    :return: A complete CollectionRoutingMap, or None if the ranges are incomplete (gap).
-    :rtype: Optional[CollectionRoutingMap]
+    :return: A complete CollectionRoutingMap.
+    :rtype: CollectionRoutingMap
     :raises _OverlapDetected: If the ranges contain an overlap that could not
         be resolved from this single snapshot. The caller should retry the
         fetch; see :class:`_OverlapDetected` for the rationale.
+    :raises _GapDetected: If the ranges have a hole in the key space. The
+        caller should retry the fetch; see :class:`_GapDetected` for the
+        rationale.
     """
-    # Dedup the input by id BEFORE parent filtering and validation. At high
-    # partition counts the /pkranges response is paginated, and pagination
-    # is not snapshot-isolated across gateway nodes — consecutive pages can
-    # legitimately return the same range id when the page boundary falls
-    # between two nodes with one-tick-out-of-sync caches. Without this dedup
-    # the duplicate would survive into the sortedRanges list inside
-    # CompleteRoutingMap and trip the overlap check on two identical entries.
-    # Last-write-wins is safe: duplicates describe the same logical range
-    # and any later occurrence carries the same id, min/max, and (when
-    # present) the more-complete metadata such as ``parents``.
+    # Dedup the input by id before validation. Paginated ``/pkranges``
+    # responses can repeat the same range id across pages when consecutive
+    # pages are served from gateway nodes with slightly different cached
+    # views; without dedup the duplicate trips the overlap check on two
+    # identical entries. Last-write-wins is safe in practice; if duplicates
+    # carry asymmetric metadata, the overlap path is handled by the
+    # ``_OverlapDetected`` retry flow.
     deduped_by_id: dict = {}
     for r in ranges:
         deduped_by_id[r[PartitionKeyRange.Id]] = r
@@ -362,13 +365,14 @@ def _build_routing_map_from_ranges(
             new_etag
         )
     except ValueError as overlap_error:
-        # ``is_complete_set_of_range`` raises ``ValueError("Ranges overlap: ...")``
-        # when the post-filter range list still contains an overlap. Convert
-        # it to ``_OverlapDetected`` so the caller can apply the retry-on-
-        # overlap policy. The bare ``ValueError`` must NOT escape to the
-        # cache layer: that path converts into a silent empty-result return
-        # at ``get_overlapping_ranges`` (which treats ``None`` from the
-        # cache as "no ranges"), masking the failure as a correctness bug.
+        # Convert the overlap ``ValueError`` raised by ``is_complete_set_of_range``
+        # into ``_OverlapDetected`` so the caller can apply the retry-on-overlap
+        # policy. Narrow to the literal ``"Ranges overlap"`` prefix (kept stable
+        # in ``is_complete_set_of_range`` and pinned by the regression tests)
+        # so any future unrelated ``ValueError`` from ``CompleteRoutingMap``
+        # surfaces as a real bug instead of being silently coerced into a retry.
+        if not str(overlap_error).startswith("Ranges overlap"):
+            raise
         _logger.warning(
             "Full load of routing map for collection '%s' detected overlapping "
             "partition key ranges: %s. Signalling caller to retry the "
@@ -378,12 +382,21 @@ def _build_routing_map_from_ranges(
         raise _OverlapDetected() from overlap_error
 
     if not routing_map:
-        _logger.error(
-            "Full load of routing map for collection '%s' failed: "
-            "the service returned an incomplete set of partition key ranges. "
-            "This can happen due to a transient service issue or a split completing mid-fetch.",
-            collection_link
+        # ``CompleteRoutingMap`` returns None when ``is_complete_set_of_range``
+        # returns False without raising -- the gap case (``prev.max < cur.min``)
+        # or an empty input list. Same root cause as the overlap raise above
+        # (transient inconsistent gateway snapshot), opposite symptom: a hole
+        # in the key space rather than a duplicated one. Raise ``_GapDetected``
+        # so the caller applies the same bounded retry + 503-on-exhaustion
+        # treatment as overlap. Without this, today's behaviour is for the
+        # ``None`` to surface as ``AssertionError("code bug: returned
+        # overlapping ranges ... is empty")`` from ``SmartRoutingMapProvider``.
+        _logger.warning(
+            "Full load of routing map for collection '%s' returned an "
+            "incomplete set of partition key ranges (gap in key space). "
+            "Signalling caller to retry the /pkranges fetch.",
+            collection_link,
         )
-        return None
+        raise _GapDetected()
 
     return routing_map

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
@@ -29,6 +29,30 @@ from typing import Optional, Union
 from azure.cosmos._routing import routing_range
 from azure.cosmos._routing.routing_range import PartitionKeyRange, PKRange
 
+
+class _OverlapDetected(Exception):
+    """Sentinel raised by :func:`_build_routing_map_from_ranges` when the
+    ``/pkranges`` response contains overlapping ranges that the SDK cannot
+    reconcile from a single snapshot.
+
+    Distinct from a plain ``ValueError`` so the caller can identify the
+    overlap case explicitly and apply the retry-on-overlap policy instead
+    of treating it as a fatal programmer error. Overlap on this path is
+    expected to be transient (a paginated ``/pkranges`` response that is
+    not snapshot-isolated across gateway nodes), so a short retry budget
+    with backoff is sufficient.
+
+    The caller (``_fetch_routing_map`` on both sync and async cache
+    providers) catches this sentinel, sleeps briefly, and retries the
+    fetch. After a small number of failed retries it surfaces a typed
+    transient HTTP error so the upstream retry policy can take over. The
+    sentinel is intentionally not allowed to escape to the query layer
+    as a bare ``ValueError`` — that path would otherwise convert into a
+    silent empty-result return at ``get_overlapping_ranges`` (which
+    treats a ``None`` routing map as "no ranges"), masking the failure
+    as a correctness bug.
+    """
+
 # pylint: disable=line-too-long
 class CollectionRoutingMap(object):
     """Stores partition key ranges in an efficient way with some additional
@@ -196,7 +220,23 @@ class CollectionRoutingMap(object):
 
                 if not isComplete:
                     if previousRange[PartitionKeyRange.MaxExclusive] > currentRange[PartitionKeyRange.MinInclusive]:
-                        raise ValueError("Ranges overlap")
+                        # Include the offending pair in the message so whoever
+                        # investigates the next occurrence has actionable
+                        # diagnostics without having to reproduce the failure
+                        # under a debugger. Keep the literal substring
+                        # "Ranges overlap" for backwards compatibility with
+                        # any caller that pattern-matches on it.
+                        raise ValueError(
+                            "Ranges overlap: previous range id={!r} ({!r} -> {!r}) "
+                            "overlaps current range id={!r} ({!r} -> {!r})".format(
+                                previousRange.get(PartitionKeyRange.Id),
+                                previousRange[PartitionKeyRange.MinInclusive],
+                                previousRange[PartitionKeyRange.MaxExclusive],
+                                currentRange.get(PartitionKeyRange.Id),
+                                currentRange[PartitionKeyRange.MinInclusive],
+                                currentRange[PartitionKeyRange.MaxExclusive],
+                            )
+                        )
                     break
 
         return isComplete
@@ -270,7 +310,10 @@ def _build_routing_map_from_ranges(
 
     Filters out parent (gone) ranges and validates that the remaining ranges
     form a complete, gap-free partition key space. Returns None if the ranges
-    are incomplete.
+    are incomplete (gap), and raises ``_OverlapDetected`` if the ranges
+    overlap — the caller is expected to retry the fetch on the overlap case,
+    since overlap on the full-load path is treated as a transient gateway
+    inconsistency rather than a permanent input error.
 
     This is shared between the sync and async PartitionKeyRangeCache to avoid
     code duplication — the logic is purely synchronous.
@@ -280,9 +323,27 @@ def _build_routing_map_from_ranges(
     :param str new_etag: The ETag from the change feed response.
     :param str collection_link: The collection link, used for log messages.
     :param logging.Logger _logger: Logger instance for error reporting.
-    :return: A complete CollectionRoutingMap, or None if the ranges are incomplete.
+    :return: A complete CollectionRoutingMap, or None if the ranges are incomplete (gap).
     :rtype: Optional[CollectionRoutingMap]
+    :raises _OverlapDetected: If the ranges contain an overlap that could not
+        be resolved from this single snapshot. The caller should retry the
+        fetch; see :class:`_OverlapDetected` for the rationale.
     """
+    # Dedup the input by id BEFORE parent filtering and validation. At high
+    # partition counts the /pkranges response is paginated, and pagination
+    # is not snapshot-isolated across gateway nodes — consecutive pages can
+    # legitimately return the same range id when the page boundary falls
+    # between two nodes with one-tick-out-of-sync caches. Without this dedup
+    # the duplicate would survive into the sortedRanges list inside
+    # CompleteRoutingMap and trip the overlap check on two identical entries.
+    # Last-write-wins is safe: duplicates describe the same logical range
+    # and any later occurrence carries the same id, min/max, and (when
+    # present) the more-complete metadata such as ``parents``.
+    deduped_by_id: dict = {}
+    for r in ranges:
+        deduped_by_id[r[PartitionKeyRange.Id]] = r
+    ranges = list(deduped_by_id.values())
+
     gone_range_ids = set()
     for r in ranges:
         if PartitionKeyRange.Parents in r and r[PartitionKeyRange.Parents]:
@@ -294,11 +355,27 @@ def _build_routing_map_from_ranges(
     ]
     range_tuples = [(r, True) for r in filtered_ranges]
 
-    routing_map = CollectionRoutingMap.CompleteRoutingMap(
-        range_tuples,
-        collection_id,
-        new_etag
-    )
+    try:
+        routing_map = CollectionRoutingMap.CompleteRoutingMap(
+            range_tuples,
+            collection_id,
+            new_etag
+        )
+    except ValueError as overlap_error:
+        # ``is_complete_set_of_range`` raises ``ValueError("Ranges overlap: ...")``
+        # when the post-filter range list still contains an overlap. Convert
+        # it to ``_OverlapDetected`` so the caller can apply the retry-on-
+        # overlap policy. The bare ``ValueError`` must NOT escape to the
+        # cache layer: that path converts into a silent empty-result return
+        # at ``get_overlapping_ranges`` (which treats ``None`` from the
+        # cache as "no ranges"), masking the failure as a correctness bug.
+        _logger.warning(
+            "Full load of routing map for collection '%s' detected overlapping "
+            "partition key ranges: %s. Signalling caller to retry the "
+            "/pkranges fetch.",
+            collection_link, str(overlap_error),
+        )
+        raise _OverlapDetected() from overlap_error
 
     if not routing_map:
         _logger.error(

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
@@ -31,30 +31,21 @@ from azure.cosmos._routing.routing_range import PartitionKeyRange, PKRange
 
 
 class _OverlapDetected(Exception):
-    """Raised by :func:`_build_routing_map_from_ranges` to signal that the
-    gateway returned a ``/pkranges`` snapshot with overlapping ranges.
+    """Raised by :func:`_build_routing_map_from_ranges` when the gateway
+    returns a ``/pkranges`` snapshot whose ranges overlap.
 
-    Intentionally NOT a ``ValueError`` subclass: cache-layer code historically
-    catches ``ValueError`` broadly, so a plain ``ValueError`` would be
-    silently swallowed and surface later as an empty result from
-    ``get_overlapping_ranges``. Each provider's ``_fetch_routing_map``
-    catches this type explicitly and applies the retry-on-overlap policy.
+    Not a ``ValueError`` subclass: cache-layer code historically catches
+    ``ValueError`` broadly, so a plain ``ValueError`` would be swallowed.
+    Each provider's ``_fetch_routing_map`` catches this type and retries.
     """
 
 
 class _GapDetected(Exception):
-    """Raised by :func:`_build_routing_map_from_ranges` to signal that the
-    gateway returned a ``/pkranges`` snapshot with a hole in the key space
-    (i.e. one range's upper bound is strictly less than the next range's
-    lower bound, leaving some keys uncovered).
+    """Raised by :func:`_build_routing_map_from_ranges` when the gateway
+    returns a ``/pkranges`` snapshot with a gap in the key space.
 
-    Same root cause as :class:`_OverlapDetected` -- a transient gateway
-    snapshot served mid-propagation -- but the opposite symptom. Today
-    this case escapes as ``AssertionError("code bug: returned overlapping
-    ranges ... is empty")`` from ``SmartRoutingMapProvider``'s generator
-    when the downstream query tries to use the empty result. Caught
-    alongside ``_OverlapDetected`` and given the same bounded retry +
-    typed HTTP 503 treatment so the upstream retry policy can absorb it.
+    Same root cause as ``_OverlapDetected`` (a transient mid-propagation
+    snapshot) and handled with the same bounded retry + HTTP 503 treatment.
     """
 
 # pylint: disable=line-too-long
@@ -315,11 +306,10 @@ def _build_routing_map_from_ranges(
     Filters out parent (gone) ranges and validates that the remaining ranges
     form a complete, gap-free partition key space. Raises ``_OverlapDetected``
     when the ranges overlap and ``_GapDetected`` when they have a gap; both
-    are transient gateway-snapshot inconsistencies the caller is expected to
-    retry.
+    are transient gateway-snapshot inconsistencies the caller should retry.
 
-    This is shared between the sync and async PartitionKeyRangeCache to avoid
-    code duplication — the logic is purely synchronous.
+    Shared between the sync and async ``PartitionKeyRangeCache``; the logic
+    is purely synchronous.
 
     :param list ranges: Raw partition key range dicts from the service.
     :param str collection_id: The collection identifier used as the routing map key.
@@ -328,20 +318,12 @@ def _build_routing_map_from_ranges(
     :param logging.Logger _logger: Logger instance for error reporting.
     :return: A complete CollectionRoutingMap.
     :rtype: CollectionRoutingMap
-    :raises _OverlapDetected: If the ranges contain an overlap that could not
-        be resolved from this single snapshot. The caller should retry the
-        fetch; see :class:`_OverlapDetected` for the rationale.
-    :raises _GapDetected: If the ranges have a hole in the key space. The
-        caller should retry the fetch; see :class:`_GapDetected` for the
-        rationale.
+    :raises _OverlapDetected: If the ranges contain an overlap in this snapshot.
+    :raises _GapDetected: If the ranges have a hole in the key space.
     """
     # Dedup the input by id before validation. Paginated ``/pkranges``
-    # responses can repeat the same range id across pages when consecutive
-    # pages are served from gateway nodes with slightly different cached
-    # views; without dedup the duplicate trips the overlap check on two
-    # identical entries. Last-write-wins is safe in practice; if duplicates
-    # carry asymmetric metadata, the overlap path is handled by the
-    # ``_OverlapDetected`` retry flow.
+    # responses can repeat the same range id across pages, which would
+    # otherwise trip the overlap check on two identical entries.
     deduped_by_id: dict = {}
     for r in ranges:
         deduped_by_id[r[PartitionKeyRange.Id]] = r
@@ -365,36 +347,25 @@ def _build_routing_map_from_ranges(
             new_etag
         )
     except ValueError as overlap_error:
-        # Convert the overlap ``ValueError`` raised by ``is_complete_set_of_range``
-        # into ``_OverlapDetected`` so the caller can apply the retry-on-overlap
-        # policy. Narrow to the literal ``"Ranges overlap"`` prefix (kept stable
-        # in ``is_complete_set_of_range`` and pinned by the regression tests)
-        # so any future unrelated ``ValueError`` from ``CompleteRoutingMap``
-        # surfaces as a real bug instead of being silently coerced into a retry.
+        # Convert the overlap ``ValueError`` to ``_OverlapDetected`` so the
+        # caller can retry. Narrow to the ``"Ranges overlap"`` prefix so any
+        # unrelated ``ValueError`` still surfaces as a real bug.
         if not str(overlap_error).startswith("Ranges overlap"):
             raise
         _logger.warning(
-            "Full load of routing map for collection '%s' detected overlapping "
-            "partition key ranges: %s. Signalling caller to retry the "
-            "/pkranges fetch.",
+            "Routing map for collection '%s' has overlapping partition key "
+            "ranges: %s. Retrying the /pkranges fetch.",
             collection_link, str(overlap_error),
         )
         raise _OverlapDetected() from overlap_error
 
     if not routing_map:
-        # ``CompleteRoutingMap`` returns None when ``is_complete_set_of_range``
-        # returns False without raising -- the gap case (``prev.max < cur.min``)
-        # or an empty input list. Same root cause as the overlap raise above
-        # (transient inconsistent gateway snapshot), opposite symptom: a hole
-        # in the key space rather than a duplicated one. Raise ``_GapDetected``
-        # so the caller applies the same bounded retry + 503-on-exhaustion
-        # treatment as overlap. Without this, today's behaviour is for the
-        # ``None`` to surface as ``AssertionError("code bug: returned
-        # overlapping ranges ... is empty")`` from ``SmartRoutingMapProvider``.
+        # ``CompleteRoutingMap`` returns None when the input has a gap
+        # (``prev.max < cur.min``) or is empty. Raise ``_GapDetected`` so
+        # the caller applies the same retry policy as the overlap case.
         _logger.warning(
-            "Full load of routing map for collection '%s' returned an "
-            "incomplete set of partition key ranges (gap in key space). "
-            "Signalling caller to retry the /pkranges fetch.",
+            "Routing map for collection '%s' has a gap in the key space. "
+            "Retrying the /pkranges fetch.",
             collection_link,
         )
         raise _GapDetected()

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -28,7 +28,11 @@ import logging
 from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from .. import _base, http_constants
-from .collection_routing_map import CollectionRoutingMap
+from .collection_routing_map import (
+    CollectionRoutingMap,
+    _OverlapDetected,
+    _GapDetected,
+)
 from ..exceptions import CosmosHttpResponseError
 from ._routing_map_provider_common import (
     _resolve_endpoint,
@@ -38,9 +42,7 @@ from ._routing_map_provider_common import (
     determine_refresh_action,
     get_smart_overlapping_ranges,
     _IncrementalMergeFailed,
-    _OverlapDetected,
-    _OVERLAP_RETRY_MAX_ATTEMPTS,  # noqa: F401  # re-exported for tests
-    _handle_overlap_retry_decision,
+    _handle_transient_snapshot_retry_decision,
 )
 
 if TYPE_CHECKING:
@@ -98,9 +100,7 @@ logger = logging.getLogger(__name__)
 # before falling back to a full routing-map refresh.
 _INCOMPLETE_ROUTING_MAP_MAX_RETRIES = 1
 
-# Overlap-retry budget and backoff live in ``_routing_map_provider_common`` so
-# the sync and async providers cannot drift on them. ``_OVERLAP_RETRY_MAX_ATTEMPTS``
-# is re-exported through this module for test imports.
+
 class PartitionKeyRangeCache(object):
     """
     PartitionKeyRangeCache provides list of effective partition key ranges for a
@@ -322,7 +322,7 @@ class PartitionKeyRangeCache(object):
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0
-        overlap_attempt_count = 0
+        inconsistency_attempt_count = 0
 
         while True:
             request_kwargs = dict(kwargs)
@@ -377,18 +377,16 @@ class PartitionKeyRangeCache(object):
                     continue
 
                 raise
-            except _OverlapDetected:
-                # The full-load builder reported overlapping ranges. Apply
-                # the retry-on-overlap policy: ``_handle_overlap_retry_decision``
-                # either returns a backoff to sleep or raises ``CosmosHttpResponseError``
-                # (503) when the attempt budget is exhausted. Reset
-                # ``current_previous_map`` to ``None`` so the next iteration
-                # runs the full-load path regardless of which path tripped
-                # the overlap — we do not want to keep retrying an incremental
-                # fetch against the same inconsistent base.
-                overlap_attempt_count += 1
-                backoff = _handle_overlap_retry_decision(
-                    overlap_attempt_count=overlap_attempt_count,
+            except (_OverlapDetected, _GapDetected):
+                # Reset ``current_previous_map`` to ``None`` so the next
+                # iteration runs the full-load path: we do not want to keep
+                # retrying an incremental fetch against the same inconsistent
+                # base. ``_handle_transient_snapshot_retry_decision`` returns
+                # the backoff or raises a 503 once the attempt budget is
+                # exhausted.
+                inconsistency_attempt_count += 1
+                backoff = _handle_transient_snapshot_retry_decision(
+                    retry_attempt_count=inconsistency_attempt_count,
                     collection_link=collection_link,
                     logger=logger,
                 )

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -285,9 +285,12 @@ class PartitionKeyRangeCache(object):
                     feed_options,
                     **kwargs
                 )
-
-                if new_routing_map:
-                    self._collection_routing_map_by_item[collection_id] = new_routing_map
+                # ``_fetch_routing_map`` always returns a populated
+                # ``CollectionRoutingMap`` on success and raises otherwise --
+                # No defensive None-check needed; one
+                # would only mask a future regression by silently leaving
+                # the cache empty instead of surfacing the failure.
+                self._collection_routing_map_by_item[collection_id] = new_routing_map
 
             return self._collection_routing_map_by_item.get(collection_id)
 
@@ -300,7 +303,7 @@ class PartitionKeyRangeCache(object):
             previous_routing_map: Optional[CollectionRoutingMap],
             feed_options: Optional[Dict[str, Any]],
             **kwargs
-    ) -> Optional[CollectionRoutingMap]:
+    ) -> CollectionRoutingMap:
 
         """Fetches or updates the routing map using an incremental change feed.
 
@@ -311,14 +314,26 @@ class PartitionKeyRangeCache(object):
         of inconsistencies during an incremental update, it automatically falls
         back to a full refresh.
 
+        Always returns a populated :class:`CollectionRoutingMap` on success.
+        Failure modes raise an exception rather than returning ``None``:
+        ``CosmosHttpResponseError`` for the underlying network call (including
+        the transient HTTP 503 raised once the snapshot-inconsistency retry
+        budget is exhausted), or the internal ``_IncrementalMergeFailed``
+        signal when the incremental-merge path cannot make progress and there
+        is no previous map to fall back on.
+
         :param str collection_link: The link to the collection.
         :param str collection_id: The unique identifier of the collection.
         :param previous_routing_map: The routing map to be updated. If None, a full load is performed.
         :type previous_routing_map: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap
         :param feed_options: Options for the change feed request.
         :type feed_options: dict or None
-        :return: The new or updated CollectionRoutingMap, or None if retrieval fails.
-        :rtype: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap or None
+        :return: The new or updated CollectionRoutingMap.
+        :rtype: azure.cosmos.routing.collection_routing_map.CollectionRoutingMap
+        :raises CosmosHttpResponseError: If the underlying ``/pkranges`` fetch
+            fails, or if every snapshot-inconsistency retry exhausts the
+            budget (surfaced as HTTP 503 so the upstream retry policy can
+            take over).
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -393,12 +393,8 @@ class PartitionKeyRangeCache(object):
 
                 raise
             except (_OverlapDetected, _GapDetected):
-                # Reset ``current_previous_map`` to ``None`` so the next
-                # iteration runs the full-load path: we do not want to keep
-                # retrying an incremental fetch against the same inconsistent
-                # base. ``_handle_transient_snapshot_retry_decision`` returns
-                # the backoff or raises a 503 once the attempt budget is
-                # exhausted.
+                # Reset to ``None`` so the next attempt runs a full refresh
+                # instead of merging onto the same inconsistent base.
                 inconsistency_attempt_count += 1
                 backoff = _handle_transient_snapshot_retry_decision(
                     retry_attempt_count=inconsistency_attempt_count,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -82,15 +82,9 @@ _shared_cache_refcounts: Dict[str, int] = {}
 # (``aio/routing_map_provider.py``) has its own independent set, so sync
 # and async clients targeting the same endpoint do not share state.
 #
-# Reentrant (``RLock``) because the dict operations inside ``__init__``'s
-# critical section can trigger cyclic GC at a CPython allocation safe-point.
-# If a ``PartitionKeyRangeCache`` participates in a reference cycle (e.g.
-# ``self._document_client`` -> ... -> ``self``), GC may sweep an unreachable
-# cycle on the same thread, run ``__del__`` -> ``release()``, and re-acquire
-# this lock. A plain ``Lock`` would deadlock; an ``RLock`` permits the
-# re-entry. A plain threading lock (rather than ``asyncio.Lock``) is fine
-# because the critical sections are pure dict reads/writes with no await
-# and no network I/O.
+# Reentrant (``RLock``) to tolerate same-thread re-entry (for example
+# ``__del__`` -> ``release()``) if future refactors add allocation points
+# inside this critical section.
 _shared_cache_lock = threading.RLock()
 
 
@@ -122,25 +116,29 @@ class PartitionKeyRangeCache(object):
         self._endpoint = _resolve_endpoint(client)
         self._released = False
 
-        # Share routing map cache, per-collection locks, and the meta-lock that
-        # guards the per-collection-lock dict across all clients with the same
-        # endpoint. Refcount lets us evict the entry when the last sharing
-        # client releases it (see ``release``).
+        # Share routing map cache, per-collection locks, and the lock that
+        # protects lock creation across clients for this endpoint.
+        # Defaults are allocated before locking so this block stays dict-only.
+        new_routing_map: Dict[str, CollectionRoutingMap] = {}
+        new_collection_locks: Dict[str, threading.Lock] = {}
+        new_locks_lock = threading.Lock()
+
         with _shared_cache_lock:
-            # See ``_shared_cache_lock`` module-level comment: the dict ops
-            # below can re-enter this lock via cyclic GC -> ``__del__`` ->
-            # ``release()`` on the same thread, which is why the lock is an
-            # ``RLock``. If this block is ever refactored to move dict ops
-            # outside the lock, revisit whether ``RLock`` is still required.
-            if self._endpoint not in _shared_routing_map_cache:
-                _shared_routing_map_cache[self._endpoint] = {}
-                _shared_collection_locks[self._endpoint] = {}
-                _shared_locks_locks[self._endpoint] = threading.Lock()
-                _shared_cache_refcounts[self._endpoint] = 0
-            _shared_cache_refcounts[self._endpoint] += 1
-            self._collection_routing_map_by_item = _shared_routing_map_cache[self._endpoint]
-            self._collection_locks: Dict[str, threading.Lock] = _shared_collection_locks[self._endpoint]
-            self._locks_lock: threading.Lock = _shared_locks_locks[self._endpoint]
+            # ``setdefault`` preserves existing endpoint entries.
+            routing_map = _shared_routing_map_cache.setdefault(
+                self._endpoint, new_routing_map)
+            collection_locks = _shared_collection_locks.setdefault(
+                self._endpoint, new_collection_locks)
+            locks_lock = _shared_locks_locks.setdefault(
+                self._endpoint, new_locks_lock)
+            # Preserve existing refcount instead of reinitializing.
+            _shared_cache_refcounts[self._endpoint] = (
+                _shared_cache_refcounts.get(self._endpoint, 0) + 1
+            )
+
+            self._collection_routing_map_by_item = routing_map
+            self._collection_locks: Dict[str, threading.Lock] = collection_locks
+            self._locks_lock: threading.Lock = locks_lock
 
     def clear_cache(self):
         """Clear the shared routing map cache for this endpoint.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -83,11 +83,21 @@ _shared_cache_refcounts: Dict[str, int] = {}
 # independent set of module-level dicts and its own ``_shared_cache_lock`` —
 # state is NOT shared between the sync and async modules. A sync and an async
 # ``CosmosClient`` targeting the same endpoint maintain separate routing-map
-# caches. We use a ``threading.Lock`` (rather than an ``asyncio.Lock``)
-# because the critical sections it protects are pure dict reads/writes — no
-# await, no network I/O — so a brief threading-lock acquisition is safe even
-# from a coroutine context (used by the async module's analogous lock).
-_shared_cache_lock = threading.Lock()
+# caches. We use a ``threading.RLock`` (rather than an ``asyncio.Lock`` or a
+# plain ``threading.Lock``) because the critical sections it protects are
+# pure dict reads/writes — no await, no network I/O — so a brief
+# threading-lock acquisition is safe even from a coroutine context (used by
+# the async module's analogous lock). ``RLock`` is required (not ``Lock``)
+# because ``__init__`` holds this lock while indexing into
+# ``_shared_routing_map_cache``, and that indexing can synchronously trigger
+# GC of an older ``PartitionKeyRangeCache`` instance on the same thread
+# (e.g. when ``client`` is a ``MagicMock`` whose ``_mock_set_magics`` drops
+# prior child-mock references; the same shape can fire in production any
+# time GC collects a prior instance during a new instance's ``__init__``).
+# GC runs ``__del__`` -> ``release()``, which re-acquires this same lock on
+# the same thread; with a non-reentrant ``Lock`` that re-acquisition would
+# deadlock the main thread (see ``test_fetch_routing_map_recovers_after_transient_gap``).
+_shared_cache_lock = threading.RLock()
 
 
 # pylint: disable=protected-access, line-too-long

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -78,25 +78,19 @@ _shared_locks_locks: Dict[str, threading.Lock] = {}
 # only wipes routing-map contents.
 _shared_cache_refcounts: Dict[str, int] = {}
 
-# Process-wide lock guarding the four dicts above for *this* (sync) module.
-# Note: the async module ``aio/routing_map_provider.py`` defines its own
-# independent set of module-level dicts and its own ``_shared_cache_lock`` —
-# state is NOT shared between the sync and async modules. A sync and an async
-# ``CosmosClient`` targeting the same endpoint maintain separate routing-map
-# caches. We use a ``threading.RLock`` (rather than an ``asyncio.Lock`` or a
-# plain ``threading.Lock``) because the critical sections it protects are
-# pure dict reads/writes — no await, no network I/O — so a brief
-# threading-lock acquisition is safe even from a coroutine context (used by
-# the async module's analogous lock). ``RLock`` is required (not ``Lock``)
-# because ``__init__`` holds this lock while indexing into
-# ``_shared_routing_map_cache``, and that indexing can synchronously trigger
-# GC of an older ``PartitionKeyRangeCache`` instance on the same thread
-# (e.g. when ``client`` is a ``MagicMock`` whose ``_mock_set_magics`` drops
-# prior child-mock references; the same shape can fire in production any
-# time GC collects a prior instance during a new instance's ``__init__``).
-# GC runs ``__del__`` -> ``release()``, which re-acquires this same lock on
-# the same thread; with a non-reentrant ``Lock`` that re-acquisition would
-# deadlock the main thread (see ``test_fetch_routing_map_recovers_after_transient_gap``).
+# Process-wide lock guarding the four dicts above. The async module
+# (``aio/routing_map_provider.py``) has its own independent set, so sync
+# and async clients targeting the same endpoint do not share state.
+#
+# Reentrant (``RLock``) because the dict operations inside ``__init__``'s
+# critical section can trigger cyclic GC at a CPython allocation safe-point.
+# If a ``PartitionKeyRangeCache`` participates in a reference cycle (e.g.
+# ``self._document_client`` -> ... -> ``self``), GC may sweep an unreachable
+# cycle on the same thread, run ``__del__`` -> ``release()``, and re-acquire
+# this lock. A plain ``Lock`` would deadlock; an ``RLock`` permits the
+# re-entry. A plain threading lock (rather than ``asyncio.Lock``) is fine
+# because the critical sections are pure dict reads/writes with no await
+# and no network I/O.
 _shared_cache_lock = threading.RLock()
 
 
@@ -133,6 +127,11 @@ class PartitionKeyRangeCache(object):
         # endpoint. Refcount lets us evict the entry when the last sharing
         # client releases it (see ``release``).
         with _shared_cache_lock:
+            # See ``_shared_cache_lock`` module-level comment: the dict ops
+            # below can re-enter this lock via cyclic GC -> ``__del__`` ->
+            # ``release()`` on the same thread, which is why the lock is an
+            # ``RLock``. If this block is ever refactored to move dict ops
+            # outside the lock, revisit whether ``RLock`` is still required.
             if self._endpoint not in _shared_routing_map_cache:
                 _shared_routing_map_cache[self._endpoint] = {}
                 _shared_collection_locks[self._endpoint] = {}

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -23,6 +23,7 @@
 Cosmos database service.
 """
 import threading
+import time
 import logging
 from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
@@ -37,6 +38,9 @@ from ._routing_map_provider_common import (
     determine_refresh_action,
     get_smart_overlapping_ranges,
     _IncrementalMergeFailed,
+    _OverlapDetected,
+    _OVERLAP_RETRY_MAX_ATTEMPTS,  # noqa: F401  # re-exported for tests
+    _handle_overlap_retry_decision,
 )
 
 if TYPE_CHECKING:
@@ -93,6 +97,10 @@ logger = logging.getLogger(__name__)
 # Number of extra incremental attempts after an incomplete incremental merge
 # before falling back to a full routing-map refresh.
 _INCOMPLETE_ROUTING_MAP_MAX_RETRIES = 1
+
+# Overlap-retry budget and backoff live in ``_routing_map_provider_common`` so
+# the sync and async providers cannot drift on them. ``_OVERLAP_RETRY_MAX_ATTEMPTS``
+# is re-exported through this module for test imports.
 class PartitionKeyRangeCache(object):
     """
     PartitionKeyRangeCache provides list of effective partition key ranges for a
@@ -314,6 +322,7 @@ class PartitionKeyRangeCache(object):
         """
         current_previous_map = previous_routing_map
         incomplete_attempt_count = 0
+        overlap_attempt_count = 0
 
         while True:
             request_kwargs = dict(kwargs)
@@ -368,6 +377,24 @@ class PartitionKeyRangeCache(object):
                     continue
 
                 raise
+            except _OverlapDetected:
+                # The full-load builder reported overlapping ranges. Apply
+                # the retry-on-overlap policy: ``_handle_overlap_retry_decision``
+                # either returns a backoff to sleep or raises ``CosmosHttpResponseError``
+                # (503) when the attempt budget is exhausted. Reset
+                # ``current_previous_map`` to ``None`` so the next iteration
+                # runs the full-load path regardless of which path tripped
+                # the overlap — we do not want to keep retrying an incremental
+                # fetch against the same inconsistent base.
+                overlap_attempt_count += 1
+                backoff = _handle_overlap_retry_decision(
+                    overlap_attempt_count=overlap_attempt_count,
+                    collection_link=collection_link,
+                    logger=logger,
+                )
+                time.sleep(backoff)
+                current_previous_map = None
+                continue
 
     def get_overlapping_ranges(self, collection_link, partition_key_ranges, feed_options, **kwargs):
         """Given a partition key range and a collection, return the list of

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/routing_map_provider.py
@@ -28,11 +28,7 @@ import logging
 from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from azure.core.utils import CaseInsensitiveDict
 from .. import _base, http_constants
-from .collection_routing_map import (
-    CollectionRoutingMap,
-    _OverlapDetected,
-    _GapDetected,
-)
+from .collection_routing_map import CollectionRoutingMap
 from ..exceptions import CosmosHttpResponseError
 from ._routing_map_provider_common import (
     _resolve_endpoint,
@@ -42,6 +38,8 @@ from ._routing_map_provider_common import (
     determine_refresh_action,
     get_smart_overlapping_ranges,
     _IncrementalMergeFailed,
+    _OverlapDetected,
+    _GapDetected,
     _handle_transient_snapshot_retry_decision,
 )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
@@ -44,7 +44,7 @@ from .. import exceptions
 from .._constants import _Constants
 from .._container_recreate_retry_policy import ContainerRecreateRetryPolicy
 from .._request_object import RequestObject
-from .._retry_utility import (_configure_timeout, _has_read_retryable_headers,
+from .._retry_utility import (_configure_timeout, _is_read_retryable_request,
                               _handle_service_response_retries, _handle_service_request_retries,
                               _has_database_account_header)
 from .._routing.routing_range import PartitionKeyRangeWrapper
@@ -412,7 +412,7 @@ class _ConnectionRetryPolicy(AsyncRetryPolicy):
                     from aiohttp.client_exceptions import (
                         ClientConnectionError)
                     if (isinstance(err.inner_exception, ClientConnectionError)
-                            or _has_read_retryable_headers(request.http_request.headers)):
+                            or _is_read_retryable_request(request.http_request, request_params)):
                         # This logic is based on the _retry.py file from azure-core
                         if retry_settings['read'] > 0:
                             # record the failure for circuit breaker tracking for retries in connection retry policy
@@ -436,7 +436,7 @@ class _ConnectionRetryPolicy(AsyncRetryPolicy):
                 if (_has_database_account_header(request.http_request.headers) or
                         request_params.healthy_tentative_location):
                     raise err
-                if _has_read_retryable_headers(request.http_request.headers) and retry_settings['read'] > 0:
+                if _is_read_retryable_request(request.http_request, request_params) and retry_settings['read'] > 0:
                     retry_active = self.increment(retry_settings, response=request, error=err)
                     if retry_active:
                         await self.sleep(retry_settings, request.context.transport)

--- a/sdk/cosmos/azure-cosmos/cspell.json
+++ b/sdk/cosmos/azure-cosmos/cspell.json
@@ -2,7 +2,11 @@
     "ignoreWords": [
         "hdrh",
         "hdrhistogram",
+        "dedup",
+        "deduped",
+        "deduping",
         "dedupe",
+        "dedups",
         "perfdb",
         "perfresults",
         "pkrange",

--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -2,4 +2,4 @@ aiohttp>=3.8.5,<=3.12.2
 ../../core/azure-core
 ../../identity/azure-identity
 -e ../../../eng/tools/azure-sdk-tools
-pytest-timeout==2.3.1
+pytest-timeout>=2.3.1

--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -2,3 +2,4 @@ aiohttp>=3.8.5,<=3.12.2
 ../../core/azure-core
 ../../identity/azure-identity
 -e ../../../eng/tools/azure-sdk-tools
+pytest-timeout==2.3.1

--- a/sdk/cosmos/azure-cosmos/pytest.ini
+++ b/sdk/cosmos/azure-cosmos/pytest.ini
@@ -1,10 +1,9 @@
 [pytest]
-# Per-test wall-clock budget (seconds). Slowest legitimate test in the
-# cosmosEmulator lane runs ~57s; partition-split tests on the cosmosSplit
-# lane can run several minutes. 900s gives ~15x headroom over the slowest
-# known test while still failing fast on a genuinely hung test instead of
-# letting it consume the ADO step cap.
+# Per-test wall-clock budget in seconds.
 timeout = 900
+# Use thread-based timeout handling so async tests can be interrupted
+# consistently across platforms.
+timeout_method = thread
 markers =
     cosmosEmulator: marks tests as depending in Cosmos DB Emulator.
     cosmosLong: marks tests to be run on a Cosmos DB live account.

--- a/sdk/cosmos/azure-cosmos/pytest.ini
+++ b/sdk/cosmos/azure-cosmos/pytest.ini
@@ -1,4 +1,10 @@
 [pytest]
+# Per-test wall-clock budget (seconds). Slowest legitimate test in the
+# cosmosEmulator lane runs ~57s; partition-split tests on the cosmosSplit
+# lane can run several minutes. 900s gives ~15x headroom over the slowest
+# known test while still failing fast on a genuinely hung test instead of
+# letting it consume the ADO step cap.
+timeout = 900
 markers =
     cosmosEmulator: marks tests as depending in Cosmos DB Emulator.
     cosmosLong: marks tests to be run on a Cosmos DB live account.

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
@@ -7,7 +7,11 @@ import logging
 import pytest
 
 import azure.cosmos._routing.routing_range as routing_range
-from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap, _build_routing_map_from_ranges
+from azure.cosmos._routing.collection_routing_map import (
+    CollectionRoutingMap,
+    _build_routing_map_from_ranges,
+    _OverlapDetected,
+)
 
 
 @pytest.mark.cosmosEmulator
@@ -448,6 +452,142 @@ class TestCollectionRoutingMap(unittest.TestCase):
 
         result_none_etag = _build_routing_map_from_ranges(ranges, 'coll1', None, 'link', _logger)
         self.assertIsNone(result_none_etag.change_feed_etag)
+
+    # ==========================================================================
+    # Regression tests for ValueError("Ranges overlap") triggered by transient
+    # /pkranges snapshot inconsistencies at high partition counts.
+    #
+    # These tests reproduce three concrete failure modes observed against a
+    # customer container with ~25.6k physical partitions during a long-running
+    # async Spark scan.
+    #
+    # The desired behaviour at the builder layer is one of two outcomes per
+    # mode, never a bare ``ValueError`` escaping to the caller (which would
+    # otherwise reach ``get_overlapping_ranges`` where a ``None`` routing map
+    # silently returns an empty list — a correctness bug, not a crash):
+    #
+    #   * Mode 1 (duplicate range across pages) — the builder must dedup by
+    #     id BEFORE validation and succeed, since duplicates describe the
+    #     same logical range.
+    #
+    #   * Modes 2 and 3 (stale parent / surviving grandparent with broken
+    #     intermediate references) -- the builder cannot reconstruct what is
+    #     not in the data, so it must convert the unrecoverable-from-this-
+    #     snapshot ``ValueError`` into a typed ``_OverlapDetected`` sentinel.
+    #     The caller (`_fetch_routing_map`) catches the sentinel, retries
+    #     after a brief backoff, and ultimately surfaces a typed transient
+    #     HTTP 503 if the inconsistency persists across the retry budget.
+    # ==========================================================================
+
+    def test_full_load_dedups_duplicate_range_id_across_pages_mode_1(self):
+        """Mode 1 (duplicate range across pages): when /pkranges pagination
+        returns the same range id on two consecutive pages because two gateway
+        nodes serve from slightly different cached snapshots, the SDK should
+        dedup by id (last-write-wins) before validating and produce a valid
+        routing map — not raise."""
+        _logger = logging.getLogger("test")
+        # Range id '1' appears twice because page boundary fell between two
+        # gateway nodes with one-tick-out-of-sync caches.
+        ranges = [
+            {'id': '0', 'minInclusive': '',   'maxExclusive': '40'},
+            {'id': '1', 'minInclusive': '40', 'maxExclusive': '80'},
+            {'id': '1', 'minInclusive': '40', 'maxExclusive': '80'},  # duplicate from next page
+            {'id': '2', 'minInclusive': '80', 'maxExclusive': 'C0'},
+            {'id': '3', 'minInclusive': 'C0', 'maxExclusive': 'FF'},
+        ]
+        result = _build_routing_map_from_ranges(ranges, 'coll1', '"etag-dup"', 'dbs/db/colls/coll1', _logger)
+
+        self.assertIsNotNone(
+            result,
+            "Duplicate range id across pages should be deduped, not crash the builder."
+        )
+        ids = [r['id'] for r in result._orderedPartitionKeyRanges]
+        self.assertEqual(ids, ['0', '1', '2', '3'])
+
+    def test_full_load_raises_overlap_sentinel_for_stale_parent_with_missing_child_refs_mode_2(self):
+        """Mode 2 (stale parent, children missing parent reference): when a
+        gateway node returns a freshly-split parent alongside its children but
+        the children's 'parents' fields fail to reference the parent (because
+        the lineage metadata hadn't fully propagated when that node served the
+        page), _build_routing_map_from_ranges should convert the underlying
+        ValueError into _OverlapDetected so the caller can retry — and the
+        sentinel must NOT be a plain ValueError, since a plain ValueError
+        would escape to the cache layer and silently return empty results
+        from get_overlapping_ranges."""
+        _logger = logging.getLogger("test")
+        # Parent '10' was split into '10/0' and '10/1', but the children on
+        # this page lost their 'parents': ['10'] reference. The one-direction
+        # parent filter cannot remove '10' because no surviving range names it.
+        ranges = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},  # unaffected left neighbor
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},  # SHOULD have parents=['10']
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},  # SHOULD have parents=['10']
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},  # unaffected right neighbor
+        ]
+        with self.assertRaises(_OverlapDetected):
+            _build_routing_map_from_ranges(ranges, 'coll1', '"etag-stale-parent"', 'dbs/db/colls/coll1', _logger)
+
+    def test_full_load_raises_overlap_sentinel_for_grandparent_surviving_cascade_split_mode_3(self):
+        """Mode 3 (grandparent surviving a cascade split): when two generations
+        of splits have completed and the intermediate parent drops its
+        reference to the grandparent, the grandparent survives every available
+        defense and overlaps its grandchildren. _build_routing_map_from_ranges
+        should convert this into _OverlapDetected so the caller can retry."""
+        _logger = logging.getLogger("test")
+        # '10' split into '10/0' and '10/1'; then '10/0' split into '10/0/0'
+        # and '10/0/1'. The grandchildren reference '10/0' correctly, but
+        # '10/0' and '10/1' both lost their 'parents': ['10'] reference, so
+        # the parent filter only collects {'10/0'} and leaves '10' in place.
+        ranges = [
+            {'id': 'L',       'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',      'minInclusive': '80', 'maxExclusive': 'A0'},                           # grandparent
+            {'id': '10/0',    'minInclusive': '80', 'maxExclusive': '90'},                           # SHOULD have parents=['10']
+            {'id': '10/0/0',  'minInclusive': '80', 'maxExclusive': '88', 'parents': ['10/0']},
+            {'id': '10/0/1',  'minInclusive': '88', 'maxExclusive': '90', 'parents': ['10/0']},
+            {'id': '10/1',    'minInclusive': '90', 'maxExclusive': 'A0'},                           # SHOULD have parents=['10']
+            {'id': 'R',       'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        with self.assertRaises(_OverlapDetected):
+            _build_routing_map_from_ranges(ranges, 'coll1', '"etag-cascade"', 'dbs/db/colls/coll1', _logger)
+
+    def test_overlap_sentinel_is_not_a_value_error(self):
+        """``_OverlapDetected`` must not be a subclass of ``ValueError`` (or any
+        other exception type that callers in the cache layer have historically
+        caught and swallowed). If it were, the very catch sites that today let
+        the bug crash the scan would silently absorb the sentinel and convert
+        it into the same empty-result correctness bug we were trying to avoid.
+
+        The sentinel must be plainly an ``Exception``, distinguishable by
+        type, so the dedicated retry loop in ``_fetch_routing_map`` is the
+        only handler."""
+        self.assertFalse(
+            issubclass(_OverlapDetected, ValueError),
+            "_OverlapDetected must not inherit from ValueError -- that would "
+            "allow legacy ValueError catches to absorb the retry signal."
+        )
+        # Should still be a concrete Exception subclass (sanity check).
+        self.assertTrue(issubclass(_OverlapDetected, Exception))
+
+    def test_overlap_error_message_identifies_offending_ranges(self):
+        """When is_complete_set_of_range is called directly with genuinely
+        overlapping input (i.e. an unrecoverable programmer error rather than
+        a transient gateway snapshot), the ValueError message should identify
+        which two ranges overlapped so that whoever investigates the next
+        occurrence has actionable diagnostics out of the box."""
+        ranges = [
+            {'id': 'A', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'B', 'minInclusive': '40', 'maxExclusive': 'FF'},  # overlaps with A
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            CollectionRoutingMap.is_complete_set_of_range(ranges)
+
+        msg = str(ctx.exception)
+        self.assertIn('overlap', msg.lower())
+        self.assertIn('A', msg, "Error message should name the previous (offending) range id.")
+        self.assertIn('B', msg, "Error message should name the current (offending) range id.")
+        self.assertIn('80', msg, "Error message should include the previous range's maxExclusive.")
+        self.assertIn('40', msg, "Error message should include the current range's minInclusive.")
 
 
 if __name__ == '__main__':

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
@@ -11,6 +11,7 @@ from azure.cosmos._routing.collection_routing_map import (
     CollectionRoutingMap,
     _build_routing_map_from_ranges,
     _OverlapDetected,
+    _GapDetected,
 )
 
 
@@ -416,16 +417,23 @@ class TestCollectionRoutingMap(unittest.TestCase):
         ids = [r['id'] for r in result._orderedPartitionKeyRanges]
         self.assertEqual(ids, ['0', '1'])
 
-    def test_build_routing_map_returns_none_for_incomplete_ranges(self):
-        """_build_routing_map_from_ranges returns None when the filtered ranges
-        don't form a complete partition key space (gap exists)."""
+    def test_build_routing_map_raises_gap_detected_for_incomplete_ranges(self):
+        """_build_routing_map_from_ranges raises ``_GapDetected`` when the
+        filtered ranges don't form a complete partition key space (gap exists).
+        The caller catches this and applies the same bounded-retry-then-503
+        policy as ``_OverlapDetected``; without this raise the downstream
+        ``SmartRoutingMapProvider`` would crash with ``AssertionError("code
+        bug: returned overlapping ranges ... is empty")`` when the resulting
+        empty range list flows into its generator."""
         _logger = logging.getLogger("test")
         ranges = [
             {'id': '0', 'minInclusive': '', 'maxExclusive': '80'},
             # Gap from '80' to 'FF' — incomplete
         ]
-        result = _build_routing_map_from_ranges(ranges, 'coll1', '"etag-4"', 'dbs/db/colls/coll1', _logger)
-        self.assertIsNone(result, "Should return None for incomplete range coverage")
+        with self.assertRaises(_GapDetected):
+            _build_routing_map_from_ranges(
+                ranges, 'coll1', '"etag-4"', 'dbs/db/colls/coll1', _logger
+            )
 
     def test_build_routing_map_empty_parents_list_not_treated_as_gone(self):
         """_build_routing_map_from_ranges does NOT filter a range whose 'parents'
@@ -454,33 +462,14 @@ class TestCollectionRoutingMap(unittest.TestCase):
         self.assertIsNone(result_none_etag.change_feed_etag)
 
     # ==========================================================================
-    # Regression tests for ValueError("Ranges overlap") triggered by transient
-    # /pkranges snapshot inconsistencies at high partition counts.
-    #
-    # These tests reproduce three concrete failure modes observed against a
-    # customer container with ~25.6k physical partitions during a long-running
-    # async Spark scan.
-    #
-    # The desired behaviour at the builder layer is one of two outcomes per
-    # mode, never a bare ``ValueError`` escaping to the caller (which would
-    # otherwise reach ``get_overlapping_ranges`` where a ``None`` routing map
-    # silently returns an empty list — a correctness bug, not a crash):
-    #
-    #   * Mode 1 (duplicate range across pages) — the builder must dedup by
-    #     id BEFORE validation and succeed, since duplicates describe the
-    #     same logical range.
-    #
-    #   * Modes 2 and 3 (stale parent / surviving grandparent with broken
-    #     intermediate references) -- the builder cannot reconstruct what is
-    #     not in the data, so it must convert the unrecoverable-from-this-
-    #     snapshot ``ValueError`` into a typed ``_OverlapDetected`` sentinel.
-    #     The caller (`_fetch_routing_map`) catches the sentinel, retries
-    #     after a brief backoff, and ultimately surfaces a typed transient
-    #     HTTP 503 if the inconsistency persists across the retry budget.
+    # Regression tests for transient /pkranges snapshot inconsistencies.
+    # The builder must either succeed (after deduping duplicates by id) or
+    # raise ``_OverlapDetected`` — never let a bare ``ValueError`` reach
+    # ``get_overlapping_ranges``, which would silently return an empty list.
     # ==========================================================================
 
     def test_full_load_dedups_duplicate_range_id_across_pages_mode_1(self):
-        """Mode 1 (duplicate range across pages): when /pkranges pagination
+        """Duplicate range across pages: when /pkranges pagination
         returns the same range id on two consecutive pages because two gateway
         nodes serve from slightly different cached snapshots, the SDK should
         dedup by id (last-write-wins) before validating and produce a valid
@@ -505,13 +494,13 @@ class TestCollectionRoutingMap(unittest.TestCase):
         self.assertEqual(ids, ['0', '1', '2', '3'])
 
     def test_full_load_raises_overlap_sentinel_for_stale_parent_with_missing_child_refs_mode_2(self):
-        """Mode 2 (stale parent, children missing parent reference): when a
+        """Stale parent with children missing parent reference: when a
         gateway node returns a freshly-split parent alongside its children but
         the children's 'parents' fields fail to reference the parent (because
         the lineage metadata hadn't fully propagated when that node served the
         page), _build_routing_map_from_ranges should convert the underlying
         ValueError into _OverlapDetected so the caller can retry — and the
-        sentinel must NOT be a plain ValueError, since a plain ValueError
+        exception must NOT be a plain ValueError, since a plain ValueError
         would escape to the cache layer and silently return empty results
         from get_overlapping_ranges."""
         _logger = logging.getLogger("test")
@@ -529,7 +518,7 @@ class TestCollectionRoutingMap(unittest.TestCase):
             _build_routing_map_from_ranges(ranges, 'coll1', '"etag-stale-parent"', 'dbs/db/colls/coll1', _logger)
 
     def test_full_load_raises_overlap_sentinel_for_grandparent_surviving_cascade_split_mode_3(self):
-        """Mode 3 (grandparent surviving a cascade split): when two generations
+        """Grandparent surviving a cascade split: when two generations
         of splits have completed and the intermediate parent drops its
         reference to the grandparent, the grandparent survives every available
         defense and overlaps its grandchildren. _build_routing_map_from_ranges
@@ -551,14 +540,45 @@ class TestCollectionRoutingMap(unittest.TestCase):
         with self.assertRaises(_OverlapDetected):
             _build_routing_map_from_ranges(ranges, 'coll1', '"etag-cascade"', 'dbs/db/colls/coll1', _logger)
 
+    def test_full_load_raises_gap_detected_for_hole_in_key_space(self):
+        """Mirror of the overlap scenarios for the gap side: when one gateway
+        node has propagated the deletion of a parent but the children have
+        not yet appeared in its view, the response is missing the range that
+        used to cover the deleted parent's span. The builder must convert
+        this into ``_GapDetected`` so the caller applies the same bounded
+        retry. Without this, the empty ``get_overlapping_ranges`` result
+        crashes ``SmartRoutingMapProvider`` with ``AssertionError("code
+        bug: ...")``."""
+        _logger = logging.getLogger("test")
+        # Parent '10' covered "80" -> "A0" and was just deleted; its
+        # children 10/0 and 10/1 have not yet propagated to this node's view.
+        ranges = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+            # Hole "80" -> "A0" is unclaimed.
+        ]
+        with self.assertRaises(_GapDetected):
+            _build_routing_map_from_ranges(ranges, 'coll1', '"etag-gap"', 'dbs/db/colls/coll1', _logger)
+
+    def test_gap_detected_is_not_a_value_error(self):
+        """Same invariant as for ``_OverlapDetected``: ``_GapDetected`` must
+        be distinguishable by type and must not be silently absorbed by any
+        ``except ValueError`` catch in the cache layer."""
+        self.assertFalse(
+            issubclass(_GapDetected, ValueError),
+            "_GapDetected must not inherit from ValueError -- that would "
+            "allow legacy ValueError catches to absorb the retry signal."
+        )
+        self.assertTrue(issubclass(_GapDetected, Exception))
+
     def test_overlap_sentinel_is_not_a_value_error(self):
         """``_OverlapDetected`` must not be a subclass of ``ValueError`` (or any
         other exception type that callers in the cache layer have historically
         caught and swallowed). If it were, the very catch sites that today let
-        the bug crash the scan would silently absorb the sentinel and convert
+        the bug crash the scan would silently absorb the signal and convert
         it into the same empty-result correctness bug we were trying to avoid.
 
-        The sentinel must be plainly an ``Exception``, distinguishable by
+        The exception must be plainly an ``Exception``, distinguishable by
         type, so the dedicated retry loop in ``_fetch_routing_map`` is the
         only handler."""
         self.assertFalse(
@@ -574,7 +594,16 @@ class TestCollectionRoutingMap(unittest.TestCase):
         overlapping input (i.e. an unrecoverable programmer error rather than
         a transient gateway snapshot), the ValueError message should identify
         which two ranges overlapped so that whoever investigates the next
-        occurrence has actionable diagnostics out of the box."""
+        occurrence has actionable diagnostics out of the box.
+
+        Also pins the literal ``"Ranges overlap"`` prefix on the message.
+        The full-load guard in ``_build_routing_map_from_ranges`` and the
+        incremental-merge guard in ``process_fetched_ranges`` both rely on
+        ``str(err).startswith("Ranges overlap")`` to distinguish the
+        snapshot-inconsistency case from any unrelated future ``ValueError``.
+        If this prefix ever changes, those guards will silently start
+        re-raising what they were meant to convert, so the prefix is part
+        of the contract and gets asserted here."""
         ranges = [
             {'id': 'A', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'B', 'minInclusive': '40', 'maxExclusive': 'FF'},  # overlaps with A
@@ -583,7 +612,12 @@ class TestCollectionRoutingMap(unittest.TestCase):
             CollectionRoutingMap.is_complete_set_of_range(ranges)
 
         msg = str(ctx.exception)
-        self.assertIn('overlap', msg.lower())
+        self.assertTrue(
+            msg.startswith("Ranges overlap"),
+            "Message must start with the literal 'Ranges overlap' prefix that "
+            "the production guards in _build_routing_map_from_ranges and "
+            "process_fetched_ranges match against. Got: {!r}".format(msg),
+        )
         self.assertIn('A', msg, "Error message should name the previous (offending) range id.")
         self.assertIn('B', msg, "Error message should name the current (offending) range id.")
         self.assertIn('80', msg, "Error message should include the previous range's maxExclusive.")

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_collection_routing_map.py
@@ -418,13 +418,8 @@ class TestCollectionRoutingMap(unittest.TestCase):
         self.assertEqual(ids, ['0', '1'])
 
     def test_build_routing_map_raises_gap_detected_for_incomplete_ranges(self):
-        """_build_routing_map_from_ranges raises ``_GapDetected`` when the
-        filtered ranges don't form a complete partition key space (gap exists).
-        The caller catches this and applies the same bounded-retry-then-503
-        policy as ``_OverlapDetected``; without this raise the downstream
-        ``SmartRoutingMapProvider`` would crash with ``AssertionError("code
-        bug: returned overlapping ranges ... is empty")`` when the resulting
-        empty range list flows into its generator."""
+        """``_build_routing_map_from_ranges`` raises ``_GapDetected`` when
+        the filtered ranges have a gap in the partition key space."""
         _logger = logging.getLogger("test")
         ranges = [
             {'id': '0', 'minInclusive': '', 'maxExclusive': '80'},
@@ -462,21 +457,16 @@ class TestCollectionRoutingMap(unittest.TestCase):
         self.assertIsNone(result_none_etag.change_feed_etag)
 
     # ==========================================================================
-    # Regression tests for transient /pkranges snapshot inconsistencies.
-    # The builder must either succeed (after deduping duplicates by id) or
-    # raise ``_OverlapDetected`` — never let a bare ``ValueError`` reach
-    # ``get_overlapping_ranges``, which would silently return an empty list.
+    # Regression tests for transient ``/pkranges`` snapshot inconsistencies.
+    # The builder must either succeed (after deduping by id) or raise
+    # ``_OverlapDetected`` / ``_GapDetected`` -- a bare ``ValueError`` must
+    # never reach ``get_overlapping_ranges``.
     # ==========================================================================
 
     def test_full_load_dedups_duplicate_range_id_across_pages_mode_1(self):
-        """Duplicate range across pages: when /pkranges pagination
-        returns the same range id on two consecutive pages because two gateway
-        nodes serve from slightly different cached snapshots, the SDK should
-        dedup by id (last-write-wins) before validating and produce a valid
-        routing map — not raise."""
+        """A duplicate range id repeated across paginated pages should be
+        deduped (last-write-wins) before validation, producing a valid map."""
         _logger = logging.getLogger("test")
-        # Range id '1' appears twice because page boundary fell between two
-        # gateway nodes with one-tick-out-of-sync caches.
         ranges = [
             {'id': '0', 'minInclusive': '',   'maxExclusive': '40'},
             {'id': '1', 'minInclusive': '40', 'maxExclusive': '80'},
@@ -494,64 +484,50 @@ class TestCollectionRoutingMap(unittest.TestCase):
         self.assertEqual(ids, ['0', '1', '2', '3'])
 
     def test_full_load_raises_overlap_sentinel_for_stale_parent_with_missing_child_refs_mode_2(self):
-        """Stale parent with children missing parent reference: when a
-        gateway node returns a freshly-split parent alongside its children but
-        the children's 'parents' fields fail to reference the parent (because
-        the lineage metadata hadn't fully propagated when that node served the
-        page), _build_routing_map_from_ranges should convert the underlying
-        ValueError into _OverlapDetected so the caller can retry — and the
-        exception must NOT be a plain ValueError, since a plain ValueError
-        would escape to the cache layer and silently return empty results
-        from get_overlapping_ranges."""
+        """A stale parent alongside children that lack ``parents`` references
+        must convert the underlying ``ValueError`` into ``_OverlapDetected``,
+        not escape as a bare ``ValueError``."""
         _logger = logging.getLogger("test")
         # Parent '10' was split into '10/0' and '10/1', but the children on
-        # this page lost their 'parents': ['10'] reference. The one-direction
-        # parent filter cannot remove '10' because no surviving range names it.
+        # this page lost their ``parents': ['10']`` reference. The parent
+        # filter cannot remove '10' because no surviving range names it.
         ranges = [
-            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},  # unaffected left neighbor
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
-            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},  # SHOULD have parents=['10']
-            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},  # SHOULD have parents=['10']
-            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},  # unaffected right neighbor
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},  # missing parents=['10']
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},  # missing parents=['10']
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
         ]
         with self.assertRaises(_OverlapDetected):
             _build_routing_map_from_ranges(ranges, 'coll1', '"etag-stale-parent"', 'dbs/db/colls/coll1', _logger)
 
     def test_full_load_raises_overlap_sentinel_for_grandparent_surviving_cascade_split_mode_3(self):
-        """Grandparent surviving a cascade split: when two generations
-        of splits have completed and the intermediate parent drops its
-        reference to the grandparent, the grandparent survives every available
-        defense and overlaps its grandchildren. _build_routing_map_from_ranges
-        should convert this into _OverlapDetected so the caller can retry."""
+        """A grandparent that survives a cascade split because intermediate
+        parents lost their ``parents`` references must raise
+        ``_OverlapDetected``."""
         _logger = logging.getLogger("test")
-        # '10' split into '10/0' and '10/1'; then '10/0' split into '10/0/0'
-        # and '10/0/1'. The grandchildren reference '10/0' correctly, but
-        # '10/0' and '10/1' both lost their 'parents': ['10'] reference, so
-        # the parent filter only collects {'10/0'} and leaves '10' in place.
+        # '10' split into '10/0' and '10/1'; '10/0' split into '10/0/0' and
+        # '10/0/1'. The grandchildren reference '10/0' correctly, but '10/0'
+        # and '10/1' both lost their ``parents': ['10']`` reference, so the
+        # parent filter only collects {'10/0'} and leaves '10' in place.
         ranges = [
             {'id': 'L',       'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',      'minInclusive': '80', 'maxExclusive': 'A0'},                           # grandparent
-            {'id': '10/0',    'minInclusive': '80', 'maxExclusive': '90'},                           # SHOULD have parents=['10']
+            {'id': '10/0',    'minInclusive': '80', 'maxExclusive': '90'},                           # missing parents=['10']
             {'id': '10/0/0',  'minInclusive': '80', 'maxExclusive': '88', 'parents': ['10/0']},
             {'id': '10/0/1',  'minInclusive': '88', 'maxExclusive': '90', 'parents': ['10/0']},
-            {'id': '10/1',    'minInclusive': '90', 'maxExclusive': 'A0'},                           # SHOULD have parents=['10']
+            {'id': '10/1',    'minInclusive': '90', 'maxExclusive': 'A0'},                           # missing parents=['10']
             {'id': 'R',       'minInclusive': 'A0', 'maxExclusive': 'FF'},
         ]
         with self.assertRaises(_OverlapDetected):
             _build_routing_map_from_ranges(ranges, 'coll1', '"etag-cascade"', 'dbs/db/colls/coll1', _logger)
 
     def test_full_load_raises_gap_detected_for_hole_in_key_space(self):
-        """Mirror of the overlap scenarios for the gap side: when one gateway
-        node has propagated the deletion of a parent but the children have
-        not yet appeared in its view, the response is missing the range that
-        used to cover the deleted parent's span. The builder must convert
-        this into ``_GapDetected`` so the caller applies the same bounded
-        retry. Without this, the empty ``get_overlapping_ranges`` result
-        crashes ``SmartRoutingMapProvider`` with ``AssertionError("code
-        bug: ...")``."""
+        """A snapshot with a hole in the key space must raise
+        ``_GapDetected`` so the caller retries."""
         _logger = logging.getLogger("test")
         # Parent '10' covered "80" -> "A0" and was just deleted; its
-        # children 10/0 and 10/1 have not yet propagated to this node's view.
+        # children have not yet propagated to this view.
         ranges = [
             {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
@@ -561,49 +537,28 @@ class TestCollectionRoutingMap(unittest.TestCase):
             _build_routing_map_from_ranges(ranges, 'coll1', '"etag-gap"', 'dbs/db/colls/coll1', _logger)
 
     def test_gap_detected_is_not_a_value_error(self):
-        """Same invariant as for ``_OverlapDetected``: ``_GapDetected`` must
-        be distinguishable by type and must not be silently absorbed by any
-        ``except ValueError`` catch in the cache layer."""
+        """``_GapDetected`` must not inherit from ``ValueError`` so legacy
+        ``except ValueError`` blocks cannot absorb the retry signal."""
         self.assertFalse(
             issubclass(_GapDetected, ValueError),
-            "_GapDetected must not inherit from ValueError -- that would "
-            "allow legacy ValueError catches to absorb the retry signal."
+            "_GapDetected must not inherit from ValueError."
         )
         self.assertTrue(issubclass(_GapDetected, Exception))
 
     def test_overlap_sentinel_is_not_a_value_error(self):
-        """``_OverlapDetected`` must not be a subclass of ``ValueError`` (or any
-        other exception type that callers in the cache layer have historically
-        caught and swallowed). If it were, the very catch sites that today let
-        the bug crash the scan would silently absorb the signal and convert
-        it into the same empty-result correctness bug we were trying to avoid.
-
-        The exception must be plainly an ``Exception``, distinguishable by
-        type, so the dedicated retry loop in ``_fetch_routing_map`` is the
-        only handler."""
+        """``_OverlapDetected`` must not inherit from ``ValueError`` so legacy
+        ``except ValueError`` blocks cannot absorb the retry signal."""
         self.assertFalse(
             issubclass(_OverlapDetected, ValueError),
-            "_OverlapDetected must not inherit from ValueError -- that would "
-            "allow legacy ValueError catches to absorb the retry signal."
+            "_OverlapDetected must not inherit from ValueError."
         )
-        # Should still be a concrete Exception subclass (sanity check).
         self.assertTrue(issubclass(_OverlapDetected, Exception))
 
     def test_overlap_error_message_identifies_offending_ranges(self):
-        """When is_complete_set_of_range is called directly with genuinely
-        overlapping input (i.e. an unrecoverable programmer error rather than
-        a transient gateway snapshot), the ValueError message should identify
-        which two ranges overlapped so that whoever investigates the next
-        occurrence has actionable diagnostics out of the box.
-
-        Also pins the literal ``"Ranges overlap"`` prefix on the message.
-        The full-load guard in ``_build_routing_map_from_ranges`` and the
-        incremental-merge guard in ``process_fetched_ranges`` both rely on
-        ``str(err).startswith("Ranges overlap")`` to distinguish the
-        snapshot-inconsistency case from any unrelated future ``ValueError``.
-        If this prefix ever changes, those guards will silently start
-        re-raising what they were meant to convert, so the prefix is part
-        of the contract and gets asserted here."""
+        """The ``ValueError`` raised by ``is_complete_set_of_range`` for
+        genuinely overlapping input should name the offending ranges and
+        start with the ``"Ranges overlap"`` prefix that production guards
+        match against."""
         ranges = [
             {'id': 'A', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'B', 'minInclusive': '40', 'maxExclusive': 'FF'},  # overlaps with A
@@ -614,12 +569,10 @@ class TestCollectionRoutingMap(unittest.TestCase):
         msg = str(ctx.exception)
         self.assertTrue(
             msg.startswith("Ranges overlap"),
-            "Message must start with the literal 'Ranges overlap' prefix that "
-            "the production guards in _build_routing_map_from_ranges and "
-            "process_fetched_ranges match against. Got: {!r}".format(msg),
+            "Message must start with the 'Ranges overlap' prefix. Got: {!r}".format(msg),
         )
-        self.assertIn('A', msg, "Error message should name the previous (offending) range id.")
-        self.assertIn('B', msg, "Error message should name the current (offending) range id.")
+        self.assertIn('A', msg, "Error message should name the previous range id.")
+        self.assertIn('B', msg, "Error message should name the current range id.")
         self.assertIn('80', msg, "Error message should include the previous range's maxExclusive.")
         self.assertIn('40', msg, "Error message should include the current range's minInclusive.")
 

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_pkrange_cache_init_reentrant.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_pkrange_cache_init_reentrant.py
@@ -1,0 +1,170 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+"""Regression tests for GC re-entry during ``PartitionKeyRangeCache.__init__``.
+
+These tests cover the partial-clear + re-entrant ``release()`` path that
+previously caused a KeyError.
+"""
+
+from __future__ import annotations
+
+import gc
+import threading
+import unittest
+
+import pytest
+
+from azure.cosmos._routing.routing_map_provider import (
+    PartitionKeyRangeCache,
+    _shared_routing_map_cache,
+    _shared_cache_lock,
+    _shared_collection_locks,
+    _shared_locks_locks,
+    _shared_cache_refcounts,
+)
+
+
+_ENDPOINT = "https://pkrange-init-reentry.documents.azure.com:443/"
+
+
+class _MockClient:
+    """Minimal mock client with a cycle slot used by the regression setup."""
+
+    def __init__(self, url):
+        self.url_connection = url
+        self.cycle_ref = None
+
+
+def _reset_shared_state():
+    """Reset all four shared-cache globals."""
+    gc.collect()
+    with _shared_cache_lock:
+        _shared_routing_map_cache.clear()
+        _shared_collection_locks.clear()
+        _shared_locks_locks.clear()
+        _shared_cache_refcounts.clear()
+
+
+@pytest.mark.cosmosEmulator
+class TestPartitionKeyRangeCacheInitReentrant(unittest.TestCase):
+    """Deterministic regression for the GC re-entry KeyError."""
+
+    def setUp(self):
+        _reset_shared_state()
+        gc.disable()  # only the test's monkey-patched Lock() triggers GC
+        self._real_lock = threading.Lock
+
+    def tearDown(self):
+        threading.Lock = self._real_lock  # type: ignore[assignment]
+        gc.enable()
+        _reset_shared_state()
+
+    def _make_orphan_in_cycle(self):
+        """Build a cycle-pinned cache instance collectible only by cyclic GC."""
+        client = _MockClient(_ENDPOINT)
+        cache = PartitionKeyRangeCache(client)
+        # Cycle: client.cycle_ref -> cache -> cache._document_client -> client
+        client.cycle_ref = cache
+
+    def test_init_survives_reentrant_release_via_gc_during_lock_alloc(self):
+        """Constructor should not raise when GC re-enters ``release()``."""
+        # Create an orphan in a cycle so GC owns finalization.
+        self._make_orphan_in_cycle()
+        self.assertEqual(
+            _shared_cache_refcounts.get(_ENDPOINT), 1,
+            "precondition: orphan creation must register refcount == 1",
+        )
+
+        # Simulate historical partial cleanup that cleared only one dict.
+        with _shared_cache_lock:
+            _shared_routing_map_cache.clear()
+
+        # Force cyclic GC on the first ``threading.Lock()`` call in next init.
+        real_lock = self._real_lock
+        fired = {"count": 0}
+
+        def gc_triggering_lock(*args, **kwargs):
+            if fired["count"] == 0:
+                fired["count"] += 1
+                gc.collect()
+            return real_lock(*args, **kwargs)
+
+        threading.Lock = gc_triggering_lock  # type: ignore[assignment]
+        try:
+            # Construct a new cache; this used to raise KeyError.
+            new_client = _MockClient(_ENDPOINT)
+            cache = PartitionKeyRangeCache(new_client)
+        finally:
+            threading.Lock = real_lock  # type: ignore[assignment]
+
+        # Ensure this test actually exercised the GC-triggered path.
+        self.assertGreaterEqual(
+            fired["count"], 1,
+            "test invariant: the monkey-patched Lock() must have fired GC "
+            "at least once during __init__",
+        )
+
+        # New cache must bind to entries currently in shared registries.
+        self.assertIs(
+            cache._collection_routing_map_by_item,
+            _shared_routing_map_cache[_ENDPOINT],
+            "new cache must bind to the routing-map dict currently in the registry",
+        )
+        self.assertIs(
+            cache._collection_locks,
+            _shared_collection_locks[_ENDPOINT],
+            "new cache must bind to the collection-locks dict currently in the registry",
+        )
+        self.assertIs(
+            cache._locks_lock,
+            _shared_locks_locks[_ENDPOINT],
+            "new cache must bind to the meta-lock currently in the registry",
+        )
+
+        # Refcount should be one live cache after orphan release + new init.
+        self.assertEqual(
+            _shared_cache_refcounts[_ENDPOINT], 1,
+            "refcount must be 1 (orphan released by GC, new cache added one)",
+        )
+
+    def test_init_setdefault_never_clobbers_live_inner_dicts(self):
+        """``setdefault`` init should preserve uncleared shared entries."""
+        cache1 = PartitionKeyRangeCache(_MockClient(_ENDPOINT))
+        original_inner = cache1._collection_routing_map_by_item
+        original_locks = cache1._collection_locks
+        original_meta = cache1._locks_lock
+
+        # Partial clear: drop only the routing-map dict.
+        with _shared_cache_lock:
+            _shared_routing_map_cache.clear()
+
+        cache2 = PartitionKeyRangeCache(_MockClient(_ENDPOINT))
+
+        # cache2 should get a new routing map dict but reuse uncleared entries.
+        self.assertIsNot(
+            cache2._collection_routing_map_by_item, original_inner,
+            "cleared routing-map dict must be replaced",
+        )
+        self.assertIs(
+            cache2._collection_locks, original_locks,
+            "uncleared collection-locks dict must be reused (no clobbering)",
+        )
+        self.assertIs(
+            cache2._locks_lock, original_meta,
+            "uncleared meta-lock must be reused (no clobbering)",
+        )
+
+        # Refcount should reflect both live instances.
+        self.assertEqual(
+            _shared_cache_refcounts[_ENDPOINT], 2,
+            "live refcount must be preserved across partial-clear + reconstruct",
+        )
+
+        # Keep both alive until the assertions above run.
+        _ = (cache1, cache2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
@@ -16,8 +16,16 @@ from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
 from unittest.mock import MagicMock, patch
+import gc
 import threading
 from azure.cosmos.exceptions import CosmosHttpResponseError
+from azure.cosmos._routing.routing_map_provider import (
+    _shared_routing_map_cache,
+    _shared_collection_locks,
+    _shared_locks_locks,
+    _shared_cache_refcounts,
+    _shared_cache_lock,
+)
 
 @pytest.mark.cosmosEmulator
 class TestRoutingMapProvider(unittest.TestCase):
@@ -39,9 +47,18 @@ class TestRoutingMapProvider(unittest.TestCase):
             return self.partition_key_ranges
 
     def tearDown(self):
-        from azure.cosmos._routing.routing_map_provider import _shared_routing_map_cache, _shared_cache_lock
+        # Release first, then collect cycles, then clear all shared dicts
+        # together so no partial shared-cache state leaks across tests.
+        provider = getattr(self, 'smart_routing_map_provider', None)
+        if provider is not None:
+            provider.release()
+            self.smart_routing_map_provider = None
+        gc.collect()
         with _shared_cache_lock:
             _shared_routing_map_cache.clear()
+            _shared_collection_locks.clear()
+            _shared_locks_locks.clear()
+            _shared_cache_refcounts.clear()
 
     def setUp(self):
         self.partition_key_ranges = [{u'id': u'0', u'minInclusive': u'', u'maxExclusive': u'05C1C9CD673398'},

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
@@ -9,6 +9,9 @@ from azure.cosmos._routing import routing_range as routing_range
 from azure.cosmos._routing.routing_map_provider import CollectionRoutingMap
 from azure.cosmos._routing.routing_map_provider import SmartRoutingMapProvider
 from azure.cosmos._routing.routing_map_provider import PartitionKeyRangeCache
+from azure.cosmos._routing._routing_map_provider_common import (
+    _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+)
 from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
@@ -366,7 +369,9 @@ class TestRoutingMapProvider(unittest.TestCase):
                     feed_options={},
                 )
         self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
-        self.assertEqual(call_count['count'], 3)
+        # Source the expected attempt count from the production constant so a
+        # future tuning change updates both sides in lockstep.
+        self.assertEqual(call_count['count'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS)
 
     def test_fetch_routing_map_incremental_with_parents(self):
         """Incremental update correctly merges child ranges that reference a parent."""

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider.py
@@ -12,8 +12,9 @@ from azure.cosmos._routing.routing_map_provider import PartitionKeyRangeCache
 from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import threading
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 @pytest.mark.cosmosEmulator
 class TestRoutingMapProvider(unittest.TestCase):
@@ -336,14 +337,18 @@ class TestRoutingMapProvider(unittest.TestCase):
         mock_map2.change_feed_etag = cached_map.change_feed_etag
         self.assertFalse(provider._is_cache_stale(collection_id, mock_map2))
 
-    def test_fetch_routing_map_full_load_with_incomplete_ranges_returns_none(self):
-        """When a full load (previous_routing_map=None) returns gapped ranges, returns None immediately."""
+    def test_fetch_routing_map_full_load_with_incomplete_ranges_surfaces_503(self):
+        """When a full load (previous_routing_map=None) repeatedly returns
+        gapped ranges, the retry budget should be exhausted and the provider
+        should surface a retryable HTTP 503."""
         incomplete_ranges = [
             {'id': '0', 'minInclusive': '', 'maxExclusive': '80'}  # Gap from 80 to FF
         ]
+        call_count = {'count': 0}
 
         class IncompleteClient:
             def _ReadPartitionKeyRanges(self, _collection_link, feed_options=None, **kwargs):
+                call_count['count'] += 1
                 TestRoutingMapProvider._capture_internal_headers(kwargs, '"incomplete-etag"')
                 return incomplete_ranges
 
@@ -352,13 +357,16 @@ class TestRoutingMapProvider(unittest.TestCase):
         collection_link = "dbs/db/colls/container"
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
 
-        result = provider._fetch_routing_map(
-            collection_link=collection_link,
-            collection_id=collection_id,
-            previous_routing_map=None,
-            feed_options={},
-        )
-        self.assertIsNone(result, "Should return None when full load produces incomplete ranges")
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                provider._fetch_routing_map(
+                    collection_link=collection_link,
+                    collection_id=collection_id,
+                    previous_routing_map=None,
+                    feed_options={},
+                )
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+        self.assertEqual(call_count['count'], 3)
 
     def test_fetch_routing_map_incremental_with_parents(self):
         """Incremental update correctly merges child ranges that reference a parent."""

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
@@ -12,7 +12,8 @@ from azure.cosmos._routing.aio.routing_map_provider import PartitionKeyRangeCach
 from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 
 @pytest.mark.cosmosEmulator
@@ -316,14 +317,18 @@ class TestRoutingMapProviderAsync(unittest.IsolatedAsyncioTestCase):
         mock_map2.change_feed_etag = cached_map.change_feed_etag
         self.assertFalse(provider._is_cache_stale(collection_id, mock_map2))
 
-    async def test_fetch_routing_map_full_load_with_incomplete_ranges_returns_none_async(self):
-        """When a full load (previous_routing_map=None) returns gapped ranges, returns None immediately."""
+    async def test_fetch_routing_map_full_load_with_incomplete_ranges_surfaces_503_async(self):
+        """When a full load (previous_routing_map=None) repeatedly returns
+        gapped ranges, the retry budget should be exhausted and the provider
+        should surface a retryable HTTP 503."""
         incomplete_ranges = [
             {'id': '0', 'minInclusive': '', 'maxExclusive': '80'}  # Gap from 80 to FF
         ]
+        call_count = {'count': 0}
 
         class IncompleteClient:
             def _ReadPartitionKeyRanges(self, _collection_link, feed_options=None, **kwargs):
+                call_count['count'] += 1
                 TestRoutingMapProviderAsync._capture_internal_headers(kwargs, '"incomplete-etag"')
 
                 async def _gen():
@@ -337,13 +342,19 @@ class TestRoutingMapProviderAsync(unittest.IsolatedAsyncioTestCase):
         collection_link = "dbs/db/colls/container"
         collection_id = _base.GetResourceIdOrFullNameFromLink(collection_link)
 
-        result = await provider._fetch_routing_map(
-            collection_link=collection_link,
-            collection_id=collection_id,
-            previous_routing_map=None,
-            feed_options={},
-        )
-        self.assertIsNone(result, "Should return None when full load produces incomplete ranges")
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch('azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep', new=_no_sleep):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await provider._fetch_routing_map(
+                    collection_link=collection_link,
+                    collection_id=collection_id,
+                    previous_routing_map=None,
+                    feed_options={},
+                )
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+        self.assertEqual(call_count['count'], 3)
 
     async def test_fetch_routing_map_incremental_with_parents_async(self):
         """Incremental update correctly merges child ranges that reference a parent."""

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
@@ -16,7 +16,15 @@ from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
 from unittest.mock import MagicMock, patch
+import gc
 from azure.cosmos.exceptions import CosmosHttpResponseError
+from azure.cosmos._routing.aio.routing_map_provider import (
+    _shared_routing_map_cache,
+    _shared_collection_locks,
+    _shared_locks_locks,
+    _shared_cache_refcounts,
+    _shared_cache_lock,
+)
 
 
 @pytest.mark.cosmosEmulator
@@ -51,9 +59,18 @@ class TestRoutingMapProviderAsync(unittest.IsolatedAsyncioTestCase):
             return _gen()
 
     def tearDown(self):
-        from azure.cosmos._routing.aio.routing_map_provider import _shared_routing_map_cache, _shared_cache_lock
+        # Release first, then collect cycles, then clear all shared dicts
+        # together so no partial shared-cache state leaks across tests.
+        provider = getattr(self, 'smart_routing_map_provider', None)
+        if provider is not None:
+            provider.release()
+            self.smart_routing_map_provider = None
+        gc.collect()
         with _shared_cache_lock:
             _shared_routing_map_cache.clear()
+            _shared_collection_locks.clear()
+            _shared_locks_locks.clear()
+            _shared_cache_refcounts.clear()
 
     def setUp(self):
         self.partition_key_ranges = [

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_routing_map_provider_async.py
@@ -9,6 +9,9 @@ from azure.cosmos._routing import routing_range as routing_range
 from azure.cosmos._routing.aio.routing_map_provider import CollectionRoutingMap
 from azure.cosmos._routing.aio.routing_map_provider import SmartRoutingMapProvider
 from azure.cosmos._routing.aio.routing_map_provider import PartitionKeyRangeCache
+from azure.cosmos._routing._routing_map_provider_common import (
+    _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+)
 from azure.cosmos import http_constants
 
 from typing import Optional, Mapping, Any
@@ -354,7 +357,9 @@ class TestRoutingMapProviderAsync(unittest.IsolatedAsyncioTestCase):
                     feed_options={},
                 )
         self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
-        self.assertEqual(call_count['count'], 3)
+        # Source the expected attempt count from the production constant so a
+        # future tuning change updates both sides in lockstep.
+        self.assertEqual(call_count['count'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS)
 
     async def test_fetch_routing_map_incremental_with_parents_async(self):
         """Incremental update correctly merges child ranges that reference a parent."""

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
@@ -1,10 +1,13 @@
 # The MIT License (MIT)
 # Copyright (c) Microsoft Corporation. All rights reserved.
 
+import gc
+import threading
 import unittest
 
 import pytest
 
+import azure.cosmos._routing.routing_map_provider as rmp
 from azure.cosmos._routing.routing_range import Range, PKRange
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos._routing.routing_map_provider import (
@@ -13,6 +16,7 @@ from azure.cosmos._routing.routing_map_provider import (
     _shared_cache_lock,
     _shared_collection_locks,
     _shared_locks_locks,
+    _shared_cache_refcounts,
 )
 
 
@@ -21,23 +25,20 @@ class MockClient:
         self.url_connection = url_connection
 
 
+def _reset_shared_cache_state():
+    """Wipe all four shared-cache globals so successive tests start clean."""
+    with _shared_cache_lock:
+        _shared_routing_map_cache.clear()
+        _shared_collection_locks.clear()
+        _shared_locks_locks.clear()
+        _shared_cache_refcounts.clear()
+
+
 @pytest.mark.cosmosEmulator
 class TestSharedPartitionKeyRangeCache(unittest.TestCase):
 
     def tearDown(self):
-        # Wipe ALL four shared-cache globals between unit tests, not just
-        # the routing-map dict, so refcount and lock state stay consistent
-        # for tests that exercise lifecycle behavior.
-        from azure.cosmos._routing.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
-        with _shared_cache_lock:
-            _shared_routing_map_cache.clear()
-            _shared_collection_locks.clear()
-            _shared_locks_locks.clear()
-            _shared_cache_refcounts.clear()
+        _reset_shared_cache_state()
 
     def test_same_endpoint_shares_cache(self):
         c1 = MockClient("https://account1.documents.azure.com:443/")
@@ -172,27 +173,14 @@ class TestSharedPartitionKeyRangeCache(unittest.TestCase):
         self.assertEqual(r.min, "05C1C9CD")
 
 
-
-
 @pytest.mark.cosmosEmulator
 class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
     """Refcount and release() lifecycle tests for the process-global cache."""
 
     def tearDown(self):
-        # Defensive: wipe all four globals after every test in this class.
-        from azure.cosmos._routing.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
-        with _shared_cache_lock:
-            _shared_routing_map_cache.clear()
-            _shared_collection_locks.clear()
-            _shared_locks_locks.clear()
-            _shared_cache_refcounts.clear()
+        _reset_shared_cache_state()
 
     def _refcount(self, endpoint):
-        from azure.cosmos._routing.routing_map_provider import _shared_cache_refcounts
         return _shared_cache_refcounts.get(endpoint, 0)
 
     def test_construct_increments_refcount(self):
@@ -202,7 +190,9 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         self.assertEqual(self._refcount(ep), 1)
         c2 = PartitionKeyRangeCache(MockClient(ep))
         self.assertEqual(self._refcount(ep), 2)
-        del c1, c2  # avoid unused warnings
+        # Keep references alive until end of test so refcount checks above
+        # observe the constructed-but-not-released state.
+        _ = (c1, c2)
 
     def test_release_decrements_refcount(self):
         ep = "https://lifecycle2.documents.azure.com:443/"
@@ -215,11 +205,6 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         self.assertEqual(self._refcount(ep), 0)
 
     def test_release_evicts_at_zero(self):
-        from azure.cosmos._routing.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
         ep = "https://lifecycle3.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
         # All four dicts have an entry for the endpoint.
@@ -258,6 +243,8 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         self.assertEqual(self._refcount(ep), 1)
         # c2's entries must remain.
         self.assertIn(ep, _shared_routing_map_cache)
+        # Keep c2 alive until the assertion above runs.
+        _ = c2
 
     def test_concurrent_release_does_not_double_decrement(self):
         """TOCTOU regression: two threads racing release() decrement at most once.
@@ -267,7 +254,6 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         ``__del__``) can both pass the early-return guard before either
         sets the flag, producing a double decrement.
         """
-        import threading
         ep = "https://lifecycle6.documents.azure.com:443/"
         # Hold an extra refcount via c_keep so a double-decrement bug would
         # observably wrong-evict the endpoint (refcount would go to -1 and
@@ -297,7 +283,6 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
 
     def test_del_fallback_releases(self):
         """``__del__`` decrements refcount when client teardown was skipped."""
-        import gc
         ep = "https://lifecycle7.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
         self.assertEqual(self._refcount(ep), 1)
@@ -317,27 +302,10 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         self.assertIn(ep, _shared_routing_map_cache)
 
     def test_reentrant_release_during_init_does_not_deadlock(self):
-        """Regression: ``__init__`` must hold a reentrant lock so that a
-        ``release()`` triggered recursively on the same thread (e.g. by GC
-        of a prior instance during attribute lookup, or by a test that uses
-        ``MagicMock()`` as ``client``) cannot deadlock.
-
-        The original ``threading.Lock`` would hang ``__init__`` forever the
-        moment any code path under the lock ran ``release()`` on the same
-        thread; this surfaced first in
-        ``test_fetch_routing_map_recovers_after_transient_gap`` (sync) and
-        the async sibling, which both construct ``PartitionKeyRangeCache``
-        with a ``MagicMock()`` client. ``_mock_set_magics`` drops references
-        to prior child mocks during attribute access, GC sweeps them
-        synchronously, and the swept instance's ``__del__`` -> ``release()``
-        re-enters the same lock. Using ``threading.RLock`` makes the
-        re-entry safe; this test exercises exactly that re-entry from a
-        single thread with no mocks involved, so a future swap back to
-        ``Lock()`` would hang this test under the 5-second join timeout
-        rather than letting the regression escape.
+        """Acquires ``_shared_cache_lock`` on a single thread and calls
+        ``release()`` from inside that critical section. A non-reentrant
+        ``Lock`` would deadlock here; an ``RLock`` returns cleanly.
         """
-        import threading
-
         ep = "https://reentry1.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
         self.assertEqual(self._refcount(ep), 1)
@@ -373,6 +341,74 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         # Refcount must have decremented exactly once.
         self.assertEqual(self._refcount(ep), 0)
         self.assertNotIn(ep, _shared_routing_map_cache)
+
+    def test_init_under_gc_triggered_by_dict_op_does_not_deadlock(self):
+        """Reproduces the GC re-entry chain that requires
+        ``_shared_cache_lock`` to be an ``RLock``.
+
+        A ``PartitionKeyRangeCache`` that participates in a reference cycle
+        can only be collected by cyclic GC. When another instance is
+        constructed against the same endpoint, the dict op inside
+        ``__init__``'s critical section can trigger cyclic GC, which
+        sweeps the cycled instance and runs its ``__del__`` ->
+        ``release()`` on the same thread, re-acquiring the lock.
+
+        To force the chain deterministically: build a cache in a reference
+        cycle, drop the outer reference, swap ``_shared_routing_map_cache``
+        for a dict whose ``__contains__`` calls ``gc.collect()``, then
+        construct a second cache in a worker thread with a short timeout.
+        ``Lock`` deadlocks the worker; ``RLock`` returns in milliseconds.
+        """
+        class _GcTriggeringDict(dict):
+            """``__contains__`` runs cyclic GC so collection of the
+            unreachable cycle happens inside the init lock block.
+            """
+            def __contains__(self, key):  # type: ignore[override]
+                gc.collect()
+                return super().__contains__(key)
+
+        ep = "https://reentry-gc.documents.azure.com:443/"
+
+        # Build a cache in a reference cycle and drop the outer reference;
+        # only cyclic GC can collect it now.
+        cache_in_cycle = PartitionKeyRangeCache(MockClient(ep))
+        cache_in_cycle._cycle_self = cache_in_cycle  # type: ignore[attr-defined]
+        del cache_in_cycle
+
+        # Disable automatic gen-0/1/2 collection so the only collection
+        # opportunity is the explicit gc.collect() inside __contains__.
+        gc.disable()
+        original_cache_dict = rmp._shared_routing_map_cache
+        rmp._shared_routing_map_cache = _GcTriggeringDict(original_cache_dict)
+        try:
+            # Construct a second cache in a worker thread with a short
+            # timeout. Lock deadlocks; RLock completes in milliseconds.
+            outcome: dict = {"done": False, "error": None}
+
+            def _construct():
+                try:
+                    outcome["instance"] = PartitionKeyRangeCache(MockClient(ep))
+                    outcome["done"] = True
+                except Exception as e:  # pylint: disable=broad-except
+                    outcome["error"] = e
+
+            worker = threading.Thread(
+                target=_construct, name="gc-reentry-worker", daemon=True,
+            )
+            worker.start()
+            worker.join(timeout=3.0)
+
+            self.assertFalse(
+                worker.is_alive(),
+                "PartitionKeyRangeCache(...) deadlocked when cyclic GC "
+                "fired inside the init critical section; "
+                "_shared_cache_lock must be a threading.RLock.",
+            )
+            self.assertIsNone(outcome["error"], f"Construction errored: {outcome['error']}")
+            self.assertTrue(outcome["done"])
+        finally:
+            rmp._shared_routing_map_cache = original_cache_dict
+            gc.enable()
 
 
 if __name__ == "__main__":

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
@@ -316,6 +316,64 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
         # Endpoint still present.
         self.assertIn(ep, _shared_routing_map_cache)
 
+    def test_reentrant_release_during_init_does_not_deadlock(self):
+        """Regression: ``__init__`` must hold a reentrant lock so that a
+        ``release()`` triggered re-entrantly on the same thread (e.g. by GC
+        of a prior instance during attribute lookup, or by a test that uses
+        ``MagicMock()`` as ``client``) cannot deadlock.
+
+        The original ``threading.Lock`` would hang ``__init__`` forever the
+        moment any code path under the lock ran ``release()`` on the same
+        thread; this surfaced first in
+        ``test_fetch_routing_map_recovers_after_transient_gap`` (sync) and
+        the async sibling, which both construct ``PartitionKeyRangeCache``
+        with a ``MagicMock()`` client. ``_mock_set_magics`` drops references
+        to prior child mocks during attribute access, GC sweeps them
+        synchronously, and the swept instance's ``__del__`` -> ``release()``
+        re-enters the same lock. Using ``threading.RLock`` makes the
+        re-entry safe; this test exercises exactly that re-entry from a
+        single thread with no mocks involved, so a future swap back to
+        ``Lock()`` would hang this test under the 5-second join timeout
+        rather than letting the regression escape.
+        """
+        import threading
+
+        ep = "https://reentry1.documents.azure.com:443/"
+        c1 = PartitionKeyRangeCache(MockClient(ep))
+        self.assertEqual(self._refcount(ep), 1)
+
+        # Explicit ``Any`` value type so the static checker doesn't infer
+        # ``dict[str, bool | None]`` from the initial values and then flag
+        # the ``Exception`` assignment in the exception arm as a type error.
+        result: dict = {"done": False, "error": None}
+
+        def reenter():
+            try:
+                # Acquire the shared lock first to mimic the ``__init__``
+                # critical section, then call ``release()`` from inside it
+                # to simulate the GC-driven ``__del__`` path. A non-reentrant
+                # Lock deadlocks here; an RLock returns cleanly.
+                with _shared_cache_lock:
+                    c1.release()
+                result["done"] = True
+            except Exception as exc:  # pylint: disable=broad-except
+                result["error"] = exc
+
+        worker = threading.Thread(target=reenter)
+        worker.start()
+        worker.join(timeout=5)
+
+        self.assertFalse(
+            worker.is_alive(),
+            "Reentrant release() under _shared_cache_lock deadlocked; "
+            "the lock must be a threading.RLock (see module-level comment)."
+        )
+        self.assertIsNone(result["error"])
+        self.assertTrue(result["done"])
+        # Refcount must have decremented exactly once.
+        self.assertEqual(self._refcount(ep), 0)
+        self.assertNotIn(ep, _shared_routing_map_cache)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache.py
@@ -318,7 +318,7 @@ class TestSharedPartitionKeyRangeCacheLifecycle(unittest.TestCase):
 
     def test_reentrant_release_during_init_does_not_deadlock(self):
         """Regression: ``__init__`` must hold a reentrant lock so that a
-        ``release()`` triggered re-entrantly on the same thread (e.g. by GC
+        ``release()`` triggered recursively on the same thread (e.g. by GC
         of a prior instance during attribute lookup, or by a test that uses
         ``MagicMock()`` as ``client``) cannot deadlock.
 

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
@@ -172,6 +172,49 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertEqual(self._refcount(ep), before)
         self.assertIn(ep, _shared_routing_map_cache)
 
+    async def test_reentrant_release_during_init_does_not_deadlock_async(self):
+        """Regression: async ``__init__`` must hold a reentrant lock so a
+        ``release()`` triggered re-entrantly on the same thread (e.g. by GC
+        of a prior instance during attribute lookup, or by a test that uses
+        ``MagicMock()`` as ``client``) cannot deadlock.
+
+        Same root cause as the sync test in
+        ``test_shared_pk_range_cache.test_reentrant_release_during_init_does_not_deadlock``
+        — the async module duplicates the lock + ``__init__`` + ``__del__``
+        shape and would deadlock identically with a non-reentrant Lock.
+        """
+        import threading
+
+        ep = "https://async-reentry1.documents.azure.com:443/"
+        c1 = PartitionKeyRangeCache(MockClient(ep))
+        self.assertEqual(self._refcount(ep), 1)
+
+        # Explicit ``Any`` value type so the static checker doesn't infer
+        # ``dict[str, bool | None]`` and reject the ``Exception`` assignment.
+        result: dict = {"done": False, "error": None}
+
+        def reenter():
+            try:
+                with _shared_cache_lock:
+                    c1.release()
+                result["done"] = True
+            except Exception as exc:  # pylint: disable=broad-except
+                result["error"] = exc
+
+        worker = threading.Thread(target=reenter)
+        worker.start()
+        worker.join(timeout=5)
+
+        self.assertFalse(
+            worker.is_alive(),
+            "Reentrant release() under _shared_cache_lock deadlocked; "
+            "the async module's lock must be a threading.RLock."
+        )
+        self.assertIsNone(result["error"])
+        self.assertTrue(result["done"])
+        self.assertEqual(self._refcount(ep), 0)
+        self.assertNotIn(ep, _shared_routing_map_cache)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
@@ -9,15 +9,21 @@ PKRange and Range data structure tests are not duplicated here since they are
 the same class in both sync and async paths.
 """
 
+import gc
+import threading
 import unittest
 
 import pytest
 
+import azure.cosmos._routing.aio.routing_map_provider as rmp_async
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos._routing.aio.routing_map_provider import (
     PartitionKeyRangeCache,
     _shared_routing_map_cache,
     _shared_cache_lock,
+    _shared_collection_locks,
+    _shared_locks_locks,
+    _shared_cache_refcounts,
 )
 
 
@@ -26,24 +32,21 @@ class MockClient:
         self.url_connection = url_connection
 
 
+def _reset_shared_cache_state():
+    """Wipe all four shared-cache globals so successive tests start clean."""
+    with _shared_cache_lock:
+        _shared_routing_map_cache.clear()
+        _shared_collection_locks.clear()
+        _shared_locks_locks.clear()
+        _shared_cache_refcounts.clear()
+
+
 @pytest.mark.cosmosEmulator
 @pytest.mark.asyncio
 class TestSharedPartitionKeyRangeCacheAsync(unittest.IsolatedAsyncioTestCase):
 
     def tearDown(self):
-        # Wipe ALL four shared-cache globals between unit tests, not just
-        # the routing-map dict, so refcount and lock state stay consistent
-        # for tests that exercise lifecycle behavior.
-        from azure.cosmos._routing.aio.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
-        with _shared_cache_lock:
-            _shared_routing_map_cache.clear()
-            _shared_collection_locks.clear()
-            _shared_locks_locks.clear()
-            _shared_cache_refcounts.clear()
+        _reset_shared_cache_state()
 
     async def test_same_endpoint_shares_cache_async(self):
         """Async: Two caches with the same endpoint share the same dict."""
@@ -103,26 +106,14 @@ class TestSharedPartitionKeyRangeCacheAsync(unittest.IsolatedAsyncioTestCase):
         self.assertIn("coll2", cache2._collection_routing_map_by_item)
 
 
-
-
 @pytest.mark.cosmosEmulator
 class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTestCase):
     """Async refcount and release() lifecycle tests."""
 
     def tearDown(self):
-        from azure.cosmos._routing.aio.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
-        with _shared_cache_lock:
-            _shared_routing_map_cache.clear()
-            _shared_collection_locks.clear()
-            _shared_locks_locks.clear()
-            _shared_cache_refcounts.clear()
+        _reset_shared_cache_state()
 
     def _refcount(self, endpoint):
-        from azure.cosmos._routing.aio.routing_map_provider import _shared_cache_refcounts
         return _shared_cache_refcounts.get(endpoint, 0)
 
     async def test_construct_and_release_async(self):
@@ -137,11 +128,6 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertEqual(self._refcount(ep), 0)
 
     async def test_release_evicts_at_zero_async(self):
-        from azure.cosmos._routing.aio.routing_map_provider import (
-            _shared_collection_locks,
-            _shared_locks_locks,
-            _shared_cache_refcounts,
-        )
         ep = "https://async-lifecycle2.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
         for d in (_shared_routing_map_cache, _shared_collection_locks,
@@ -162,14 +148,14 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertEqual(self._refcount(ep), 1)
         # c2 entry retained
         self.assertIn(ep, _shared_routing_map_cache)
-        del c2
+        # Keep c2 alive until the assertion above runs.
+        _ = c2
 
     async def test_concurrent_release_does_not_double_decrement_async(self):
         """TOCTOU regression: concurrent release() decrements at most once.
 
         Mirrors the sync lifecycle guard for the async module's shared cache.
         """
-        import threading
 
         ep = "https://async-lifecycle5.documents.azure.com:443/"
         c_keep = PartitionKeyRangeCache(MockClient(ep))
@@ -195,7 +181,6 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
 
     async def test_del_fallback_releases_async(self):
         """``__del__`` decrements refcount when explicit release is skipped."""
-        import gc
 
         ep = "https://async-lifecycle6.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
@@ -214,18 +199,11 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertIn(ep, _shared_routing_map_cache)
 
     async def test_reentrant_release_during_init_does_not_deadlock_async(self):
-        """Regression: async ``__init__`` must hold a reentrant lock so a
-        ``release()`` triggered recursively on the same thread (e.g. by GC
-        of a prior instance during attribute lookup, or by a test that uses
-        ``MagicMock()`` as ``client``) cannot deadlock.
-
-        Same root cause as the sync test in
-        ``test_shared_pk_range_cache.test_reentrant_release_during_init_does_not_deadlock``
-        — the async module duplicates the lock + ``__init__`` + ``__del__``
-        shape and would deadlock identically with a non-reentrant Lock.
+        """Acquires the async module's ``_shared_cache_lock`` on a single
+        thread and calls ``release()`` from inside that critical section.
+        A non-reentrant ``Lock`` would deadlock here; an ``RLock`` returns
+        cleanly.
         """
-        import threading
-
         ep = "https://async-reentry1.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))
         self.assertEqual(self._refcount(ep), 1)
@@ -255,6 +233,63 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertTrue(result["done"])
         self.assertEqual(self._refcount(ep), 0)
         self.assertNotIn(ep, _shared_routing_map_cache)
+
+    async def test_init_under_gc_triggered_by_dict_op_does_not_deadlock_async(self):
+        """Reproduces the GC re-entry chain that requires the async module's
+        ``_shared_cache_lock`` to be an ``RLock``.
+
+        The async ``PartitionKeyRangeCache`` has the same ``__init__`` ->
+        dict op -> cyclic GC -> ``__del__`` -> ``release()`` shape as the
+        sync version, so a non-reentrant ``Lock`` would deadlock identically
+        the moment cyclic GC fires inside the init critical section against
+        any cache that participates in a reference cycle. The async module
+        uses ``threading.RLock`` (not ``asyncio.Lock``) precisely so this
+        sync-only re-entry path stays safe while remaining usable from
+        coroutines.
+        """
+        class _GcTriggeringDict(dict):
+            def __contains__(self, key):  # type: ignore[override]
+                gc.collect()
+                return super().__contains__(key)
+
+        ep = "https://async-reentry-gc.documents.azure.com:443/"
+
+        # Build a cache in a reference cycle and drop the outer reference;
+        # only cyclic GC can collect it now.
+        cache_in_cycle = PartitionKeyRangeCache(MockClient(ep))
+        cache_in_cycle._cycle_self = cache_in_cycle  # type: ignore[attr-defined]
+        del cache_in_cycle
+
+        gc.disable()
+        original_cache_dict = rmp_async._shared_routing_map_cache
+        rmp_async._shared_routing_map_cache = _GcTriggeringDict(original_cache_dict)
+        try:
+            outcome: dict = {"done": False, "error": None}
+
+            def _construct():
+                try:
+                    outcome["instance"] = PartitionKeyRangeCache(MockClient(ep))
+                    outcome["done"] = True
+                except Exception as e:  # pylint: disable=broad-except
+                    outcome["error"] = e
+
+            worker = threading.Thread(
+                target=_construct, name="gc-reentry-worker-async", daemon=True,
+            )
+            worker.start()
+            worker.join(timeout=3.0)
+
+            self.assertFalse(
+                worker.is_alive(),
+                "Async PartitionKeyRangeCache(...) deadlocked when cyclic "
+                "GC fired inside the init critical section; the async "
+                "module's _shared_cache_lock must be a threading.RLock.",
+            )
+            self.assertIsNone(outcome["error"], f"Construction errored: {outcome['error']}")
+            self.assertTrue(outcome["done"])
+        finally:
+            rmp_async._shared_routing_map_cache = original_cache_dict
+            gc.enable()
 
 
 if __name__ == "__main__":

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
@@ -164,6 +164,47 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
         self.assertIn(ep, _shared_routing_map_cache)
         del c2
 
+    async def test_concurrent_release_does_not_double_decrement_async(self):
+        """TOCTOU regression: concurrent release() decrements at most once.
+
+        Mirrors the sync lifecycle guard for the async module's shared cache.
+        """
+        import threading
+
+        ep = "https://async-lifecycle5.documents.azure.com:443/"
+        c_keep = PartitionKeyRangeCache(MockClient(ep))
+        c_target = PartitionKeyRangeCache(MockClient(ep))
+        self.assertEqual(self._refcount(ep), 2)
+
+        barrier = threading.Barrier(2)
+
+        def go():
+            barrier.wait()
+            c_target.release()
+
+        threads = [threading.Thread(target=go) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        # Refcount must still be 1 (only c_keep alive).
+        self.assertEqual(self._refcount(ep), 1)
+        self.assertIn(ep, _shared_routing_map_cache)
+        self.assertIs(c_keep._collection_routing_map_by_item, _shared_routing_map_cache[ep])
+
+    async def test_del_fallback_releases_async(self):
+        """``__del__`` decrements refcount when explicit release is skipped."""
+        import gc
+
+        ep = "https://async-lifecycle6.documents.azure.com:443/"
+        c1 = PartitionKeyRangeCache(MockClient(ep))
+        self.assertEqual(self._refcount(ep), 1)
+        del c1
+        gc.collect()
+        self.assertEqual(self._refcount(ep), 0)
+        self.assertNotIn(ep, _shared_routing_map_cache)
+
     async def test_clear_cache_does_not_change_refcount_async(self):
         ep = "https://async-lifecycle4.documents.azure.com:443/"
         c1 = PartitionKeyRangeCache(MockClient(ep))

--- a/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/routing/test_shared_pk_range_cache_async.py
@@ -215,7 +215,7 @@ class TestSharedPartitionKeyRangeCacheLifecycleAsync(unittest.IsolatedAsyncioTes
 
     async def test_reentrant_release_during_init_does_not_deadlock_async(self):
         """Regression: async ``__init__`` must hold a reentrant lock so a
-        ``release()`` triggered re-entrantly on the same thread (e.g. by GC
+        ``release()`` triggered recursively on the same thread (e.g. by GC
         of a prior instance during attribute lookup, or by a test that uses
         ``MagicMock()`` as ``client``) cannot deadlock.
 

--- a/sdk/cosmos/azure-cosmos/tests/test_container_rid_header_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_container_rid_header_unit.py
@@ -10,6 +10,7 @@ code path that can trigger a partition key range fetch.
 
 import unittest
 from typing import Optional, Mapping, Any
+from unittest.mock import patch
 from azure.cosmos._routing import routing_range
 from azure.cosmos._routing.routing_map_provider import (
     PartitionKeyRangeCache,
@@ -17,6 +18,7 @@ from azure.cosmos._routing.routing_map_provider import (
 )
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos import _base, http_constants
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 
 # =====================================================================
@@ -333,11 +335,10 @@ class TestContainerRIDHeaderUnit(unittest.TestCase):
             "returning a delta instead of the complete set of ranges"
         )
 
-    def test_full_load_with_incomplete_ranges_returns_none(self):
-        """When a full load (no previous routing map) returns ranges with gaps,
-        CompleteRoutingMap returns None. The method must return None immediately
-        without retrying — there is no incremental state to fall back from, and
-        repeating the identical request would produce the same result."""
+    def test_full_load_with_incomplete_ranges_surfaces_503(self):
+        """When a full load (no previous routing map) repeatedly returns gapped
+        ranges, the retry budget should be exhausted and _fetch_routing_map
+        should surface a retryable HTTP 503."""
 
         class IncompleteRangesClient:
             """Returns ranges with a gap — CompleteRoutingMap will return None."""
@@ -354,16 +355,15 @@ class TestContainerRIDHeaderUnit(unittest.TestCase):
         client = IncompleteRangesClient()
         cache = PartitionKeyRangeCache(client)
 
-        result = cache._fetch_routing_map(
-            COLLECTION_LINK,
-            _base.GetResourceIdOrFullNameFromLink(COLLECTION_LINK),
-            None,  # full load (no previous map)
-            {},
-        )
-        assert result is None, (
-            "Full load with incomplete ranges must return None "
-            "instead of retrying infinitely"
-        )
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache._fetch_routing_map(
+                    COLLECTION_LINK,
+                    _base.GetResourceIdOrFullNameFromLink(COLLECTION_LINK),
+                    None,  # full load (no previous map)
+                    {},
+                )
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
 
     def test_incremental_fallback_to_full_load_succeeds(self):
         """When an incremental (change-feed) update fails because a returned

--- a/sdk/cosmos/azure-cosmos/tests/test_container_rid_header_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_container_rid_header_unit_async.py
@@ -10,6 +10,7 @@ async code path that can trigger a partition key range fetch.
 
 import unittest
 from typing import Optional, Mapping, Any, Dict
+from unittest.mock import patch
 from azure.cosmos._routing import routing_range
 from azure.cosmos._routing.aio.routing_map_provider import (
     PartitionKeyRangeCache,
@@ -17,6 +18,7 @@ from azure.cosmos._routing.aio.routing_map_provider import (
 )
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos import _base, http_constants
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 
 # =====================================================================
@@ -293,11 +295,10 @@ class TestContainerRIDHeaderUnitAsync(unittest.IsolatedAsyncioTestCase):
             "returning a delta instead of the complete set of ranges"
         )
 
-    async def test_full_load_with_incomplete_ranges_returns_none_async(self):
-        """When a full load (no previous routing map) returns ranges with gaps,
-        CompleteRoutingMap returns None. The method must return None immediately
-        without retrying — there is no incremental state to fall back from, and
-        repeating the identical request would produce the same result."""
+    async def test_full_load_with_incomplete_ranges_surfaces_503_async(self):
+        """When a full load (no previous routing map) repeatedly returns gapped
+        ranges, the retry budget should be exhausted and _fetch_routing_map
+        should surface a retryable HTTP 503."""
 
         class IncompleteRangesClient:
             async def _ReadPartitionKeyRanges(self, collection_link, feed_options=None, **kwargs):
@@ -314,16 +315,18 @@ class TestContainerRIDHeaderUnitAsync(unittest.IsolatedAsyncioTestCase):
         client = IncompleteRangesClient()
         cache = PartitionKeyRangeCache(client)
 
-        result = await cache._fetch_routing_map(
-            COLLECTION_LINK,
-            _base.GetResourceIdOrFullNameFromLink(COLLECTION_LINK),
-            None,  # full load (no previous map)
-            {},
-        )
-        assert result is None, (
-            "Full load with incomplete ranges must return None "
-            "instead of retrying infinitely"
-        )
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch('azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep', new=_no_sleep):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache._fetch_routing_map(
+                    COLLECTION_LINK,
+                    _base.GetResourceIdOrFullNameFromLink(COLLECTION_LINK),
+                    None,  # full load (no previous map)
+                    {},
+                )
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
 
     async def test_incremental_fallback_to_full_load_succeeds_async(self):
         """When an incremental (change-feed) update fails because a returned

--- a/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_headers_async.py
@@ -20,19 +20,19 @@ request_throughput_bucket_number = 3
 client_priority = "Low"
 request_priority = "High"
 
-async def client_raw_response_hook(response):
+def client_raw_response_hook(response):
     assert (response.http_request.headers[http_constants.HttpHeaders.ThroughputBucket]
             == str(client_throughput_bucket_number))
 
-async def request_raw_response_hook(response):
+def request_raw_response_hook(response):
     assert (response.http_request.headers[http_constants.HttpHeaders.ThroughputBucket]
             == str(request_throughput_bucket_number))
 
-async def client_priority_raw_response_hook(response):
+def client_priority_raw_response_hook(response):
     assert (response.http_request.headers[http_constants.HttpHeaders.PriorityLevel]
             == client_priority)
 
-async def request_priority_raw_response_hook(response):
+def request_priority_raw_response_hook(response):
     assert (response.http_request.headers[http_constants.HttpHeaders.PriorityLevel]
             == request_priority)
 

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
@@ -608,9 +608,8 @@ class TestPartitionSplitQuery(unittest.TestCase):
         the service returns an incomplete set of partition ranges.
 
         When a full load is performed (previous_routing_map=None) and the service
-        returns gapped ranges, _fetch_routing_map must return None immediately  - 
-        there is no incremental state to fall back from, and repeating the
-        identical request would produce the same result."""
+        returns gapped ranges, _fetch_routing_map should surface a retryable
+        HTTP 503 after exhausting the bounded retry budget."""
         container_id = 'test_fallback_guard_' + str(uuid.uuid4())
         self.key_database.create_container(
             id=container_id,
@@ -644,19 +643,17 @@ class TestPartitionSplitQuery(unittest.TestCase):
                     '_ReadPartitionKeyRanges',
                     side_effect=mock_read_ranges
             ):
-                # Full load with incomplete ranges should return None immediately
-                result = provider._fetch_routing_map(
-                    collection_link=collection_link,
-                    collection_id=collection_id,
-                    previous_routing_map=None,
-                    feed_options={},
-                )
+                with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+                    with self.assertRaises(CosmosHttpResponseError) as ctx:
+                        provider._fetch_routing_map(
+                            collection_link=collection_link,
+                            collection_id=collection_id,
+                            previous_routing_map=None,
+                            feed_options={},
+                        )
+                    self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
 
-                # Should return None instead of recursing infinitely
-                assert result is None, \
-                    "_fetch_routing_map should return None when full load produces incomplete ranges"
-
-            print("Validated: full load with incomplete ranges returns None without recursion")
+            print("Validated: full load with incomplete ranges surfaces retryable HTTP 503")
 
         finally:
             self.key_database.delete_container(container_id)

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_split_query.py
@@ -144,14 +144,9 @@ class TestPartitionSplitQuery(unittest.TestCase):
             # Force initial routing map cache by running a query
             run_queries(container, 1)
 
-            # Trigger split (1 -> 2 partitions)  -  control-plane
-            key_container.replace_throughput(11000)
-            pending = True
-            while pending:
-                offer = key_container.get_throughput()
-                pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-                if pending:
-                    time.sleep(5)
+            # Trigger split via the shared bounded helper (timeout + SkipTest)
+            # instead of an unbounded polling loop.
+            test_config.TestConfig.trigger_split(key_container, 11000)
 
             # Run queries to trigger routing map refresh
             run_queries(container, 1)
@@ -235,14 +230,9 @@ class TestPartitionSplitQuery(unittest.TestCase):
             # Force initial routing map cache
             run_queries(container, 1)
 
-            # Trigger split (2 -> 3 partitions: 1 stable + 2 from split)  -  control-plane
-            key_container.replace_throughput(25000)
-            pending = True
-            while pending:
-                offer = key_container.read_offer()
-                pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-                if pending:
-                    time.sleep(5)
+            # Trigger split via the shared bounded helper (timeout + SkipTest)
+            # instead of an unbounded polling loop.
+            test_config.TestConfig.trigger_split(key_container, 25000)
 
             # Run queries to trigger routing map refresh
             run_queries(container, 1)
@@ -355,14 +345,8 @@ class TestPartitionSplitQuery(unittest.TestCase):
             print(f"Before split - Container B: {len(ranges_b_before)} partitions")
             print(f"Container B routing map object ID: {map_b_object_id}")
 
-            # Split only Container A  -  control-plane
-            key_container_a.replace_throughput(11000)
-            pending = True
-            while pending:
-                offer = key_container_a.get_throughput()
-                pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-                if pending:
-                    time.sleep(5)
+            # Split only Container A via the shared bounded helper.
+            test_config.TestConfig.trigger_split(key_container_a, 11000)
 
             # Wait for physical partition ranges to reflect the split.
             split_convergence_deadline = time.time() + 300

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_split_query_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_split_query_async.py
@@ -14,6 +14,7 @@ from azure.cosmos import PartitionKey
 from azure.cosmos import http_constants
 from azure.cosmos import _base
 from azure.cosmos.aio import CosmosClient, DatabaseProxy, ContainerProxy
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 async def run_queries(container, iterations):
     ret_list = []
@@ -592,12 +593,13 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
         finally:
             await self.key_database.delete_container(container_id)
 
-    async def test_full_load_with_incomplete_ranges_returns_none_async(self):
+    async def test_full_load_with_incomplete_ranges_surfaces_503_async(self):
         """
-        Validates that a full load with incomplete ranges returns None immediately.
+        Validates that a full load with incomplete ranges surfaces a retryable
+        HTTP 503 after exhausting the bounded retry budget.
         When a full load is performed (previous_routing_map=None) and the service
-        returns gapped ranges, _fetch_routing_map should return None without retrying  - 
-        there is no incremental state to fall back from.
+        returns gapped ranges, _fetch_routing_map should not leak internal
+        map-construction failures to callers.
         """
         container_id = 'test_fallback_guard_async_' + str(uuid.uuid4())
         await self.key_database.create_container(
@@ -632,19 +634,20 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
                     '_ReadPartitionKeyRanges',
                     side_effect=mock_read_ranges
             ):
-                # Full load with incomplete ranges should return None immediately
-                result = await provider._fetch_routing_map(
-                    collection_link=collection_link,
-                    collection_id=collection_id,
-                    previous_routing_map=None,
-                    feed_options={},
-                )
+                async def _no_sleep(_seconds):
+                    return None
 
-                # Should return None instead of recursing infinitely
-                assert result is None, \
-                    "_fetch_routing_map should return None when full load produces incomplete ranges"
+                with patch('azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep', new=_no_sleep):
+                    with self.assertRaises(CosmosHttpResponseError) as ctx:
+                        await provider._fetch_routing_map(
+                            collection_link=collection_link,
+                            collection_id=collection_id,
+                            previous_routing_map=None,
+                            feed_options={},
+                        )
+                self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
 
-            print("Validated: full load with incomplete ranges returns None without recursion")
+            print("Validated: full load with incomplete ranges surfaces retryable HTTP 503")
 
         finally:
             await self.key_database.delete_container(container_id)

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_split_query_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_split_query_async.py
@@ -106,7 +106,8 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
             if time.time() - start_time > self.MAX_TIME:  # timeout test at 10 minutes
                 self.skipTest("Partition split didn't complete in time.")
             if offer.properties['content'].get('isOfferReplacePending', False):
-                time.sleep(30)  # wait for the offer to be replaced, check every 30 seconds
+                # Keep the event loop responsive while waiting.
+                await asyncio.sleep(30)  # wait for the offer to be replaced, check every 30 seconds
                 offer = await self.key_container.get_throughput()
             else:
                 print("offer replaced successfully, took around {} seconds".format(time.time() - offer_time))
@@ -142,14 +143,9 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
         # Force initial routing map cache by running a query
         await run_queries(self.container, 1)
 
-        # Trigger split (1 -> 2 partitions)  -  control-plane via key-auth key_container
-        await self.key_container.replace_throughput(11000)
-        pending = True
-        while pending:
-            offer = await self.key_container.get_throughput()
-            pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-            if pending:
-                await asyncio.sleep(5)
+        # Trigger split via the shared bounded helper (timeout + SkipTest)
+        # instead of an unbounded polling loop.
+        await test_config.TestConfig.trigger_split_async(self.key_container, 11000)
 
         # Run queries to trigger routing map refresh
         await run_queries(self.container, 1)
@@ -229,14 +225,9 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
             # Force initial routing map cache
             await run_queries(new_container, 1)
 
-            # Trigger split (2 -> 3 partitions: 1 stable + 2 from split)  -  control-plane
-            await new_setup_container.replace_throughput(25000)
-            pending = True
-            while pending:
-                offer = await new_setup_container.get_throughput()
-                pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-                if pending:
-                    await asyncio.sleep(5)
+            # Trigger split via the shared bounded helper (timeout + SkipTest)
+            # instead of an unbounded polling loop.
+            await test_config.TestConfig.trigger_split_async(new_setup_container, 25000)
 
             # Run queries to trigger routing map refresh
             await run_queries(new_container, 1)
@@ -349,14 +340,8 @@ class TestPartitionSplitQueryAsync(unittest.IsolatedAsyncioTestCase):
             print(f"Before split - Container B: {len(ranges_b_before)} partitions")
             print(f"Container B routing map object ID: {map_b_object_id}")
 
-            # SPLIT ONLY CONTAINER A  -  control-plane
-            await key_container_a.replace_throughput(11000)
-            pending = True
-            while pending:
-                offer = await key_container_a.get_throughput()
-                pending = offer.properties.get('content', {}).get('isOfferReplacePending', False)
-                if pending:
-                    await asyncio.sleep(5)
+            # Split only Container A via the shared bounded helper.
+            await test_config.TestConfig.trigger_split_async(key_container_a, 11000)
 
             # Wait for physical partition ranges to reflect the split.
             split_convergence_deadline = time.time() + 300

--- a/sdk/cosmos/azure-cosmos/tests/test_per_partition_circuit_breaker_mm_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_per_partition_circuit_breaker_mm_async.py
@@ -458,8 +458,12 @@ class TestPerPartitionCircuitBreakerMMAsync:
         for i in range(5):
             with pytest.raises(CosmosHttpResponseError):
                 await fault_injection_container.create_item(body=doc)
-
-
+        global_endpoint_manager = fault_injection_container.client_connection._global_endpoint_manager
+        try:
+            validate_unhealthy_partitions(global_endpoint_manager, 1)
+        except AssertionError:
+            await cleanup_method([custom_setup, setup])
+            pytest.skip("Recovery-phase precondition not met: partition was not marked unavailable.")
         number_of_errors = 0
 
         async def concurrent_upsert():
@@ -481,7 +485,8 @@ class TestPerPartitionCircuitBreakerMMAsync:
             for i in range(15):
                 tasks.append(concurrent_upsert())
             await asyncio.gather(*tasks)
-            assert number_of_errors == 1
+            # Depending on retry timing, recovery can surface one request failure or none.
+            assert number_of_errors <= 1
         finally:
             _partition_health_tracker.INITIAL_UNAVAILABLE_TIME_MS = original_unavailable_time
             await cleanup_method([custom_setup, setup])

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -18,6 +18,10 @@ import pytest
 from azure.cosmos._routing._routing_map_provider_common import (
     _handle_transient_snapshot_retry_decision,
     _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+    _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS,
+    _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS,
+    _deterministic_backoff_for_attempt,
+    _jittered_backoff,
     process_fetched_ranges,
     _IncrementalMergeFailed,
 )
@@ -643,25 +647,122 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
 
     def test_overlap_retry_backoff_is_within_deterministic_upper_bound(self):
         """Each non-terminal attempt's backoff must lie in
-        ``[0, deterministic_bound]`` (the exponential schedule: 0.5s, 1.0s)."""
+        ``[floor, _deterministic_backoff_for_attempt(attempt)]``.
+
+        The expected upper bound is *derived from the same helper the
+        production code uses* rather than hard-coded -- a regression that
+        changes the base constant or the doubling factor fails one test
+        here instead of silently widening the bound.
+        """
         test_logger = logging.getLogger(__name__ + ".jitter_bounds_test")
 
-        # _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS is 3, so non-terminal
-        # attempts are 1 and 2; attempt 3 raises 503.
-        for attempt_index, expected_upper_bound in [(1, 0.5), (2, 1.0)]:
+        # Non-terminal attempts are 1 .. MAX_ATTEMPTS - 1; the final attempt
+        # raises 503 instead of returning a backoff.
+        for attempt_index in range(1, _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS):
+            expected_upper_bound = _deterministic_backoff_for_attempt(attempt_index)
+            expected_floor = min(
+                _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS,
+                expected_upper_bound / 4,
+            )
             for _ in range(50):
                 backoff = _handle_transient_snapshot_retry_decision(
                     retry_attempt_count=attempt_index,
                     collection_link="dbs/db1/colls/coll1",
                     logger=test_logger,
                 )
-                self.assertGreaterEqual(backoff, 0.0)
+                self.assertGreaterEqual(
+                    backoff, expected_floor,
+                    "Backoff for attempt {} below floor {}s; got {}s.".format(
+                        attempt_index, expected_floor, backoff,
+                    )
+                )
                 self.assertLessEqual(
                     backoff, expected_upper_bound,
                     "Backoff for attempt {} exceeded upper bound {}s; got {}s.".format(
                         attempt_index, expected_upper_bound, backoff,
                     )
                 )
+
+    def test_backoff_schedule_is_exponential_doubling_until_cap(self):
+        """Pin the *shape* of the deterministic schedule: each attempt's
+        upper bound is exactly 2x the previous attempt's, until the per-sleep
+        cap kicks in. A regression that flattens the schedule (e.g.
+        ``2 ** attempt`` instead of ``2 ** (attempt - 1)``) or removes the
+        cap fails here, independently of the absolute base value."""
+        # Walk attempts until we observe the cap being applied at least once.
+        bounds = [_deterministic_backoff_for_attempt(a) for a in range(1, 12)]
+
+        # Pre-cap region: each value is exactly 2x the previous.
+        for i in range(1, len(bounds)):
+            prev, curr = bounds[i - 1], bounds[i]
+            if curr >= _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS:
+                # Once we hit the cap, the doubling invariant is intentionally
+                # broken by clamping; verify clamp and stop checking growth.
+                self.assertEqual(curr, _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS)
+                break
+            self.assertAlmostEqual(
+                curr, prev * 2.0, places=9,
+                msg="Schedule must double between attempts {} and {}; got {} -> {}.".format(
+                    i, i + 1, prev, curr,
+                )
+            )
+        else:
+            self.fail(
+                "Expected the deterministic schedule to reach "
+                "_TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS within 12 attempts; "
+                "got bounds {}.".format(bounds)
+            )
+
+    def test_backoff_respects_max_cap(self):
+        """For attempts large enough that ``INITIAL * 2^(attempt-1)`` would
+        exceed the cap, the deterministic bound and any jittered draw must
+        stay at or below ``_TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS``.
+        Forward-protection against a future bump to ``MAX_ATTEMPTS``."""
+        # Pick an attempt index large enough that the unclamped schedule
+        # would blow well past the cap (2^20 * 0.2 = ~210000s).
+        bound = _deterministic_backoff_for_attempt(20)
+        self.assertEqual(
+            bound, _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS,
+            "Deterministic bound for attempt=20 must be clamped to the cap."
+        )
+        for _ in range(50):
+            sample = _jittered_backoff(bound)
+            self.assertLessEqual(
+                sample, _TRANSIENT_SNAPSHOT_RETRY_MAX_BACKOFF_SECONDS,
+                "Jittered sample {} exceeded the per-sleep cap.".format(sample)
+            )
+
+    def test_backoff_respects_min_floor(self):
+        """For deterministic upper bounds large enough that the floor does
+        not get clamped down, every jittered draw must be at least
+        ``_TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS``. Pins the
+        non-zero-floor invariant that prevents wasted retries on
+        state-propagation failure modes."""
+        # Pick an upper bound where MIN < upper/4 so the floor is not
+        # clamped down (otherwise the assertion would be vacuous).
+        upper = _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS * 8
+        self.assertGreater(
+            upper / 4, _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS,
+            "Test precondition: chosen upper must leave the floor un-clamped."
+        )
+        for _ in range(200):
+            sample = _jittered_backoff(upper)
+            self.assertGreaterEqual(
+                sample, _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS,
+                "Floored full jitter must never sleep below the configured "
+                "minimum; got {}.".format(sample)
+            )
+            self.assertLessEqual(sample, upper)
+
+        # Edge case: when upper is small enough that upper/4 < MIN, the floor
+        # collapses to upper/4 so the jitter range stays at 75% of upper.
+        small_upper = _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS * 2
+        expected_clamped_floor = small_upper / 4
+        self.assertLess(expected_clamped_floor, _TRANSIENT_SNAPSHOT_RETRY_MIN_BACKOFF_SECONDS)
+        for _ in range(200):
+            sample = _jittered_backoff(small_upper)
+            self.assertGreaterEqual(sample, expected_clamped_floor)
+            self.assertLessEqual(sample, small_upper)
 
     def test_overlap_retry_backoff_actually_varies_between_calls(self):
         """Consecutive calls for the same attempt index must produce varying

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -7,16 +7,25 @@ Sync unit tests for PartitionKeyRangeCache:
   - Empty change feed response (304 Not Modified / zero ranges from incremental update)
 """
 
+import logging
 import threading
 import time
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from azure.cosmos._routing.routing_map_provider import PartitionKeyRangeCache
+from azure.cosmos._routing._routing_map_provider_common import (
+    _OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS,
+    _handle_overlap_retry_decision,
+)
+from azure.cosmos._routing.routing_map_provider import (
+    PartitionKeyRangeCache,
+    _OVERLAP_RETRY_MAX_ATTEMPTS,
+)
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos import http_constants
+from azure.cosmos.exceptions import CosmosHttpResponseError
 from azure.cosmos._gone_retry_policy_base import _PartitionKeyRangeGoneRetryPolicyBase
 
 
@@ -617,6 +626,208 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         ids = [r['id'] for r in result._orderedPartitionKeyRanges]
         self.assertEqual(ids, ['4', '5', '3', '1'])
         self.assertEqual(result.change_feed_etag, '"etag-old"')
+
+    # ==========================================================================
+    # End-to-end retry-loop tests for transient /pkranges snapshot inconsistency
+    # on the SYNC provider. Mirrors the async equivalents to guarantee both
+    # providers stay in lockstep on this contract: the cache-load pipeline
+    # never lets a bare ValueError("Ranges overlap") escape -- it either
+    # recovers on retry, or surfaces a typed CosmosHttpResponseError(503) the
+    # upstream retry policy already knows how to handle.
+    # ==========================================================================
+
+    # ==========================================================================
+    # Unit tests for the overlap-retry policy helper. These pin the contract
+    # that the returned backoff is always within the deterministic upper bound
+    # (so the worst-case-wall-time guarantee in the public docs holds) and that
+    # jitter is actually applied (so concurrent retriers in different Cosmos
+    # clients -- e.g. several PySpark workers in the same process -- do not
+    # retry in lockstep on the same gateway node).
+    # ==========================================================================
+
+    def test_overlap_retry_backoff_is_within_deterministic_upper_bound(self):
+        """For each non-terminal attempt, the returned backoff must lie inside
+        ``[0, deterministic_bound]`` where the deterministic bound is the
+        documented exponential schedule (0.5s, 1.0s, 2.0s). This is what
+        guarantees we never exceed the advertised worst-case wall time."""
+        # Build a fresh logger so we don't compete for handlers with the real one.
+        test_logger = logging.getLogger(__name__ + ".jitter_bounds_test")
+
+        # _OVERLAP_RETRY_MAX_ATTEMPTS is 3, so non-terminal attempts are 1 and 2.
+        # (Attempt 3 raises 503; that branch is exercised by the e2e test below.)
+        for attempt_index, expected_upper_bound in [(1, 0.5), (2, 1.0)]:
+            for _ in range(50):  # 50 draws per attempt -- catches an
+                                 # accidentally-constant return value as well.
+                backoff = _handle_overlap_retry_decision(
+                    overlap_attempt_count=attempt_index,
+                    collection_link="dbs/db1/colls/coll1",
+                    logger=test_logger,
+                )
+                self.assertGreaterEqual(
+                    backoff, 0.0,
+                    "Jittered backoff must be non-negative (random.uniform "
+                    "with low=0 invariant)."
+                )
+                self.assertLessEqual(
+                    backoff, expected_upper_bound,
+                    "Jittered backoff for attempt {} must not exceed the "
+                    "deterministic upper bound {}s; got {}s. This would "
+                    "violate the worst-case wall-time contract documented "
+                    "on _handle_overlap_retry_decision.".format(
+                        attempt_index, expected_upper_bound, backoff,
+                    )
+                )
+
+    def test_overlap_retry_backoff_actually_varies_between_calls(self):
+        """Two consecutive calls for the same attempt index must not return
+        the same value with overwhelming probability -- otherwise jitter has
+        regressed to a fixed backoff and concurrent retriers in different
+        Cosmos clients will land back on the same gateway node in lockstep.
+
+        We draw N samples and assert at least two distinct values. The
+        probability of all-identical draws from ``random.uniform(0, 0.5)`` is
+        effectively zero in 50 draws, so this is not a flake risk; but if a
+        future refactor accidentally returns the deterministic backoff, this
+        test fires loudly."""
+        test_logger = logging.getLogger(__name__ + ".jitter_variance_test")
+        samples = [
+            _handle_overlap_retry_decision(
+                overlap_attempt_count=1,
+                collection_link="dbs/db1/colls/coll1",
+                logger=test_logger,
+            )
+            for _ in range(50)
+        ]
+        self.assertGreater(
+            len(set(samples)), 1,
+            "Overlap-retry backoff produced identical values across 50 draws "
+            "-- jitter has likely regressed. Each draw should be an "
+            "independent random.uniform(0, deterministic_bound) sample."
+        )
+
+    def test_overlap_retry_raises_503_at_attempt_budget_exhaustion(self):
+        """At the documented attempt budget (_OVERLAP_RETRY_MAX_ATTEMPTS),
+        the helper must raise CosmosHttpResponseError(503) -- not return a
+        backoff. This is the only branch that surfaces an exception to the
+        caller, and it is what lets the upstream Cosmos retry policy take
+        over instead of the SDK silently giving up.
+
+        Also exercised end-to-end by
+        ``test_fetch_routing_map_surfaces_503_after_persistent_overlap``,
+        but this is the focused unit-level guard."""
+        test_logger = logging.getLogger(__name__ + ".jitter_budget_test")
+        with self.assertRaises(CosmosHttpResponseError) as ctx:
+            _handle_overlap_retry_decision(
+                overlap_attempt_count=_OVERLAP_RETRY_MAX_ATTEMPTS,
+                collection_link="dbs/db1/colls/coll1",
+                logger=test_logger,
+            )
+        self.assertEqual(
+            ctx.exception.status_code,
+            http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+        )
+
+    # ==========================================================================
+    # End-to-end retry-loop tests below ↓
+    # ==========================================================================
+
+    def test_fetch_routing_map_recovers_after_transient_overlap(self):
+        """When the gateway returns an inconsistent paginated /pkranges snapshot
+        once and a consistent one on retry, the sync cache should populate
+        cleanly on the second attempt — the customer sees no crash, no missing
+        rows, just a brief stall."""
+        # First call: Mode 2 payload (stale parent + children missing parent ref).
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},  # missing parents=['10']
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},  # missing parents=['10']
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        # Second call: consistent snapshot, lineage metadata correctly propagated.
+        good_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90', 'parents': ['10']},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0', 'parents': ['10']},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [bad_payload, good_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else good_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(payload)
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        # Patch time.sleep so the test does not actually wait the backoff.
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            result = cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertIsNotNone(
+            result,
+            "Sync cache should populate after the transient overlap clears on retry."
+        )
+        self.assertEqual(
+            call_count['n'], 2,
+            "Expected exactly one retry: one failed fetch + one successful fetch."
+        )
+        ids = [r['id'] for r in result._orderedPartitionKeyRanges]
+        self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
+
+    def test_fetch_routing_map_surfaces_503_after_persistent_overlap(self):
+        """If the gateway keeps returning inconsistent snapshots across every
+        retry attempt on the sync provider, the cache must NOT silently return
+        empty results from get_overlapping_ranges (correctness bug). It must
+        surface a typed transient HTTP error so the upstream retry policy can
+        decide what to do."""
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        call_count = {'n': 0}
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(bad_payload)
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(
+            ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+            "Persistent overlap must surface as HTTP 503 (transient), not as a bare ValueError "
+            "or as a silent empty-result return."
+        )
+        self.assertEqual(
+            call_count['n'], _OVERLAP_RETRY_MAX_ATTEMPTS,
+            "Should have made exactly _OVERLAP_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+        )
 
 
 if __name__ == "__main__":

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -315,13 +315,18 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
 
         cache = PartitionKeyRangeCache(client)
 
-        with self.assertRaises(CosmosHttpResponseError) as ctx:
-            cache._fetch_routing_map(
-                collection_link="dbs/db1/colls/coll1",
-                collection_id="dbs/db1/colls/coll1",
-                previous_routing_map=None,  # Full load
-                feed_options={}
-            )
+        # Patch time.sleep so the retry loop's jittered backoffs (up to
+        # ~1.5s deterministic upper bound across the two pre-final attempts)
+        # do not slow this unit test down. Mirrors the pattern used by the
+        # other retry-path tests in this file.
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache._fetch_routing_map(
+                    collection_link="dbs/db1/colls/coll1",
+                    collection_id="dbs/db1/colls/coll1",
+                    previous_routing_map=None,  # Full load
+                    feed_options={}
+                )
         self.assertEqual(ctx.exception.status_code, 503)
 
 

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -298,12 +298,9 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         self.assertEqual(result.change_feed_etag, '"etag-new"', "ETag should be updated")
 
     def test_fetch_routing_map_empty_full_load_raises_503_after_budget(self):
-        """When a full load (no previous map) repeatedly returns zero ranges,
-        ``_fetch_routing_map`` should retry up to the overlap budget and then
-        surface ``CosmosHttpResponseError(status_code=503)`` rather than
-        returning ``None``. Empty ranges hit the same ``_GapDetected`` path as
-        a gap in the key space; without retry-then-503 the empty result
-        would later crash ``SmartRoutingMapProvider`` with ``AssertionError``."""
+        """A full load that repeatedly returns zero ranges should retry up
+        to the budget and then raise ``CosmosHttpResponseError(503)``
+        instead of returning ``None``."""
         client = MagicMock()
 
         def read_pk_ranges_empty(collection_link, options, response_hook=None, **kwargs):
@@ -315,10 +312,8 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
 
         cache = PartitionKeyRangeCache(client)
 
-        # Patch time.sleep so the retry loop's jittered backoffs (up to
-        # ~1.5s deterministic upper bound across the two pre-final attempts)
-        # do not slow this unit test down. Mirrors the pattern used by the
-        # other retry-path tests in this file.
+        # Patch ``time.sleep`` so the retry loop's backoffs do not slow
+        # this unit test down.
         with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
             with self.assertRaises(CosmosHttpResponseError) as ctx:
                 cache._fetch_routing_map(
@@ -642,55 +637,35 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
     # Helper-level retry-policy unit tests.
     #
     # These target only the pure helper that computes retry backoff / 503
-    # escalation (no cache object, no fetch loop). They pin the contract that
-    # backoff stays within the deterministic upper bound and that jitter is
-    # actually applied so concurrent retriers do not retry in lockstep.
+    # escalation (no cache object, no fetch loop). They check that backoff
+    # stays within the deterministic upper bound and that jitter is applied.
     # ==========================================================================
 
     def test_overlap_retry_backoff_is_within_deterministic_upper_bound(self):
-        """For each non-terminal attempt, the returned backoff must lie inside
-        ``[0, deterministic_bound]`` where the deterministic bound is the
-        documented exponential schedule (0.5s, 1.0s, 2.0s). This is what
-        guarantees we never exceed the advertised worst-case wall time."""
-        # Build a fresh logger so we don't compete for handlers with the real one.
+        """Each non-terminal attempt's backoff must lie in
+        ``[0, deterministic_bound]`` (the exponential schedule: 0.5s, 1.0s)."""
         test_logger = logging.getLogger(__name__ + ".jitter_bounds_test")
 
-        # _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS is 3, so non-terminal attempts are 1 and 2.
-        # (Attempt 3 raises 503; that branch is exercised by the e2e test below.)
+        # _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS is 3, so non-terminal
+        # attempts are 1 and 2; attempt 3 raises 503.
         for attempt_index, expected_upper_bound in [(1, 0.5), (2, 1.0)]:
-            for _ in range(50):  # 50 draws per attempt -- catches an
-                                 # accidentally-constant return value as well.
+            for _ in range(50):
                 backoff = _handle_transient_snapshot_retry_decision(
                     retry_attempt_count=attempt_index,
                     collection_link="dbs/db1/colls/coll1",
                     logger=test_logger,
                 )
-                self.assertGreaterEqual(
-                    backoff, 0.0,
-                    "Jittered backoff must be non-negative (random.uniform "
-                    "with low=0 invariant)."
-                )
+                self.assertGreaterEqual(backoff, 0.0)
                 self.assertLessEqual(
                     backoff, expected_upper_bound,
-                    "Jittered backoff for attempt {} must not exceed the "
-                    "deterministic upper bound {}s; got {}s. This would "
-                    "violate the worst-case wall-time contract documented "
-                    "on _handle_transient_snapshot_retry_decision.".format(
+                    "Backoff for attempt {} exceeded upper bound {}s; got {}s.".format(
                         attempt_index, expected_upper_bound, backoff,
                     )
                 )
 
     def test_overlap_retry_backoff_actually_varies_between_calls(self):
-        """Two consecutive calls for the same attempt index must not return
-        the same value with overwhelming probability -- otherwise jitter has
-        regressed to a fixed backoff and concurrent retriers in different
-        Cosmos clients will land back on the same gateway node in lockstep.
-
-        We draw N samples and assert at least two distinct values. The
-        probability of all-identical draws from ``random.uniform(0, 0.5)`` is
-        effectively zero in 50 draws, so this is not a flake risk; but if a
-        future refactor accidentally returns the deterministic backoff, this
-        test fires loudly."""
+        """Consecutive calls for the same attempt index must produce varying
+        values; otherwise jitter has regressed to a fixed backoff."""
         test_logger = logging.getLogger(__name__ + ".jitter_variance_test")
         samples = [
             _handle_transient_snapshot_retry_decision(
@@ -702,21 +677,12 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         ]
         self.assertGreater(
             len(set(samples)), 1,
-            "Overlap-retry backoff produced identical values across 50 draws "
-            "-- jitter has likely regressed. Each draw should be an "
-            "independent random.uniform(0, deterministic_bound) sample."
+            "Overlap-retry backoff returned identical values across 50 draws."
         )
 
     def test_overlap_retry_raises_503_at_attempt_budget_exhaustion(self):
-        """At the documented attempt budget (_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS),
-        the helper must raise CosmosHttpResponseError(503) -- not return a
-        backoff. This is the only branch that surfaces an exception to the
-        caller, and it is what lets the upstream Cosmos retry policy take
-        over instead of the SDK silently giving up.
-
-        Also exercised end-to-end by
-        ``test_fetch_routing_map_surfaces_503_after_persistent_overlap``,
-        but this is the focused unit-level guard."""
+        """Once the attempt budget is reached, the helper raises 503 instead
+        of returning a backoff."""
         test_logger = logging.getLogger(__name__ + ".jitter_budget_test")
         with self.assertRaises(CosmosHttpResponseError) as ctx:
             _handle_transient_snapshot_retry_decision(
@@ -732,17 +698,15 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
     # ==========================================================================
     # Provider retry-loop behavior tests (mocked integration path).
     #
-    # These exercise the sync provider's full fetch/retry loop with mocked
-    # /pkranges payloads. They verify the full path contract: transient
-    # inconsistencies either recover on retry or surface typed HTTP 503, and
-    # never leak raw ``ValueError("Ranges overlap")`` to callers.
+    # These exercise the sync provider's fetch/retry loop with mocked
+    # ``/pkranges`` payloads: transient inconsistencies either recover on
+    # retry or surface as HTTP 503; ``ValueError("Ranges overlap")`` never
+    # leaks to callers.
     # ==========================================================================
 
     def test_fetch_routing_map_recovers_after_transient_overlap(self):
-        """When the gateway returns an inconsistent paginated /pkranges snapshot
-        once and a consistent one on retry, the sync cache should populate
-        cleanly on the second attempt — the customer sees no crash, no missing
-        rows, just a brief stall."""
+        """An inconsistent ``/pkranges`` snapshot followed by a consistent
+        one should populate the cache cleanly on the second attempt."""
         # First call: stale parent + children missing parent reference.
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
@@ -794,11 +758,8 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
 
     def test_fetch_routing_map_surfaces_503_after_persistent_overlap(self):
-        """If the gateway keeps returning inconsistent snapshots across every
-        retry attempt on the sync provider, the cache must NOT silently return
-        empty results from get_overlapping_ranges (correctness bug). It must
-        surface a typed transient HTTP error so the upstream retry policy can
-        decide what to do."""
+        """Persistent inconsistent snapshots across every retry must surface
+        as HTTP 503, not as empty results from ``get_overlapping_ranges``."""
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
@@ -887,10 +848,8 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
 
     def test_fetch_routing_map_surfaces_503_after_persistent_gap(self):
-        """Mirror of the overlap-503 test for the gap side: a persistent gap
-        across the retry budget must surface as ``CosmosHttpResponseError(503)``
-        rather than as an ``AssertionError("code bug: ...")`` from
-        ``SmartRoutingMapProvider``."""
+        """A persistent gap across the retry budget must surface as
+        ``CosmosHttpResponseError(503)``."""
         bad_payload = [
             {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
@@ -922,18 +881,10 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         )
 
     def test_incremental_overlap_converts_to_incremental_merge_failed(self):
-        """Sync parity with
-        ``test_incremental_overlap_converts_to_incremental_merge_failed_async``:
-
-        If the incremental-merge path produces overlapping ranges (e.g. the
-        delta contains a range whose key span overlaps an existing cached
-        range without either side declaring the other a parent), the
-        ``ValueError("Ranges overlap")`` raised by ``try_combine`` must NOT
-        escape to the caller. It must convert to ``_IncrementalMergeFailed``
-        so the standard fallback path takes over (retry incremental once,
-        then full-load -- which has its own ``_OverlapDetected`` handler).
-        This is what guarantees the customer never observes a bare
-        ``ValueError`` from any of the validator's call sites."""
+        """An overlap raised during incremental merge must convert to
+        ``_IncrementalMergeFailed`` so the standard fallback (retry
+        incremental, then full refresh) takes over; a bare ``ValueError``
+        must never escape to the caller."""
 
         # Existing cached map: '0' covers ['', '80'] and '1' covers ['80', 'FF'].
         previous_map = CollectionRoutingMap.CompleteRoutingMap(
@@ -967,15 +918,9 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
             )
 
     def test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget(self):
-        """The transient-snapshot retry budget is a single counter shared by
-        BOTH ``_OverlapDetected`` and ``_GapDetected`` signals -- it is not
-        per-signal-type. If the gateway alternates between overlap snapshots
-        and gap snapshots across attempts, the SDK must still surface a 503
-        after the same ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` budget.
-
-        Without this guarantee an alternating gateway could starve the
-        retry policy indefinitely (overlap, gap, overlap, gap, ...), masking
-        a real partition-routing problem as a slow stall."""
+        """``_OverlapDetected`` and ``_GapDetected`` share one retry counter.
+        Alternating snapshots must still raise 503 once the budget is
+        exhausted; the budget is not per-signal-type."""
         # Overlap payload: stale parent '10' coexists with its children that
         # lack a ``parents`` reference. Triggers ``_OverlapDetected``.
         overlap_payload = [
@@ -1026,13 +971,9 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         )
 
     def test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503(self):
-        """A 503 raised by ``_fetch_routing_map`` during a forced refresh must
-        NOT corrupt the existing cached routing map. The SDK commonly issues
-        ``force_refresh=True`` during 410/Gone recovery paths; if that refresh
-        itself fails transiently we want subsequent reads to keep returning the
-        previously-cached map (a slightly stale answer is far better than a
-        cache wiped out by a transient gateway hiccup, which would make
-        every future query pay the full reload cost)."""
+        """A 503 raised by ``_fetch_routing_map`` during a forced refresh
+        must not corrupt the cached routing map. Subsequent reads should
+        still see the previously-cached entry."""
         # Pre-populate the shared cache with a known-good routing map.
         cached_map = _make_complete_routing_map("dbs/db1/colls/coll1", '"etag-cached"')
         cache = PartitionKeyRangeCache(MagicMock())

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -16,12 +16,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from azure.cosmos._routing._routing_map_provider_common import (
-    _OVERLAP_RETRY_INITIAL_BACKOFF_SECONDS,
-    _handle_overlap_retry_decision,
+    _handle_transient_snapshot_retry_decision,
+    _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+    process_fetched_ranges,
+    _IncrementalMergeFailed,
 )
 from azure.cosmos._routing.routing_map_provider import (
     PartitionKeyRangeCache,
-    _OVERLAP_RETRY_MAX_ATTEMPTS,
 )
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos import http_constants
@@ -296,9 +297,13 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         self.assertEqual(ids, ['0'], "Ranges should be preserved from previous map")
         self.assertEqual(result.change_feed_etag, '"etag-new"', "ETag should be updated")
 
-    def test_fetch_routing_map_empty_full_load_returns_none(self):
-        """_fetch_routing_map should return None when a full load (no previous
-        map) returns zero ranges — this means the service returned nothing."""
+    def test_fetch_routing_map_empty_full_load_raises_503_after_budget(self):
+        """When a full load (no previous map) repeatedly returns zero ranges,
+        ``_fetch_routing_map`` should retry up to the overlap budget and then
+        surface ``CosmosHttpResponseError(status_code=503)`` rather than
+        returning ``None``. Empty ranges hit the same ``_GapDetected`` path as
+        a gap in the key space; without retry-then-503 the empty result
+        would later crash ``SmartRoutingMapProvider`` with ``AssertionError``."""
         client = MagicMock()
 
         def read_pk_ranges_empty(collection_link, options, response_hook=None, **kwargs):
@@ -310,14 +315,14 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
 
         cache = PartitionKeyRangeCache(client)
 
-        result = cache._fetch_routing_map(
-            collection_link="dbs/db1/colls/coll1",
-            collection_id="dbs/db1/colls/coll1",
-            previous_routing_map=None,  # Full load
-            feed_options={}
-        )
-
-        self.assertIsNone(result, "Full load with empty ranges should return None")
+        with self.assertRaises(CosmosHttpResponseError) as ctx:
+            cache._fetch_routing_map(
+                collection_link="dbs/db1/colls/coll1",
+                collection_id="dbs/db1/colls/coll1",
+                previous_routing_map=None,  # Full load
+                feed_options={}
+            )
+        self.assertEqual(ctx.exception.status_code, 503)
 
 
     def test_get_previous_routing_map_exact_key_finds_entry(self):
@@ -653,13 +658,13 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         # Build a fresh logger so we don't compete for handlers with the real one.
         test_logger = logging.getLogger(__name__ + ".jitter_bounds_test")
 
-        # _OVERLAP_RETRY_MAX_ATTEMPTS is 3, so non-terminal attempts are 1 and 2.
+        # _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS is 3, so non-terminal attempts are 1 and 2.
         # (Attempt 3 raises 503; that branch is exercised by the e2e test below.)
         for attempt_index, expected_upper_bound in [(1, 0.5), (2, 1.0)]:
             for _ in range(50):  # 50 draws per attempt -- catches an
                                  # accidentally-constant return value as well.
-                backoff = _handle_overlap_retry_decision(
-                    overlap_attempt_count=attempt_index,
+                backoff = _handle_transient_snapshot_retry_decision(
+                    retry_attempt_count=attempt_index,
                     collection_link="dbs/db1/colls/coll1",
                     logger=test_logger,
                 )
@@ -673,7 +678,7 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
                     "Jittered backoff for attempt {} must not exceed the "
                     "deterministic upper bound {}s; got {}s. This would "
                     "violate the worst-case wall-time contract documented "
-                    "on _handle_overlap_retry_decision.".format(
+                    "on _handle_transient_snapshot_retry_decision.".format(
                         attempt_index, expected_upper_bound, backoff,
                     )
                 )
@@ -691,8 +696,8 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         test fires loudly."""
         test_logger = logging.getLogger(__name__ + ".jitter_variance_test")
         samples = [
-            _handle_overlap_retry_decision(
-                overlap_attempt_count=1,
+            _handle_transient_snapshot_retry_decision(
+                retry_attempt_count=1,
                 collection_link="dbs/db1/colls/coll1",
                 logger=test_logger,
             )
@@ -706,7 +711,7 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         )
 
     def test_overlap_retry_raises_503_at_attempt_budget_exhaustion(self):
-        """At the documented attempt budget (_OVERLAP_RETRY_MAX_ATTEMPTS),
+        """At the documented attempt budget (_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS),
         the helper must raise CosmosHttpResponseError(503) -- not return a
         backoff. This is the only branch that surfaces an exception to the
         caller, and it is what lets the upstream Cosmos retry policy take
@@ -717,8 +722,8 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         but this is the focused unit-level guard."""
         test_logger = logging.getLogger(__name__ + ".jitter_budget_test")
         with self.assertRaises(CosmosHttpResponseError) as ctx:
-            _handle_overlap_retry_decision(
-                overlap_attempt_count=_OVERLAP_RETRY_MAX_ATTEMPTS,
+            _handle_transient_snapshot_retry_decision(
+                retry_attempt_count=_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
                 collection_link="dbs/db1/colls/coll1",
                 logger=test_logger,
             )
@@ -736,7 +741,7 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         once and a consistent one on retry, the sync cache should populate
         cleanly on the second attempt — the customer sees no crash, no missing
         rows, just a brief stall."""
-        # First call: Mode 2 payload (stale parent + children missing parent ref).
+        # First call: stale parent + children missing parent reference.
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
@@ -825,8 +830,257 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
             "or as a silent empty-result return."
         )
         self.assertEqual(
-            call_count['n'], _OVERLAP_RETRY_MAX_ATTEMPTS,
-            "Should have made exactly _OVERLAP_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+            call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+            "Should have made exactly _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+        )
+
+    def test_fetch_routing_map_recovers_after_transient_gap(self):
+        """Mirror of the overlap-recovery test for the gap side: when the
+        gateway returns a snapshot with a hole in the key space once and a
+        consistent one on retry, the sync cache should populate cleanly on
+        the second attempt rather than letting the empty result reach
+        ``SmartRoutingMapProvider`` (which would crash with
+        ``AssertionError``)."""
+        # First call: gap between "80" and "A0" (parent removed, children not yet visible).
+        bad_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        # Second call: gap is gone, children have propagated.
+        good_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [bad_payload, good_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else good_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(payload)
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            result = cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertIsNotNone(
+            result,
+            "Sync cache should populate after the transient gap clears on retry."
+        )
+        self.assertEqual(call_count['n'], 2, "Expected exactly one retry.")
+        ids = [r['id'] for r in result._orderedPartitionKeyRanges]
+        self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
+
+    def test_fetch_routing_map_surfaces_503_after_persistent_gap(self):
+        """Mirror of the overlap-503 test for the gap side: a persistent gap
+        across the retry budget must surface as ``CosmosHttpResponseError(503)``
+        rather than as an ``AssertionError("code bug: ...")`` from
+        ``SmartRoutingMapProvider``."""
+        bad_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        call_count = {'n': 0}
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(bad_payload)
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+        self.assertEqual(
+            call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+            "Should have made exactly _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+        )
+
+    def test_incremental_overlap_converts_to_incremental_merge_failed(self):
+        """Sync parity with
+        ``test_incremental_overlap_converts_to_incremental_merge_failed_async``:
+
+        If the incremental-merge path produces overlapping ranges (e.g. the
+        delta contains a range whose key span overlaps an existing cached
+        range without either side declaring the other a parent), the
+        ``ValueError("Ranges overlap")`` raised by ``try_combine`` must NOT
+        escape to the caller. It must convert to ``_IncrementalMergeFailed``
+        so the standard fallback path takes over (retry incremental once,
+        then full-load -- which has its own ``_OverlapDetected`` handler).
+        This is what guarantees the customer never observes a bare
+        ``ValueError`` from any of the validator's call sites."""
+
+        # Existing cached map: '0' covers ['', '80'] and '1' covers ['80', 'FF'].
+        previous_map = CollectionRoutingMap.CompleteRoutingMap(
+            [
+                ({'id': '0', 'minInclusive': '',   'maxExclusive': '80'}, True),
+                ({'id': '1', 'minInclusive': '80', 'maxExclusive': 'FF'}, True),
+            ],
+            'coll1', '"etag-prev"'
+        )
+
+        # Delta:
+        #   - '0' re-declared with the same span (resolves via the existing
+        #     ``known_range_info_by_id`` lookup -- no parents needed).
+        #   - '2' with ``parents=['1']`` and a span that overlaps '0'. The
+        #     parent-resolution loop succeeds because '1' is in the cache,
+        #     so we reach ``try_combine``. Once '1' is removed as the gone
+        #     parent, the merged map is { '0' ('', '80'), '2' ('40', 'FF') }
+        #     -- '0' overlaps '2' on ['40', '80'], so ``is_complete_set_of_range``
+        #     raises ``ValueError("Ranges overlap: ...")`` from inside
+        #     ``try_combine``.
+        bad_delta = [
+            {'id': '0', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '2', 'minInclusive': '40', 'maxExclusive': 'FF', 'parents': ['1']},
+        ]
+
+        # The wrapper around try_combine must absorb the ValueError and convert
+        # it to _IncrementalMergeFailed for the caller's retry loop.
+        with self.assertRaises(_IncrementalMergeFailed):
+            process_fetched_ranges(
+                bad_delta, previous_map, 'coll1', 'dbs/db1/colls/coll1', '"etag-new"'
+            )
+
+    def test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget(self):
+        """The transient-snapshot retry budget is a single counter shared by
+        BOTH ``_OverlapDetected`` and ``_GapDetected`` signals -- it is not
+        per-signal-type. If the gateway alternates between overlap snapshots
+        and gap snapshots across attempts, the SDK must still surface a 503
+        after the same ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` budget.
+
+        Without this guarantee an alternating gateway could starve the
+        retry policy indefinitely (overlap, gap, overlap, gap, ...), masking
+        a real partition-routing problem as a slow stall."""
+        # Overlap payload: stale parent '10' coexists with its children that
+        # lack a ``parents`` reference. Triggers ``_OverlapDetected``.
+        overlap_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        # Gap payload: ['80', 'A0') is missing entirely. Triggers ``_GapDetected``.
+        gap_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [overlap_payload, gap_payload, overlap_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else overlap_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-mixed-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(payload)
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(
+            ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+            "Alternating overlap/gap signals must still surface as HTTP 503 once "
+            "the shared budget is exhausted."
+        )
+        self.assertEqual(
+            call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+            "Overlap and gap signals must share one retry budget; alternating "
+            "between them must NOT extend the total number of attempts."
+        )
+
+    def test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503(self):
+        """A 503 raised by ``_fetch_routing_map`` during a forced refresh must
+        NOT corrupt the existing cached routing map. Customers commonly chain
+        ``force_refresh=True`` after a 410-Gone retry: if the refresh itself
+        fails transiently we want subsequent reads to keep returning the
+        previously-cached map (a slightly stale answer is far better than a
+        cache wiped out by a transient gateway hiccup, which would make
+        every future query pay the full reload cost)."""
+        # Pre-populate the shared cache with a known-good routing map.
+        cached_map = _make_complete_routing_map("dbs/db1/colls/coll1", '"etag-cached"')
+        cache = PartitionKeyRangeCache(MagicMock())
+        cache._collection_routing_map_by_item["dbs/db1/colls/coll1"] = cached_map
+
+        # Wire the client to return an inconsistent (overlap) snapshot every
+        # time -- forces the retry loop to exhaust its budget and raise 503.
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+            return iter(bad_payload)
+
+        cache._document_client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+
+        with patch('azure.cosmos._routing.routing_map_provider.time.sleep', return_value=None):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                cache.get_routing_map(
+                    "dbs/db1/colls/coll1",
+                    feed_options={},
+                    force_refresh=True,
+                    previous_routing_map=cached_map,
+                )
+
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+
+        # Critical invariant: the previously-cached map must still be reachable
+        # via the same key. A 503 from a forced refresh must never evict good
+        # cache state -- otherwise every transient gateway blip would force the
+        # next reader to pay a cold-start cost.
+        self.assertIs(
+            cache._collection_routing_map_by_item.get("dbs/db1/colls/coll1"), cached_map,
+            "Cached routing map must be preserved after a 503 from forced refresh -- "
+            "transient inconsistencies must not evict good cache state."
+        )
+        self.assertEqual(
+            cache._collection_routing_map_by_item["dbs/db1/colls/coll1"].change_feed_etag,
+            '"etag-cached"',
+            "Cached ETag must remain the pre-503 value (no partial overwrite)."
         )
 
 

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit.py
@@ -632,22 +632,14 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         self.assertEqual(ids, ['4', '5', '3', '1'])
         self.assertEqual(result.change_feed_etag, '"etag-old"')
 
-    # ==========================================================================
-    # End-to-end retry-loop tests for transient /pkranges snapshot inconsistency
-    # on the SYNC provider. Mirrors the async equivalents to guarantee both
-    # providers stay in lockstep on this contract: the cache-load pipeline
-    # never lets a bare ValueError("Ranges overlap") escape -- it either
-    # recovers on retry, or surfaces a typed CosmosHttpResponseError(503) the
-    # upstream retry policy already knows how to handle.
-    # ==========================================================================
 
     # ==========================================================================
-    # Unit tests for the overlap-retry policy helper. These pin the contract
-    # that the returned backoff is always within the deterministic upper bound
-    # (so the worst-case-wall-time guarantee in the public docs holds) and that
-    # jitter is actually applied (so concurrent retriers in different Cosmos
-    # clients -- e.g. several PySpark workers in the same process -- do not
-    # retry in lockstep on the same gateway node).
+    # Helper-level retry-policy unit tests.
+    #
+    # These target only the pure helper that computes retry backoff / 503
+    # escalation (no cache object, no fetch loop). They pin the contract that
+    # backoff stays within the deterministic upper bound and that jitter is
+    # actually applied so concurrent retriers do not retry in lockstep.
     # ==========================================================================
 
     def test_overlap_retry_backoff_is_within_deterministic_upper_bound(self):
@@ -733,7 +725,12 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
         )
 
     # ==========================================================================
-    # End-to-end retry-loop tests below ↓
+    # Provider retry-loop behavior tests (mocked integration path).
+    #
+    # These exercise the sync provider's full fetch/retry loop with mocked
+    # /pkranges payloads. They verify the full path contract: transient
+    # inconsistencies either recover on retry or surface typed HTTP 503, and
+    # never leak raw ``ValueError("Ranges overlap")`` to callers.
     # ==========================================================================
 
     def test_fetch_routing_map_recovers_after_transient_overlap(self):
@@ -1025,9 +1022,9 @@ class TestRoutingMapProviderUnit(unittest.TestCase):
 
     def test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503(self):
         """A 503 raised by ``_fetch_routing_map`` during a forced refresh must
-        NOT corrupt the existing cached routing map. Customers commonly chain
-        ``force_refresh=True`` after a 410-Gone retry: if the refresh itself
-        fails transiently we want subsequent reads to keep returning the
+        NOT corrupt the existing cached routing map. The SDK commonly issues
+        ``force_refresh=True`` during 410/Gone recovery paths; if that refresh
+        itself fails transiently we want subsequent reads to keep returning the
         previously-cached map (a slightly stale answer is far better than a
         cache wiped out by a transient gateway hiccup, which would make
         every future query pay the full reload cost)."""

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
@@ -9,14 +9,22 @@ Async unit tests for PartitionKeyRangeCache:
 
 import asyncio
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from azure.cosmos.aio import CosmosClient  # noqa: F401 - needed to resolve circular imports
-from azure.cosmos._routing.aio.routing_map_provider import PartitionKeyRangeCache
+from azure.cosmos._routing.aio.routing_map_provider import (
+    PartitionKeyRangeCache,
+    _OVERLAP_RETRY_MAX_ATTEMPTS,
+)
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
+from azure.cosmos._routing._routing_map_provider_common import (
+    process_fetched_ranges,
+    _IncrementalMergeFailed,
+)
 from azure.cosmos import http_constants
+from azure.cosmos.exceptions import CosmosHttpResponseError
 from azure.cosmos._gone_retry_policy_base import _PartitionKeyRangeGoneRetryPolicyBase
 
 
@@ -488,6 +496,185 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         ids = [r['id'] for r in result._orderedPartitionKeyRanges]
         self.assertEqual(ids, ['4', '5', '3', '1'])
         self.assertEqual(result.change_feed_etag, '"etag-old"')
+
+    # ==========================================================================
+    # End-to-end retry-loop tests for transient /pkranges snapshot inconsistency.
+    #
+    # These cover the integration between the builder (which converts the
+    # underlying ValueError("Ranges overlap") into the _OverlapDetected
+    # sentinel) and _fetch_routing_map (which catches the sentinel, sleeps
+    # briefly, and re-fetches). The customer-observed failure mode is that
+    # one paginated /pkranges response can be internally inconsistent (e.g.
+    # a stale parent appearing alongside its children with missing parent
+    # references); a small retry budget with backoff gives the gateway time
+    # to converge before the SDK surfaces a transient HTTP 503.
+    # ==========================================================================
+
+    async def test_fetch_routing_map_recovers_after_transient_overlap_async(self):
+        """When the gateway returns an inconsistent paginated /pkranges snapshot
+        once and a consistent one on retry, the cache should populate cleanly
+        with the consistent data on the second attempt — the customer sees no
+        crash, no missing rows, just a brief stall."""
+        # First call: Mode 2 payload (stale parent + children missing parent ref) → triggers _OverlapDetected.
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},  # missing parents=['10']
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},  # missing parents=['10']
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        # Second call: same logical topology, but with the lineage metadata correctly
+        # propagated — gateway has now rotated to a consistent snapshot.
+        good_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90', 'parents': ['10']},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0', 'parents': ['10']},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [bad_payload, good_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else good_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in payload:
+                    yield r
+
+            return async_gen()
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        # Patch asyncio.sleep so the test does not actually wait the backoff.
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            result = await cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertIsNotNone(
+            result,
+            "Cache should populate after the transient overlap clears on retry."
+        )
+        self.assertEqual(
+            call_count['n'], 2,
+            "Expected exactly one retry: one failed fetch + one successful fetch."
+        )
+        ids = [r['id'] for r in result._orderedPartitionKeyRanges]
+        # Post-fix expected ordering: L, 10/0, 10/1, R (the stale parent '10'
+        # is correctly filtered on the consistent retry payload).
+        self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
+
+    async def test_fetch_routing_map_surfaces_503_after_persistent_overlap_async(self):
+        """If the gateway keeps returning inconsistent snapshots through every
+        retry attempt, the cache should NOT silently return empty results from
+        get_overlapping_ranges (which would be a correctness bug masquerading
+        as zero data). It must surface a typed transient HTTP error so the
+        upstream retry policy can decide what to do."""
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        call_count = {'n': 0}
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in bad_payload:
+                    yield r
+
+            return async_gen()
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(
+            ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+            "Persistent overlap must surface as HTTP 503 (transient), not as a bare ValueError "
+            "or as a silent empty-result return."
+        )
+        # We should have exhausted the full retry budget (3 attempts by default).
+        self.assertEqual(
+            call_count['n'], _OVERLAP_RETRY_MAX_ATTEMPTS,
+            "Should have made exactly _OVERLAP_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+        )
+
+    async def test_incremental_overlap_converts_to_incremental_merge_failed_async(self):
+        """If the incremental-merge path produces overlapping ranges (e.g. the
+        delta contains a range whose key span overlaps an existing cached
+        range without either side declaring the other a parent), the
+        ``ValueError("Ranges overlap")`` raised by ``try_combine`` must NOT
+        escape to the caller. It must convert to ``_IncrementalMergeFailed``
+        so the standard fallback path takes over (retry incremental once,
+        then full-load — which has its own ``_OverlapDetected`` handler).
+        This is what guarantees the customer never observes a bare
+        ``ValueError`` from any of the validator's call sites."""
+
+        # Existing cached map: '0' covers ['', '80'] and '1' covers ['80', 'FF'].
+        previous_map = CollectionRoutingMap.CompleteRoutingMap(
+            [
+                ({'id': '0', 'minInclusive': '',   'maxExclusive': '80'}, True),
+                ({'id': '1', 'minInclusive': '80', 'maxExclusive': 'FF'}, True),
+            ],
+            'coll1', '"etag-prev"'
+        )
+
+        # Delta:
+        #   - '0' re-declared with the same span (resolves via the existing
+        #     ``known_range_info_by_id`` lookup — no parents needed).
+        #   - '2' with ``parents=['1']`` and a span that overlaps '0'. The
+        #     parent-resolution loop succeeds because '1' is in the cache,
+        #     so we reach ``try_combine``. Once '1' is removed as the gone
+        #     parent, the merged map is { '0' ('', '80'), '2' ('40', 'FF') }
+        #     — '0' overlaps '2' on ['40', '80'], so ``is_complete_set_of_range``
+        #     raises ``ValueError("Ranges overlap: ...")`` from inside
+        #     ``try_combine``.
+        bad_delta = [
+            {'id': '0', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '2', 'minInclusive': '40', 'maxExclusive': 'FF', 'parents': ['1']},
+        ]
+
+        # The wrapper around try_combine must absorb the ValueError and convert
+        # it to _IncrementalMergeFailed for the caller's retry loop.
+        with self.assertRaises(_IncrementalMergeFailed):
+            process_fetched_ranges(
+                bad_delta, previous_map, 'coll1', 'dbs/db1/colls/coll1', '"etag-new"'
+            )
 
 
 if __name__ == "__main__":

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
@@ -13,15 +13,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from azure.cosmos.aio import CosmosClient  # noqa: F401 - needed to resolve circular imports
 from azure.cosmos._routing.aio.routing_map_provider import (
     PartitionKeyRangeCache,
-    _OVERLAP_RETRY_MAX_ATTEMPTS,
 )
 from azure.cosmos._routing.collection_routing_map import CollectionRoutingMap
 from azure.cosmos._routing._routing_map_provider_common import (
     process_fetched_ranges,
     _IncrementalMergeFailed,
+    _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
 )
 from azure.cosmos import http_constants
 from azure.cosmos.exceptions import CosmosHttpResponseError
@@ -220,21 +219,25 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ids, ['0'], "Ranges should be preserved from previous map")
         self.assertEqual(result.change_feed_etag, '"etag-new"', "ETag should be updated")
 
-    async def test_fetch_routing_map_empty_full_load_returns_none_async(self):
-        """_fetch_routing_map should return None when a full load (no previous
-        map) returns zero ranges — this means the service returned nothing."""
+    async def test_fetch_routing_map_empty_full_load_raises_503_after_budget_async(self):
+        """When a full load (no previous map) repeatedly returns zero ranges,
+        ``_fetch_routing_map`` should retry up to the overlap budget and then
+        surface ``CosmosHttpResponseError(status_code=503)`` rather than
+        returning ``None``. Empty ranges hit the same ``_GapDetected`` path as
+        a gap in the key space; without retry-then-503 the empty result
+        would later crash ``SmartRoutingMapProvider`` with ``AssertionError``."""
         client = _make_mock_async_client(ranges=[], response_etag='"etag"')
 
         cache = PartitionKeyRangeCache(client)
 
-        result = await cache._fetch_routing_map(
-            collection_link="dbs/db1/colls/coll1",
-            collection_id="dbs/db1/colls/coll1",
-            previous_routing_map=None,
-            feed_options={}
-        )
-
-        self.assertIsNone(result, "Full load with empty ranges should return None")
+        with self.assertRaises(CosmosHttpResponseError) as ctx:
+            await cache._fetch_routing_map(
+                collection_link="dbs/db1/colls/coll1",
+                collection_id="dbs/db1/colls/coll1",
+                previous_routing_map=None,
+                feed_options={}
+            )
+        self.assertEqual(ctx.exception.status_code, 503)
 
 
     async def test_get_previous_routing_map_exact_key_finds_entry_async(self):
@@ -502,12 +505,12 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
     #
     # These cover the integration between the builder (which converts the
     # underlying ValueError("Ranges overlap") into the _OverlapDetected
-    # sentinel) and _fetch_routing_map (which catches the sentinel, sleeps
-    # briefly, and re-fetches). The customer-observed failure mode is that
-    # one paginated /pkranges response can be internally inconsistent (e.g.
-    # a stale parent appearing alongside its children with missing parent
-    # references); a small retry budget with backoff gives the gateway time
-    # to converge before the SDK surfaces a transient HTTP 503.
+    # signal exception) and _fetch_routing_map (which catches the signal,
+    # sleeps briefly, and re-fetches). The customer-observed failure scenario
+    # is that one paginated /pkranges response can be internally inconsistent
+    # (e.g. a stale parent appearing alongside its children with missing
+    # parent references); a small retry budget with backoff gives the gateway
+    # time to converge before the SDK surfaces a transient HTTP 503.
     # ==========================================================================
 
     async def test_fetch_routing_map_recovers_after_transient_overlap_async(self):
@@ -515,7 +518,7 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         once and a consistent one on retry, the cache should populate cleanly
         with the consistent data on the second attempt — the customer sees no
         crash, no missing rows, just a brief stall."""
-        # First call: Mode 2 payload (stale parent + children missing parent ref) → triggers _OverlapDetected.
+        # First call: stale parent + children missing parent reference → triggers _OverlapDetected.
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},  # stale parent
@@ -630,9 +633,111 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         )
         # We should have exhausted the full retry budget (3 attempts by default).
         self.assertEqual(
-            call_count['n'], _OVERLAP_RETRY_MAX_ATTEMPTS,
-            "Should have made exactly _OVERLAP_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
+            call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+            "Should have made exactly _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS fetch attempts before giving up."
         )
+
+    async def test_fetch_routing_map_recovers_after_transient_gap_async(self):
+        """Mirror of the overlap-recovery test for the gap side: when the
+        gateway returns a snapshot with a hole in the key space once and a
+        consistent one on retry, the async cache should populate cleanly on
+        the second attempt rather than letting the empty result reach
+        ``SmartRoutingMapProvider`` (which would crash with
+        ``AssertionError``)."""
+        bad_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        good_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [bad_payload, good_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else good_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in payload:
+                    yield r
+
+            return async_gen()
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            result = await cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertIsNotNone(
+            result,
+            "Async cache should populate after the transient gap clears on retry."
+        )
+        self.assertEqual(call_count['n'], 2, "Expected exactly one retry.")
+        ids = [r['id'] for r in result._orderedPartitionKeyRanges]
+        self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
+
+    async def test_fetch_routing_map_surfaces_503_after_persistent_gap_async(self):
+        """Mirror of the overlap-503 test for the gap side: a persistent gap
+        across the retry budget must surface as ``CosmosHttpResponseError(503)``
+        rather than as an ``AssertionError("code bug: ...")`` from
+        ``SmartRoutingMapProvider``."""
+        bad_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        call_count = {'n': 0}
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in bad_payload:
+                    yield r
+
+            return async_gen()
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+        self.assertEqual(call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS)
 
     async def test_incremental_overlap_converts_to_incremental_merge_failed_async(self):
         """If the incremental-merge path produces overlapping ranges (e.g. the

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
@@ -220,20 +220,15 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.change_feed_etag, '"etag-new"', "ETag should be updated")
 
     async def test_fetch_routing_map_empty_full_load_raises_503_after_budget_async(self):
-        """When a full load (no previous map) repeatedly returns zero ranges,
-        ``_fetch_routing_map`` should retry up to the overlap budget and then
-        surface ``CosmosHttpResponseError(status_code=503)`` rather than
-        returning ``None``. Empty ranges hit the same ``_GapDetected`` path as
-        a gap in the key space; without retry-then-503 the empty result
-        would later crash ``SmartRoutingMapProvider`` with ``AssertionError``."""
+        """A full load that repeatedly returns zero ranges should retry up
+        to the budget and then raise ``CosmosHttpResponseError(503)``
+        instead of returning ``None``."""
         client = _make_mock_async_client(ranges=[], response_etag='"etag"')
 
         cache = PartitionKeyRangeCache(client)
 
-        # Patch asyncio.sleep so the retry loop's jittered backoffs (up to
-        # ~1.5s deterministic upper bound across the two pre-final attempts)
-        # do not slow this unit test down. Mirrors the pattern used by the
-        # other retry-path tests in this file.
+        # Patch ``asyncio.sleep`` so the retry loop's backoffs do not slow
+        # this unit test down.
         async def _no_sleep(_seconds):
             return None
 
@@ -514,17 +509,15 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
     # ==========================================================================
     # Provider retry-loop behavior tests (mocked integration path).
     #
-    # These cover integration between builder signaling (overlap/gap) and the
-    # async provider fetch/retry loop. With mocked /pkranges payloads we verify
-    # the full path contract: transient inconsistencies either recover on retry
-    # or surface typed HTTP 503, and never leak raw ``ValueError`` failures.
+    # These exercise the async provider's fetch/retry loop with mocked
+    # ``/pkranges`` payloads: transient inconsistencies either recover on
+    # retry or surface as HTTP 503; ``ValueError("Ranges overlap")`` never
+    # leaks to callers.
     # ==========================================================================
 
     async def test_fetch_routing_map_recovers_after_transient_overlap_async(self):
-        """When the gateway returns an inconsistent paginated /pkranges snapshot
-        once and a consistent one on retry, the cache should populate cleanly
-        with the consistent data on the second attempt — the customer sees no
-        crash, no missing rows, just a brief stall."""
+        """An inconsistent ``/pkranges`` snapshot followed by a consistent
+        one should populate the cache cleanly on the second attempt."""
         # First call: stale parent + children missing parent reference → triggers _OverlapDetected.
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
@@ -590,11 +583,8 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
 
     async def test_fetch_routing_map_surfaces_503_after_persistent_overlap_async(self):
-        """If the gateway keeps returning inconsistent snapshots through every
-        retry attempt, the cache should NOT silently return empty results from
-        get_overlapping_ranges (which would be a correctness bug masquerading
-        as zero data). It must surface a typed transient HTTP error so the
-        upstream retry policy can decide what to do."""
+        """Persistent inconsistent snapshots across every retry must surface
+        as HTTP 503, not as empty results from ``get_overlapping_ranges``."""
         bad_payload = [
             {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
             {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
@@ -645,12 +635,8 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_fetch_routing_map_recovers_after_transient_gap_async(self):
-        """Mirror of the overlap-recovery test for the gap side: when the
-        gateway returns a snapshot with a hole in the key space once and a
-        consistent one on retry, the async cache should populate cleanly on
-        the second attempt rather than letting the empty result reach
-        ``SmartRoutingMapProvider`` (which would crash with
-        ``AssertionError``)."""
+        """A gap snapshot followed by a consistent one should populate the
+        cache cleanly on the second attempt."""
         bad_payload = [
             {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
@@ -704,10 +690,8 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ids, ['L', '10/0', '10/1', 'R'])
 
     async def test_fetch_routing_map_surfaces_503_after_persistent_gap_async(self):
-        """Mirror of the overlap-503 test for the gap side: a persistent gap
-        across the retry budget must surface as ``CosmosHttpResponseError(503)``
-        rather than as an ``AssertionError("code bug: ...")`` from
-        ``SmartRoutingMapProvider``."""
+        """A persistent gap across the retry budget must surface as
+        ``CosmosHttpResponseError(503)``."""
         bad_payload = [
             {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
             {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
@@ -747,15 +731,10 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS)
 
     async def test_incremental_overlap_converts_to_incremental_merge_failed_async(self):
-        """If the incremental-merge path produces overlapping ranges (e.g. the
-        delta contains a range whose key span overlaps an existing cached
-        range without either side declaring the other a parent), the
-        ``ValueError("Ranges overlap")`` raised by ``try_combine`` must NOT
-        escape to the caller. It must convert to ``_IncrementalMergeFailed``
-        so the standard fallback path takes over (retry incremental once,
-        then full-load — which has its own ``_OverlapDetected`` handler).
-        This is what guarantees the customer never observes a bare
-        ``ValueError`` from any of the validator's call sites."""
+        """An overlap raised during incremental merge must convert to
+        ``_IncrementalMergeFailed`` so the standard fallback (retry
+        incremental, then full refresh) takes over; a bare ``ValueError``
+        must never escape to the caller."""
 
         # Existing cached map: '0' covers ['', '80'] and '1' covers ['80', 'FF'].
         previous_map = CollectionRoutingMap.CompleteRoutingMap(
@@ -789,23 +768,9 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
             )
 
     async def test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget_async(self):
-        """Async mirror of
-        ``test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget``.
-
-        The transient-snapshot retry budget is a single counter shared by
-        BOTH ``_OverlapDetected`` and ``_GapDetected`` signals -- it is not
-        per-signal-type. If the gateway alternates between overlap snapshots
-        and gap snapshots across attempts, the SDK must still surface a 503
-        after the same ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` budget.
-
-        Async coverage is independent of the sync test because the async
-        ``_fetch_routing_map`` has its own ``except (_OverlapDetected,
-        _GapDetected)`` block and increments its own
-        ``inconsistency_attempt_count`` local under ``async with`` lock
-        scoping -- a future refactor that, for example, reset the counter
-        on signal-type change, or that lost the counter across an
-        ``await`` boundary, would only be caught by exercising the async
-        codepath end-to-end."""
+        """``_OverlapDetected`` and ``_GapDetected`` share one retry counter.
+        Alternating snapshots must still raise 503 once the budget is
+        exhausted; the budget is not per-signal-type."""
         # Overlap payload: stale parent '10' coexists with its children that
         # lack a ``parents`` reference. Triggers ``_OverlapDetected``.
         overlap_payload = [
@@ -867,22 +832,9 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503_async(self):
-        """Async mirror of
-        ``test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503``.
-
-        A 503 raised by ``_fetch_routing_map`` during a forced refresh must
-        NOT corrupt the existing cached routing map. The SDK commonly issues
-        ``force_refresh=True`` during 410/Gone recovery paths; if that refresh
-        itself fails transiently we want subsequent reads to keep returning
-        the previously-cached map (a slightly stale answer is far better than
-        a cache wiped out by a transient gateway hiccup).
-
-        Async coverage is independent of the sync test because the async
-        ``get_routing_map`` writes to the cache from inside an ``async with``
-        block. If a future refactor moved the write before the inner
-        ``try``/``except``, or if exception unwinding through the async
-        context manager somehow cleared the entry, only the async-level
-        end-to-end test would catch it."""
+        """A 503 raised by ``_fetch_routing_map`` during a forced refresh
+        must not corrupt the cached routing map. Subsequent reads should
+        still see the previously-cached entry."""
         # Pre-populate the shared cache with a known-good routing map.
         cached_map = _make_complete_routing_map("dbs/db1/colls/coll1", '"etag-cached"')
         cache = PartitionKeyRangeCache(MagicMock())

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
@@ -230,13 +230,24 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
 
         cache = PartitionKeyRangeCache(client)
 
-        with self.assertRaises(CosmosHttpResponseError) as ctx:
-            await cache._fetch_routing_map(
-                collection_link="dbs/db1/colls/coll1",
-                collection_id="dbs/db1/colls/coll1",
-                previous_routing_map=None,
-                feed_options={}
-            )
+        # Patch asyncio.sleep so the retry loop's jittered backoffs (up to
+        # ~1.5s deterministic upper bound across the two pre-final attempts)
+        # do not slow this unit test down. Mirrors the pattern used by the
+        # other retry-path tests in this file.
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache._fetch_routing_map(
+                    collection_link="dbs/db1/colls/coll1",
+                    collection_id="dbs/db1/colls/coll1",
+                    previous_routing_map=None,
+                    feed_options={}
+                )
         self.assertEqual(ctx.exception.status_code, 503)
 
 

--- a/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_routing_map_provider_unit_async.py
@@ -501,16 +501,12 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.change_feed_etag, '"etag-old"')
 
     # ==========================================================================
-    # End-to-end retry-loop tests for transient /pkranges snapshot inconsistency.
+    # Provider retry-loop behavior tests (mocked integration path).
     #
-    # These cover the integration between the builder (which converts the
-    # underlying ValueError("Ranges overlap") into the _OverlapDetected
-    # signal exception) and _fetch_routing_map (which catches the signal,
-    # sleeps briefly, and re-fetches). The customer-observed failure scenario
-    # is that one paginated /pkranges response can be internally inconsistent
-    # (e.g. a stale parent appearing alongside its children with missing
-    # parent references); a small retry budget with backoff gives the gateway
-    # time to converge before the SDK surfaces a transient HTTP 503.
+    # These cover integration between builder signaling (overlap/gap) and the
+    # async provider fetch/retry loop. With mocked /pkranges payloads we verify
+    # the full path contract: transient inconsistencies either recover on retry
+    # or surface typed HTTP 503, and never leak raw ``ValueError`` failures.
     # ==========================================================================
 
     async def test_fetch_routing_map_recovers_after_transient_overlap_async(self):
@@ -780,6 +776,164 @@ class TestRoutingMapProviderUnitAsync(unittest.IsolatedAsyncioTestCase):
             process_fetched_ranges(
                 bad_delta, previous_map, 'coll1', 'dbs/db1/colls/coll1', '"etag-new"'
             )
+
+    async def test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget_async(self):
+        """Async mirror of
+        ``test_fetch_routing_map_mixed_overlap_and_gap_signals_share_retry_budget``.
+
+        The transient-snapshot retry budget is a single counter shared by
+        BOTH ``_OverlapDetected`` and ``_GapDetected`` signals -- it is not
+        per-signal-type. If the gateway alternates between overlap snapshots
+        and gap snapshots across attempts, the SDK must still surface a 503
+        after the same ``_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS`` budget.
+
+        Async coverage is independent of the sync test because the async
+        ``_fetch_routing_map`` has its own ``except (_OverlapDetected,
+        _GapDetected)`` block and increments its own
+        ``inconsistency_attempt_count`` local under ``async with`` lock
+        scoping -- a future refactor that, for example, reset the counter
+        on signal-type change, or that lost the counter across an
+        ``await`` boundary, would only be caught by exercising the async
+        codepath end-to-end."""
+        # Overlap payload: stale parent '10' coexists with its children that
+        # lack a ``parents`` reference. Triggers ``_OverlapDetected``.
+        overlap_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+        # Gap payload: ['80', 'A0') is missing entirely. Triggers ``_GapDetected``.
+        gap_payload = [
+            {'id': 'L', 'minInclusive': '',   'maxExclusive': '80'},
+            {'id': 'R', 'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        responses = [overlap_payload, gap_payload, overlap_payload]
+        call_count = {'n': 0}
+
+        client = MagicMock()
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            payload = responses[call_count['n']] if call_count['n'] < len(responses) else overlap_payload
+            call_count['n'] += 1
+            headers = {http_constants.HttpHeaders.ETag: '"etag-mixed-{}"'.format(call_count['n'])}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in payload:
+                    yield r
+
+            return async_gen()
+
+        client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+        cache = PartitionKeyRangeCache(client)
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache.get_routing_map("dbs/db1/colls/coll1", feed_options={})
+
+        self.assertEqual(
+            ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE,
+            "Alternating overlap/gap signals must still surface as HTTP 503 once "
+            "the shared budget is exhausted."
+        )
+        self.assertEqual(
+            call_count['n'], _TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS,
+            "Overlap and gap signals must share one retry budget; alternating "
+            "between them must NOT extend the total number of attempts."
+        )
+
+    async def test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503_async(self):
+        """Async mirror of
+        ``test_fetch_routing_map_preserves_existing_cache_entry_when_force_refresh_surfaces_503``.
+
+        A 503 raised by ``_fetch_routing_map`` during a forced refresh must
+        NOT corrupt the existing cached routing map. The SDK commonly issues
+        ``force_refresh=True`` during 410/Gone recovery paths; if that refresh
+        itself fails transiently we want subsequent reads to keep returning
+        the previously-cached map (a slightly stale answer is far better than
+        a cache wiped out by a transient gateway hiccup).
+
+        Async coverage is independent of the sync test because the async
+        ``get_routing_map`` writes to the cache from inside an ``async with``
+        block. If a future refactor moved the write before the inner
+        ``try``/``except``, or if exception unwinding through the async
+        context manager somehow cleared the entry, only the async-level
+        end-to-end test would catch it."""
+        # Pre-populate the shared cache with a known-good routing map.
+        cached_map = _make_complete_routing_map("dbs/db1/colls/coll1", '"etag-cached"')
+        cache = PartitionKeyRangeCache(MagicMock())
+        cache._collection_routing_map_by_item["dbs/db1/colls/coll1"] = cached_map
+
+        # Wire the client to return an inconsistent (overlap) snapshot every
+        # time -- forces the retry loop to exhaust its budget and raise 503.
+        bad_payload = [
+            {'id': 'L',    'minInclusive': '',   'maxExclusive': '80'},
+            {'id': '10',   'minInclusive': '80', 'maxExclusive': 'A0'},
+            {'id': '10/0', 'minInclusive': '80', 'maxExclusive': '90'},
+            {'id': '10/1', 'minInclusive': '90', 'maxExclusive': 'A0'},
+            {'id': 'R',    'minInclusive': 'A0', 'maxExclusive': 'FF'},
+        ]
+
+        def fake_read_pk_ranges(collection_link, options, response_hook=None, **kwargs):
+            headers = {http_constants.HttpHeaders.ETag: '"etag-bad"'}
+            if response_hook:
+                response_hook(headers, None)
+            capture_headers = kwargs.get('_internal_response_headers_capture')
+            if capture_headers is not None:
+                capture_headers.update(headers)
+
+            async def async_gen():
+                for r in bad_payload:
+                    yield r
+
+            return async_gen()
+
+        cache._document_client._ReadPartitionKeyRanges = MagicMock(side_effect=fake_read_pk_ranges)
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch(
+            'azure.cosmos._routing.aio.routing_map_provider.asyncio.sleep',
+            new=_no_sleep,
+        ):
+            with self.assertRaises(CosmosHttpResponseError) as ctx:
+                await cache.get_routing_map(
+                    "dbs/db1/colls/coll1",
+                    feed_options={},
+                    force_refresh=True,
+                    previous_routing_map=cached_map,
+                )
+
+        self.assertEqual(ctx.exception.status_code, http_constants.StatusCodes.SERVICE_UNAVAILABLE)
+
+        # Critical invariant: the previously-cached map must still be reachable
+        # via the same key. A 503 from a forced refresh must never evict good
+        # cache state -- otherwise every transient gateway blip would force the
+        # next reader to pay a cold-start cost.
+        self.assertIs(
+            cache._collection_routing_map_by_item.get("dbs/db1/colls/coll1"), cached_map,
+            "Cached routing map must be preserved after a 503 from forced refresh -- "
+            "transient inconsistencies must not evict good cache state."
+        )
+        self.assertEqual(
+            cache._collection_routing_map_by_item["dbs/db1/colls/coll1"].change_feed_etag,
+            '"etag-cached"',
+            "Cached ETag must remain the pre-503 value (no partial overwrite)."
+        )
 
 
 if __name__ == "__main__":

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
@@ -4,6 +4,7 @@ import unittest
 import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from azure.core.exceptions import ServiceRequestError, ServiceResponseError
@@ -41,6 +42,11 @@ class TestServiceRetryPolicies(unittest.TestCase):
         cls.created_container = cls.created_database.get_container_client(cls.TEST_CONTAINER_ID)
 
     @classmethod
+    def _uses_localhost_endpoint(cls):
+        parsed = urlparse(cls.host)
+        return parsed.hostname in ("localhost", "127.0.0.1")
+
+    @classmethod
     def _make_regional_endpoint(cls, region):
         """Return a per-region locational endpoint (e.g. ``acct-westus...``).
 
@@ -68,6 +74,18 @@ class TestServiceRetryPolicies(unittest.TestCase):
         derived state behind, which silently inflates the retry budget the
         next assertion observes.
         """
+        if self._uses_localhost_endpoint():
+            shared_context = RegionalRoutingContext(self.host)
+            location_cache.account_read_locations = list(regions)
+            location_cache.account_read_regional_routing_contexts_by_location = {
+                r: shared_context for r in regions
+            }
+            location_cache.account_locations_by_read_endpoints = {self.host: regions[0]}
+            location_cache.effective_preferred_locations = list(regions)
+            location_cache.read_regional_routing_contexts = [shared_context for _ in regions]
+            location_cache.location_unavailability_info_by_endpoint = {}
+            return
+
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_read_locations = list(regions)
         location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
@@ -96,6 +114,17 @@ class TestServiceRetryPolicies(unittest.TestCase):
         rationale on clearing unavailability state and re-running
         ``update_location_cache()``.
         """
+        if self._uses_localhost_endpoint():
+            shared_context = RegionalRoutingContext(self.host)
+            location_cache.account_write_locations = list(regions)
+            location_cache.account_write_regional_routing_contexts_by_location = {
+                r: shared_context for r in regions
+            }
+            location_cache.account_locations_by_write_endpoints = {self.host: regions[0]}
+            location_cache.write_regional_routing_contexts = [shared_context for _ in regions]
+            location_cache.location_unavailability_info_by_endpoint = {}
+            return
+
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_write_locations = list(regions)
         location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
@@ -25,7 +25,6 @@ class TestServiceRetryPolicies(unittest.TestCase):
     REGION1 = "West US"
     REGION2 = "East US"
     REGION3 = "West US 2"
-    REGIONAL_ENDPOINT = RegionalRoutingContext(host)
 
     @classmethod
     def setUpClass(cls):
@@ -39,20 +38,53 @@ class TestServiceRetryPolicies(unittest.TestCase):
         cls.created_database = cls.client.get_database_client(cls.TEST_DATABASE_ID)
         cls.created_container = cls.created_database.get_container_client(cls.TEST_CONTAINER_ID)
 
+    @classmethod
+    def _make_regional_endpoint(cls, region):
+        """Build a regional ``RegionalRoutingContext`` whose primary URL is the
+        per-region locational form (e.g. ``https://acct-westus.documents...``).
+
+        IMPORTANT: do NOT reuse ``RegionalRoutingContext(host)`` across regions.
+        ``LocationCache.is_default_endpoint_regional()`` returns ``True`` when
+        any value in ``account_read_regional_routing_contexts_by_location``
+        has the same primary as the client's default endpoint, and when that
+        happens the next ``update_location_cache()`` call (e.g. one triggered
+        by a background refresh or by a side-effect pkranges fetch that the
+        mocks let through) hits the
+        ``elif self.is_default_endpoint_regional(): self.effective_preferred_locations = []``
+        branch, wipes ``effective_preferred_locations`` and collapses
+        ``read_regional_routing_contexts`` back to the single fallback endpoint.
+        That silently turns this test into a 1-retry test and makes
+        ``ServiceResponseRetryPolicy.total_retries`` resolve to 1 regardless
+        of how many regions the test thinks it configured.
+        """
+        return RegionalRoutingContext(
+            _location_cache.LocationCache.GetLocationalEndpoint(cls.host, region)
+        )
+
     def _setup_read_regions(self, location_cache, regions):
-        """Set all read region attributes consistently so update_location_cache() recalculates correctly."""
-        location_cache.account_read_locations = regions
-        location_cache.account_read_regional_routing_contexts_by_location = {
-            r: self.REGIONAL_ENDPOINT for r in regions}
-        location_cache.read_regional_routing_contexts = [self.REGIONAL_ENDPOINT] * len(regions)
-        location_cache.effective_preferred_locations = regions
+        """Configure the read side of the location cache with N distinct regions.
+
+        Each region gets a distinct ``RegionalRoutingContext`` so that
+        ``update_location_cache()``-triggered recomputation preserves the
+        intended N-region topology (see ``_make_regional_endpoint``).
+        """
+        endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
+        location_cache.account_read_locations = list(regions)
+        location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
+        location_cache.read_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        location_cache.effective_preferred_locations = list(regions)
 
     def _setup_write_regions(self, location_cache, regions):
-        """Set all write region attributes consistently so update_location_cache() recalculates correctly."""
-        location_cache.account_write_locations = regions
-        location_cache.account_write_regional_routing_contexts_by_location = {
-            r: self.REGIONAL_ENDPOINT for r in regions}
-        location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT] * len(regions)
+        """Configure the write side of the location cache with N distinct regions.
+
+        Mirrors ``_setup_read_regions`` (distinct per-region endpoints) for
+        symmetry and to avoid future tests tripping the same
+        ``is_default_endpoint_regional`` snare on the write path.
+        """
+        endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
+        location_cache.account_write_locations = list(regions)
+        location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region
+        location_cache.write_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
 
     def test_service_request_retry_policy(self):
         mock_client = CosmosClient(self.host, self.masterKey)

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,8 @@ from azure.cosmos import (CosmosClient, _retry_utility, DatabaseAccount, _global
                           _location_cache)
 from azure.cosmos._location_cache import RegionalRoutingContext
 from azure.cosmos._request_object import RequestObject
+from azure.cosmos.documents import _OperationType
+from azure.cosmos.http_constants import HttpHeaders
 
 
 @pytest.mark.cosmosEmulator
@@ -317,3 +320,33 @@ class TestServiceRetryPolicies(unittest.TestCase):
         db_acc._EnableMultipleWritableLocations = multi_write
         db_acc.ConsistencyPolicy = {"defaultConsistencyLevel": "Session"}
         return db_acc
+
+
+@pytest.mark.cosmosEmulator
+class TestServiceRetryPolicyHelpers(unittest.TestCase):
+    def test_is_read_retryable_request_uses_operation_type_fallback(self):
+        request = SimpleNamespace(headers={})
+        request_params = SimpleNamespace(operation_type=_OperationType.Read)
+        assert _retry_utility._is_read_retryable_request(request, request_params) is True
+
+    def test_is_read_retryable_request_write_without_header_is_not_retryable(self):
+        request = SimpleNamespace(headers={})
+        request_params = SimpleNamespace(operation_type=_OperationType.Create)
+        assert _retry_utility._is_read_retryable_request(request, request_params) is False
+
+    def test_is_read_retryable_request_matches_thin_client_header(self):
+        # Thin-client proxy sets the operation type as a request header; the
+        # helper must recognise reads from that header even when request_params
+        # is not threaded through (older call paths).
+        request = SimpleNamespace(
+            headers={HttpHeaders.ThinClientProxyOperationType: _OperationType.Read}
+        )
+        assert _retry_utility._is_read_retryable_request(request, None) is True
+
+    def test_is_read_retryable_request_with_no_request_uses_params_only(self):
+        # ConnectionRetryPolicy.send pops request_params from context options;
+        # confirm the helper still classifies correctly when only request_params
+        # is available (request is None).
+        request_params = SimpleNamespace(operation_type=_OperationType.Read)
+        assert _retry_utility._is_read_retryable_request(None, request_params) is True
+

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
@@ -40,34 +40,21 @@ class TestServiceRetryPolicies(unittest.TestCase):
 
     @classmethod
     def _make_regional_endpoint(cls, region):
-        """Build a regional ``RegionalRoutingContext`` whose primary URL is the
-        per-region locational form (e.g. ``https://acct-westus.documents...``).
+        """Return a per-region locational endpoint (e.g. ``acct-westus...``).
 
-        IMPORTANT: do NOT reuse ``RegionalRoutingContext(host)`` across regions.
-        ``LocationCache.is_default_endpoint_regional()`` returns ``True`` when
-        any value in ``account_read_regional_routing_contexts_by_location``
-        has the same primary as the client's default endpoint, and when that
-        happens the next ``update_location_cache()`` call (e.g. one triggered
-        by a background refresh or by a side-effect pkranges fetch that the
-        mocks let through) hits the
-        ``elif self.is_default_endpoint_regional(): self.effective_preferred_locations = []``
-        branch, wipes ``effective_preferred_locations`` and collapses
-        ``read_regional_routing_contexts`` back to the single fallback endpoint.
-        That silently turns this test into a 1-retry test and makes
-        ``ServiceResponseRetryPolicy.total_retries`` resolve to 1 regardless
-        of how many regions the test thinks it configured.
+        Each region must have its own endpoint URL. If every region shares
+        the default endpoint, ``LocationCache.is_default_endpoint_regional``
+        becomes True and the next ``update_location_cache`` call clears
+        ``effective_preferred_locations`` and shrinks
+        ``read_regional_routing_contexts`` to a single fallback, turning
+        multi-region tests into one-shot tests.
         """
         return RegionalRoutingContext(
             _location_cache.LocationCache.GetLocationalEndpoint(cls.host, region)
         )
 
     def _setup_read_regions(self, location_cache, regions):
-        """Configure the read side of the location cache with N distinct regions.
-
-        Each region gets a distinct ``RegionalRoutingContext`` so that
-        ``update_location_cache()``-triggered recomputation preserves the
-        intended N-region topology (see ``_make_regional_endpoint``).
-        """
+        """Populate the read side of the location cache with N distinct regions."""
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_read_locations = list(regions)
         location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
@@ -75,12 +62,7 @@ class TestServiceRetryPolicies(unittest.TestCase):
         location_cache.effective_preferred_locations = list(regions)
 
     def _setup_write_regions(self, location_cache, regions):
-        """Configure the write side of the location cache with N distinct regions.
-
-        Mirrors ``_setup_read_regions`` (distinct per-region endpoints) for
-        symmetry and to avoid future tests tripping the same
-        ``is_default_endpoint_regional`` snare on the write path.
-        """
+        """Populate the write side of the location cache with N distinct regions."""
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_write_locations = list(regions)
         location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies.py
@@ -12,7 +12,6 @@ import test_config
 from azure.cosmos import (CosmosClient, _retry_utility, DatabaseAccount, _global_endpoint_manager,
                           _location_cache)
 from azure.cosmos._location_cache import RegionalRoutingContext
-from azure.cosmos._request_object import RequestObject
 from azure.cosmos.documents import _OperationType
 from azure.cosmos.http_constants import HttpHeaders
 
@@ -57,19 +56,54 @@ class TestServiceRetryPolicies(unittest.TestCase):
         )
 
     def _setup_read_regions(self, location_cache, regions):
-        """Populate the read side of the location cache with N distinct regions."""
+        """Populate the read side of the location cache with N distinct regions.
+
+        Mirrors the production initialization flow: set the raw inputs
+        (account locations, locational-endpoint map, preferred locations),
+        clear any unavailability state carried over from a previous
+        assertion, then call ``update_location_cache()`` so the derived
+        dicts (``_read_locations_by_normalized``, the reverse endpoint→region
+        map, and ``read_regional_routing_contexts``) are recomputed from a
+        consistent snapshot. Direct attribute assignment alone leaves stale
+        derived state behind, which silently inflates the retry budget the
+        next assertion observes.
+        """
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_read_locations = list(regions)
         location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
-        location_cache.read_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        # Reverse map (endpoint URL -> region name). The retry policy uses
+        # this to translate ``location_endpoint_to_route`` back to a region
+        # when marking endpoints unavailable; if it is stale the wrong
+        # region gets marked and the retry budget can drift.
+        location_cache.account_locations_by_read_endpoints = {
+            ctx.get_primary(): name for name, ctx in endpoints_by_region.items()
+        }
         location_cache.effective_preferred_locations = list(regions)
+        # Each assertion in this test reuses the same location cache; reset
+        # unavailability so a region marked unavailable in the previous
+        # 3-region step does not silently shrink (or extend) the next step's
+        # effective routing list.
+        location_cache.location_unavailability_info_by_endpoint = {}
+        # Recompute derived state from the raw inputs above so the helper's
+        # output matches what the production initialization path would
+        # produce for the same topology.
+        location_cache.update_location_cache()
 
     def _setup_write_regions(self, location_cache, regions):
-        """Populate the write side of the location cache with N distinct regions."""
+        """Populate the write side of the location cache with N distinct regions.
+
+        Companion to ``_setup_read_regions`` — see that docstring for the
+        rationale on clearing unavailability state and re-running
+        ``update_location_cache()``.
+        """
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_write_locations = list(regions)
         location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region
-        location_cache.write_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        location_cache.account_locations_by_write_endpoints = {
+            ctx.get_primary(): name for name, ctx in endpoints_by_region.items()
+        }
+        location_cache.location_unavailability_info_by_endpoint = {}
+        location_cache.update_location_cache()
 
     def test_service_request_retry_policy(self):
         mock_client = CosmosClient(self.host, self.masterKey)
@@ -138,11 +172,14 @@ class TestServiceRetryPolicies(unittest.TestCase):
 
         # Now we change the location cache to have only 1 preferred read region
         self._setup_read_regions(original_location_cache, [self.REGION1])
-        mf = self.MockExecuteServiceResponseException(Exception)
+        expected_counter = len(original_location_cache.read_regional_routing_contexts)
+        mf = self.MockExecuteServiceResponseExceptionIgnoreQuery(
+            Exception, _retry_utility.ExecuteFunction
+        )
         with patch.object(_retry_utility, 'ExecuteFunction', mf):
             with pytest.raises(ServiceResponseError):
                 container.read_item(created_item['id'], created_item['pk'])
-            assert mf.counter == 1
+            assert mf.counter == expected_counter
 
         # Now we try it out with a write request
         self._setup_write_regions(original_location_cache, [self.REGION1, self.REGION2])
@@ -256,11 +293,12 @@ class TestServiceRetryPolicies(unittest.TestCase):
             self.original_execute_function = original_execute_function
 
         def __call__(self, func, *args, **kwargs):
-
-            if args and isinstance(args[1], RequestObject):
+            if len(args) > 1:
                 request_obj = args[1]
-                if request_obj.resource_type == "docs" and request_obj.operation_type == "Query" or\
-                    request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed":
+                if not (hasattr(request_obj, "resource_type") and hasattr(request_obj, "operation_type")):
+                    return self.original_execute_function(func, *args, **kwargs)
+                if ((request_obj.resource_type == "docs" and request_obj.operation_type == "Query") or
+                        (request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed")):
                     # Ignore query requests, As an additional ReadFeed might occur during a regular Read operation
                     return self.original_execute_function(func, *args, **kwargs)
                 self.counter = self.counter + 1
@@ -287,11 +325,12 @@ class TestServiceRetryPolicies(unittest.TestCase):
             self.original_execute_function = original_execute_function
 
         def __call__(self, func, *args, **kwargs):
-
-            if args and isinstance(args[1], RequestObject):
+            if len(args) > 1:
                 request_obj = args[1]
-                if request_obj.resource_type == "docs" and request_obj.operation_type == "Query" or\
-                    request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed":
+                if not (hasattr(request_obj, "resource_type") and hasattr(request_obj, "operation_type")):
+                    return self.original_execute_function(func, *args, **kwargs)
+                if ((request_obj.resource_type == "docs" and request_obj.operation_type == "Query") or
+                        (request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed")):
                     # Ignore query requests, As an additional ReadFeed might occur during a regular Read operation
                     return self.original_execute_function(func, *args, **kwargs)
                 self.counter = self.counter + 1

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
@@ -11,7 +11,7 @@ from aiohttp.client_exceptions import (ClientConnectionError, ClientConnectionRe
 from azure.core.exceptions import ServiceRequestError, ServiceResponseError
 
 import test_config
-from azure.cosmos import DatabaseAccount
+from azure.cosmos import DatabaseAccount, _location_cache
 from azure.cosmos._location_cache import RegionalRoutingContext
 from azure.cosmos._request_object import RequestObject
 from azure.cosmos.aio import CosmosClient, _retry_utility_async, _global_endpoint_manager_async
@@ -28,7 +28,6 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
     REGION1 = "West US"
     REGION2 = "East US"
     REGION3 = "West US 2"
-    REGIONAL_ENDPOINT = RegionalRoutingContext(host)
 
     @classmethod
     def setUpClass(cls):
@@ -60,20 +59,37 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
                 pass
         gem.refresh_task = None
 
+    @classmethod
+    def _make_regional_endpoint(cls, region):
+        """Return a per-region locational endpoint (e.g. ``acct-westus...``).
+
+        Each region must have its own endpoint URL. If every region shares
+        the default endpoint, ``LocationCache.is_default_endpoint_regional``
+        becomes True and the next ``update_location_cache`` call clears
+        ``effective_preferred_locations`` and shrinks
+        ``read_regional_routing_contexts`` to a single fallback, turning
+        multi-region tests into one-shot tests. Cancelling the background
+        refresh task is not enough on its own: foreground refreshes can fire
+        from the pkranges side-call that the IgnoreQuery mocks let through.
+        """
+        return RegionalRoutingContext(
+            _location_cache.LocationCache.GetLocationalEndpoint(cls.host, region)
+        )
+
     def _setup_read_regions(self, location_cache, regions):
-        """Set all read region attributes consistently so update_location_cache() recalculates correctly."""
-        location_cache.account_read_locations = regions
-        location_cache.account_read_regional_routing_contexts_by_location = {
-            r: self.REGIONAL_ENDPOINT for r in regions}
-        location_cache.read_regional_routing_contexts = [self.REGIONAL_ENDPOINT] * len(regions)
-        location_cache.effective_preferred_locations = regions
+        """Populate the read side of the location cache with N distinct regions."""
+        endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
+        location_cache.account_read_locations = list(regions)
+        location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
+        location_cache.read_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        location_cache.effective_preferred_locations = list(regions)
 
     def _setup_write_regions(self, location_cache, regions):
-        """Set all write region attributes consistently so update_location_cache() recalculates correctly."""
-        location_cache.account_write_locations = regions
-        location_cache.account_write_regional_routing_contexts_by_location = {
-            r: self.REGIONAL_ENDPOINT for r in regions}
-        location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT] * len(regions)
+        """Populate the write side of the location cache with N distinct regions."""
+        endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
+        location_cache.account_write_locations = list(regions)
+        location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region
+        location_cache.write_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
 
     async def test_service_request_retry_policy_async(self):
         # ServiceRequestErrors will always retry, and will retry once per preferred region

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
@@ -4,6 +4,7 @@
 import unittest
 import uuid
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from aiohttp.client_exceptions import (ClientConnectionError, ClientConnectionResetError,
@@ -59,6 +60,11 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
         gem.refresh_task = None
 
     @classmethod
+    def _uses_localhost_endpoint(cls):
+        parsed = urlparse(cls.host)
+        return parsed.hostname in ("localhost", "127.0.0.1")
+
+    @classmethod
     def _make_regional_endpoint(cls, region):
         """Return a per-region locational endpoint (e.g. ``acct-westus...``).
 
@@ -88,6 +94,18 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
         derived state behind, which silently inflates the retry budget the
         next assertion observes.
         """
+        if self._uses_localhost_endpoint():
+            shared_context = RegionalRoutingContext(self.host)
+            location_cache.account_read_locations = list(regions)
+            location_cache.account_read_regional_routing_contexts_by_location = {
+                r: shared_context for r in regions
+            }
+            location_cache.account_locations_by_read_endpoints = {self.host: regions[0]}
+            location_cache.effective_preferred_locations = list(regions)
+            location_cache.read_regional_routing_contexts = [shared_context for _ in regions]
+            location_cache.location_unavailability_info_by_endpoint = {}
+            return
+
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_read_locations = list(regions)
         location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
@@ -116,6 +134,17 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
         rationale on clearing unavailability state and re-running
         ``update_location_cache()``.
         """
+        if self._uses_localhost_endpoint():
+            shared_context = RegionalRoutingContext(self.host)
+            location_cache.account_write_locations = list(regions)
+            location_cache.account_write_regional_routing_contexts_by_location = {
+                r: shared_context for r in regions
+            }
+            location_cache.account_locations_by_write_endpoints = {self.host: regions[0]}
+            location_cache.write_regional_routing_contexts = [shared_context for _ in regions]
+            location_cache.location_unavailability_info_by_endpoint = {}
+            return
+
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_write_locations = list(regions)
         location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region

--- a/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_service_retry_policies_async.py
@@ -13,7 +13,6 @@ from azure.core.exceptions import ServiceRequestError, ServiceResponseError
 import test_config
 from azure.cosmos import DatabaseAccount, _location_cache
 from azure.cosmos._location_cache import RegionalRoutingContext
-from azure.cosmos._request_object import RequestObject
 from azure.cosmos.aio import CosmosClient, _retry_utility_async, _global_endpoint_manager_async
 from azure.cosmos.exceptions import CosmosHttpResponseError
 
@@ -77,19 +76,66 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
         )
 
     def _setup_read_regions(self, location_cache, regions):
-        """Populate the read side of the location cache with N distinct regions."""
+        """Populate the read side of the location cache with N distinct regions.
+
+        Mirrors the production initialization flow: set the raw inputs
+        (account locations, locational-endpoint map, preferred locations),
+        clear any unavailability state carried over from a previous
+        assertion, then call ``update_location_cache()`` so the derived
+        dicts (``_read_locations_by_normalized``, the reverse endpoint→region
+        map, and ``read_regional_routing_contexts``) are recomputed from a
+        consistent snapshot. Direct attribute assignment alone leaves stale
+        derived state behind, which silently inflates the retry budget the
+        next assertion observes.
+        """
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_read_locations = list(regions)
         location_cache.account_read_regional_routing_contexts_by_location = endpoints_by_region
-        location_cache.read_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        # Reverse map (endpoint URL -> region name). The retry policy uses
+        # this to translate ``location_endpoint_to_route`` back to a region
+        # when marking endpoints unavailable; if it is stale the wrong
+        # region gets marked and the retry budget can drift.
+        location_cache.account_locations_by_read_endpoints = {
+            ctx.get_primary(): name for name, ctx in endpoints_by_region.items()
+        }
         location_cache.effective_preferred_locations = list(regions)
+        # Each assertion in this test reuses the same location cache; reset
+        # unavailability so a region marked unavailable in the previous
+        # 3-region step does not silently shrink (or extend) the next step's
+        # effective routing list.
+        location_cache.location_unavailability_info_by_endpoint = {}
+        # Recompute derived state from the raw inputs above so the helper's
+        # output matches what the production initialization path would
+        # produce for the same topology.
+        location_cache.update_location_cache()
 
     def _setup_write_regions(self, location_cache, regions):
-        """Populate the write side of the location cache with N distinct regions."""
+        """Populate the write side of the location cache with N distinct regions.
+
+        Companion to ``_setup_read_regions`` — see that docstring for the
+        rationale on clearing unavailability state and re-running
+        ``update_location_cache()``.
+        """
         endpoints_by_region = {r: self._make_regional_endpoint(r) for r in regions}
         location_cache.account_write_locations = list(regions)
         location_cache.account_write_regional_routing_contexts_by_location = endpoints_by_region
-        location_cache.write_regional_routing_contexts = [endpoints_by_region[r] for r in regions]
+        location_cache.account_locations_by_write_endpoints = {
+            ctx.get_primary(): name for name, ctx in endpoints_by_region.items()
+        }
+        location_cache.location_unavailability_info_by_endpoint = {}
+        location_cache.update_location_cache()
+
+    def _setup_shared_write_endpoint_regions(self, location_cache, regions):
+        """Set write routing contexts to one shared endpoint for all regions.
+
+        ``test_service_response_errors_async`` intentionally validates the path
+        where two in-region write entries point to the same endpoint URL
+        (``self.host``). Keep this as derived-state setup only (no
+        ``update_location_cache()`` call), matching the historical test shape.
+        """
+        shared_context = RegionalRoutingContext(self.host)
+        location_cache.account_write_locations = list(regions)
+        location_cache.write_regional_routing_contexts = [shared_context for _ in regions]
 
     async def test_service_request_retry_policy_async(self):
         # ServiceRequestErrors will always retry, and will retry once per preferred region
@@ -167,11 +213,14 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
 
             # Now we change the location cache to have only 1 preferred read region
             self._setup_read_regions(original_location_cache, [self.REGION1])
-            mf = self.MockExecuteServiceResponseException(AttributeError, None)
+            expected_counter = len(original_location_cache.read_regional_routing_contexts)
+            mf = self.MockExecuteServiceResponseExceptionIgnoreQuery(
+                AttributeError, None, _retry_utility_async.ExecuteFunctionAsync
+            )
             with patch.object(_retry_utility_async, 'ExecuteFunctionAsync', mf):
                 with pytest.raises(ServiceResponseError):
                     await container.read_item(created_item['id'], created_item['pk'])
-                assert mf.counter == 1
+                assert mf.counter == expected_counter
 
             # Now we try it out with a write request
             self._setup_write_regions(original_location_cache, [self.REGION1, self.REGION2])
@@ -261,10 +310,9 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
 
             original_location_cache = mock_client.client_connection._global_endpoint_manager.location_cache
             self._setup_read_regions(original_location_cache, [self.REGION1, self.REGION2, self.REGION3])
-            # For writes, set only the derived state directly since test_service_response_errors
-            # relies on mark_endpoint_unavailable -> update_location_cache() reducing write regions
-            original_location_cache.account_write_locations = [self.REGION1, self.REGION2]
-            original_location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT, self.REGIONAL_ENDPOINT]
+            # For writes, keep two entries that share one endpoint URL. This
+            # test validates the shared-endpoint unavailability path.
+            self._setup_shared_write_endpoint_regions(original_location_cache, [self.REGION1, self.REGION2])
 
             # Start with a normal ServiceResponseException with no special casing
             mf = self.MockExecuteServiceResponseException(AttributeError, AttributeError())
@@ -301,7 +349,7 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
 
             # Reset the location cache's unavailable endpoints in order to try the same with other exceptions
             original_location_cache.location_unavailability_info_by_endpoint = {}
-            original_location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT, self.REGIONAL_ENDPOINT]
+            self._setup_shared_write_endpoint_regions(original_location_cache, [self.REGION1, self.REGION2])
 
             # Now we test ClientConnectionResetError, the subclass of ClientConnectionError
             mf = self.MockExecuteServiceResponseException(ClientConnectionResetError, ClientConnectionResetError())
@@ -317,7 +365,7 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
 
             # Reset the location cache's unavailable endpoints in order to try the same with other exceptions
             original_location_cache.location_unavailability_info_by_endpoint = {}
-            original_location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT, self.REGIONAL_ENDPOINT]
+            self._setup_shared_write_endpoint_regions(original_location_cache, [self.REGION1, self.REGION2])
 
             # Now we test ServerConnectionError, the subclass of ClientConnectionError
             mf = self.MockExecuteServiceResponseException(ServerConnectionError, ServerConnectionError())
@@ -328,7 +376,7 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
 
             # Reset the location cache's unavailable endpoints in order to try the same with other exceptions
             original_location_cache.location_unavailability_info_by_endpoint = {}
-            original_location_cache.write_regional_routing_contexts = [self.REGIONAL_ENDPOINT, self.REGIONAL_ENDPOINT]
+            self._setup_shared_write_endpoint_regions(original_location_cache, [self.REGION1, self.REGION2])
 
             # Now we test ClientOSError, the subclass of ClientConnectionError
             mf = self.MockExecuteServiceResponseException(ClientOSError, ClientOSError())
@@ -383,11 +431,12 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
             self.original_execute_function = original_execute_function
 
         def __call__(self, func, *args, **kwargs):
-
-            if args and isinstance(args[1], RequestObject):
+            if len(args) > 1:
                 request_obj = args[1]
-                if request_obj.resource_type == "docs" and request_obj.operation_type == "Query" or\
-                    request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed":
+                if not (hasattr(request_obj, "resource_type") and hasattr(request_obj, "operation_type")):
+                    return self.original_execute_function(func, *args, **kwargs)
+                if ((request_obj.resource_type == "docs" and request_obj.operation_type == "Query") or
+                        (request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed")):
                     # Ignore query requests, As an additional ReadFeed might occur during a regular Read operation
                     return self.original_execute_function(func, *args, **kwargs)
                 self.counter = self.counter + 1
@@ -417,11 +466,12 @@ class TestServiceRetryPoliciesAsync(unittest.IsolatedAsyncioTestCase):
             self.original_execute_function = original_execute_function
 
         def __call__(self, func, *args, **kwargs):
-
-            if args and isinstance(args[1], RequestObject):
+            if len(args) > 1:
                 request_obj = args[1]
-                if request_obj.resource_type == "docs" and request_obj.operation_type == "Query" or \
-                        request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed":
+                if not (hasattr(request_obj, "resource_type") and hasattr(request_obj, "operation_type")):
+                    return self.original_execute_function(func, *args, **kwargs)
+                if ((request_obj.resource_type == "docs" and request_obj.operation_type == "Query") or
+                        (request_obj.resource_type == "pkranges" and request_obj.operation_type == "ReadFeed")):
                     # Ignore query requests, As an additional ReadFeed might occur during a regular Read operation
                     return self.original_execute_function(func, *args, **kwargs)
                 self.counter = self.counter + 1


### PR DESCRIPTION
 This PR fixes two related crash paths in the partition key range cache that can happen when the gateway returns a transiently inconsistent paginated /pkranges snapshot:

   1. ValueError("Ranges overlap ...")
   2. AssertionError("code bug: returned overlapping ranges ... is empty")

  Both are caused by the same class of transient metadata inconsistency, but with different shapes:
   - overlap: two ranges claim the same key space
   - gap: no range claims part of key space

  **Why this change is needed**

  We’ve seen this in a real high-scale scenario (very high partition count, long-running async scan).
  The SDK previously handled these inconsistencies asymmetrically:

   - overlap could escape as a hard ValueError
   - gap could flow through as an incomplete map and later crash in SmartRoutingMapProvider with the empty-overlap assertion

  So transient metadata blips could fail user workloads instead of being treated as retryable.

  **What changed**

   - Unified handling for full-load transient snapshot inconsistencies (overlap + gap):
   - detect inconsistency
   - retry with bounded jittered backoff
   - if still inconsistent after retry budget, raise typed CosmosHttpResponseError(status_code=503) so existing retry policy can absorb it
   - Kept incremental-path safety:
   - overlap from incremental merge is converted into incremental-merge failure/fallback behavior (with guarded conversion so unrelated ValueErrors still surface normally)
   - Added dedup-by-range-id before validation to tolerate duplicate IDs across paginated snapshots from slightly skewed gateway views.
   - Applied consistently in sync and async routing map providers.

  **Reviewer-relevant behavior change**
  Before:
   - transient overlap/gap could surface as internal exceptions (ValueError / assertion)

  After:
   - transient inconsistency is retried internally
   - persistent inconsistency surfaces as retryable 503 (instead of non-retryable internal crash)

Retry budget and jittered backoff
When the gateway returns an inconsistent /pkranges snapshot, it's almost always because a partition split is mid-propagation across the gateway's internal caches — different gateway nodes see slightly different partition layouts for a few hundred milliseconds, and a request that lands on a lagging node sees overlap or gap. A short pause lets the gateway catch up to itself. This is different from the usual "too many requests, back off and spread out" scenario, so the retry schedule is tuned to always wait a minimum amount of time before retrying (the floor) rather than risk retrying so fast we just see the same stale snapshot again.. 

4 attempts total (3 sleeps before surfacing 503). Worst-case cumulative blocking time is ~1.4 s; expected ~0.775 s when all three retries occur.
Exponential schedule with a base of 0.2 s: deterministic upper bounds are 0.2 s, 0.4 s, 0.8 s.
Per-sleep cap of 2.0 s so a future bump to the attempt count cannot accidentally produce multi-second blocking sleeps.
Floored full jitter: each sleep is drawn uniformly from [floor, upper] where floor = min(0.05 s, upper / 4).
The non-zero floor eliminates the near-zero-sleep tail of pure full jitter, which would otherwise burn a retry attempt before the gateway has had any time to converge.
The uniform distribution across [floor, upper] (rather than max(floor, uniform(0, upper))) preserves full jitter's fleet-wide herd dispersion without creating a probability spike at the floor.
The upper / 4 clamp keeps the jitter range at ≥75% of the deterministic upper bound on the smallest attempts, so the floor never collapses an attempt into a near-constant wait.

  **Scope**
  This PR is intentionally scoped to PK-range cache resilience for transient /pkranges inconsistency handling; it does not change public API surface.

