### PR TITLE
[Key Vault] Added API 2026-01-01-preview with key_size property for oct-HSM keys

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,19 +1,16 @@
 # Release History
 
-## 4.12.0b1 (2026-05-25)
+## 4.12.0b1 (2026-05-26)
 
 ### Features Added
 
-- Added support for service API version `2026-01-01-preview`.
+- Added support for service API version `2026-01-01-preview` [#47116](https://github.com/Azure/azure-sdk-for-python/pull/47116).
 - Added `KeyProperties.key_size` read-only property.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 
-- Key Vault API version `2026-01-01-preview` is now the default
+- Key Vault API version `2026-01-01-preview` is now the default.
+- Python 3.9 is no longer supported. Please use Python version 3.10 or later.
 
 ## 4.11.1 (2026-05-19)
 

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Release History
 
-## 4.11.2 (Unreleased)
+## 4.12.0b1 (2026-05-25)
 
 ### Features Added
+
+- Added support for service API version `2026-01-01-preview`.
+- Added `KeyProperties.key_size` read-only property.
 
 ### Breaking Changes
 
@@ -10,7 +13,9 @@
 
 ### Other Changes
 
-## 4.11.1 (2026-05-18)
+- Key Vault API version `2026-01-01-preview` is now the default
+
+## 4.11.1 (2026-05-19)
 
 ### Features Added
 

--- a/sdk/keyvault/azure-keyvault-keys/_metadata.json
+++ b/sdk/keyvault/azure-keyvault-keys/_metadata.json
@@ -1,6 +1,6 @@
 {
-  "apiVersion": "2025-07-01",
+  "apiVersion": "2026-01-01-preview",
   "apiVersions": {
-    "KeyVault": "2025-07-01"
+    "KeyVault": "2026-01-01-preview"
   }
 }

--- a/sdk/keyvault/azure-keyvault-keys/apiview-properties.json
+++ b/sdk/keyvault/azure-keyvault-keys/apiview-properties.json
@@ -4,6 +4,7 @@
         "azure.keyvault.keys._generated.models.BackupKeyResult": "KeyVault.BackupKeyResult",
         "azure.keyvault.keys._generated.models.DeletedKeyBundle": "KeyVault.DeletedKeyBundle",
         "azure.keyvault.keys._generated.models.DeletedKeyItem": "KeyVault.DeletedKeyItem",
+        "azure.keyvault.keys._generated.models.ExternalKey": "KeyVault.ExternalKey",
         "azure.keyvault.keys._generated.models.GetRandomBytesRequest": "KeyVault.GetRandomBytesRequest",
         "azure.keyvault.keys._generated.models.JsonWebKey": "KeyVault.JsonWebKey",
         "azure.keyvault.keys._generated.models.KeyAttestation": "KeyVault.KeyAttestation",
@@ -30,12 +31,16 @@
         "azure.keyvault.keys._generated.models.LifetimeActionsTrigger": "KeyVault.LifetimeActionsTrigger",
         "azure.keyvault.keys._generated.models.LifetimeActionsType": "KeyVault.LifetimeActionsType",
         "azure.keyvault.keys._generated.models.RandomBytes": "KeyVault.RandomBytes",
+        "azure.keyvault.keys._generated.models.SecureKeyOperationResult": "KeyVault.SecureKeyOperationResult",
+        "azure.keyvault.keys._generated.models.SecureKeyUnWrapOperationParameters": "KeyVault.SecureKeyUnWrapOperationParameters",
+        "azure.keyvault.keys._generated.models.SecureKeyWrapOperationParameters": "KeyVault.SecureKeyWrapOperationParameters",
         "azure.keyvault.keys._generated.models.JsonWebKeyType": "KeyVault.JsonWebKeyType",
         "azure.keyvault.keys._generated.models.JsonWebKeyCurveName": "KeyVault.JsonWebKeyCurveName",
         "azure.keyvault.keys._generated.models.DeletionRecoveryLevel": "KeyVault.DeletionRecoveryLevel",
         "azure.keyvault.keys._generated.models.JsonWebKeyOperation": "KeyVault.JsonWebKeyOperation",
         "azure.keyvault.keys._generated.models.JsonWebKeyEncryptionAlgorithm": "KeyVault.JsonWebKeyEncryptionAlgorithm",
         "azure.keyvault.keys._generated.models.JsonWebKeySignatureAlgorithm": "KeyVault.JsonWebKeySignatureAlgorithm",
+        "azure.keyvault.keys._generated.models.JsonWebKeyWrapAlgorithm": "KeyVault.JsonWebKeyWrapAlgorithm",
         "azure.keyvault.keys._generated.models.KeyEncryptionAlgorithm": "KeyVault.KeyEncryptionAlgorithm",
         "azure.keyvault.keys._generated.models.KeyRotationPolicyAction": "KeyVault.KeyRotationPolicyAction",
         "azure.keyvault.keys._generated.KeyVaultClient.create_key": "KeyVault.createKey",
@@ -68,6 +73,10 @@
         "azure.keyvault.keys._generated.aio.KeyVaultClient.verify": "KeyVault.verify",
         "azure.keyvault.keys._generated.KeyVaultClient.wrap_key": "KeyVault.wrapKey",
         "azure.keyvault.keys._generated.aio.KeyVaultClient.wrap_key": "KeyVault.wrapKey",
+        "azure.keyvault.keys._generated.KeyVaultClient.secure_wrap_key": "KeyVault.secureWrapKey",
+        "azure.keyvault.keys._generated.aio.KeyVaultClient.secure_wrap_key": "KeyVault.secureWrapKey",
+        "azure.keyvault.keys._generated.KeyVaultClient.secure_unwrap_key": "KeyVault.secureUnwrapKey",
+        "azure.keyvault.keys._generated.aio.KeyVaultClient.secure_unwrap_key": "KeyVault.secureUnwrapKey",
         "azure.keyvault.keys._generated.KeyVaultClient.unwrap_key": "KeyVault.unwrapKey",
         "azure.keyvault.keys._generated.aio.KeyVaultClient.unwrap_key": "KeyVault.unwrapKey",
         "azure.keyvault.keys._generated.KeyVaultClient.release": "KeyVault.release",
@@ -88,5 +97,6 @@
         "azure.keyvault.keys._generated.aio.KeyVaultClient.get_random_bytes": "KeyVault.getRandomBytes",
         "azure.keyvault.keys._generated.KeyVaultClient.get_key_attestation": "KeyVault.getKeyAttestation",
         "azure.keyvault.keys._generated.aio.KeyVaultClient.get_key_attestation": "KeyVault.getKeyAttestation"
-    }
+    },
+    "CrossLanguageVersion": "8246843b8f9d"
 }

