### PR TITLE
Switch PAT - GitHubApps Add TargetingString parameter

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -1,5 +1,10 @@
 trigger: none
 
+parameters:
+  - name: TargetingString
+    type: string
+    default: "*"
+
 pr:
   branches:
     include:
@@ -14,6 +19,8 @@ pool:
 
 variables:
   - template: ./templates/variables/globals.yml
+  - name: TargetingString
+    value: ${{ parameters.TargetingString }}
 
 stages:
   - stage: ValidateDependencies
@@ -79,11 +86,16 @@ stages:
               python -m pip install -r scripts/repo_health_status_report/dev_requirements.txt
             displayName: 'Prep Environment'
 
+          - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+            parameters:
+              TokenOwners:
+                - azure
+
           - task: PythonScript@0
             condition: succeededOrFailed()
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              GH_TOKEN: $(azuresdk-github-pat)
+              GH_TOKEN: $(GH_TOKEN)
             inputs:
               scriptPath: 'scripts/repo_health_status_report/output_health_report.py'
             displayName: 'Generate Health Status Report'
@@ -95,7 +107,7 @@ stages:
           - task: PythonScript@0
             condition: succeededOrFailed()
             env:
-              GH_TOKEN: $(azuresdk-github-pat)
+              GH_TOKEN: $(GH_TOKEN)
             inputs:
               scriptPath: 'scripts/repo_type_completeness/generate_main_typescores.py'
             displayName: 'Update Type Completeness Scores'


### PR DESCRIPTION
This pull request updates the `eng/pipelines/aggregate-reports.yml` pipeline to improve parameterization and authentication handling. The main changes introduce a configurable `TargetingString` parameter, ensure its value is set as a variable, and update GitHub authentication to use a centralized login template and environment variable.

**Pipeline Parameterization:**

* Added a `TargetingString` parameter to the pipeline, allowing more flexible targeting for pipeline runs.
* Set the `TargetingString` variable from the parameter to ensure its value is available throughout the pipeline.

**Authentication and Environment Setup:**

* Added a step to log in to GitHub using the shared `login-to-github.yml` template, specifying the `azure` token owner for centralized authentication management.
* Updated environment variables for Python script tasks to use the `GH_TOKEN` set by the login step instead of the previous `azuresdk-github-pat`, ensuring consistent and secure token usage. [[1]](diffhunk://#diff-bfacec66140f910af02bd8e346f0e1bfadd24b717c3874ad31b5381b1bbd8293R89-R98) [[2]](diffhunk://#diff-bfacec66140f910af02bd8e346f0e1bfadd24b717c3874ad31b5381b1bbd8293L98-R110)

Test pipeline https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6342714&view=results