### PR TITLE
[Storage][Tools] Bypass cibuildwheel for local dev_requirement builds

### DIFF
--- a/eng/tools/azure-sdk-tools/ci_tools/build.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/build.py
@@ -1,8 +1,17 @@
-import argparse, sys, os, logging, glob, shutil
+import argparse, sys, os, logging, glob, shutil, shlex
 
+from collections.abc import Mapping as MappingABC
 from subprocess import run
 
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+try:
+    # py 311 adds this library natively
+    import tomllib as toml
+except ImportError:
+    # otherwise fall back to pypi package tomli
+    import tomli as toml
+
 from ci_tools.functions import discover_targeted_packages, process_requires, get_pip_list_output
 from ci_tools.parsing import ParsedSetup, parse_require
 from ci_tools.variables import DEFAULT_BUILD_ID, str_to_bool, discover_repo_root, get_artifact_directory
@@ -217,8 +226,84 @@ def build_packages(
         create_package(package_root, dist_dir, enable_wheel, enable_sdist)
 
 
+def _local_build_env(folder: str) -> Optional[Dict[str, str]]:
+    """Merge ``[tool.cibuildwheel].environment`` from ``folder/pyproject.toml`` into
+    ``os.environ.copy()`` so the same compiler flags apply when we build without
+    cibuildwheel. Returns ``None`` when no such config exists.
+    """
+    pyproject = os.path.join(folder, "pyproject.toml")
+    if not os.path.exists(pyproject):
+        return None
+    try:
+        with open(pyproject, "rb") as f:
+            data = toml.load(f)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(f"Could not parse {pyproject} to extract cibuildwheel environment: {exc}")
+        return None
+
+    env_value = data.get("tool", {}).get("cibuildwheel", {}).get("environment", None)
+    if not env_value:
+        return None
+
+    overrides: Dict[str, str] = {}
+    if isinstance(env_value, MappingABC):
+        overrides = {str(k): str(v) for k, v in env_value.items()}
+    elif isinstance(env_value, str):
+        # Shell-style form: ``CFLAGS='-Wno-implicit-function-declaration' FOO=bar``.
+        for token in shlex.split(env_value):
+            if "=" in token:
+                k, v = token.split("=", 1)
+                overrides[k] = v
+    else:
+        return None
+
+    if not overrides:
+        return None
+
+    merged = os.environ.copy()
+    merged.update(overrides)
+    return merged
+
+
+def build_whl_locally(pkg_path: str, dist_dir: str) -> None:
+    """Build a wheel for ``pkg_path`` into ``dist_dir`` via ``python -m build`` (PEP 517).
+
+    Used to resolve local relative dev_requirements on network-isolated test agents,
+    where cibuildwheel can't run. For C ``ext_modules`` packages,
+    ``[tool.cibuildwheel].environment`` from pyproject.toml is applied to the build
+    subprocess so platform-specific compiler flags still reach the compiler.
+    """
+    parsed = ParsedSetup.from_path(pkg_path)
+    should_log_build_output = logger.getEffectiveLevel() <= logging.DEBUG
+
+    # `python -m build -n` needs the package's runtime requires importable to read __version__.
+    pip_output = get_pip_list_output(sys.executable)
+    necessary_install_requirements = [
+        req for req in parsed.requires if parse_require(req).name not in pip_output.keys()
+    ]
+    if necessary_install_requirements:
+        run_logged(
+            [sys.executable, "-m", "pip", "install", *necessary_install_requirements],
+            cwd=parsed.folder,
+            check=False,
+            should_stream_to_console=should_log_build_output,
+        )
+
+    build_env = _local_build_env(parsed.folder) if parsed.ext_modules else None
+    run_logged(
+        [sys.executable, "-m", "build", "-n", "-w", "-o", dist_dir, parsed.folder],
+        cwd=parsed.folder,
+        check=True,
+        should_stream_to_console=should_log_build_output,
+        env=build_env,
+    )
+
+
 def create_package(
-    setup_directory_or_file: str, dest_folder: str, enable_wheel: bool = True, enable_sdist: bool = True
+    setup_directory_or_file: str,
+    dest_folder: str,
+    enable_wheel: bool = True,
+    enable_sdist: bool = True,
 ):
     """
     Uses the invoking python executable to build a wheel and sdist file given a setup.py or setup.py directory. Outputs
@@ -248,6 +333,9 @@ def create_package(
             check=False,
             should_stream_to_console=should_log_build_output,
         )
+        # Apply [tool.cibuildwheel].environment when building ext_modules pyproject packages
+        # so platform-specific compiler flags reach the compiler. No-op otherwise.
+        build_env = _local_build_env(setup_parsed.folder) if setup_parsed.ext_modules else None
         run_logged(
             [
                 sys.executable,
@@ -260,6 +348,7 @@ def create_package(
             cwd=setup_parsed.folder,
             check=True,
             should_stream_to_console=should_log_build_output,
+            env=build_env,
         )
     else:
         if enable_wheel:

--- a/eng/tools/azure-sdk-tools/ci_tools/logging/__init__.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/logging/__init__.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 
 from logging import Logger
+from typing import Mapping, Optional
 
 from ci_tools.variables import get_log_directory, in_ci
 
@@ -79,7 +80,13 @@ def run_logged_to_file(*args, prefix="", **kwargs):
         subprocess.run(*args, **kwargs, stdout=log_output, stderr=log_output)
 
 
-def run_logged(cmd: list[str], cwd: str, check: bool, should_stream_to_console: bool):
+def run_logged(
+    cmd: list[str],
+    cwd: str,
+    check: bool,
+    should_stream_to_console: bool,
+    env: Optional[Mapping[str, str]] = None,
+):
     """
     Runs a command, logging output to subprocess.PIPE or streaming live to console based on log level.
 
@@ -88,11 +95,17 @@ def run_logged(cmd: list[str], cwd: str, check: bool, should_stream_to_console: 
     try:
         if should_stream_to_console:
             # Stream live, no capturing
-            return subprocess.run(cmd, cwd=cwd, check=check, text=True, stderr=subprocess.STDOUT)
+            return subprocess.run(cmd, cwd=cwd, check=check, text=True, stderr=subprocess.STDOUT, env=env)
         else:
             # Capture merged output but don't print unless there's a failure
             return subprocess.run(
-                cmd, cwd=cwd, check=check, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                cmd,
+                cwd=cwd,
+                check=check,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
             )
     except subprocess.CalledProcessError as e:
         logger.error(f"Command failed: {' '.join(cmd)}")

--- a/eng/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -15,7 +15,7 @@ from ci_tools.functions import (
     pip_uninstall,
     get_pip_command,
 )
-from ci_tools.build import cleanup_build_artifacts, create_package
+from ci_tools.build import build_whl_locally, cleanup_build_artifacts, create_package
 from ci_tools.parsing import ParsedSetup, parse_require
 from ci_tools.functions import get_package_from_repo_or_folder, find_whl, get_pip_list_output, pytest
 from .managed_virtual_env import ManagedVirtualEnv
@@ -350,7 +350,7 @@ def build_whl_for_req(req: str, package_path: str, wheel_dir: Optional[str]) -> 
                     os.mkdir(temp_dir)
 
             logging.info("Building wheel for package {}".format(parsed.name))
-            create_package(req_pkg_path, temp_dir, enable_sdist=False)
+            build_whl_locally(req_pkg_path, temp_dir)
 
             whl_path = os.path.join(temp_dir, find_whl(temp_dir, parsed.name, parsed.version))
 

--- a/eng/tools/azure-sdk-tools/tests/test_local_build_env.py
+++ b/eng/tools/azure-sdk-tools/tests/test_local_build_env.py
@@ -1,0 +1,252 @@
+import os
+import sys
+import textwrap
+import types
+from unittest.mock import patch
+
+from ci_tools.build import _local_build_env, build_whl_locally, create_package
+from ci_tools.logging import run_logged
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _local_build_env
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_pkg(tmp_path, pyproject_body=None):
+    """Create a minimal package directory with an optional pyproject.toml."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    if pyproject_body is not None:
+        (pkg / "pyproject.toml").write_text(pyproject_body, encoding="utf-8")
+    return pkg
+
+
+def test_local_build_env_missing_pyproject_returns_none(tmp_path):
+    pkg = _make_pkg(tmp_path)  # no pyproject.toml
+    assert _local_build_env(str(pkg)) is None
+
+
+def test_local_build_env_pyproject_without_cibuildwheel_returns_none(tmp_path):
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [build-system]
+            requires = ["setuptools"]
+            """
+        ),
+    )
+    assert _local_build_env(str(pkg)) is None
+
+
+def test_local_build_env_shell_style_environment(tmp_path):
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel]
+            environment = "CFLAGS='-Wno-implicit-function-declaration' FOO=bar"
+            """
+        ),
+    )
+    env = _local_build_env(str(pkg))
+    assert env is not None
+    # CFLAGS gets the value from the shlex-split, single-quotes stripped.
+    assert env["CFLAGS"] == "-Wno-implicit-function-declaration"
+    assert env["FOO"] == "bar"
+    # Inherits the rest of os.environ.
+    for key in os.environ:
+        if key not in {"CFLAGS", "FOO"}:
+            assert env.get(key) == os.environ[key]
+
+
+def test_local_build_env_table_style_environment(tmp_path):
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel.environment]
+            CFLAGS = "-Wno-implicit-function-declaration"
+            MY_FLAG = "value"
+            """
+        ),
+    )
+    env = _local_build_env(str(pkg))
+    assert env is not None
+    assert env["CFLAGS"] == "-Wno-implicit-function-declaration"
+    assert env["MY_FLAG"] == "value"
+
+
+def test_local_build_env_does_not_mutate_os_environ(tmp_path):
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel]
+            environment = "CFLAGS='-Wno-implicit-function-declaration'"
+            """
+        ),
+    )
+    sentinel = "__local_build_env_sentinel__"
+    assert sentinel not in os.environ
+    _local_build_env(str(pkg))
+    assert sentinel not in os.environ
+    # CFLAGS should not have been injected into the live env either.
+    assert "CFLAGS" not in os.environ or os.environ.get("CFLAGS") != "-Wno-implicit-function-declaration"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_whl_locally
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _fake_parsed(folder, ext_modules=True, is_pyproject=False, requires=None):
+    """Return a minimal object that quacks like ParsedSetup for create_package's needs."""
+    return types.SimpleNamespace(
+        folder=str(folder),
+        is_pyproject=is_pyproject,
+        ext_modules=ext_modules,
+        requires=requires or [],
+    )
+
+
+def test_build_whl_locally_does_not_invoke_cibuildwheel(tmp_path):
+    """build_whl_locally must never call cibuildwheel - it's the dev_req bypass."""
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel]
+            environment = "CFLAGS='-Wno-implicit-function-declaration'"
+            """
+        ),
+    )
+    parsed = _fake_parsed(pkg, ext_modules=True, requires=[])
+
+    with patch("ci_tools.build.ParsedSetup") as mock_parse, patch("ci_tools.build.run_logged") as mock_run, patch(
+        "ci_tools.build.get_pip_list_output", return_value={}
+    ):
+        mock_parse.from_path.return_value = parsed
+        build_whl_locally(str(pkg), str(tmp_path / "dist"))
+
+    cmds = [call.args[0] for call in mock_run.call_args_list]
+    assert not any(
+        "cibuildwheel" in part for cmd in cmds for part in cmd
+    ), f"cibuildwheel must not run in build_whl_locally, got: {cmds}"
+
+
+def test_build_whl_locally_ext_modules_applies_local_build_env(tmp_path):
+    """ext_modules packages get [tool.cibuildwheel].environment applied to the `python -m build` subprocess."""
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel]
+            environment = "CFLAGS='-Wno-implicit-function-declaration'"
+            """
+        ),
+    )
+    parsed = _fake_parsed(pkg, ext_modules=True, requires=[])
+
+    with patch("ci_tools.build.ParsedSetup") as mock_parse, patch("ci_tools.build.run_logged") as mock_run, patch(
+        "ci_tools.build.get_pip_list_output", return_value={}
+    ):
+        mock_parse.from_path.return_value = parsed
+        build_whl_locally(str(pkg), str(tmp_path / "dist"))
+
+    build_calls = [call for call in mock_run.call_args_list if "build" in call.args[0] and "-m" in call.args[0]]
+    assert build_calls, "Expected `python -m build` invocation"
+    # cwd is a required positional kwarg of run_logged - guard against regressions.
+    assert build_calls[0].kwargs.get("cwd") == str(pkg), f"Expected cwd={pkg}, got {build_calls[0].kwargs}"
+    build_env = build_calls[0].kwargs.get("env")
+    assert build_env is not None, "Expected env=<merged dict> on the `python -m build` call"
+    assert build_env["CFLAGS"] == "-Wno-implicit-function-declaration"
+
+
+def test_build_whl_locally_pure_python_keeps_default_env(tmp_path):
+    """Pure-python dev_reqs must keep env=None so we don't perturb the subprocess env."""
+    pkg = _make_pkg(tmp_path)
+    parsed = _fake_parsed(pkg, ext_modules=False, requires=[])
+
+    with patch("ci_tools.build.ParsedSetup") as mock_parse, patch("ci_tools.build.run_logged") as mock_run, patch(
+        "ci_tools.build.get_pip_list_output", return_value={}
+    ):
+        mock_parse.from_path.return_value = parsed
+        build_whl_locally(str(pkg), str(tmp_path / "dist"))
+
+    build_calls = [call for call in mock_run.call_args_list if "build" in call.args[0] and "-m" in call.args[0]]
+    assert build_calls, "Expected `python -m build` invocation"
+    assert build_calls[0].kwargs.get("env") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# create_package pyproject branch (publish path - for future ext_modules pyproject packages)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_create_package_pyproject_ext_modules_applies_local_build_env(tmp_path):
+    """Fully-pyproject packages with ext_modules must also get [tool.cibuildwheel].environment applied
+    to the `python -m build` subprocess so macOS Apple Clang doesn't fail on implicit declarations."""
+    pkg = _make_pkg(
+        tmp_path,
+        textwrap.dedent(
+            """
+            [tool.cibuildwheel]
+            environment = "CFLAGS='-Wno-implicit-function-declaration'"
+            """
+        ),
+    )
+    parsed = _fake_parsed(pkg, ext_modules=True, is_pyproject=True, requires=[])
+
+    with patch("ci_tools.build.ParsedSetup") as mock_parse, patch("ci_tools.build.run_logged") as mock_run, patch(
+        "ci_tools.build.get_artifact_directory", side_effect=lambda x: str(x)
+    ), patch("ci_tools.build.get_pip_list_output", return_value={}):
+        mock_parse.from_path.return_value = parsed
+        create_package(str(pkg), str(tmp_path / "dist"))
+
+    build_calls = [call for call in mock_run.call_args_list if "build" in call.args[0] and "-m" in call.args[0]]
+    assert build_calls, "Expected `python -m build` invocation"
+    build_env = build_calls[0].kwargs.get("env")
+    assert build_env is not None, "Expected env=<merged dict> on the `python -m build` call"
+    assert build_env["CFLAGS"] == "-Wno-implicit-function-declaration"
+
+
+def test_create_package_pyproject_pure_python_keeps_default_env(tmp_path):
+    """Pure-python pyproject packages must keep env=None to not perturb existing behavior."""
+    pkg = _make_pkg(tmp_path)
+    parsed = _fake_parsed(pkg, ext_modules=False, is_pyproject=True, requires=[])
+
+    with patch("ci_tools.build.ParsedSetup") as mock_parse, patch("ci_tools.build.run_logged") as mock_run, patch(
+        "ci_tools.build.get_artifact_directory", side_effect=lambda x: str(x)
+    ), patch("ci_tools.build.get_pip_list_output", return_value={}):
+        mock_parse.from_path.return_value = parsed
+        create_package(str(pkg), str(tmp_path / "dist"))
+
+    build_calls = [call for call in mock_run.call_args_list if "build" in call.args[0] and "-m" in call.args[0]]
+    assert build_calls, "Expected `python -m build` invocation"
+    assert build_calls[0].kwargs.get("env") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_logged(env=...) forwarding
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_run_logged_default_env_is_none():
+    with patch("ci_tools.logging.subprocess.run") as mock_run:
+        run_logged([sys.executable, "-c", "pass"], cwd=os.getcwd(), check=False, should_stream_to_console=False)
+        assert mock_run.call_args.kwargs.get("env") is None
+
+
+def test_run_logged_forwards_env():
+    custom = {"CFLAGS": "-Wno-implicit-function-declaration", "PATH": os.environ.get("PATH", "")}
+    with patch("ci_tools.logging.subprocess.run") as mock_run:
+        run_logged(
+            [sys.executable, "-c", "pass"],
+            cwd=os.getcwd(),
+            check=False,
+            should_stream_to_console=True,
+            env=custom,
+        )
+        assert mock_run.call_args.kwargs.get("env") is custom