--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_229759aadf"
+  "Tag": "python/keyvault/azure-keyvault-keys_e47dc10e22"
 }

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
@@ -2,7 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # -------------------------------------
-from ._enums import KeyCurveName, KeyExportEncryptionAlgorithm, KeyOperation, KeyRotationPolicyAction, KeyType
+from ._enums import (
+    KeyCurveName,
+    KeyExportEncryptionAlgorithm,
+    KeyOperation,
+    KeyRotationPolicyAction,
+    KeyType,
+)
 from ._shared.client_base import ApiVersion
 from ._models import (
     DeletedKey,

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_client.py
@@ -7,8 +7,8 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
+import sys
 from typing import Any, TYPE_CHECKING
-from typing_extensions import Self
 
 from azure.core import PipelineClient
 from azure.core.pipeline import policies
@@ -17,6 +17,11 @@ from azure.core.rest import HttpRequest, HttpResponse
 from ._configuration import KeyVaultClientConfiguration
 from ._operations import _KeyVaultClientOperationsMixin
 from ._utils.serialization import Deserializer, Serializer
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self  # type: ignore
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -30,9 +35,10 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_configuration.py
@@ -26,14 +26,15 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, vault_base_url: str, credential: "TokenCredential", **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-07-01")
+        api_version: str = kwargs.pop("api_version", "2026-01-01-preview")
 
         if vault_base_url is None:
             raise ValueError("Parameter 'vault_base_url' must not be None.")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations/_operations.py
@@ -49,7 +49,7 @@ def build_key_vault_create_key_request(key_name: str, **kwargs: Any) -> HttpRequ
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -75,7 +75,7 @@ def build_key_vault_rotate_key_request(key_name: str, **kwargs: Any) -> HttpRequ
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -100,7 +100,7 @@ def build_key_vault_import_key_request(key_name: str, **kwargs: Any) -> HttpRequ
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -126,7 +126,7 @@ def build_key_vault_delete_key_request(key_name: str, **kwargs: Any) -> HttpRequ
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -151,7 +151,7 @@ def build_key_vault_update_key_request(key_name: str, key_version: str, **kwargs
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -178,7 +178,7 @@ def build_key_vault_get_key_request(key_name: str, key_version: str, **kwargs: A
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -205,7 +205,7 @@ def build_key_vault_get_key_versions_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -231,7 +231,7 @@ def build_key_vault_get_keys_request(*, maxresults: Optional[int] = None, **kwar
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -252,7 +252,7 @@ def build_key_vault_backup_key_request(key_name: str, **kwargs: Any) -> HttpRequ
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -277,7 +277,7 @@ def build_key_vault_restore_key_request(**kwargs: Any) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -299,7 +299,7 @@ def build_key_vault_encrypt_request(key_name: str, key_version: str, **kwargs: A
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -327,7 +327,7 @@ def build_key_vault_decrypt_request(key_name: str, key_version: str, **kwargs: A
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -355,7 +355,7 @@ def build_key_vault_sign_request(key_name: str, key_version: str, **kwargs: Any)
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -383,7 +383,7 @@ def build_key_vault_verify_request(key_name: str, key_version: str, **kwargs: An
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -411,11 +411,69 @@ def build_key_vault_wrap_key_request(key_name: str, key_version: str, **kwargs: 
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
     _url = "/keys/{key-name}/{key-version}/wrapkey"
+    path_format_arguments = {
+        "key-name": _SERIALIZER.url("key_name", key_name, "str"),
+        "key-version": _SERIALIZER.url("key_version", key_version, "str"),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_secure_wrap_key_request(key_name: str, key_version: str, **kwargs: Any) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/keys/{key-name}/{key-version}/securewrapkey"
+    path_format_arguments = {
+        "key-name": _SERIALIZER.url("key_name", key_name, "str"),
+        "key-version": _SERIALIZER.url("key_version", key_version, "str"),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_key_vault_secure_unwrap_key_request(  # pylint: disable=name-too-long
+    key_name: str, key_version: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/keys/{key-name}/{key-version}/secureunwrapkey"
     path_format_arguments = {
         "key-name": _SERIALIZER.url("key_name", key_name, "str"),
         "key-version": _SERIALIZER.url("key_version", key_version, "str"),
@@ -439,7 +497,7 @@ def build_key_vault_unwrap_key_request(key_name: str, key_version: str, **kwargs
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -467,7 +525,7 @@ def build_key_vault_release_request(key_name: str, key_version: str, **kwargs: A
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -494,7 +552,7 @@ def build_key_vault_get_deleted_keys_request(*, maxresults: Optional[int] = None
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -515,7 +573,7 @@ def build_key_vault_get_deleted_key_request(key_name: str, **kwargs: Any) -> Htt
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -540,7 +598,7 @@ def build_key_vault_purge_deleted_key_request(  # pylint: disable=name-too-long
 ) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     # Construct URL
     _url = "/deletedkeys/{key-name}"
     path_format_arguments = {
@@ -561,7 +619,7 @@ def build_key_vault_recover_deleted_key_request(  # pylint: disable=name-too-lon
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -587,7 +645,7 @@ def build_key_vault_get_key_rotation_policy_request(  # pylint: disable=name-too
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -614,7 +672,7 @@ def build_key_vault_update_key_rotation_policy_request(  # pylint: disable=name-
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -641,7 +699,7 @@ def build_key_vault_get_random_bytes_request(**kwargs: Any) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -664,7 +722,7 @@ def build_key_vault_get_key_attestation_request(  # pylint: disable=name-too-lon
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2025-07-01"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-01-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -1495,7 +1553,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -1593,7 +1654,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -2874,6 +2938,428 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
         return deserialized  # type: ignore
 
     @overload
+    def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: _models.SecureKeyWrapOperationParameters,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyWrapOperationParameters
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["key_name", "key_version", "content_type", "accept", "api_version"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: Union[_models.SecureKeyWrapOperationParameters, JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Is one of the following types:
+         SecureKeyWrapOperationParameters, JSON, IO[bytes] Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyWrapOperationParameters or
+         JSON or IO[bytes]
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.SecureKeyOperationResult] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(parameters, (IOBase, bytes)):
+            _content = parameters
+        else:
+            _content = json.dumps(parameters, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_secure_wrap_key_request(
+            key_name=key_name,
+            key_version=key_version,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.SecureKeyOperationResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: _models.SecureKeyUnWrapOperationParameters,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyUnWrapOperationParameters
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["key_name", "key_version", "content_type", "accept", "api_version"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: Union[_models.SecureKeyUnWrapOperationParameters, JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Is one of the following types:
+         SecureKeyUnWrapOperationParameters, JSON, IO[bytes] Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyUnWrapOperationParameters or
+         JSON or IO[bytes]
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.SecureKeyOperationResult] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(parameters, (IOBase, bytes)):
+            _content = parameters
+        else:
+            _content = json.dumps(parameters, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_secure_unwrap_key_request(
+            key_name=key_name,
+            key_version=key_version,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.SecureKeyOperationResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
     def unwrap_key(
         self,
         key_name: str,
@@ -3304,7 +3790,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -3911,7 +4400,7 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["key_name", "key_version", "accept", "api_version"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     def get_key_attestation(self, key_name: str, key_version: str, **kwargs: Any) -> _models.KeyBundle:
         """Gets the public part of a stored key along with its attestation blob.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations/_patch.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_patch.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_utils/model_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_utils/model_base.py
@@ -23,13 +23,18 @@ from datetime import datetime, date, time, timedelta, timezone
 from json import JSONEncoder
 import xml.etree.ElementTree as ET
 from collections.abc import MutableMapping
-from typing_extensions import Self
 import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
 from azure.core.serialization import _Null
+
 from azure.core.rest import HttpResponse
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -595,11 +600,7 @@ class Model(_MyMutableMapping):
         class_name = self.__class__.__name__
         if len(args) > 1:
             raise TypeError(f"{class_name}.__init__() takes 2 positional arguments but {len(args) + 1} were given")
-        dict_to_pass = {
-            rest_field._rest_name: rest_field._default
-            for rest_field in self._attr_to_rest_field.values()
-            if rest_field._default is not _UNSET
-        }
+        dict_to_pass: dict[str, typing.Any] = {}
         if args:
             if isinstance(args[0], ET.Element):
                 dict_to_pass.update(self._init_from_xml(args[0]))
@@ -619,6 +620,14 @@ class Model(_MyMutableMapping):
                     if v is not None
                 }
             )
+        # Apply client default values for fields the caller didn't set so that
+        # defaults are part of `_data` and therefore included during serialization.
+        for rf in self._attr_to_rest_field.values():
+            if rf._default is _UNSET:
+                continue
+            if rf._rest_name in dict_to_pass:
+                continue
+            dict_to_pass[rf._rest_name] = _create_value(rf, rf._default)
         super().__init__(dict_to_pass)
 
     def _init_from_xml(self, element: ET.Element) -> dict[str, typing.Any]:
@@ -1113,7 +1122,10 @@ class _RestField:
         # by this point, type and rest_name will have a value bc we default
         # them in __new__ of the Model class
         # Use _data.get() directly to avoid triggering __getitem__ which clears the cache
-        item = obj._data.get(self._rest_name)
+        item = obj._data.get(self._rest_name, _UNSET)
+        if item is _UNSET:
+            # Field not set by user; return the client default if one exists, otherwise None
+            return self._default if self._default is not _UNSET else None
         if item is None:
             return item
         if self._is_model:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_utils/serialization.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_utils/serialization.py
@@ -39,10 +39,14 @@ except ImportError:
 import xml.etree.ElementTree as ET
 
 import isodate  # type: ignore
-from typing_extensions import Self
 
 from azure.core.exceptions import DeserializationError, SerializationError
 from azure.core.serialization import NULL as CoreNull
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _BOM = codecs.BOM_UTF8.decode(encoding="utf-8")
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_client.py
@@ -7,8 +7,8 @@
 # --------------------------------------------------------------------------
 
 from copy import deepcopy
+import sys
 from typing import Any, Awaitable, TYPE_CHECKING
-from typing_extensions import Self
 
 from azure.core import AsyncPipelineClient
 from azure.core.pipeline import policies
@@ -17,6 +17,11 @@ from azure.core.rest import AsyncHttpResponse, HttpRequest
 from .._utils.serialization import Deserializer, Serializer
 from ._configuration import KeyVaultClientConfiguration
 from ._operations import _KeyVaultClientOperationsMixin
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self  # type: ignore
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
@@ -30,9 +35,10 @@ class KeyVaultClient(_KeyVaultClientOperationsMixin):
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_configuration.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_configuration.py
@@ -26,14 +26,15 @@ class KeyVaultClientConfiguration:  # pylint: disable=too-many-instance-attribut
     :type vault_base_url: str
     :param credential: Credential used to authenticate requests to the service. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: The API version to use for this operation. Known values are "2025-07-01".
-     Default value is "2025-07-01". Note that overriding this default value may result in
-     unsupported behavior.
+    :keyword api_version: The API version to use for this operation. Known values are
+     "2026-01-01-preview" and None. Default value is None. If not set, the operation's default API
+     version will be used. Note that overriding this default value may result in unsupported
+     behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, vault_base_url: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-07-01")
+        api_version: str = kwargs.pop("api_version", "2026-01-01-preview")
 
         if vault_base_url is None:
             raise ValueError("Parameter 'vault_base_url' must not be None.")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations/_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations/_operations.py
@@ -51,6 +51,8 @@ from ..._operations._operations import (
     build_key_vault_release_request,
     build_key_vault_restore_key_request,
     build_key_vault_rotate_key_request,
+    build_key_vault_secure_unwrap_key_request,
+    build_key_vault_secure_wrap_key_request,
     build_key_vault_sign_request,
     build_key_vault_unwrap_key_request,
     build_key_vault_update_key_request,
@@ -878,7 +880,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -976,7 +981,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -2257,6 +2265,428 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
         return deserialized  # type: ignore
 
     @overload
+    async def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: _models.SecureKeyWrapOperationParameters,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyWrapOperationParameters
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Required.
+        :type parameters: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["key_name", "key_version", "content_type", "accept", "api_version"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def secure_wrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: Union[_models.SecureKeyWrapOperationParameters, JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Creates a new 256 bit AES key within the trusted execution environment and wraps this key using
+        a specified key.
+
+        The SECURE WRAP operation creates a new 256 bit AES key within the trusted execution
+        environment(TEE) and encrypts the same with a key encryption key that has previously been
+        stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys
+        stored in Azure Key Vault since protection with an asymmetric key can be performed using the
+        public portion of the key. This operation is supported for asymmetric keys as a convenience for
+        callers that have a key-reference but do not have access to the public key material. This
+        operation requires the keys/wrapKey permission.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for wrap operation. Is one of the following types:
+         SecureKeyWrapOperationParameters, JSON, IO[bytes] Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyWrapOperationParameters or
+         JSON or IO[bytes]
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.SecureKeyOperationResult] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(parameters, (IOBase, bytes)):
+            _content = parameters
+        else:
+            _content = json.dumps(parameters, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_secure_wrap_key_request(
+            key_name=key_name,
+            key_version=key_version,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.SecureKeyOperationResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    async def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: _models.SecureKeyUnWrapOperationParameters,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyUnWrapOperationParameters
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Required.
+        :type parameters: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    @api_version_validation(
+        method_added_on="2026-01-01-preview",
+        params_added_on={"2026-01-01-preview": ["key_name", "key_version", "content_type", "accept", "api_version"]},
+        api_versions_list=["2026-01-01-preview"],
+    )
+    async def secure_unwrap_key(
+        self,
+        key_name: str,
+        key_version: str,
+        parameters: Union[_models.SecureKeyUnWrapOperationParameters, JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> _models.SecureKeyOperationResult:
+        """Securely unwraps a previously wrapped symmetric key using a specified key, ensuring TEE
+        attestation via Microsoft Azure Attestation (MAA) before unwrapping.
+
+        The SECURE UNWRAP operation supports decryption of a symmetric key using the target key
+        encryption key. This operation is the reverse of the SECURE WRAP operation. The SECURE UNWRAP
+        operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the
+        private portion of the key. This operation requires the keys/unwrapKey permission. The SECURE
+        UNWRAP operation ensures that MAA (Microsoft Azure Attestation Service) is used to attest the
+        TEE (Trusted Execution Environment) before the key is unwrapped.
+
+        :param key_name: The name of the key. Required.
+        :type key_name: str
+        :param key_version: The version of the key. Required.
+        :type key_version: str
+        :param parameters: The parameters for unwrap operation. Is one of the following types:
+         SecureKeyUnWrapOperationParameters, JSON, IO[bytes] Required.
+        :type parameters: ~azure.keyvault.keys._generated.models.SecureKeyUnWrapOperationParameters or
+         JSON or IO[bytes]
+        :return: SecureKeyOperationResult. The SecureKeyOperationResult is compatible with
+         MutableMapping
+        :rtype: ~azure.keyvault.keys._generated.models.SecureKeyOperationResult
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[_models.SecureKeyOperationResult] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(parameters, (IOBase, bytes)):
+            _content = parameters
+        else:
+            _content = json.dumps(parameters, cls=SdkJSONEncoder, exclude_readonly=True)  # type: ignore
+
+        _request = build_key_vault_secure_unwrap_key_request(
+            key_name=key_name,
+            key_version=key_version,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        path_format_arguments = {
+            "vaultBaseUrl": self._serialize.url(
+                "self._config.vault_base_url", self._config.vault_base_url, "str", skip_quote=True
+            ),
+        }
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
+
+        _decompress = kwargs.pop("decompress", True)
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            if _stream:
+                try:
+                    await response.read()  # Load the body in memory and close the socket
+                except (StreamConsumedError, StreamClosedError):
+                    pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            error = _failsafe_deserialize(
+                _models.KeyVaultError,
+                response,
+            )
+            raise HttpResponseError(response=response, model=error)
+
+        if _stream:
+            deserialized = response.iter_bytes() if _decompress else response.iter_raw()
+        else:
+            deserialized = _deserialize(_models.SecureKeyOperationResult, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
     async def unwrap_key(
         self,
         key_name: str,
@@ -2688,7 +3118,10 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
                 )
                 _next_request_params["api-version"] = self._config.api_version
                 _request = HttpRequest(
-                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                    "GET",
+                    urllib.parse.urljoin(next_link, _parsed_next_link.path),
+                    headers=_headers,
+                    params=_next_request_params,
                 )
                 path_format_arguments = {
                     "vaultBaseUrl": self._serialize.url(
@@ -3295,7 +3728,7 @@ class _KeyVaultClientOperationsMixin(  # pylint: disable=too-many-public-methods
     @api_version_validation(
         method_added_on="7.6-preview.2",
         params_added_on={"7.6-preview.2": ["key_name", "key_version", "accept", "api_version"]},
-        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01"],
+        api_versions_list=["7.6-preview.2", "7.6", "2025-06-01-preview", "2025-07-01", "2026-01-01-preview"],
     )
     async def get_key_attestation(self, key_name: str, key_version: str, **kwargs: Any) -> _models.KeyBundle:
         """Gets the public part of a stored key along with its attestation blob.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations/_patch.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_patch.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/__init__.py
@@ -17,6 +17,7 @@ from ._models import (  # type: ignore
     BackupKeyResult,
     DeletedKeyBundle,
     DeletedKeyItem,
+    ExternalKey,
     GetRandomBytesRequest,
     JsonWebKey,
     KeyAttestation,
@@ -43,6 +44,9 @@ from ._models import (  # type: ignore
     LifetimeActionsTrigger,
     LifetimeActionsType,
     RandomBytes,
+    SecureKeyOperationResult,
+    SecureKeyUnWrapOperationParameters,
+    SecureKeyWrapOperationParameters,
 )
 
 from ._enums import (  # type: ignore
@@ -52,6 +56,7 @@ from ._enums import (  # type: ignore
     JsonWebKeyOperation,
     JsonWebKeySignatureAlgorithm,
     JsonWebKeyType,
+    JsonWebKeyWrapAlgorithm,
     KeyEncryptionAlgorithm,
     KeyRotationPolicyAction,
 )
@@ -63,6 +68,7 @@ __all__ = [
     "BackupKeyResult",
     "DeletedKeyBundle",
     "DeletedKeyItem",
+    "ExternalKey",
     "GetRandomBytesRequest",
     "JsonWebKey",
     "KeyAttestation",
@@ -89,12 +95,16 @@ __all__ = [
     "LifetimeActionsTrigger",
     "LifetimeActionsType",
     "RandomBytes",
+    "SecureKeyOperationResult",
+    "SecureKeyUnWrapOperationParameters",
+    "SecureKeyWrapOperationParameters",
     "DeletionRecoveryLevel",
     "JsonWebKeyCurveName",
     "JsonWebKeyEncryptionAlgorithm",
     "JsonWebKeyOperation",
     "JsonWebKeySignatureAlgorithm",
     "JsonWebKeyType",
+    "JsonWebKeyWrapAlgorithm",
     "KeyEncryptionAlgorithm",
     "KeyRotationPolicyAction",
 ]

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_enums.py
@@ -206,14 +206,38 @@ class JsonWebKeyType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Octet sequence (used to represent symmetric keys) which is stored the HSM."""
 
 
+class JsonWebKeyWrapAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """An algorithm used for key wrapping and unwrapping."""
+
+    RSA_OAEP256 = "RSA-OAEP-256"
+    """RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256 and a mask
+    generation function of MGF1 with SHA-256."""
+    A128_KW = "A128KW"
+    """128-bit AES key wrap."""
+    A192_KW = "A192KW"
+    """192-bit AES key wrap."""
+    A256_KW = "A256KW"
+    """256-bit AES key wrap."""
+    A256_KWPAD = "A256KWPAD"
+    """128-bit AES key wrap with padding."""
+    A128_KWPAD = "A128KWPAD"
+    """192-bit AES key wrap with padding."""
+    A192_KWPAD = "A192KWPAD"
+    """256-bit AES key wrap with padding."""
+    CKM_AES_KEY_WRAP = "CKM_AES_KEY_WRAP"
+    """CKM AES key wrap."""
+    CKM_AES_KEY_WRAP_PAD = "CKM_AES_KEY_WRAP_PAD"
+    """CKM AES key wrap with padding."""
+
+
 class KeyEncryptionAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """The encryption algorithm to use to protected the exported key material."""
 
     CKM_RSA_AES_KEY_WRAP = "CKM_RSA_AES_KEY_WRAP"
     """The CKM_RSA_AES_KEY_WRAP key wrap mechanism."""
-    RSA_AES_KEY_WRAP_256 = "RSA_AES_KEY_WRAP_256"
+    RSA_AES_KEY_WRAP256 = "RSA_AES_KEY_WRAP_256"
     """The RSA_AES_KEY_WRAP_256 key wrap mechanism."""
-    RSA_AES_KEY_WRAP_384 = "RSA_AES_KEY_WRAP_384"
+    RSA_AES_KEY_WRAP384 = "RSA_AES_KEY_WRAP_384"
     """The RSA_AES_KEY_WRAP_384 key wrap mechanism."""
 
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_models.py
@@ -167,6 +167,36 @@ class DeletedKeyItem(_Model):
         super().__init__(*args, **kwargs)
 
 
+class ExternalKey(_Model):
+    """External Key parameters.
+
+    :ivar id: The external key identifier. The valid id can only contain characters in the set
+     [a-zA-Z0-9-]. Maximum length is 64 characters. Required.
+    :vartype id: str
+    """
+
+    id: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """The external key identifier. The valid id can only contain characters in the set [a-zA-Z0-9-].
+     Maximum length is 64 characters. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        id: str,  # pylint: disable=redefined-builtin
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class GetRandomBytesRequest(_Model):
     """The get random bytes request object.
 
@@ -399,6 +429,11 @@ class KeyAttributes(_Model):
     :vartype hsm_platform: str
     :ivar attestation: The key or key version attestation information.
     :vartype attestation: ~azure.keyvault.keys._generated.models.KeyAttestation
+    :ivar external_key: The external key information.
+    :vartype external_key: ~azure.keyvault.keys._generated.models.ExternalKey
+    :ivar key_size: The optional key size in bits for symmetric keys. For example: 128, 192, or 256
+     for AES keys.
+    :vartype key_size: int
     """
 
     enabled: Optional[bool] = rest_field(visibility=["read", "create", "update", "delete", "query"])
@@ -434,6 +469,12 @@ class KeyAttributes(_Model):
     """The underlying HSM Platform."""
     attestation: Optional["_models.KeyAttestation"] = rest_field(visibility=["read"])
     """The key or key version attestation information."""
+    external_key: Optional["_models.ExternalKey"] = rest_field(
+        visibility=["read", "create", "update", "delete", "query"]
+    )
+    """The external key information."""
+    key_size: Optional[int] = rest_field(visibility=["read"])
+    """The optional key size in bits for symmetric keys. For example: 128, 192, or 256 for AES keys."""
 
     @overload
     def __init__(
@@ -443,6 +484,7 @@ class KeyAttributes(_Model):
         not_before: Optional[datetime.datetime] = None,
         expires: Optional[datetime.datetime] = None,
         exportable: Optional[bool] = None,
+        external_key: Optional["_models.ExternalKey"] = None,
     ) -> None: ...
 
     @overload
@@ -1299,6 +1341,131 @@ class RandomBytes(_Model):
         self,
         *,
         value: bytes,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class SecureKeyOperationResult(_Model):
+    """The secure key wrap operation result.
+
+    :ivar kid: Key identifier. Required.
+    :vartype kid: str
+    :ivar algorithm: The algorithm used for the operation. Required. Known values are:
+     "RSA-OAEP-256", "A128KW", "A192KW", "A256KW", "A256KWPAD", "A128KWPAD", "A192KWPAD",
+     "CKM_AES_KEY_WRAP", and "CKM_AES_KEY_WRAP_PAD".
+    :vartype algorithm: str or ~azure.keyvault.keys._generated.models.JsonWebKeyWrapAlgorithm
+    :ivar value: The result of the operation. Required.
+    :vartype value: bytes
+    """
+
+    kid: str = rest_field(visibility=["read", "create", "update", "delete", "query"])
+    """Key identifier. Required."""
+    algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"] = rest_field(
+        name="alg", visibility=["read", "create", "update", "delete", "query"]
+    )
+    """The algorithm used for the operation. Required. Known values are: \"RSA-OAEP-256\", \"A128KW\",
+     \"A192KW\", \"A256KW\", \"A256KWPAD\", \"A128KWPAD\", \"A192KWPAD\", \"CKM_AES_KEY_WRAP\", and
+     \"CKM_AES_KEY_WRAP_PAD\"."""
+    value: bytes = rest_field(visibility=["read", "create", "update", "delete", "query"], format="base64url")
+    """The result of the operation. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        kid: str,
+        algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"],
+        value: bytes,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class SecureKeyUnWrapOperationParameters(_Model):
+    """The Secure Key unwrap attributes.
+
+    :ivar algorithm: algorithm identifier. Required. Known values are: "RSA-OAEP-256", "A128KW",
+     "A192KW", "A256KW", "A256KWPAD", "A128KWPAD", "A192KWPAD", "CKM_AES_KEY_WRAP", and
+     "CKM_AES_KEY_WRAP_PAD".
+    :vartype algorithm: str or ~azure.keyvault.keys._generated.models.JsonWebKeyWrapAlgorithm
+    :ivar value: The value to operate on. Required.
+    :vartype value: bytes
+    :ivar target_attestation_token: The attestation assertion for the target of the key release.
+     Required.
+    :vartype target_attestation_token: str
+    """
+
+    algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"] = rest_field(
+        name="alg", visibility=["read", "create", "update", "delete", "query"]
+    )
+    """algorithm identifier. Required. Known values are: \"RSA-OAEP-256\", \"A128KW\", \"A192KW\",
+     \"A256KW\", \"A256KWPAD\", \"A128KWPAD\", \"A192KWPAD\", \"CKM_AES_KEY_WRAP\", and
+     \"CKM_AES_KEY_WRAP_PAD\"."""
+    value: bytes = rest_field(visibility=["read", "create", "update", "delete", "query"], format="base64url")
+    """The value to operate on. Required."""
+    target_attestation_token: str = rest_field(
+        name="target", visibility=["read", "create", "update", "delete", "query"]
+    )
+    """The attestation assertion for the target of the key release. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"],
+        value: bytes,
+        target_attestation_token: str,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class SecureKeyWrapOperationParameters(_Model):
+    """The Secure Key wrap attributes.
+
+    :ivar algorithm: algorithm identifier. Required. Known values are: "RSA-OAEP-256", "A128KW",
+     "A192KW", "A256KW", "A256KWPAD", "A128KWPAD", "A192KWPAD", "CKM_AES_KEY_WRAP", and
+     "CKM_AES_KEY_WRAP_PAD".
+    :vartype algorithm: str or ~azure.keyvault.keys._generated.models.JsonWebKeyWrapAlgorithm
+    """
+
+    algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"] = rest_field(
+        name="alg", visibility=["read", "create", "update", "delete", "query"]
+    )
+    """algorithm identifier. Required. Known values are: \"RSA-OAEP-256\", \"A128KW\", \"A192KW\",
+     \"A256KW\", \"A256KWPAD\", \"A128KWPAD\", \"A192KWPAD\", \"CKM_AES_KEY_WRAP\", and
+     \"CKM_AES_KEY_WRAP_PAD\"."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        algorithm: Union[str, "_models.JsonWebKeyWrapAlgorithm"],
     ) -> None: ...
 
     @overload

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_patch.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+
 from typing import List
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -317,6 +317,21 @@ class KeyProperties(object):
                 return KeyAttestation._from_generated(attestation=attestation)  # pylint:disable=protected-access
         return None
 
+    @property
+    def key_size(self) -> Optional[int]:
+        """The key size in bits (e.g. 128, 192, or 256 for AES).
+
+        Available for oct (symmetric) keys when using API version 2026-01-01-preview or later.
+        Returns None for RSA keys, EC keys, and older API versions.
+
+        :returns: The key size in bits, or None when not applicable.
+        :rtype: int or None
+        """
+        # key_size was added in 2026-01-01-preview
+        if self._attributes:
+            return getattr(self._attributes, "key_size", None)
+        return None
+
 
 class KeyReleasePolicy(object):
     """The policy rules under which a key can be exported.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -24,6 +24,7 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Key Vault API versions supported by this package"""
 
     #: this is the default version
+    V2026_01_01_PREVIEW = "2026-01-01-preview"
     V2025_07_01 = "2025-07-01"
     V7_6 = "7.6"
     V7_5 = "7.5"
@@ -35,7 +36,7 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     V2016_10_01 = "2016-10-01"
 
 
-DEFAULT_VERSION = ApiVersion.V2025_07_01
+DEFAULT_VERSION = ApiVersion.V2026_01_01_PREVIEW
 
 _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge_cache.py
@@ -8,7 +8,6 @@ from urllib import parse
 
 from .http_challenge import HttpChallenge
 
-
 _cache: "Dict[str, HttpChallenge]" = {}
 _lock = threading.Lock()
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.11.2"
+VERSION = "4.12.0b1"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
@@ -15,7 +15,6 @@ from ._models import (
 from ._enums import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from ._client import CryptographyClient
 
-
 __all__ = [
     "CryptographyClient",
     "DecryptResult",

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
@@ -9,7 +9,6 @@ from cryptography.hazmat.primitives import padding
 from ..algorithm import SymmetricEncryptionAlgorithm
 from ..transform import BlockCryptoTransform
 
-
 # pylint: disable=W0223
 
 _CBC_BLOCK_SIZE = 128

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/__init__.py
@@ -6,7 +6,6 @@ from typing import Any, List, Optional
 
 from ._client import CryptographyClient
 
-
 __all__ = [
     "CryptographyClient",
 ]

--- a/sdk/keyvault/azure-keyvault-keys/pyproject.toml
+++ b/sdk/keyvault/azure-keyvault-keys/pyproject.toml
@@ -21,13 +21,12 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["azure", "azure sdk"]
 
 dependencies = [

--- a/sdk/keyvault/azure-keyvault-keys/pyproject.toml
+++ b/sdk/keyvault/azure-keyvault-keys/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 description = "Microsoft Corporation Azure Key Vault Keys Client Library for Python"
 license = "MIT"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -12,7 +12,6 @@ from azure.keyvault.keys import KeyReleasePolicy
 from azure.keyvault.keys._shared.client_base import ApiVersion
 from devtools_testutils import AzureRecordedTestCase
 
-
 HSM_UNSUPPORTED_VERSIONS = {ApiVersion.V2016_10_01, ApiVersion.V7_0, ApiVersion.V7_1}
 
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/decrypt.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/decrypt.py
@@ -13,7 +13,6 @@ from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm
 from azure.keyvault.keys.crypto.aio import CryptographyClient as AsyncCryptographyClient
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 
-
 # without keys/get, a CryptographyClient created with a key ID performs all ops remotely
 NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/sign.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/sign.py
@@ -14,7 +14,6 @@ from azure.keyvault.keys.crypto import CryptographyClient, SignatureAlgorithm
 from azure.keyvault.keys.crypto.aio import CryptographyClient as AsyncCryptographyClient
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 
-
 # without keys/get, a CryptographyClient created with a key ID performs all ops remotely
 NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/unwrap.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/perfstress_tests/unwrap.py
@@ -13,7 +13,6 @@ from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm
 from azure.keyvault.keys.crypto.aio import CryptographyClient as AsyncCryptographyClient
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 
-
 # without keys/get, a CryptographyClient created with a key ID performs all ops remotely
 NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -6,6 +6,7 @@
 Tests for the HTTP challenge authentication implementation. These tests aren't parallelizable, because
 the challenge cache is global to the process.
 """
+
 import base64
 import functools
 from itertools import product

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -6,6 +6,7 @@
 Tests for the HTTP challenge authentication implementation. These tests aren't parallelizable, because
 the challenge cache is global to the process.
 """
+
 import asyncio
 import functools
 from itertools import product

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -46,7 +46,6 @@ from _shared.test_case import KeyVaultTestCase
 from _test_case import KeysClientPreparer, get_decorator
 from _keys_test_case import KeysTestCase
 
-
 all_api_versions = get_decorator()
 only_hsm = get_decorator(only_hsm=True)
 only_vault_default = get_decorator(only_vault=True, api_versions=[DEFAULT_VERSION])

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -32,7 +32,6 @@ from _shared.helpers_async import get_completed_future
 from _shared.test_case_async import KeyVaultTestCase
 from _keys_test_case import KeysTestCase
 
-
 all_api_versions = get_decorator(is_async=True)
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 only_vault_7_4_plus = get_decorator(only_vault=True, is_async=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -39,6 +39,7 @@ from _keys_test_case import KeysTestCase
 all_api_versions = get_decorator()
 only_hsm = get_decorator(only_hsm=True)
 only_hsm_default = get_decorator(only_hsm=True, api_versions=[DEFAULT_VERSION])
+default_version = get_decorator(api_versions=[DEFAULT_VERSION])
 only_hsm_7_4_plus = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
 only_vault_7_4_plus = get_decorator(only_vault=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
 only_7_4_plus = get_decorator(api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
@@ -110,6 +111,16 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         self._validate_ec_key_bundle(key_curve, created_key, client.vault_url, key_name, key_type)
         return created_key
 
+    def _create_oct_key(self, client, key_name, **kwargs):
+        hsm = kwargs.get("hardware_protected") or False
+        size = kwargs.get("size") or 256
+        if self.is_live:
+            time.sleep(2)  # to avoid throttling by the service
+        created_key = client.create_oct_key(key_name, **kwargs)
+        kty = "oct-HSM"
+        self._validate_oct_key_bundle(created_key, client.vault_url, key_name, kty, size)
+        return created_key
+
     def _validate_ec_key_bundle(self, key_curve, key_attributes, vault, key_name, kty):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
@@ -129,6 +140,19 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
         assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
+        assert (
+            key_attributes.properties.created_on and key_attributes.properties.updated_on
+        ), "Missing required date attributes."
+
+    def _validate_oct_key_bundle(self, key_attributes, vault, key_name, kty, size):
+        prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
+        key = key_attributes.key
+        kid = key_attributes.id
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
+        assert key_attributes.properties.key_size == size, (
+            f"key_size should be {size}, but is {key_attributes.properties.key_size}"
+        )
         assert (
             key_attributes.properties.created_on and key_attributes.properties.updated_on
         ), "Missing required date attributes."
@@ -189,687 +213,706 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         self._validate_rsa_key_bundle(imported_key, client.vault_url, name, key.kty, key.key_ops)
         return imported_key
 
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_key_crud_operations(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     # create ec key
+    #     ec_key_name = self.get_resource_name("crud-ec-key")
+    #     tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
+    #     ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=is_hsm, tags=tags)
+    #     assert ec_key.properties.enabled
+    #     assert tags == ec_key.properties.tags
+    #     # create ec with curve
+    #     ec_key_curve_name = self.get_resource_name("crud-P-256-ec-key")
+    #     created_ec_key_curve = self._create_ec_key(
+    #         client, key_name=ec_key_curve_name, curve="P-256", hardware_protected=is_hsm
+    #     )
+    #     assert "P-256" == created_ec_key_curve.key.crv
+
+    #     # import key
+    #     import_test_key_name = self.get_resource_name("import-test-key")
+    #     self._import_test_key(client, import_test_key_name, hardware_protected=is_hsm)
+
+    #     # create rsa key
+    #     rsa_key_name = self.get_resource_name("crud-rsa-key")
+    #     tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
+    #     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
+    #     rsa_key = self._create_rsa_key(
+    #         client, key_name=rsa_key_name, key_operations=key_ops, size=2048, tags=tags, hardware_protected=is_hsm
+    #     )
+    #     assert tags == rsa_key.properties.tags
+
+    #     # get the created key with version
+    #     key = client.get_key(rsa_key.name, rsa_key.properties.version)
+    #     assert key.properties.version == rsa_key.properties.version
+    #     self._assert_key_attributes_equal(rsa_key.properties, key.properties)
+
+    #     # get key without version
+    #     self._assert_key_attributes_equal(rsa_key.properties, client.get_key(rsa_key.name).properties)
+
+    #     # update key with version
+    #     if self.is_live:
+    #         # wait to ensure the key's update time won't equal its creation time
+    #         time.sleep(1)
+
+    #     self._update_key_properties(client, rsa_key)
+
+    #     # delete the new key
+    #     deleted_key_poller = client.begin_delete_key(rsa_key.name)
+    #     deleted_key = deleted_key_poller.result()
+    #     assert deleted_key is not None
+
+    #     # aside from key_ops, the original updated keys should have the same JWKs
+    #     self._assert_jwks_equal(rsa_key.key, deleted_key.key)
+    #     assert deleted_key.id == rsa_key.id
+    #     assert (
+    #         deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date
+    #     ), "Missing required deleted key attributes."
+
+    #     deleted_key_poller.wait()
+
+    #     # get the deleted key when soft deleted enabled
+    #     deleted_key = client.get_deleted_key(rsa_key.name)
+    #     assert deleted_key is not None
+    #     assert rsa_key.id == deleted_key.id
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_rsa_public_exponent(self, client, **kwargs):
+    #     """The public exponent of a Managed HSM RSA key can be specified during creation"""
+    #     assert client is not None
+
+    #     key_name = self.get_resource_name("rsa-key")
+    #     key = self._create_rsa_key(client, key_name, hardware_protected=True, public_exponent=17)
+    #     public_exponent = key.key.e[0]
+    #     assert public_exponent == 17
+
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_backup_restore(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     key_name = self.get_resource_name("keybak")
+
+    #     # create key
+    #     created_bundle = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # backup key
+    #     key_backup = client.backup_key(created_bundle.name)
+    #     assert key_backup is not None
+
+    #     # delete key
+    #     client.begin_delete_key(created_bundle.name).wait()
+
+    #     # purge key
+    #     client.purge_deleted_key(created_bundle.name)
+
+    #     # restore key
+    #     restore_function = functools.partial(client.restore_key_backup, key_backup)
+    #     restored_key = self._poll_until_no_exception(restore_function, ResourceExistsError)
+    #     self._assert_key_attributes_equal(created_bundle.properties, restored_key.properties)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_key_list(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     max_keys = LIST_TEST_SIZE
+    #     expected = {}
+
+    #     # create many keys
+    #     for x in range(max_keys):
+    #         key_name = self.get_resource_name(f"key{x}")
+    #         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+    #         expected[key.name] = key
+
+    #     # list keys
+    #     result = client.list_properties_of_keys(max_page_size=max_keys - 1)
+    #     for key in result:
+    #         if key.name in expected.keys():
+    #             self._assert_key_attributes_equal(expected[key.name].properties, key)
+    #             del expected[key.name]
+    #     assert len(expected) == 0
+
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_list_versions(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     key_name = self.get_resource_name("testKey")
+
+    #     max_keys = LIST_TEST_SIZE
+    #     expected = {}
+
+    #     # create many key versions
+    #     for _ in range(max_keys):
+    #         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+    #         expected[key.id] = key
+
+    #     result = client.list_properties_of_key_versions(key_name, max_page_size=max_keys - 1)
+
+    #     # validate list key versions with attributes
+    #     for key in result:
+    #         if key.id in expected.keys():
+    #             expected_key = expected[key.id]
+    #             del expected[key.id]
+    #             self._assert_key_attributes_equal(expected_key.properties, key)
+    #     assert 0 == len(expected)
+
+    # @pytest.mark.skip("Temporarily disabled due to service issue")
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_list_deleted_keys(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     expected = {}
+
+    #     # create keys
+    #     for i in range(LIST_TEST_SIZE):
+    #         key_name = self.get_resource_name(f"key{i}")
+    #         expected[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # delete them
+    #     for key_name in expected.keys():
+    #         client.begin_delete_key(key_name).wait()
+
+    #     # validate list deleted keys with attributes
+    #     for deleted_key in client.list_deleted_keys():
+    #         assert deleted_key.deleted_date is not None
+    #         assert deleted_key.scheduled_purge_date is not None
+    #         assert deleted_key.recovery_id is not None
+
+    #     result = client.list_deleted_keys()
+    #     # validate all the deleted keys are returned by list_deleted_keys
+    #     for key in result:
+    #         if key.name in expected.keys():
+    #             self._assert_key_attributes_equal(expected[key.name].properties, key.properties)
+    #             del expected[key.name]
+
+    # @pytest.mark.skip("Temporarily disabled due to service issue")
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_recover(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     # create keys
+    #     keys = {}
+    #     for i in range(LIST_TEST_SIZE):
+    #         key_name = self.get_resource_name(f"key{i}")
+    #         keys[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # delete them
+    #     for key_name in keys.keys():
+    #         client.begin_delete_key(key_name).wait()
+
+    #     # validate the deleted keys are returned by list_deleted_keys
+    #     deleted = [s.name for s in client.list_deleted_keys()]
+    #     assert all(s in deleted for s in keys.keys())
+
+    #     # recover the keys
+    #     for key_name in keys.keys():
+    #         recovered_key = client.begin_recover_deleted_key(key_name).result()
+    #         expected_key = keys[key_name]
+    #         self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_purge(self, client, is_hsm, **kwargs):
+    #     assert client is not None
+
+    #     # create keys
+    #     key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
+    #     for name in key_names:
+    #         self._create_rsa_key(client, name, hardware_protected=is_hsm)
+
+    #     # delete them
+    #     for key_name in key_names:
+    #         client.begin_delete_key(key_name).wait()
+
+    #     # validate all our deleted keys are returned by list_deleted_keys
+    #     deleted = [k.name for k in client.list_deleted_keys()]
+    #     assert all(n in deleted for n in key_names)
+
+    #     # purge them
+    #     for key_name in key_names:
+    #         client.purge_deleted_key(key_name)
+    #     for key_name in key_names:
+    #         self._poll_until_exception(
+    #             functools.partial(client.get_deleted_key, key_name), expected_exception=ResourceNotFoundError
+    #         )
+
+    #     # validate none are returned by list_deleted_keys
+    #     deleted = [s.name for s in client.list_deleted_keys()]
+    #     assert not any(s in deleted for s in key_names)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
+    # @KeysClientPreparer(logging_enable=True)
+    # @recorded_by_proxy
+    # def test_logging_enabled(self, client, is_hsm, **kwargs):
+    #     mock_handler = MockHandler()
+
+    #     logger = logging.getLogger("azure")
+    #     logger.addHandler(mock_handler)
+    #     logger.setLevel(logging.DEBUG)
+
+    #     rsa_key_name = self.get_resource_name("rsa-key-name")
+    #     self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
+
+    #     for message in mock_handler.messages:
+    #         if message.levelname == "DEBUG" and message.funcName == "on_request":
+    #             # parts of the request are logged on new lines in a single message
+    #             if "'/n" in message.message:
+    #                 request_sections = message.message.split("/n")
+    #             else:
+    #                 request_sections = message.message.split("\n")
+    #             for section in request_sections:
+    #                 try:
+    #                     # the body of the request should be JSON
+    #                     body = json.loads(section)
+    #                     expected_kty = "RSA-HSM" if is_hsm else "RSA"
+    #                     if body["kty"] == expected_kty:
+    #                         mock_handler.close()
+    #                         return
+    #                 except (ValueError, KeyError):
+    #                     # this means the request section is not JSON or has no kty property
+    #                     pass
+
+    #     mock_handler.close()
+    #     assert False, "Expected request body wasn't logged"
+
+    # @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
+    # @KeysClientPreparer(logging_enable=False)
+    # @recorded_by_proxy
+    # def test_logging_disabled(self, client, is_hsm, **kwargs):
+    #     mock_handler = MockHandler()
+
+    #     logger = logging.getLogger("azure")
+    #     logger.addHandler(mock_handler)
+    #     logger.setLevel(logging.DEBUG)
+
+    #     rsa_key_name = self.get_resource_name("rsa-key-name")
+    #     self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
+
+    #     for message in mock_handler.messages:
+    #         if message.levelname == "DEBUG" and message.funcName == "on_request":
+    #             # parts of the request are logged on new lines in a single message
+    #             if "'/n" in message.message:
+    #                 request_sections = message.message.split("/n")
+    #             else:
+    #                 request_sections = message.message.split("\n")
+    #             for section in request_sections:
+    #                 try:
+    #                     # the body of the request should be JSON
+    #                     body = json.loads(section)
+    #                     expected_kty = "RSA-HSM" if is_hsm else "RSA"
+    #                     if body["kty"] == expected_kty:
+    #                         mock_handler.close()
+    #                         assert False, "Client request body was logged"
+    #                 except (ValueError, KeyError):
+    #                     # this means the request section is not JSON or has no kty property
+    #                     pass
+
+    #     mock_handler.close()
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_get_random_bytes(self, client, **kwargs):
+    #     assert client
+
+    #     generated_random_bytes = []
+    #     for i in range(5):
+    #         # [START get_random_bytes]
+    #         # get eight random bytes from a managed HSM
+    #         random_bytes = client.get_random_bytes(count=8)
+    #         # [END get_random_bytes]
+    #         assert len(random_bytes) == 8
+    #         assert all(random_bytes != rb for rb in generated_random_bytes)
+    #         generated_random_bytes.append(random_bytes)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_key_release(self, client, is_hsm, **kwargs):
+    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+    #     if is_hsm and client.api_version == ApiVersion.V7_5:
+    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+    #     attestation_uri = self._get_attestation_uri()
+    #     attestation = get_attestation_token(attestation_uri)
+    #     release_policy = get_release_policy(attestation_uri)
+
+    #     rsa_key_name = self.get_resource_name("rsa-key-name")
+    #     key = self._create_rsa_key(
+    #         client, rsa_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+    #     )
+    #     assert key.properties.release_policy
+    #     assert key.properties.release_policy.encoded_policy
+    #     assert key.properties.exportable
+
+    #     try:
+    #         release_result = client.release_key(rsa_key_name, attestation)
+    #         assert release_result.value
+    #     except HttpResponseError as ex:
+    #         # In live pipeline tests, the service can frequently throw a transient error regarding attestation
+    #         if self.is_live and "Target environment attestation statement cannot be verified" in ex.message:
+    #             pytest.skip("Target environment attestation statement cannot be verified. Likely transient failure.")
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_imported_key_release(self, client, **kwargs):
+    #     if client.api_version == ApiVersion.V7_5:
+    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+    #     attestation_uri = self._get_attestation_uri()
+    #     attestation = get_attestation_token(attestation_uri)
+    #     release_policy = get_release_policy(attestation_uri)
+
+    #     imported_key_name = self.get_resource_name("imported-key-name")
+    #     key = self._import_test_key(
+    #         client, imported_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+    #     )
+    #     assert key.properties.release_policy
+    #     assert key.properties.release_policy.encoded_policy
+    #     assert key.properties.exportable
+
+    #     release_result = client.release_key(imported_key_name, attestation)
+    #     assert release_result.value
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_update_release_policy(self, client, **kwargs):
+    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+    #     if client.api_version == ApiVersion.V7_5:
+    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+    #     attestation_uri = self._get_attestation_uri()
+    #     release_policy = get_release_policy(attestation_uri)
+    #     key_name = self.get_resource_name("key-name")
+    #     key = self._create_rsa_key(
+    #         client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+    #     )
+
+    #     policy = json.loads(key.properties.release_policy.encoded_policy.decode())
+    #     claim_condition = policy["anyOf"][0]["anyOf"][0]["equals"]
+    #     # for some reason, claim_condition may be 'true' here for KV, but should be True here for MHSM
+    #     claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
+    #     assert claim_condition is True
+
+    #     new_release_policy_json = {
+    #         "anyOf": [
+    #             {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
+    #         ],
+    #         "version": "1.0.0",
+    #     }
+    #     policy_string = json.dumps(new_release_policy_json).encode()
+    #     new_release_policy = KeyReleasePolicy(policy_string)
+
+    #     updated_key = self._update_key_properties(client, key, new_release_policy)
+    #     updated_policy = json.loads(updated_key.properties.release_policy.encoded_policy.decode())
+    #     claim_condition = updated_policy["anyOf"][0]["anyOf"][0]["equals"]
+    #     claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
+    #     assert claim_condition is False
+
+    # # Immutable policies aren't currently supported on Managed HSM
+    # @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_immutable_release_policy(self, client, **kwargs):
+    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
+    #     attestation_uri = self._get_attestation_uri()
+    #     release_policy = get_release_policy(attestation_uri, immutable=True)
+    #     key_name = self.get_resource_name("key-name")
+    #     key = self._create_rsa_key(
+    #         client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+    #     )
+    #     assert key.properties.release_policy.encoded_policy
+    #     assert key.properties.release_policy.immutable
+
+    #     new_release_policy_json = {
+    #         "anyOf": [
+    #             {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
+    #         ],
+    #         "version": "1.0.0",
+    #     }
+    #     policy_string = json.dumps(new_release_policy_json).encode()
+    #     new_release_policy = KeyReleasePolicy(policy_string, immutable=True)
+
+    #     with pytest.raises(HttpResponseError):
+    #         self._update_key_properties(client, key, new_release_policy)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_key_rotation(self, client, is_hsm, **kwargs):
+    #     if not is_public_cloud() and self.is_live:
+    #         pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
+
+    #     key_name = self.get_resource_name("rotation-key")
+    #     key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # MHSM doesn't automatically give keys a default rotation policy, unlike KV
+    #     if is_hsm:
+    #         actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
+    #         client.update_key_rotation_policy(key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y"))
+    #     rotated_key = client.rotate_key(key_name)
+
+    #     # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
+    #     assert key.id != rotated_key.id
+    #     assert key.properties.version != rotated_key.properties.version
+    #     assert key.key.n != rotated_key.key.n
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_key_rotation_policy(self, client, is_hsm, **kwargs):
+    #     if not is_public_cloud() and self.is_live:
+    #         pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
+
+    #     key_name = self.get_resource_name("rotation-key")
+    #     self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
+    #     if not is_hsm:
+    #         client.update_key_rotation_policy(key_name, KeyRotationPolicy())
+
+    #     # updating a rotation policy with an empty policy and override(s)
+    #     actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
+    #     if is_hsm:
+    #         updated_policy = client.update_key_rotation_policy(
+    #             key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
+    #         )
+    #         assert updated_policy.expires_in == "P6M"
+    #     else:  # try a policy without an expiry time (only allowed on KV)
+    #         updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
+    #         assert updated_policy.expires_in is None
+
+    #     fetched_policy = client.get_key_rotation_policy(key_name)
+    #     _assert_rotation_policies_equal(updated_policy, fetched_policy)
+
+    #     updated_policy_actions = None
+    #     for i in range(len(updated_policy.lifetime_actions)):
+    #         if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+    #             updated_policy_actions = updated_policy.lifetime_actions[i]
+    #     assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
+    #     assert updated_policy_actions.time_after_create == "P2M"
+    #     assert updated_policy_actions.time_before_expiry is None
+
+    #     fetched_policy_actions = None
+    #     for i in range(len(fetched_policy.lifetime_actions)):
+    #         if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+    #             fetched_policy_actions = fetched_policy.lifetime_actions[i]
+    #     assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
+    #     _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
+
+    #     # updating with a round-tripped policy and overriding expires_in
+    #     new_policy = client.update_key_rotation_policy(key_name, policy=updated_policy, expires_in="P90D")
+    #     assert new_policy.expires_in == "P90D"
+
+    #     new_policy_actions = None
+    #     for i in range(len(new_policy.lifetime_actions)):
+    #         if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+    #             new_policy_actions = new_policy.lifetime_actions[i]
+    #     _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
+
+    #     # at this time, MHSM doesn't support notify actions
+    #     if not is_hsm:
+    #         # updating with a round-tripped policy and overriding lifetime_actions
+    #         newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
+    #         newest_policy = client.update_key_rotation_policy(
+    #             key_name, policy=new_policy, lifetime_actions=newest_actions
+    #         )
+    #         newest_fetched_policy = client.get_key_rotation_policy(key_name)
+    #         assert newest_policy.expires_in == "P90D"
+    #         _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
+
+    #         newest_policy_actions = None
+    #         for i in range(len(newest_policy.lifetime_actions)):
+    #             if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+    #                 newest_policy_actions = newest_policy.lifetime_actions[i]
+    #         assert newest_policy_actions.time_after_create is None
+    #         assert newest_policy_actions.time_before_expiry == "P60D"
+
+    #         newest_fetched_policy_actions = None
+    #         for i in range(len(newest_fetched_policy.lifetime_actions)):
+    #             if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+    #                 newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
+    #         _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
+
+    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_get_cryptography_client(self, client, is_hsm, **kwargs):
+    #     key_name = self.get_resource_name("key-name")
+    #     key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+    #     # try specifying the key version
+    #     crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
+    #     # both clients should use the same generated client
+    #     assert client._client == crypto_client._client
+
+    #     # the crypto client should successfully perform crypto operations
+    #     plaintext = b"plaintext"
+    #     result = crypto_client.encrypt("RSA-OAEP", plaintext)
+    #     assert result.key_id == key.id
+
+    #     result = crypto_client.decrypt(result.algorithm, result.ciphertext)
+    #     assert result.key_id == key.id
+    #     assert "RSA-OAEP" == result.algorithm
+    #     assert plaintext == result.plaintext
+
+    #     # try omitting the key version
+    #     crypto_client = client.get_cryptography_client(key_name)
+    #     # both clients should use the same generated client
+    #     assert client._client == crypto_client._client
+
+    #     # the crypto client should successfully perform crypto operations
+    #     result = crypto_client.encrypt("RSA-OAEP", plaintext)
+    #     assert result.key_id == key.id
+
+    #     result = crypto_client.decrypt(result.algorithm, result.ciphertext)
+    #     assert result.key_id == key.id
+    #     assert "RSA-OAEP" == result.algorithm
+    #     assert plaintext == result.plaintext
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_send_request(self, client, is_hsm, **kwargs):
+    #     key_name = self.get_resource_name("key-name")
+    #     key = self._create_rsa_key(client, key_name)
+
+    #     # fetch the key we just created
+    #     request = HttpRequest(
+    #         method="GET",
+    #         url=f"keys/{key_name}/{key.properties.version}",
+    #         headers={"Accept": "application/json"},
+    #     )
+    #     response = client.send_request(request)
+    #     assert response.json()["key"]["kid"] == key.id
+
+    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_default)
+    # @KeysClientPreparer()
+    # @recorded_by_proxy
+    # def test_get_key_attestation(self, client, **kwargs):
+    #     # create a key
+    #     key_name = self.get_resource_name("key-name")
+    #     key = self._create_rsa_key(client, key_name, hardware_protected=True)
+    #     # attestation info shouldn't be included unless requested with get_key_attestation
+    #     assert key.properties.attestation is None
+
+    #     # fetch the key we just created
+    #     fetched_key = client.get_key_attestation(key_name)
+    #     attestation = fetched_key.properties.attestation
+    #     assert attestation is not None
+    #     assert attestation.certificate_pem_file is not None
+    #     assert attestation.private_key_attestation is not None
+    #     assert attestation.public_key_attestation is not None
+    #     assert attestation.version
+
+    #     # create new key version to validate versioned fetching
+    #     updated_key = client.update_key_properties(key_name, tags={"tag": "value"})
+    #     updated_attestation = client.get_key_attestation(key_name).properties.attestation
+    #     assert updated_attestation is not None
+    #     assert updated_attestation.certificate_pem_file == attestation.certificate_pem_file
+    #     assert updated_attestation.private_key_attestation == attestation.private_key_attestation
+    #     assert updated_attestation.public_key_attestation == attestation.public_key_attestation
+    #     assert updated_attestation.version != updated_key.properties.version
+
+    #     original_attestation = client.get_key_attestation(key_name, key.properties.version).properties.attestation
+    #     assert original_attestation.version == attestation.version
+
+    @pytest.mark.parametrize("api_version,is_hsm", default_version)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_crud_operations(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        # create ec key
-        ec_key_name = self.get_resource_name("crud-ec-key")
-        tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
-        ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=is_hsm, tags=tags)
-        assert ec_key.properties.enabled
-        assert tags == ec_key.properties.tags
-        # create ec with curve
-        ec_key_curve_name = self.get_resource_name("crud-P-256-ec-key")
-        created_ec_key_curve = self._create_ec_key(
-            client, key_name=ec_key_curve_name, curve="P-256", hardware_protected=is_hsm
-        )
-        assert "P-256" == created_ec_key_curve.key.crv
-
-        # import key
-        import_test_key_name = self.get_resource_name("import-test-key")
-        self._import_test_key(client, import_test_key_name, hardware_protected=is_hsm)
-
-        # create rsa key
-        rsa_key_name = self.get_resource_name("crud-rsa-key")
-        tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
-        key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
-        rsa_key = self._create_rsa_key(
-            client, key_name=rsa_key_name, key_operations=key_ops, size=2048, tags=tags, hardware_protected=is_hsm
-        )
-        assert tags == rsa_key.properties.tags
-
-        # get the created key with version
-        key = client.get_key(rsa_key.name, rsa_key.properties.version)
-        assert key.properties.version == rsa_key.properties.version
-        self._assert_key_attributes_equal(rsa_key.properties, key.properties)
-
-        # get key without version
-        self._assert_key_attributes_equal(rsa_key.properties, client.get_key(rsa_key.name).properties)
-
-        # update key with version
-        if self.is_live:
-            # wait to ensure the key's update time won't equal its creation time
-            time.sleep(1)
-
-        self._update_key_properties(client, rsa_key)
-
-        # delete the new key
-        deleted_key_poller = client.begin_delete_key(rsa_key.name)
-        deleted_key = deleted_key_poller.result()
-        assert deleted_key is not None
-
-        # aside from key_ops, the original updated keys should have the same JWKs
-        self._assert_jwks_equal(rsa_key.key, deleted_key.key)
-        assert deleted_key.id == rsa_key.id
-        assert (
-            deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date
-        ), "Missing required deleted key attributes."
-
-        deleted_key_poller.wait()
-
-        # get the deleted key when soft deleted enabled
-        deleted_key = client.get_deleted_key(rsa_key.name)
-        assert deleted_key is not None
-        assert rsa_key.id == deleted_key.id
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_rsa_public_exponent(self, client, **kwargs):
-        """The public exponent of a Managed HSM RSA key can be specified during creation"""
-        assert client is not None
-
-        key_name = self.get_resource_name("rsa-key")
-        key = self._create_rsa_key(client, key_name, hardware_protected=True, public_exponent=17)
-        public_exponent = key.key.e[0]
-        assert public_exponent == 17
-
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_backup_restore(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        key_name = self.get_resource_name("keybak")
-
-        # create key
-        created_bundle = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # backup key
-        key_backup = client.backup_key(created_bundle.name)
-        assert key_backup is not None
-
-        # delete key
-        client.begin_delete_key(created_bundle.name).wait()
-
-        # purge key
-        client.purge_deleted_key(created_bundle.name)
-
-        # restore key
-        restore_function = functools.partial(client.restore_key_backup, key_backup)
-        restored_key = self._poll_until_no_exception(restore_function, ResourceExistsError)
-        self._assert_key_attributes_equal(created_bundle.properties, restored_key.properties)
-
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_key_list(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        max_keys = LIST_TEST_SIZE
-        expected = {}
-
-        # create many keys
-        for x in range(max_keys):
-            key_name = self.get_resource_name(f"key{x}")
-            key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-            expected[key.name] = key
-
-        # list keys
-        result = client.list_properties_of_keys(max_page_size=max_keys - 1)
-        for key in result:
-            if key.name in expected.keys():
-                self._assert_key_attributes_equal(expected[key.name].properties, key)
-                del expected[key.name]
-        assert len(expected) == 0
-
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_list_versions(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        key_name = self.get_resource_name("testKey")
-
-        max_keys = LIST_TEST_SIZE
-        expected = {}
-
-        # create many key versions
-        for _ in range(max_keys):
-            key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-            expected[key.id] = key
-
-        result = client.list_properties_of_key_versions(key_name, max_page_size=max_keys - 1)
-
-        # validate list key versions with attributes
-        for key in result:
-            if key.id in expected.keys():
-                expected_key = expected[key.id]
-                del expected[key.id]
-                self._assert_key_attributes_equal(expected_key.properties, key)
-        assert 0 == len(expected)
-
-    @pytest.mark.skip("Temporarily disabled due to service issue")
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_list_deleted_keys(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        expected = {}
-
-        # create keys
-        for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name(f"key{i}")
-            expected[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # delete them
-        for key_name in expected.keys():
-            client.begin_delete_key(key_name).wait()
-
-        # validate list deleted keys with attributes
-        for deleted_key in client.list_deleted_keys():
-            assert deleted_key.deleted_date is not None
-            assert deleted_key.scheduled_purge_date is not None
-            assert deleted_key.recovery_id is not None
-
-        result = client.list_deleted_keys()
-        # validate all the deleted keys are returned by list_deleted_keys
-        for key in result:
-            if key.name in expected.keys():
-                self._assert_key_attributes_equal(expected[key.name].properties, key.properties)
-                del expected[key.name]
-
-    @pytest.mark.skip("Temporarily disabled due to service issue")
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_recover(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        # create keys
-        keys = {}
-        for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name(f"key{i}")
-            keys[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # delete them
-        for key_name in keys.keys():
-            client.begin_delete_key(key_name).wait()
-
-        # validate the deleted keys are returned by list_deleted_keys
-        deleted = [s.name for s in client.list_deleted_keys()]
-        assert all(s in deleted for s in keys.keys())
-
-        # recover the keys
-        for key_name in keys.keys():
-            recovered_key = client.begin_recover_deleted_key(key_name).result()
-            expected_key = keys[key_name]
-            self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
-
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_purge(self, client, is_hsm, **kwargs):
-        assert client is not None
-
-        # create keys
-        key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
-        for name in key_names:
-            self._create_rsa_key(client, name, hardware_protected=is_hsm)
-
-        # delete them
-        for key_name in key_names:
-            client.begin_delete_key(key_name).wait()
-
-        # validate all our deleted keys are returned by list_deleted_keys
-        deleted = [k.name for k in client.list_deleted_keys()]
-        assert all(n in deleted for n in key_names)
-
-        # purge them
-        for key_name in key_names:
-            client.purge_deleted_key(key_name)
-        for key_name in key_names:
-            self._poll_until_exception(
-                functools.partial(client.get_deleted_key, key_name), expected_exception=ResourceNotFoundError
-            )
-
-        # validate none are returned by list_deleted_keys
-        deleted = [s.name for s in client.list_deleted_keys()]
-        assert not any(s in deleted for s in key_names)
-
-    @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
-    @KeysClientPreparer(logging_enable=True)
-    @recorded_by_proxy
-    def test_logging_enabled(self, client, is_hsm, **kwargs):
-        mock_handler = MockHandler()
-
-        logger = logging.getLogger("azure")
-        logger.addHandler(mock_handler)
-        logger.setLevel(logging.DEBUG)
-
-        rsa_key_name = self.get_resource_name("rsa-key-name")
-        self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
-
-        for message in mock_handler.messages:
-            if message.levelname == "DEBUG" and message.funcName == "on_request":
-                # parts of the request are logged on new lines in a single message
-                if "'/n" in message.message:
-                    request_sections = message.message.split("/n")
-                else:
-                    request_sections = message.message.split("\n")
-                for section in request_sections:
-                    try:
-                        # the body of the request should be JSON
-                        body = json.loads(section)
-                        expected_kty = "RSA-HSM" if is_hsm else "RSA"
-                        if body["kty"] == expected_kty:
-                            mock_handler.close()
-                            return
-                    except (ValueError, KeyError):
-                        # this means the request section is not JSON or has no kty property
-                        pass
-
-        mock_handler.close()
-        assert False, "Expected request body wasn't logged"
-
-    @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
-    @KeysClientPreparer(logging_enable=False)
-    @recorded_by_proxy
-    def test_logging_disabled(self, client, is_hsm, **kwargs):
-        mock_handler = MockHandler()
-
-        logger = logging.getLogger("azure")
-        logger.addHandler(mock_handler)
-        logger.setLevel(logging.DEBUG)
-
-        rsa_key_name = self.get_resource_name("rsa-key-name")
-        self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
-
-        for message in mock_handler.messages:
-            if message.levelname == "DEBUG" and message.funcName == "on_request":
-                # parts of the request are logged on new lines in a single message
-                if "'/n" in message.message:
-                    request_sections = message.message.split("/n")
-                else:
-                    request_sections = message.message.split("\n")
-                for section in request_sections:
-                    try:
-                        # the body of the request should be JSON
-                        body = json.loads(section)
-                        expected_kty = "RSA-HSM" if is_hsm else "RSA"
-                        if body["kty"] == expected_kty:
-                            mock_handler.close()
-                            assert False, "Client request body was logged"
-                    except (ValueError, KeyError):
-                        # this means the request section is not JSON or has no kty property
-                        pass
-
-        mock_handler.close()
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_get_random_bytes(self, client, **kwargs):
-        assert client
-
-        generated_random_bytes = []
-        for i in range(5):
-            # [START get_random_bytes]
-            # get eight random bytes from a managed HSM
-            random_bytes = client.get_random_bytes(count=8)
-            # [END get_random_bytes]
-            assert len(random_bytes) == 8
-            assert all(random_bytes != rb for rb in generated_random_bytes)
-            generated_random_bytes.append(random_bytes)
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_key_release(self, client, is_hsm, **kwargs):
-        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-        if is_hsm and client.api_version == ApiVersion.V7_5:
-            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-        attestation_uri = self._get_attestation_uri()
-        attestation = get_attestation_token(attestation_uri)
-        release_policy = get_release_policy(attestation_uri)
-
-        rsa_key_name = self.get_resource_name("rsa-key-name")
-        key = self._create_rsa_key(
-            client, rsa_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-        )
-        assert key.properties.release_policy
-        assert key.properties.release_policy.encoded_policy
-        assert key.properties.exportable
-
-        try:
-            release_result = client.release_key(rsa_key_name, attestation)
-            assert release_result.value
-        except HttpResponseError as ex:
-            # In live pipeline tests, the service can frequently throw a transient error regarding attestation
-            if self.is_live and "Target environment attestation statement cannot be verified" in ex.message:
-                pytest.skip("Target environment attestation statement cannot be verified. Likely transient failure.")
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_imported_key_release(self, client, **kwargs):
-        if client.api_version == ApiVersion.V7_5:
-            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-        attestation_uri = self._get_attestation_uri()
-        attestation = get_attestation_token(attestation_uri)
-        release_policy = get_release_policy(attestation_uri)
-
-        imported_key_name = self.get_resource_name("imported-key-name")
-        key = self._import_test_key(
-            client, imported_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-        )
-        assert key.properties.release_policy
-        assert key.properties.release_policy.encoded_policy
-        assert key.properties.exportable
-
-        release_result = client.release_key(imported_key_name, attestation)
-        assert release_result.value
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_update_release_policy(self, client, **kwargs):
-        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-        if client.api_version == ApiVersion.V7_5:
-            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-        attestation_uri = self._get_attestation_uri()
-        release_policy = get_release_policy(attestation_uri)
-        key_name = self.get_resource_name("key-name")
-        key = self._create_rsa_key(
-            client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-        )
-
-        policy = json.loads(key.properties.release_policy.encoded_policy.decode())
-        claim_condition = policy["anyOf"][0]["anyOf"][0]["equals"]
-        # for some reason, claim_condition may be 'true' here for KV, but should be True here for MHSM
-        claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
-        assert claim_condition is True
-
-        new_release_policy_json = {
-            "anyOf": [
-                {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
-            ],
-            "version": "1.0.0",
-        }
-        policy_string = json.dumps(new_release_policy_json).encode()
-        new_release_policy = KeyReleasePolicy(policy_string)
-
-        updated_key = self._update_key_properties(client, key, new_release_policy)
-        updated_policy = json.loads(updated_key.properties.release_policy.encoded_policy.decode())
-        claim_condition = updated_policy["anyOf"][0]["anyOf"][0]["equals"]
-        claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
-        assert claim_condition is False
-
-    # Immutable policies aren't currently supported on Managed HSM
-    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_immutable_release_policy(self, client, **kwargs):
-        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-
-        attestation_uri = self._get_attestation_uri()
-        release_policy = get_release_policy(attestation_uri, immutable=True)
-        key_name = self.get_resource_name("key-name")
-        key = self._create_rsa_key(
-            client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-        )
-        assert key.properties.release_policy.encoded_policy
-        assert key.properties.release_policy.immutable
-
-        new_release_policy_json = {
-            "anyOf": [
-                {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
-            ],
-            "version": "1.0.0",
-        }
-        policy_string = json.dumps(new_release_policy_json).encode()
-        new_release_policy = KeyReleasePolicy(policy_string, immutable=True)
-
-        with pytest.raises(HttpResponseError):
-            self._update_key_properties(client, key, new_release_policy)
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_key_rotation(self, client, is_hsm, **kwargs):
-        if not is_public_cloud() and self.is_live:
-            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
-
-        key_name = self.get_resource_name("rotation-key")
-        key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # MHSM doesn't automatically give keys a default rotation policy, unlike KV
-        if is_hsm:
-            actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
-            client.update_key_rotation_policy(key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y"))
-        rotated_key = client.rotate_key(key_name)
-
-        # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
-        assert key.id != rotated_key.id
-        assert key.properties.version != rotated_key.properties.version
-        assert key.key.n != rotated_key.key.n
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_key_rotation_policy(self, client, is_hsm, **kwargs):
-        if not is_public_cloud() and self.is_live:
-            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
-
-        key_name = self.get_resource_name("rotation-key")
-        self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
-        if not is_hsm:
-            client.update_key_rotation_policy(key_name, KeyRotationPolicy())
-
-        # updating a rotation policy with an empty policy and override(s)
-        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
-        if is_hsm:
-            updated_policy = client.update_key_rotation_policy(
-                key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
-            )
-            assert updated_policy.expires_in == "P6M"
-        else:  # try a policy without an expiry time (only allowed on KV)
-            updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
-            assert updated_policy.expires_in is None
-
-        fetched_policy = client.get_key_rotation_policy(key_name)
-        _assert_rotation_policies_equal(updated_policy, fetched_policy)
-
-        updated_policy_actions = None
-        for i in range(len(updated_policy.lifetime_actions)):
-            if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-                updated_policy_actions = updated_policy.lifetime_actions[i]
-        assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
-        assert updated_policy_actions.time_after_create == "P2M"
-        assert updated_policy_actions.time_before_expiry is None
-
-        fetched_policy_actions = None
-        for i in range(len(fetched_policy.lifetime_actions)):
-            if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-                fetched_policy_actions = fetched_policy.lifetime_actions[i]
-        assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
-        _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
-
-        # updating with a round-tripped policy and overriding expires_in
-        new_policy = client.update_key_rotation_policy(key_name, policy=updated_policy, expires_in="P90D")
-        assert new_policy.expires_in == "P90D"
-
-        new_policy_actions = None
-        for i in range(len(new_policy.lifetime_actions)):
-            if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-                new_policy_actions = new_policy.lifetime_actions[i]
-        _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
-
-        # at this time, MHSM doesn't support notify actions
-        if not is_hsm:
-            # updating with a round-tripped policy and overriding lifetime_actions
-            newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
-            newest_policy = client.update_key_rotation_policy(
-                key_name, policy=new_policy, lifetime_actions=newest_actions
-            )
-            newest_fetched_policy = client.get_key_rotation_policy(key_name)
-            assert newest_policy.expires_in == "P90D"
-            _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
-
-            newest_policy_actions = None
-            for i in range(len(newest_policy.lifetime_actions)):
-                if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
-                    newest_policy_actions = newest_policy.lifetime_actions[i]
-            assert newest_policy_actions.time_after_create is None
-            assert newest_policy_actions.time_before_expiry == "P60D"
-
-            newest_fetched_policy_actions = None
-            for i in range(len(newest_fetched_policy.lifetime_actions)):
-                if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
-                    newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
-            _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
-
-    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_get_cryptography_client(self, client, is_hsm, **kwargs):
-        key_name = self.get_resource_name("key-name")
-        key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-        # try specifying the key version
-        crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
-        # both clients should use the same generated client
-        assert client._client == crypto_client._client
-
-        # the crypto client should successfully perform crypto operations
-        plaintext = b"plaintext"
-        result = crypto_client.encrypt("RSA-OAEP", plaintext)
-        assert result.key_id == key.id
-
-        result = crypto_client.decrypt(result.algorithm, result.ciphertext)
-        assert result.key_id == key.id
-        assert "RSA-OAEP" == result.algorithm
-        assert plaintext == result.plaintext
-
-        # try omitting the key version
-        crypto_client = client.get_cryptography_client(key_name)
-        # both clients should use the same generated client
-        assert client._client == crypto_client._client
-
-        # the crypto client should successfully perform crypto operations
-        result = crypto_client.encrypt("RSA-OAEP", plaintext)
-        assert result.key_id == key.id
-
-        result = crypto_client.decrypt(result.algorithm, result.ciphertext)
-        assert result.key_id == key.id
-        assert "RSA-OAEP" == result.algorithm
-        assert plaintext == result.plaintext
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_send_request(self, client, is_hsm, **kwargs):
-        key_name = self.get_resource_name("key-name")
-        key = self._create_rsa_key(client, key_name)
-
-        # fetch the key we just created
-        request = HttpRequest(
-            method="GET",
-            url=f"keys/{key_name}/{key.properties.version}",
-            headers={"Accept": "application/json"},
-        )
-        response = client.send_request(request)
-        assert response.json()["key"]["kid"] == key.id
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_default)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_get_key_attestation(self, client, **kwargs):
-        # create a key
-        key_name = self.get_resource_name("key-name")
-        key = self._create_rsa_key(client, key_name, hardware_protected=True)
-        # attestation info shouldn't be included unless requested with get_key_attestation
-        assert key.properties.attestation is None
-
-        # fetch the key we just created
-        fetched_key = client.get_key_attestation(key_name)
-        attestation = fetched_key.properties.attestation
-        assert attestation is not None
-        assert attestation.certificate_pem_file is not None
-        assert attestation.private_key_attestation is not None
-        assert attestation.public_key_attestation is not None
-        assert attestation.version
-
-        # create new key version to validate versioned fetching
-        updated_key = client.update_key_properties(key_name, tags={"tag": "value"})
-        updated_attestation = client.get_key_attestation(key_name).properties.attestation
-        assert updated_attestation is not None
-        assert updated_attestation.certificate_pem_file == attestation.certificate_pem_file
-        assert updated_attestation.private_key_attestation == attestation.private_key_attestation
-        assert updated_attestation.public_key_attestation == attestation.public_key_attestation
-        assert updated_attestation.version != updated_key.properties.version
-
-        original_attestation = client.get_key_attestation(key_name, key.properties.version).properties.attestation
-        assert original_attestation.version == attestation.version
-
-    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-    @KeysClientPreparer()
-    @recorded_by_proxy
-    def test_40x_handling(self, client, **kwargs):
-        """Ensure 404 and 409 responses are raised with azure-core exceptions instead of generated KV ones"""
-
-        # Test that 404 is raised correctly by fetching a nonexistent key
-        with pytest.raises(ResourceNotFoundError):
-            client.get_key("key-that-does-not-exist")
-
-        # Test that 409 is raised correctly (`create_key` shouldn't actually trigger this, but for raising behavior)
-        def run(*_, **__):
-            return Mock(http_response=Mock(status_code=409))
-
-        with patch.object(client._client._client._pipeline, "run", run):
-            with pytest.raises(ResourceExistsError):
-                client.create_key("...", "RSA")
-
-
-def test_positive_bytes_count_required():
-    client = KeyClient("...", object())
-    with pytest.raises(ValueError):
-        client.get_random_bytes(count=0)
-    with pytest.raises(ValueError):
-        client.get_random_bytes(count=-1)
-
-
-def test_service_headers_allowed_in_logs():
-    service_headers = {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
-    client = KeyClient("...", object())
-    assert service_headers.issubset(client._client._config.http_logging_policy.allowed_header_names)
-
-
-def test_custom_hook_policy():
-    class CustomHookPolicy(SansIOHTTPPolicy):
-        pass
-
-    client = KeyClient("...", object(), custom_hook_policy=CustomHookPolicy())
-    assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
-
-
-def test_case_insensitive_key_type():
-    """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
-    See https://github.com/Azure/azure-sdk-for-python/issues/22797
-    """
-    # KeyType with all upper-case value
-    assert KeyType("rsa") == KeyType.rsa
-    # KeyType with all lower-case value
-    assert KeyType("OCT") == KeyType.oct
-    # KeyType with mixed-case value
-    assert KeyType("oct-hsm") == KeyType.oct_hsm
-
-
-def test_empty_rotation_policy_actions():
-    """Regression test: make sure a KeyRotationPolicy can be created with a response that has None properties"""
-    generated_policy = _KeyRotationPolicy()
-    assert generated_policy.lifetime_actions is None
-    policy = KeyRotationPolicy._from_generated(generated_policy)
-    assert policy.lifetime_actions == []
+    def test_key_size(self, client, is_hsm, **kwargs):
+        """The key_size property is returned for oct keys created with 2026-01-01-preview"""
+        # EC-HSM keys should return None for key_size
+        ec_key_name = self.get_resource_name("ec-key-size")
+        ec_key = self._create_ec_key(client, ec_key_name, hardware_protected=True)
+        assert ec_key.properties.key_size is None
+
+        # oct-HSM keys should return the correct key_size
+        oct_key_name = self.get_resource_name("oct-key-256")
+        oct_key = self._create_oct_key(client, oct_key_name, size=256, hardware_protected=True)
+        assert oct_key.properties.key_size == 256
+
+        # key_size is also available when fetching an existing oct-HSM key
+        fetched = client.get_key(oct_key_name)
+        assert fetched.properties.key_size == 256
+
+#     @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+#     @KeysClientPreparer()
+#     @recorded_by_proxy
+#     def test_40x_handling(self, client, **kwargs):
+#         """Ensure 404 and 409 responses are raised with azure-core exceptions instead of generated KV ones"""
+
+#         # Test that 404 is raised correctly by fetching a nonexistent key
+#         with pytest.raises(ResourceNotFoundError):
+#             client.get_key("key-that-does-not-exist")
+
+#         # Test that 409 is raised correctly (`create_key` shouldn't actually trigger this, but for raising behavior)
+#         def run(*_, **__):
+#             return Mock(http_response=Mock(status_code=409))
+
+#         with patch.object(client._client._client._pipeline, "run", run):
+#             with pytest.raises(ResourceExistsError):
+#                 client.create_key("...", "RSA")
+
+
+# def test_positive_bytes_count_required():
+#     client = KeyClient("...", object())
+#     with pytest.raises(ValueError):
+#         client.get_random_bytes(count=0)
+#     with pytest.raises(ValueError):
+#         client.get_random_bytes(count=-1)
+
+
+# def test_service_headers_allowed_in_logs():
+#     service_headers = {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+#     client = KeyClient("...", object())
+#     assert service_headers.issubset(client._client._config.http_logging_policy.allowed_header_names)
+
+
+# def test_custom_hook_policy():
+#     class CustomHookPolicy(SansIOHTTPPolicy):
+#         pass
+
+#     client = KeyClient("...", object(), custom_hook_policy=CustomHookPolicy())
+#     assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
+
+
+# def test_case_insensitive_key_type():
+#     """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
+#     See https://github.com/Azure/azure-sdk-for-python/issues/22797
+#     """
+#     # KeyType with all upper-case value
+#     assert KeyType("rsa") == KeyType.rsa
+#     # KeyType with all lower-case value
+#     assert KeyType("OCT") == KeyType.oct
+#     # KeyType with mixed-case value
+#     assert KeyType("oct-hsm") == KeyType.oct_hsm
+
+
+# def test_empty_rotation_policy_actions():
+#     """Regression test: make sure a KeyRotationPolicy can be created with a response that has None properties"""
+#     generated_policy = _KeyRotationPolicy()
+#     assert generated_policy.lifetime_actions is None
+#     policy = KeyRotationPolicy._from_generated(generated_policy)
+#     assert policy.lifetime_actions == []

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -150,9 +150,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         kid = key_attributes.id
         assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
         assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
-        assert key_attributes.properties.key_size == size, (
-            f"key_size should be {size}, but is {key_attributes.properties.key_size}"
-        )
+        assert (
+            key_attributes.properties.key_size == size
+        ), f"key_size should be {size}, but is {key_attributes.properties.key_size}"
         assert (
             key_attributes.properties.created_on and key_attributes.properties.updated_on
         ), "Missing required date attributes."
@@ -213,630 +213,630 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         self._validate_rsa_key_bundle(imported_key, client.vault_url, name, key.kty, key.key_ops)
         return imported_key
 
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_key_crud_operations(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     # create ec key
-    #     ec_key_name = self.get_resource_name("crud-ec-key")
-    #     tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
-    #     ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=is_hsm, tags=tags)
-    #     assert ec_key.properties.enabled
-    #     assert tags == ec_key.properties.tags
-    #     # create ec with curve
-    #     ec_key_curve_name = self.get_resource_name("crud-P-256-ec-key")
-    #     created_ec_key_curve = self._create_ec_key(
-    #         client, key_name=ec_key_curve_name, curve="P-256", hardware_protected=is_hsm
-    #     )
-    #     assert "P-256" == created_ec_key_curve.key.crv
-
-    #     # import key
-    #     import_test_key_name = self.get_resource_name("import-test-key")
-    #     self._import_test_key(client, import_test_key_name, hardware_protected=is_hsm)
-
-    #     # create rsa key
-    #     rsa_key_name = self.get_resource_name("crud-rsa-key")
-    #     tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
-    #     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
-    #     rsa_key = self._create_rsa_key(
-    #         client, key_name=rsa_key_name, key_operations=key_ops, size=2048, tags=tags, hardware_protected=is_hsm
-    #     )
-    #     assert tags == rsa_key.properties.tags
-
-    #     # get the created key with version
-    #     key = client.get_key(rsa_key.name, rsa_key.properties.version)
-    #     assert key.properties.version == rsa_key.properties.version
-    #     self._assert_key_attributes_equal(rsa_key.properties, key.properties)
-
-    #     # get key without version
-    #     self._assert_key_attributes_equal(rsa_key.properties, client.get_key(rsa_key.name).properties)
-
-    #     # update key with version
-    #     if self.is_live:
-    #         # wait to ensure the key's update time won't equal its creation time
-    #         time.sleep(1)
-
-    #     self._update_key_properties(client, rsa_key)
-
-    #     # delete the new key
-    #     deleted_key_poller = client.begin_delete_key(rsa_key.name)
-    #     deleted_key = deleted_key_poller.result()
-    #     assert deleted_key is not None
-
-    #     # aside from key_ops, the original updated keys should have the same JWKs
-    #     self._assert_jwks_equal(rsa_key.key, deleted_key.key)
-    #     assert deleted_key.id == rsa_key.id
-    #     assert (
-    #         deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date
-    #     ), "Missing required deleted key attributes."
-
-    #     deleted_key_poller.wait()
-
-    #     # get the deleted key when soft deleted enabled
-    #     deleted_key = client.get_deleted_key(rsa_key.name)
-    #     assert deleted_key is not None
-    #     assert rsa_key.id == deleted_key.id
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_rsa_public_exponent(self, client, **kwargs):
-    #     """The public exponent of a Managed HSM RSA key can be specified during creation"""
-    #     assert client is not None
-
-    #     key_name = self.get_resource_name("rsa-key")
-    #     key = self._create_rsa_key(client, key_name, hardware_protected=True, public_exponent=17)
-    #     public_exponent = key.key.e[0]
-    #     assert public_exponent == 17
-
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_backup_restore(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     key_name = self.get_resource_name("keybak")
-
-    #     # create key
-    #     created_bundle = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # backup key
-    #     key_backup = client.backup_key(created_bundle.name)
-    #     assert key_backup is not None
-
-    #     # delete key
-    #     client.begin_delete_key(created_bundle.name).wait()
-
-    #     # purge key
-    #     client.purge_deleted_key(created_bundle.name)
-
-    #     # restore key
-    #     restore_function = functools.partial(client.restore_key_backup, key_backup)
-    #     restored_key = self._poll_until_no_exception(restore_function, ResourceExistsError)
-    #     self._assert_key_attributes_equal(created_bundle.properties, restored_key.properties)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_key_list(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     max_keys = LIST_TEST_SIZE
-    #     expected = {}
-
-    #     # create many keys
-    #     for x in range(max_keys):
-    #         key_name = self.get_resource_name(f"key{x}")
-    #         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-    #         expected[key.name] = key
-
-    #     # list keys
-    #     result = client.list_properties_of_keys(max_page_size=max_keys - 1)
-    #     for key in result:
-    #         if key.name in expected.keys():
-    #             self._assert_key_attributes_equal(expected[key.name].properties, key)
-    #             del expected[key.name]
-    #     assert len(expected) == 0
-
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_list_versions(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     key_name = self.get_resource_name("testKey")
-
-    #     max_keys = LIST_TEST_SIZE
-    #     expected = {}
-
-    #     # create many key versions
-    #     for _ in range(max_keys):
-    #         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-    #         expected[key.id] = key
-
-    #     result = client.list_properties_of_key_versions(key_name, max_page_size=max_keys - 1)
-
-    #     # validate list key versions with attributes
-    #     for key in result:
-    #         if key.id in expected.keys():
-    #             expected_key = expected[key.id]
-    #             del expected[key.id]
-    #             self._assert_key_attributes_equal(expected_key.properties, key)
-    #     assert 0 == len(expected)
-
-    # @pytest.mark.skip("Temporarily disabled due to service issue")
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_list_deleted_keys(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     expected = {}
-
-    #     # create keys
-    #     for i in range(LIST_TEST_SIZE):
-    #         key_name = self.get_resource_name(f"key{i}")
-    #         expected[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # delete them
-    #     for key_name in expected.keys():
-    #         client.begin_delete_key(key_name).wait()
-
-    #     # validate list deleted keys with attributes
-    #     for deleted_key in client.list_deleted_keys():
-    #         assert deleted_key.deleted_date is not None
-    #         assert deleted_key.scheduled_purge_date is not None
-    #         assert deleted_key.recovery_id is not None
-
-    #     result = client.list_deleted_keys()
-    #     # validate all the deleted keys are returned by list_deleted_keys
-    #     for key in result:
-    #         if key.name in expected.keys():
-    #             self._assert_key_attributes_equal(expected[key.name].properties, key.properties)
-    #             del expected[key.name]
-
-    # @pytest.mark.skip("Temporarily disabled due to service issue")
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_recover(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     # create keys
-    #     keys = {}
-    #     for i in range(LIST_TEST_SIZE):
-    #         key_name = self.get_resource_name(f"key{i}")
-    #         keys[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # delete them
-    #     for key_name in keys.keys():
-    #         client.begin_delete_key(key_name).wait()
-
-    #     # validate the deleted keys are returned by list_deleted_keys
-    #     deleted = [s.name for s in client.list_deleted_keys()]
-    #     assert all(s in deleted for s in keys.keys())
-
-    #     # recover the keys
-    #     for key_name in keys.keys():
-    #         recovered_key = client.begin_recover_deleted_key(key_name).result()
-    #         expected_key = keys[key_name]
-    #         self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_purge(self, client, is_hsm, **kwargs):
-    #     assert client is not None
-
-    #     # create keys
-    #     key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
-    #     for name in key_names:
-    #         self._create_rsa_key(client, name, hardware_protected=is_hsm)
-
-    #     # delete them
-    #     for key_name in key_names:
-    #         client.begin_delete_key(key_name).wait()
-
-    #     # validate all our deleted keys are returned by list_deleted_keys
-    #     deleted = [k.name for k in client.list_deleted_keys()]
-    #     assert all(n in deleted for n in key_names)
-
-    #     # purge them
-    #     for key_name in key_names:
-    #         client.purge_deleted_key(key_name)
-    #     for key_name in key_names:
-    #         self._poll_until_exception(
-    #             functools.partial(client.get_deleted_key, key_name), expected_exception=ResourceNotFoundError
-    #         )
-
-    #     # validate none are returned by list_deleted_keys
-    #     deleted = [s.name for s in client.list_deleted_keys()]
-    #     assert not any(s in deleted for s in key_names)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
-    # @KeysClientPreparer(logging_enable=True)
-    # @recorded_by_proxy
-    # def test_logging_enabled(self, client, is_hsm, **kwargs):
-    #     mock_handler = MockHandler()
-
-    #     logger = logging.getLogger("azure")
-    #     logger.addHandler(mock_handler)
-    #     logger.setLevel(logging.DEBUG)
-
-    #     rsa_key_name = self.get_resource_name("rsa-key-name")
-    #     self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
-
-    #     for message in mock_handler.messages:
-    #         if message.levelname == "DEBUG" and message.funcName == "on_request":
-    #             # parts of the request are logged on new lines in a single message
-    #             if "'/n" in message.message:
-    #                 request_sections = message.message.split("/n")
-    #             else:
-    #                 request_sections = message.message.split("\n")
-    #             for section in request_sections:
-    #                 try:
-    #                     # the body of the request should be JSON
-    #                     body = json.loads(section)
-    #                     expected_kty = "RSA-HSM" if is_hsm else "RSA"
-    #                     if body["kty"] == expected_kty:
-    #                         mock_handler.close()
-    #                         return
-    #                 except (ValueError, KeyError):
-    #                     # this means the request section is not JSON or has no kty property
-    #                     pass
-
-    #     mock_handler.close()
-    #     assert False, "Expected request body wasn't logged"
-
-    # @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
-    # @KeysClientPreparer(logging_enable=False)
-    # @recorded_by_proxy
-    # def test_logging_disabled(self, client, is_hsm, **kwargs):
-    #     mock_handler = MockHandler()
-
-    #     logger = logging.getLogger("azure")
-    #     logger.addHandler(mock_handler)
-    #     logger.setLevel(logging.DEBUG)
-
-    #     rsa_key_name = self.get_resource_name("rsa-key-name")
-    #     self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
-
-    #     for message in mock_handler.messages:
-    #         if message.levelname == "DEBUG" and message.funcName == "on_request":
-    #             # parts of the request are logged on new lines in a single message
-    #             if "'/n" in message.message:
-    #                 request_sections = message.message.split("/n")
-    #             else:
-    #                 request_sections = message.message.split("\n")
-    #             for section in request_sections:
-    #                 try:
-    #                     # the body of the request should be JSON
-    #                     body = json.loads(section)
-    #                     expected_kty = "RSA-HSM" if is_hsm else "RSA"
-    #                     if body["kty"] == expected_kty:
-    #                         mock_handler.close()
-    #                         assert False, "Client request body was logged"
-    #                 except (ValueError, KeyError):
-    #                     # this means the request section is not JSON or has no kty property
-    #                     pass
-
-    #     mock_handler.close()
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_get_random_bytes(self, client, **kwargs):
-    #     assert client
-
-    #     generated_random_bytes = []
-    #     for i in range(5):
-    #         # [START get_random_bytes]
-    #         # get eight random bytes from a managed HSM
-    #         random_bytes = client.get_random_bytes(count=8)
-    #         # [END get_random_bytes]
-    #         assert len(random_bytes) == 8
-    #         assert all(random_bytes != rb for rb in generated_random_bytes)
-    #         generated_random_bytes.append(random_bytes)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_key_release(self, client, is_hsm, **kwargs):
-    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-    #     if is_hsm and client.api_version == ApiVersion.V7_5:
-    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-    #     attestation_uri = self._get_attestation_uri()
-    #     attestation = get_attestation_token(attestation_uri)
-    #     release_policy = get_release_policy(attestation_uri)
-
-    #     rsa_key_name = self.get_resource_name("rsa-key-name")
-    #     key = self._create_rsa_key(
-    #         client, rsa_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-    #     )
-    #     assert key.properties.release_policy
-    #     assert key.properties.release_policy.encoded_policy
-    #     assert key.properties.exportable
-
-    #     try:
-    #         release_result = client.release_key(rsa_key_name, attestation)
-    #         assert release_result.value
-    #     except HttpResponseError as ex:
-    #         # In live pipeline tests, the service can frequently throw a transient error regarding attestation
-    #         if self.is_live and "Target environment attestation statement cannot be verified" in ex.message:
-    #             pytest.skip("Target environment attestation statement cannot be verified. Likely transient failure.")
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_imported_key_release(self, client, **kwargs):
-    #     if client.api_version == ApiVersion.V7_5:
-    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-    #     attestation_uri = self._get_attestation_uri()
-    #     attestation = get_attestation_token(attestation_uri)
-    #     release_policy = get_release_policy(attestation_uri)
-
-    #     imported_key_name = self.get_resource_name("imported-key-name")
-    #     key = self._import_test_key(
-    #         client, imported_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-    #     )
-    #     assert key.properties.release_policy
-    #     assert key.properties.release_policy.encoded_policy
-    #     assert key.properties.exportable
-
-    #     release_result = client.release_key(imported_key_name, attestation)
-    #     assert release_result.value
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_update_release_policy(self, client, **kwargs):
-    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-    #     if client.api_version == ApiVersion.V7_5:
-    #         pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
-
-    #     attestation_uri = self._get_attestation_uri()
-    #     release_policy = get_release_policy(attestation_uri)
-    #     key_name = self.get_resource_name("key-name")
-    #     key = self._create_rsa_key(
-    #         client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-    #     )
-
-    #     policy = json.loads(key.properties.release_policy.encoded_policy.decode())
-    #     claim_condition = policy["anyOf"][0]["anyOf"][0]["equals"]
-    #     # for some reason, claim_condition may be 'true' here for KV, but should be True here for MHSM
-    #     claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
-    #     assert claim_condition is True
-
-    #     new_release_policy_json = {
-    #         "anyOf": [
-    #             {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
-    #         ],
-    #         "version": "1.0.0",
-    #     }
-    #     policy_string = json.dumps(new_release_policy_json).encode()
-    #     new_release_policy = KeyReleasePolicy(policy_string)
-
-    #     updated_key = self._update_key_properties(client, key, new_release_policy)
-    #     updated_policy = json.loads(updated_key.properties.release_policy.encoded_policy.decode())
-    #     claim_condition = updated_policy["anyOf"][0]["anyOf"][0]["equals"]
-    #     claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
-    #     assert claim_condition is False
-
-    # # Immutable policies aren't currently supported on Managed HSM
-    # @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_immutable_release_policy(self, client, **kwargs):
-    #     if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
-    #         pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
-
-    #     attestation_uri = self._get_attestation_uri()
-    #     release_policy = get_release_policy(attestation_uri, immutable=True)
-    #     key_name = self.get_resource_name("key-name")
-    #     key = self._create_rsa_key(
-    #         client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
-    #     )
-    #     assert key.properties.release_policy.encoded_policy
-    #     assert key.properties.release_policy.immutable
-
-    #     new_release_policy_json = {
-    #         "anyOf": [
-    #             {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
-    #         ],
-    #         "version": "1.0.0",
-    #     }
-    #     policy_string = json.dumps(new_release_policy_json).encode()
-    #     new_release_policy = KeyReleasePolicy(policy_string, immutable=True)
-
-    #     with pytest.raises(HttpResponseError):
-    #         self._update_key_properties(client, key, new_release_policy)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_key_rotation(self, client, is_hsm, **kwargs):
-    #     if not is_public_cloud() and self.is_live:
-    #         pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
-
-    #     key_name = self.get_resource_name("rotation-key")
-    #     key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # MHSM doesn't automatically give keys a default rotation policy, unlike KV
-    #     if is_hsm:
-    #         actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
-    #         client.update_key_rotation_policy(key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y"))
-    #     rotated_key = client.rotate_key(key_name)
-
-    #     # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
-    #     assert key.id != rotated_key.id
-    #     assert key.properties.version != rotated_key.properties.version
-    #     assert key.key.n != rotated_key.key.n
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_key_rotation_policy(self, client, is_hsm, **kwargs):
-    #     if not is_public_cloud() and self.is_live:
-    #         pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
-
-    #     key_name = self.get_resource_name("rotation-key")
-    #     self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
-    #     if not is_hsm:
-    #         client.update_key_rotation_policy(key_name, KeyRotationPolicy())
-
-    #     # updating a rotation policy with an empty policy and override(s)
-    #     actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
-    #     if is_hsm:
-    #         updated_policy = client.update_key_rotation_policy(
-    #             key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
-    #         )
-    #         assert updated_policy.expires_in == "P6M"
-    #     else:  # try a policy without an expiry time (only allowed on KV)
-    #         updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
-    #         assert updated_policy.expires_in is None
-
-    #     fetched_policy = client.get_key_rotation_policy(key_name)
-    #     _assert_rotation_policies_equal(updated_policy, fetched_policy)
-
-    #     updated_policy_actions = None
-    #     for i in range(len(updated_policy.lifetime_actions)):
-    #         if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-    #             updated_policy_actions = updated_policy.lifetime_actions[i]
-    #     assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
-    #     assert updated_policy_actions.time_after_create == "P2M"
-    #     assert updated_policy_actions.time_before_expiry is None
-
-    #     fetched_policy_actions = None
-    #     for i in range(len(fetched_policy.lifetime_actions)):
-    #         if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-    #             fetched_policy_actions = fetched_policy.lifetime_actions[i]
-    #     assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
-    #     _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
-
-    #     # updating with a round-tripped policy and overriding expires_in
-    #     new_policy = client.update_key_rotation_policy(key_name, policy=updated_policy, expires_in="P90D")
-    #     assert new_policy.expires_in == "P90D"
-
-    #     new_policy_actions = None
-    #     for i in range(len(new_policy.lifetime_actions)):
-    #         if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
-    #             new_policy_actions = new_policy.lifetime_actions[i]
-    #     _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
-
-    #     # at this time, MHSM doesn't support notify actions
-    #     if not is_hsm:
-    #         # updating with a round-tripped policy and overriding lifetime_actions
-    #         newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
-    #         newest_policy = client.update_key_rotation_policy(
-    #             key_name, policy=new_policy, lifetime_actions=newest_actions
-    #         )
-    #         newest_fetched_policy = client.get_key_rotation_policy(key_name)
-    #         assert newest_policy.expires_in == "P90D"
-    #         _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
-
-    #         newest_policy_actions = None
-    #         for i in range(len(newest_policy.lifetime_actions)):
-    #             if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
-    #                 newest_policy_actions = newest_policy.lifetime_actions[i]
-    #         assert newest_policy_actions.time_after_create is None
-    #         assert newest_policy_actions.time_before_expiry == "P60D"
-
-    #         newest_fetched_policy_actions = None
-    #         for i in range(len(newest_fetched_policy.lifetime_actions)):
-    #             if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
-    #                 newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
-    #         _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
-
-    # @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_get_cryptography_client(self, client, is_hsm, **kwargs):
-    #     key_name = self.get_resource_name("key-name")
-    #     key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
-
-    #     # try specifying the key version
-    #     crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
-    #     # both clients should use the same generated client
-    #     assert client._client == crypto_client._client
-
-    #     # the crypto client should successfully perform crypto operations
-    #     plaintext = b"plaintext"
-    #     result = crypto_client.encrypt("RSA-OAEP", plaintext)
-    #     assert result.key_id == key.id
-
-    #     result = crypto_client.decrypt(result.algorithm, result.ciphertext)
-    #     assert result.key_id == key.id
-    #     assert "RSA-OAEP" == result.algorithm
-    #     assert plaintext == result.plaintext
-
-    #     # try omitting the key version
-    #     crypto_client = client.get_cryptography_client(key_name)
-    #     # both clients should use the same generated client
-    #     assert client._client == crypto_client._client
-
-    #     # the crypto client should successfully perform crypto operations
-    #     result = crypto_client.encrypt("RSA-OAEP", plaintext)
-    #     assert result.key_id == key.id
-
-    #     result = crypto_client.decrypt(result.algorithm, result.ciphertext)
-    #     assert result.key_id == key.id
-    #     assert "RSA-OAEP" == result.algorithm
-    #     assert plaintext == result.plaintext
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_send_request(self, client, is_hsm, **kwargs):
-    #     key_name = self.get_resource_name("key-name")
-    #     key = self._create_rsa_key(client, key_name)
-
-    #     # fetch the key we just created
-    #     request = HttpRequest(
-    #         method="GET",
-    #         url=f"keys/{key_name}/{key.properties.version}",
-    #         headers={"Accept": "application/json"},
-    #     )
-    #     response = client.send_request(request)
-    #     assert response.json()["key"]["kid"] == key.id
-
-    # @pytest.mark.parametrize("api_version,is_hsm", only_hsm_default)
-    # @KeysClientPreparer()
-    # @recorded_by_proxy
-    # def test_get_key_attestation(self, client, **kwargs):
-    #     # create a key
-    #     key_name = self.get_resource_name("key-name")
-    #     key = self._create_rsa_key(client, key_name, hardware_protected=True)
-    #     # attestation info shouldn't be included unless requested with get_key_attestation
-    #     assert key.properties.attestation is None
-
-    #     # fetch the key we just created
-    #     fetched_key = client.get_key_attestation(key_name)
-    #     attestation = fetched_key.properties.attestation
-    #     assert attestation is not None
-    #     assert attestation.certificate_pem_file is not None
-    #     assert attestation.private_key_attestation is not None
-    #     assert attestation.public_key_attestation is not None
-    #     assert attestation.version
-
-    #     # create new key version to validate versioned fetching
-    #     updated_key = client.update_key_properties(key_name, tags={"tag": "value"})
-    #     updated_attestation = client.get_key_attestation(key_name).properties.attestation
-    #     assert updated_attestation is not None
-    #     assert updated_attestation.certificate_pem_file == attestation.certificate_pem_file
-    #     assert updated_attestation.private_key_attestation == attestation.private_key_attestation
-    #     assert updated_attestation.public_key_attestation == attestation.public_key_attestation
-    #     assert updated_attestation.version != updated_key.properties.version
-
-    #     original_attestation = client.get_key_attestation(key_name, key.properties.version).properties.attestation
-    #     assert original_attestation.version == attestation.version
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_key_crud_operations(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        # create ec key
+        ec_key_name = self.get_resource_name("crud-ec-key")
+        tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
+        ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=is_hsm, tags=tags)
+        assert ec_key.properties.enabled
+        assert tags == ec_key.properties.tags
+        # create ec with curve
+        ec_key_curve_name = self.get_resource_name("crud-P-256-ec-key")
+        created_ec_key_curve = self._create_ec_key(
+            client, key_name=ec_key_curve_name, curve="P-256", hardware_protected=is_hsm
+        )
+        assert "P-256" == created_ec_key_curve.key.crv
+
+        # import key
+        import_test_key_name = self.get_resource_name("import-test-key")
+        self._import_test_key(client, import_test_key_name, hardware_protected=is_hsm)
+
+        # create rsa key
+        rsa_key_name = self.get_resource_name("crud-rsa-key")
+        tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
+        key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
+        rsa_key = self._create_rsa_key(
+            client, key_name=rsa_key_name, key_operations=key_ops, size=2048, tags=tags, hardware_protected=is_hsm
+        )
+        assert tags == rsa_key.properties.tags
+
+        # get the created key with version
+        key = client.get_key(rsa_key.name, rsa_key.properties.version)
+        assert key.properties.version == rsa_key.properties.version
+        self._assert_key_attributes_equal(rsa_key.properties, key.properties)
+
+        # get key without version
+        self._assert_key_attributes_equal(rsa_key.properties, client.get_key(rsa_key.name).properties)
+
+        # update key with version
+        if self.is_live:
+            # wait to ensure the key's update time won't equal its creation time
+            time.sleep(1)
+
+        self._update_key_properties(client, rsa_key)
+
+        # delete the new key
+        deleted_key_poller = client.begin_delete_key(rsa_key.name)
+        deleted_key = deleted_key_poller.result()
+        assert deleted_key is not None
+
+        # aside from key_ops, the original updated keys should have the same JWKs
+        self._assert_jwks_equal(rsa_key.key, deleted_key.key)
+        assert deleted_key.id == rsa_key.id
+        assert (
+            deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date
+        ), "Missing required deleted key attributes."
+
+        deleted_key_poller.wait()
+
+        # get the deleted key when soft deleted enabled
+        deleted_key = client.get_deleted_key(rsa_key.name)
+        assert deleted_key is not None
+        assert rsa_key.id == deleted_key.id
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_rsa_public_exponent(self, client, **kwargs):
+        """The public exponent of a Managed HSM RSA key can be specified during creation"""
+        assert client is not None
+
+        key_name = self.get_resource_name("rsa-key")
+        key = self._create_rsa_key(client, key_name, hardware_protected=True, public_exponent=17)
+        public_exponent = key.key.e[0]
+        assert public_exponent == 17
+
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_backup_restore(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        key_name = self.get_resource_name("keybak")
+
+        # create key
+        created_bundle = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # backup key
+        key_backup = client.backup_key(created_bundle.name)
+        assert key_backup is not None
+
+        # delete key
+        client.begin_delete_key(created_bundle.name).wait()
+
+        # purge key
+        client.purge_deleted_key(created_bundle.name)
+
+        # restore key
+        restore_function = functools.partial(client.restore_key_backup, key_backup)
+        restored_key = self._poll_until_no_exception(restore_function, ResourceExistsError)
+        self._assert_key_attributes_equal(created_bundle.properties, restored_key.properties)
+
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_key_list(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        max_keys = LIST_TEST_SIZE
+        expected = {}
+
+        # create many keys
+        for x in range(max_keys):
+            key_name = self.get_resource_name(f"key{x}")
+            key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+            expected[key.name] = key
+
+        # list keys
+        result = client.list_properties_of_keys(max_page_size=max_keys - 1)
+        for key in result:
+            if key.name in expected.keys():
+                self._assert_key_attributes_equal(expected[key.name].properties, key)
+                del expected[key.name]
+        assert len(expected) == 0
+
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_list_versions(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        key_name = self.get_resource_name("testKey")
+
+        max_keys = LIST_TEST_SIZE
+        expected = {}
+
+        # create many key versions
+        for _ in range(max_keys):
+            key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+            expected[key.id] = key
+
+        result = client.list_properties_of_key_versions(key_name, max_page_size=max_keys - 1)
+
+        # validate list key versions with attributes
+        for key in result:
+            if key.id in expected.keys():
+                expected_key = expected[key.id]
+                del expected[key.id]
+                self._assert_key_attributes_equal(expected_key.properties, key)
+        assert 0 == len(expected)
+
+    @pytest.mark.skip("Temporarily disabled due to service issue")
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_list_deleted_keys(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        expected = {}
+
+        # create keys
+        for i in range(LIST_TEST_SIZE):
+            key_name = self.get_resource_name(f"key{i}")
+            expected[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # delete them
+        for key_name in expected.keys():
+            client.begin_delete_key(key_name).wait()
+
+        # validate list deleted keys with attributes
+        for deleted_key in client.list_deleted_keys():
+            assert deleted_key.deleted_date is not None
+            assert deleted_key.scheduled_purge_date is not None
+            assert deleted_key.recovery_id is not None
+
+        result = client.list_deleted_keys()
+        # validate all the deleted keys are returned by list_deleted_keys
+        for key in result:
+            if key.name in expected.keys():
+                self._assert_key_attributes_equal(expected[key.name].properties, key.properties)
+                del expected[key.name]
+
+    @pytest.mark.skip("Temporarily disabled due to service issue")
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_recover(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        # create keys
+        keys = {}
+        for i in range(LIST_TEST_SIZE):
+            key_name = self.get_resource_name(f"key{i}")
+            keys[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # delete them
+        for key_name in keys.keys():
+            client.begin_delete_key(key_name).wait()
+
+        # validate the deleted keys are returned by list_deleted_keys
+        deleted = [s.name for s in client.list_deleted_keys()]
+        assert all(s in deleted for s in keys.keys())
+
+        # recover the keys
+        for key_name in keys.keys():
+            recovered_key = client.begin_recover_deleted_key(key_name).result()
+            expected_key = keys[key_name]
+            self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
+
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_purge(self, client, is_hsm, **kwargs):
+        assert client is not None
+
+        # create keys
+        key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
+        for name in key_names:
+            self._create_rsa_key(client, name, hardware_protected=is_hsm)
+
+        # delete them
+        for key_name in key_names:
+            client.begin_delete_key(key_name).wait()
+
+        # validate all our deleted keys are returned by list_deleted_keys
+        deleted = [k.name for k in client.list_deleted_keys()]
+        assert all(n in deleted for n in key_names)
+
+        # purge them
+        for key_name in key_names:
+            client.purge_deleted_key(key_name)
+        for key_name in key_names:
+            self._poll_until_exception(
+                functools.partial(client.get_deleted_key, key_name), expected_exception=ResourceNotFoundError
+            )
+
+        # validate none are returned by list_deleted_keys
+        deleted = [s.name for s in client.list_deleted_keys()]
+        assert not any(s in deleted for s in key_names)
+
+    @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
+    @KeysClientPreparer(logging_enable=True)
+    @recorded_by_proxy
+    def test_logging_enabled(self, client, is_hsm, **kwargs):
+        mock_handler = MockHandler()
+
+        logger = logging.getLogger("azure")
+        logger.addHandler(mock_handler)
+        logger.setLevel(logging.DEBUG)
+
+        rsa_key_name = self.get_resource_name("rsa-key-name")
+        self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
+
+        for message in mock_handler.messages:
+            if message.levelname == "DEBUG" and message.funcName == "on_request":
+                # parts of the request are logged on new lines in a single message
+                if "'/n" in message.message:
+                    request_sections = message.message.split("/n")
+                else:
+                    request_sections = message.message.split("\n")
+                for section in request_sections:
+                    try:
+                        # the body of the request should be JSON
+                        body = json.loads(section)
+                        expected_kty = "RSA-HSM" if is_hsm else "RSA"
+                        if body["kty"] == expected_kty:
+                            mock_handler.close()
+                            return
+                    except (ValueError, KeyError):
+                        # this means the request section is not JSON or has no kty property
+                        pass
+
+        mock_handler.close()
+        assert False, "Expected request body wasn't logged"
+
+    @pytest.mark.parametrize("api_version,is_hsm", logging_enabled)
+    @KeysClientPreparer(logging_enable=False)
+    @recorded_by_proxy
+    def test_logging_disabled(self, client, is_hsm, **kwargs):
+        mock_handler = MockHandler()
+
+        logger = logging.getLogger("azure")
+        logger.addHandler(mock_handler)
+        logger.setLevel(logging.DEBUG)
+
+        rsa_key_name = self.get_resource_name("rsa-key-name")
+        self._create_rsa_key(client, rsa_key_name, size=2048, hardware_protected=is_hsm)
+
+        for message in mock_handler.messages:
+            if message.levelname == "DEBUG" and message.funcName == "on_request":
+                # parts of the request are logged on new lines in a single message
+                if "'/n" in message.message:
+                    request_sections = message.message.split("/n")
+                else:
+                    request_sections = message.message.split("\n")
+                for section in request_sections:
+                    try:
+                        # the body of the request should be JSON
+                        body = json.loads(section)
+                        expected_kty = "RSA-HSM" if is_hsm else "RSA"
+                        if body["kty"] == expected_kty:
+                            mock_handler.close()
+                            assert False, "Client request body was logged"
+                    except (ValueError, KeyError):
+                        # this means the request section is not JSON or has no kty property
+                        pass
+
+        mock_handler.close()
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_get_random_bytes(self, client, **kwargs):
+        assert client
+
+        generated_random_bytes = []
+        for i in range(5):
+            # [START get_random_bytes]
+            # get eight random bytes from a managed HSM
+            random_bytes = client.get_random_bytes(count=8)
+            # [END get_random_bytes]
+            assert len(random_bytes) == 8
+            assert all(random_bytes != rb for rb in generated_random_bytes)
+            generated_random_bytes.append(random_bytes)
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_key_release(self, client, is_hsm, **kwargs):
+        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+        if is_hsm and client.api_version == ApiVersion.V7_5:
+            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+        attestation_uri = self._get_attestation_uri()
+        attestation = get_attestation_token(attestation_uri)
+        release_policy = get_release_policy(attestation_uri)
+
+        rsa_key_name = self.get_resource_name("rsa-key-name")
+        key = self._create_rsa_key(
+            client, rsa_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+        )
+        assert key.properties.release_policy
+        assert key.properties.release_policy.encoded_policy
+        assert key.properties.exportable
+
+        try:
+            release_result = client.release_key(rsa_key_name, attestation)
+            assert release_result.value
+        except HttpResponseError as ex:
+            # In live pipeline tests, the service can frequently throw a transient error regarding attestation
+            if self.is_live and "Target environment attestation statement cannot be verified" in ex.message:
+                pytest.skip("Target environment attestation statement cannot be verified. Likely transient failure.")
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_imported_key_release(self, client, **kwargs):
+        if client.api_version == ApiVersion.V7_5:
+            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+        attestation_uri = self._get_attestation_uri()
+        attestation = get_attestation_token(attestation_uri)
+        release_policy = get_release_policy(attestation_uri)
+
+        imported_key_name = self.get_resource_name("imported-key-name")
+        key = self._import_test_key(
+            client, imported_key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+        )
+        assert key.properties.release_policy
+        assert key.properties.release_policy.encoded_policy
+        assert key.properties.exportable
+
+        release_result = client.release_key(imported_key_name, attestation)
+        assert release_result.value
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_update_release_policy(self, client, **kwargs):
+        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+        if client.api_version == ApiVersion.V7_5:
+            pytest.skip("Currently failing on 7.5-preview.1; skipping for now")
+
+        attestation_uri = self._get_attestation_uri()
+        release_policy = get_release_policy(attestation_uri)
+        key_name = self.get_resource_name("key-name")
+        key = self._create_rsa_key(
+            client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+        )
+
+        policy = json.loads(key.properties.release_policy.encoded_policy.decode())
+        claim_condition = policy["anyOf"][0]["anyOf"][0]["equals"]
+        # for some reason, claim_condition may be 'true' here for KV, but should be True here for MHSM
+        claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
+        assert claim_condition is True
+
+        new_release_policy_json = {
+            "anyOf": [
+                {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
+            ],
+            "version": "1.0.0",
+        }
+        policy_string = json.dumps(new_release_policy_json).encode()
+        new_release_policy = KeyReleasePolicy(policy_string)
+
+        updated_key = self._update_key_properties(client, key, new_release_policy)
+        updated_policy = json.loads(updated_key.properties.release_policy.encoded_policy.decode())
+        claim_condition = updated_policy["anyOf"][0]["anyOf"][0]["equals"]
+        claim_condition = claim_condition if isinstance(claim_condition, bool) else json.loads(claim_condition)
+        assert claim_condition is False
+
+    # Immutable policies aren't currently supported on Managed HSM
+    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_immutable_release_policy(self, client, **kwargs):
+        if self.is_live and os.environ["KEYVAULT_SKU"] != "premium":
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
+        attestation_uri = self._get_attestation_uri()
+        release_policy = get_release_policy(attestation_uri, immutable=True)
+        key_name = self.get_resource_name("key-name")
+        key = self._create_rsa_key(
+            client, key_name, hardware_protected=True, exportable=True, release_policy=release_policy
+        )
+        assert key.properties.release_policy.encoded_policy
+        assert key.properties.release_policy.immutable
+
+        new_release_policy_json = {
+            "anyOf": [
+                {"anyOf": [{"claim": "sdk-test", "equals": False}], "authority": attestation_uri.rstrip("/") + "/"}
+            ],
+            "version": "1.0.0",
+        }
+        policy_string = json.dumps(new_release_policy_json).encode()
+        new_release_policy = KeyReleasePolicy(policy_string, immutable=True)
+
+        with pytest.raises(HttpResponseError):
+            self._update_key_properties(client, key, new_release_policy)
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_key_rotation(self, client, is_hsm, **kwargs):
+        if not is_public_cloud() and self.is_live:
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
+
+        key_name = self.get_resource_name("rotation-key")
+        key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # MHSM doesn't automatically give keys a default rotation policy, unlike KV
+        if is_hsm:
+            actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
+            client.update_key_rotation_policy(key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y"))
+        rotated_key = client.rotate_key(key_name)
+
+        # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
+        assert key.id != rotated_key.id
+        assert key.properties.version != rotated_key.properties.version
+        assert key.key.n != rotated_key.key.n
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_key_rotation_policy(self, client, is_hsm, **kwargs):
+        if not is_public_cloud() and self.is_live:
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
+
+        key_name = self.get_resource_name("rotation-key")
+        self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
+        if not is_hsm:
+            client.update_key_rotation_policy(key_name, KeyRotationPolicy())
+
+        # updating a rotation policy with an empty policy and override(s)
+        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
+        if is_hsm:
+            updated_policy = client.update_key_rotation_policy(
+                key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
+            )
+            assert updated_policy.expires_in == "P6M"
+        else:  # try a policy without an expiry time (only allowed on KV)
+            updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
+            assert updated_policy.expires_in is None
+
+        fetched_policy = client.get_key_rotation_policy(key_name)
+        _assert_rotation_policies_equal(updated_policy, fetched_policy)
+
+        updated_policy_actions = None
+        for i in range(len(updated_policy.lifetime_actions)):
+            if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+                updated_policy_actions = updated_policy.lifetime_actions[i]
+        assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
+        assert updated_policy_actions.time_after_create == "P2M"
+        assert updated_policy_actions.time_before_expiry is None
+
+        fetched_policy_actions = None
+        for i in range(len(fetched_policy.lifetime_actions)):
+            if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+                fetched_policy_actions = fetched_policy.lifetime_actions[i]
+        assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
+        _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
+
+        # updating with a round-tripped policy and overriding expires_in
+        new_policy = client.update_key_rotation_policy(key_name, policy=updated_policy, expires_in="P90D")
+        assert new_policy.expires_in == "P90D"
+
+        new_policy_actions = None
+        for i in range(len(new_policy.lifetime_actions)):
+            if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
+                new_policy_actions = new_policy.lifetime_actions[i]
+        _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
+
+        # at this time, MHSM doesn't support notify actions
+        if not is_hsm:
+            # updating with a round-tripped policy and overriding lifetime_actions
+            newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
+            newest_policy = client.update_key_rotation_policy(
+                key_name, policy=new_policy, lifetime_actions=newest_actions
+            )
+            newest_fetched_policy = client.get_key_rotation_policy(key_name)
+            assert newest_policy.expires_in == "P90D"
+            _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
+
+            newest_policy_actions = None
+            for i in range(len(newest_policy.lifetime_actions)):
+                if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_policy_actions = newest_policy.lifetime_actions[i]
+            assert newest_policy_actions.time_after_create is None
+            assert newest_policy_actions.time_before_expiry == "P60D"
+
+            newest_fetched_policy_actions = None
+            for i in range(len(newest_fetched_policy.lifetime_actions)):
+                if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
+            _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
+
+    @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_get_cryptography_client(self, client, is_hsm, **kwargs):
+        key_name = self.get_resource_name("key-name")
+        key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # try specifying the key version
+        crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
+        # both clients should use the same generated client
+        assert client._client == crypto_client._client
+
+        # the crypto client should successfully perform crypto operations
+        plaintext = b"plaintext"
+        result = crypto_client.encrypt("RSA-OAEP", plaintext)
+        assert result.key_id == key.id
+
+        result = crypto_client.decrypt(result.algorithm, result.ciphertext)
+        assert result.key_id == key.id
+        assert "RSA-OAEP" == result.algorithm
+        assert plaintext == result.plaintext
+
+        # try omitting the key version
+        crypto_client = client.get_cryptography_client(key_name)
+        # both clients should use the same generated client
+        assert client._client == crypto_client._client
+
+        # the crypto client should successfully perform crypto operations
+        result = crypto_client.encrypt("RSA-OAEP", plaintext)
+        assert result.key_id == key.id
+
+        result = crypto_client.decrypt(result.algorithm, result.ciphertext)
+        assert result.key_id == key.id
+        assert "RSA-OAEP" == result.algorithm
+        assert plaintext == result.plaintext
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_send_request(self, client, is_hsm, **kwargs):
+        key_name = self.get_resource_name("key-name")
+        key = self._create_rsa_key(client, key_name)
+
+        # fetch the key we just created
+        request = HttpRequest(
+            method="GET",
+            url=f"keys/{key_name}/{key.properties.version}",
+            headers={"Accept": "application/json"},
+        )
+        response = client.send_request(request)
+        assert response.json()["key"]["kid"] == key.id
+
+    @pytest.mark.parametrize("api_version,is_hsm", only_hsm_default)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_get_key_attestation(self, client, **kwargs):
+        # create a key
+        key_name = self.get_resource_name("key-name")
+        key = self._create_rsa_key(client, key_name, hardware_protected=True)
+        # attestation info shouldn't be included unless requested with get_key_attestation
+        assert key.properties.attestation is None
+
+        # fetch the key we just created
+        fetched_key = client.get_key_attestation(key_name)
+        attestation = fetched_key.properties.attestation
+        assert attestation is not None
+        assert attestation.certificate_pem_file is not None
+        assert attestation.private_key_attestation is not None
+        assert attestation.public_key_attestation is not None
+        assert attestation.version
+
+        # create new key version to validate versioned fetching
+        updated_key = client.update_key_properties(key_name, tags={"tag": "value"})
+        updated_attestation = client.get_key_attestation(key_name).properties.attestation
+        assert updated_attestation is not None
+        assert updated_attestation.certificate_pem_file == attestation.certificate_pem_file
+        assert updated_attestation.private_key_attestation == attestation.private_key_attestation
+        assert updated_attestation.public_key_attestation == attestation.public_key_attestation
+        assert updated_attestation.version != updated_key.properties.version
+
+        original_attestation = client.get_key_attestation(key_name, key.properties.version).properties.attestation
+        assert original_attestation.version == attestation.version
 
     @pytest.mark.parametrize("api_version,is_hsm", default_version)
     @KeysClientPreparer()
@@ -857,62 +857,62 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         fetched = client.get_key(oct_key_name)
         assert fetched.properties.key_size == 256
 
-#     @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
-#     @KeysClientPreparer()
-#     @recorded_by_proxy
-#     def test_40x_handling(self, client, **kwargs):
-#         """Ensure 404 and 409 responses are raised with azure-core exceptions instead of generated KV ones"""
+    @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)
+    @KeysClientPreparer()
+    @recorded_by_proxy
+    def test_40x_handling(self, client, **kwargs):
+        """Ensure 404 and 409 responses are raised with azure-core exceptions instead of generated KV ones"""
 
-#         # Test that 404 is raised correctly by fetching a nonexistent key
-#         with pytest.raises(ResourceNotFoundError):
-#             client.get_key("key-that-does-not-exist")
+        # Test that 404 is raised correctly by fetching a nonexistent key
+        with pytest.raises(ResourceNotFoundError):
+            client.get_key("key-that-does-not-exist")
 
-#         # Test that 409 is raised correctly (`create_key` shouldn't actually trigger this, but for raising behavior)
-#         def run(*_, **__):
-#             return Mock(http_response=Mock(status_code=409))
+        # Test that 409 is raised correctly (`create_key` shouldn't actually trigger this, but for raising behavior)
+        def run(*_, **__):
+            return Mock(http_response=Mock(status_code=409))
 
-#         with patch.object(client._client._client._pipeline, "run", run):
-#             with pytest.raises(ResourceExistsError):
-#                 client.create_key("...", "RSA")
-
-
-# def test_positive_bytes_count_required():
-#     client = KeyClient("...", object())
-#     with pytest.raises(ValueError):
-#         client.get_random_bytes(count=0)
-#     with pytest.raises(ValueError):
-#         client.get_random_bytes(count=-1)
+        with patch.object(client._client._client._pipeline, "run", run):
+            with pytest.raises(ResourceExistsError):
+                client.create_key("...", "RSA")
 
 
-# def test_service_headers_allowed_in_logs():
-#     service_headers = {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
-#     client = KeyClient("...", object())
-#     assert service_headers.issubset(client._client._config.http_logging_policy.allowed_header_names)
+def test_positive_bytes_count_required():
+    client = KeyClient("...", object())
+    with pytest.raises(ValueError):
+        client.get_random_bytes(count=0)
+    with pytest.raises(ValueError):
+        client.get_random_bytes(count=-1)
 
 
-# def test_custom_hook_policy():
-#     class CustomHookPolicy(SansIOHTTPPolicy):
-#         pass
-
-#     client = KeyClient("...", object(), custom_hook_policy=CustomHookPolicy())
-#     assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
+def test_service_headers_allowed_in_logs():
+    service_headers = {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+    client = KeyClient("...", object())
+    assert service_headers.issubset(client._client._config.http_logging_policy.allowed_header_names)
 
 
-# def test_case_insensitive_key_type():
-#     """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
-#     See https://github.com/Azure/azure-sdk-for-python/issues/22797
-#     """
-#     # KeyType with all upper-case value
-#     assert KeyType("rsa") == KeyType.rsa
-#     # KeyType with all lower-case value
-#     assert KeyType("OCT") == KeyType.oct
-#     # KeyType with mixed-case value
-#     assert KeyType("oct-hsm") == KeyType.oct_hsm
+def test_custom_hook_policy():
+    class CustomHookPolicy(SansIOHTTPPolicy):
+        pass
+
+    client = KeyClient("...", object(), custom_hook_policy=CustomHookPolicy())
+    assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
 
 
-# def test_empty_rotation_policy_actions():
-#     """Regression test: make sure a KeyRotationPolicy can be created with a response that has None properties"""
-#     generated_policy = _KeyRotationPolicy()
-#     assert generated_policy.lifetime_actions is None
-#     policy = KeyRotationPolicy._from_generated(generated_policy)
-#     assert policy.lifetime_actions == []
+def test_case_insensitive_key_type():
+    """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
+    See https://github.com/Azure/azure-sdk-for-python/issues/22797
+    """
+    # KeyType with all upper-case value
+    assert KeyType("rsa") == KeyType.rsa
+    # KeyType with all lower-case value
+    assert KeyType("OCT") == KeyType.oct
+    # KeyType with mixed-case value
+    assert KeyType("oct-hsm") == KeyType.oct_hsm
+
+
+def test_empty_rotation_policy_actions():
+    """Regression test: make sure a KeyRotationPolicy can be created with a response that has None properties"""
+    generated_policy = _KeyRotationPolicy()
+    assert generated_policy.lifetime_actions is None
+    policy = KeyRotationPolicy._from_generated(generated_policy)
+    assert policy.lifetime_actions == []

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -35,7 +35,6 @@ from test_key_client import _assert_lifetime_actions_equal, _assert_rotation_pol
 from devtools_testutils.aio import recorded_by_proxy_async
 from _keys_test_case import KeysTestCase
 
-
 all_api_versions = get_decorator(is_async=True)
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 only_hsm_default = get_decorator(only_hsm=True, is_async=True, api_versions=[DEFAULT_VERSION])

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -38,6 +38,7 @@ from _keys_test_case import KeysTestCase
 all_api_versions = get_decorator(is_async=True)
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 only_hsm_default = get_decorator(only_hsm=True, is_async=True, api_versions=[DEFAULT_VERSION])
+default_version = get_decorator(is_async=True, api_versions=[DEFAULT_VERSION])
 only_hsm_7_4_plus = get_decorator(only_hsm=True, is_async=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
 only_vault_7_4_plus = get_decorator(only_vault=True, is_async=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
 only_7_4_plus = get_decorator(is_async=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
@@ -96,6 +97,16 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         self._validate_ec_key_bundle(key_curve, created_key, client.vault_url, key_name, key_type)
         return created_key
 
+    async def _create_oct_key(self, client, key_name, **kwargs):
+        hsm = kwargs.get("hardware_protected") or False
+        size = kwargs.get("size") or 256
+        if self.is_live:
+            await asyncio.sleep(2)  # to avoid throttling by the service
+        created_key = await client.create_oct_key(key_name, **kwargs)
+        kty = "oct-HSM"
+        self._validate_oct_key_bundle(created_key, client.vault_url, key_name, kty, size)
+        return created_key
+
     def _validate_ec_key_bundle(self, key_curve, key_attributes, vault, key_name, kty):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
@@ -115,6 +126,19 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
         assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
+        assert (
+            key_attributes.properties.created_on and key_attributes.properties.updated_on
+        ), "Missing required date attributes."
+
+    def _validate_oct_key_bundle(self, key_attributes, vault, key_name, kty, size):
+        prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
+        key = key_attributes.key
+        kid = key_attributes.id
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
+        assert key_attributes.properties.key_size == size, (
+            f"key_size should be {size}, but is {key_attributes.properties.key_size}"
+        )
         assert (
             key_attributes.properties.created_on and key_attributes.properties.updated_on
         ), "Missing required date attributes."
@@ -833,6 +857,26 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         original = await client.get_key_attestation(key_name, key.properties.version)
         original_attestation = original.properties.attestation
         assert original_attestation.version == attestation.version
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version,is_hsm", default_version)
+    @AsyncKeysClientPreparer()
+    @recorded_by_proxy_async
+    async def test_key_size(self, client, is_hsm, **kwargs):
+        """The key_size property is returned for oct keys created with 2026-01-01-preview"""
+        # EC keys should return None for key_size
+        ec_key_name = self.get_resource_name("ec-key-size")
+        ec_key = await self._create_ec_key(client, ec_key_name, hardware_protected=True)
+        assert ec_key.properties.key_size is None
+
+        # oct-HSM keys should return the correct key_size
+        oct_key_name = self.get_resource_name("oct-key-256")
+        oct_key = await self._create_oct_key(client, oct_key_name, size=256, hardware_protected=True)
+        assert oct_key.properties.key_size == 256
+
+        # key_size is also available when fetching an existing oct-HSM key
+        fetched = await client.get_key(oct_key_name)
+        assert fetched.properties.key_size == 256
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("api_version,is_hsm", only_vault_7_4_plus)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -136,9 +136,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         kid = key_attributes.id
         assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
         assert key.kty == kty, f"kty should be '{kty}', but is '{key.kty}'"
-        assert key_attributes.properties.key_size == size, (
-            f"key_size should be {size}, but is {key_attributes.properties.key_size}"
-        )
+        assert (
+            key_attributes.properties.key_size == size
+        ), f"key_size should be {size}, but is {key_attributes.properties.key_size}"
         assert (
             key_attributes.properties.created_on and key_attributes.properties.updated_on
         ), "Missing required date attributes."

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -10,10 +10,12 @@ from azure.keyvault.keys import KeyType
 from devtools_testutils import recorded_by_proxy
 
 from _shared.test_case import KeyVaultTestCase
+from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION
 from _test_case import KeysClientPreparer, get_decorator
 from _keys_test_case import KeysTestCase
 
 all_api_versions = get_decorator(only_vault=True)
+default_version = get_decorator(api_versions=[DEFAULT_VERSION])
 only_hsm = get_decorator(only_hsm=True)
 
 
@@ -131,7 +133,7 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
         deleted_key_poller.wait()
         # [END delete_key]
 
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
+    @pytest.mark.parametrize("api_version,is_hsm", default_version)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_example_create_oct_key(self, key_client, **kwargs):
@@ -143,6 +145,7 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
         print(key.id)
         print(key.name)
         print(key.key_type)
+        print(key.properties.key_size)
         # [END create_oct_key]
 
     @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -9,11 +9,13 @@ import pytest
 from azure.keyvault.keys import KeyType
 from devtools_testutils.aio import recorded_by_proxy_async
 
+from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION
 from _async_test_case import AsyncKeysClientPreparer
 from _test_case import get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True, only_vault=True)
+default_version = get_decorator(is_async=True, api_versions=[DEFAULT_VERSION])
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 
 
@@ -133,7 +135,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [END delete_key]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
+    @pytest.mark.parametrize("api_version,is_hsm", default_version)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_example_create_oct_key(self, key_client, **kwargs):
@@ -145,6 +147,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.key_type)
+        print(key.properties.key_size)
         # [END create_oct_key]
 
     @pytest.mark.asyncio

--- a/sdk/keyvault/azure-keyvault-keys/tsp-location.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/keyvault/data-plane/Keys
-commit: f6bd06be22baf3a18504ffef0f590230850953e5
+commit: 0aea5f5666b9d631d37074a2f9c9bd8ba0dd1eff
 repo: Azure/azure-rest-api-specs

--- a/sdk/keyvault/test-resources-cleanup.py
+++ b/sdk/keyvault/test-resources-cleanup.py
@@ -90,7 +90,7 @@ async def close_sessions():
         await hsm_client.close()
     await secret_client.close()
 
-loop = asyncio.get_event_loop()
+loop = asyncio.new_event_loop()
 loop.run_until_complete(delete_certificates())
 loop.run_until_complete(delete_keys_and_secrets())
 loop.run_until_complete(purge_resources())


### PR DESCRIPTION
# Description

- Added support for service API version `2026-01-01-preview` (https://github.com/Azure/azure-rest-api-specs/pull/40761)
- Added key_size attribute and property to oct-HSM keys.
- Python 3.9 is no longer supported. Please use Python version 3.10 or later.
- Key Vault API version `2026-01-01-preview` is now the default.
- 
# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
