### PR TITLE
[azure-mgmt-workloads] Update Development Status classifier to Production/Stable

### DIFF
--- a/sdk/workloads/azure-mgmt-workloads/setup.py
+++ b/sdk/workloads/azure-mgmt-workloads/setup.py
@@ -47,7 +47,7 @@ setup(
     url='https://github.com/Azure/azure-sdk-for-python',
     keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Fix CI of https://github.com/Azure/azure-sdk-for-python/pull/47102

The package azure-mgmt-workloads 1.0.0 is a GA release, but setup.py still declares 'Development Status :: 4 - Beta'. Update to '5 - Production/Stable' to reflect the GA status.