### PR DESCRIPTION
## Problem

`azure-storage-extensions` was added as a relative dev_requirement of storage data-plane packages (#47001). It''s the only package in the repo with C `ext_modules` and `[tool.cibuildwheel]` config. When CI tests resolve that dev_req, `build_whl_for_req` invokes `cibuildwheel`, which needs network (manylinux pull on Linux, nuget on Windows, python.org on macOS). Test agents are network-isolated -> every storage data-plane job is red on all three legs.

## Fix

New `build_whl_locally(pkg_path, dist_dir)` runs `python -m build -n -w` (handles setup.py + pyproject). For ext_modules packages it applies `[tool.cibuildwheel].environment` to the subprocess so platform compiler flags (e.g. `CFLAGS=''-Wno-implicit-function-declaration''` required by Apple Clang 15+) reach the compiler. `build_whl_for_req` calls it directly. `create_package`''s pyproject branch gets the same env passthrough for future ext_modules pyproject packages. `run_logged` gains an optional `env=` kwarg.

## Why safe

- `create_package` setup.py + ext_modules path unchanged from main - publish flow untouched.
- New env-merging only fires for `ext_modules` packages; pure-Python dev_reqs get `env=None`.
- `azure-storage-extensions` is the only such package today.

## Verification

12 new tests. Local build of `azure-storage-extensions` produces the expected `cp313-abi3-win_amd64.whl`. CI run validates macOS clang.

## Open question

Extend the bypass to `build_and_discover_package` so cibuildwheel never runs in tests? Here or follow-up.