### PR TITLE
Cosmos: change query response headers to only return latest page

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added **preview** support for the optional `embeddingSource` field on entries in `vector_embedding_policy.vectorEmbeddings`, which allows the service to generate vector embeddings from the specified item paths. Requires the embedding-generation service to be enabled on the account. See [46870](https://github.com/Azure/azure-sdk-for-python/pull/46870)
 
 #### Breaking Changes
+* Removed `get_last_response_headers()` from `CosmosItemPaged` and `CosmosAsyncItemPaged` changes introduced in 4.16.0b1. `get_response_headers()` now returns only the most recent page's headers instead of a list of all pages' headers, to avoid unbounded memory growth on large queries. See [PR ](https://github.com/Azure/azure-sdk-for-python/pull/)
 
 #### Bugs Fixed
 * Fixed bug where the `Content-Length` HTTP request header was computed from the character count of the request body instead of its UTF-8 byte count. See [PR 47008](https://github.com/Azure/azure-sdk-for-python/pull/47008)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added **preview** support for the optional `embeddingSource` field on entries in `vector_embedding_policy.vectorEmbeddings`, which allows the service to generate vector embeddings from the specified item paths. Requires the embedding-generation service to be enabled on the account. See [46870](https://github.com/Azure/azure-sdk-for-python/pull/46870)
 
 #### Breaking Changes
-* Removed `get_last_response_headers()` from `CosmosItemPaged` and `CosmosAsyncItemPaged` changes introduced in 4.16.0b1. `get_response_headers()` now returns only the most recent page's headers instead of a list of all pages' headers, to avoid unbounded memory growth on large queries. See [PR 47172](https://github.com/Azure/azure-sdk-for-python/pull/47172)
+* `CosmosItemPaged.get_response_headers()` and `CosmosAsyncItemPaged.get_response_headers()` now return a single `CaseInsensitiveDict` (the latest page) instead of `List[CaseInsensitiveDict]` (introduced in 4.16.0b1); `get_last_response_headers()` has been removed. This avoids unbounded memory growth on large queries. **Migration:** code that previously accessed `headers[i]['x-ms-request-charge']` should switch to `headers['x-ms-request-charge']` for the latest page, or pass `response_hook=` to the query method to receive per-page headers as they arrive. See [PR 47172](https://github.com/Azure/azure-sdk-for-python/pull/47172).
 
 #### Bugs Fixed
 * Fixed bug where the `Content-Length` HTTP request header was computed from the character count of the request body instead of its UTF-8 byte count. See [PR 47008](https://github.com/Azure/azure-sdk-for-python/pull/47008)

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added **preview** support for the optional `embeddingSource` field on entries in `vector_embedding_policy.vectorEmbeddings`, which allows the service to generate vector embeddings from the specified item paths. Requires the embedding-generation service to be enabled on the account. See [46870](https://github.com/Azure/azure-sdk-for-python/pull/46870)
 
 #### Breaking Changes
-* Removed `get_last_response_headers()` from `CosmosItemPaged` and `CosmosAsyncItemPaged` changes introduced in 4.16.0b1. `get_response_headers()` now returns only the most recent page's headers instead of a list of all pages' headers, to avoid unbounded memory growth on large queries. See [PR ](https://github.com/Azure/azure-sdk-for-python/pull/)
+* Removed `get_last_response_headers()` from `CosmosItemPaged` and `CosmosAsyncItemPaged` changes introduced in 4.16.0b1. `get_response_headers()` now returns only the most recent page's headers instead of a list of all pages' headers, to avoid unbounded memory growth on large queries. See [PR 47172](https://github.com/Azure/azure-sdk-for-python/pull/47172)
 
 #### Bugs Fixed
 * Fixed bug where the `Content-Length` HTTP request header was computed from the character count of the request body instead of its UTF-8 byte count. See [PR 47008](https://github.com/Azure/azure-sdk-for-python/pull/47008)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -1191,7 +1191,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         path = base.GetPathFromLink(database_or_container_link, http_constants.ResourceType.Document)
         collection_id = base.GetResourceIdOrFullNameFromLink(database_or_container_link)
 
-        # Shared dict for thread-safe header capture — overwritten each page fetch
+        # Shared dict for header capture — overwritten each page fetch
         response_headers: CaseInsensitiveDict = CaseInsensitiveDict()
 
         def fetch_fn(options: Mapping[str, Any]) -> Tuple[list[dict[str, Any]], CaseInsensitiveDict]:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -1191,8 +1191,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         path = base.GetPathFromLink(database_or_container_link, http_constants.ResourceType.Document)
         collection_id = base.GetResourceIdOrFullNameFromLink(database_or_container_link)
 
-        # Create shared list for thread-safe header capture
-        response_headers_list: list[CaseInsensitiveDict] = []
+        # Shared dict for thread-safe header capture — overwritten each page fetch
+        response_headers: CaseInsensitiveDict = CaseInsensitiveDict()
 
         def fetch_fn(options: Mapping[str, Any]) -> Tuple[list[dict[str, Any]], CaseInsensitiveDict]:
             return self.__QueryFeed(
@@ -1204,7 +1204,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                     query,
                     options,
                     response_hook=response_hook,
-                    response_headers_list=response_headers_list,
+                    response_headers=response_headers,
                     **kwargs)
 
         return CosmosItemPaged(
@@ -1217,7 +1217,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             response_hook=response_hook,
             raw_response_hook=kwargs.get('raw_response_hook'),
             resource_type=http_constants.ResourceType.Document,
-            response_headers_list=response_headers_list
+            response_headers=response_headers
         )
 
     def QueryItemsChangeFeed(
@@ -3200,7 +3200,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         partition_key_range_id: Optional[str] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], dict[str, Any]], None]] = None,
         is_query_plan: bool = False,
-        response_headers_list: Optional[list[CaseInsensitiveDict]] = None,
+        response_headers: Optional[CaseInsensitiveDict] = None,
         **kwargs: Any
     ) -> Tuple[list[dict[str, Any]], CaseInsensitiveDict]:
         """Query for more than one Azure Cosmos resources.
@@ -3219,8 +3219,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         :type response_hook: Callable[[Mapping[str, Any], dict[str, Any]], None]
         :param bool is_query_plan:
             Specifies if the call is to fetch query plan
-        :param response_headers_list: Optional list to capture response headers from each page fetch.
-        :type response_headers_list: Optional[list[CaseInsensitiveDict]]
+        :param response_headers: Optional dict to capture response headers from the most recent page fetch.
+        :type response_headers: Optional[CaseInsensitiveDict]
         :returns: A list of the queried resources.
         :rtype: list
         :raises SystemError: If the query compatibility mode is undefined.
@@ -3295,8 +3295,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             if internal_headers_capture is not None:
                 internal_headers_capture.clear()
                 internal_headers_capture.update(last_response_headers)
-            if response_headers_list is not None:
-                response_headers_list.append(last_response_headers.copy())
+            if response_headers is not None:
+                response_headers.clear()
+                response_headers.update(last_response_headers)
             if response_hook:
                 response_hook(last_response_headers, result)
             return __GetBodiesFromQueryResult(result), last_response_headers
@@ -3402,8 +3403,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                         results["Documents"].extend(partial_result["Documents"])
                     else:
                         results = partial_result
-                if response_headers_list is not None:
-                    response_headers_list.append(last_response_headers.copy())
+                if response_headers is not None:
+                    response_headers.clear()
+                    response_headers.update(last_response_headers)
                 if response_hook:
                     response_hook(last_response_headers, partial_result)
             # if the prefix partition query has results lets return it
@@ -3431,8 +3433,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         if last_response_headers.get(http_constants.HttpHeaders.QueryAdvice) is not None:
             query_advice_raw = last_response_headers[http_constants.HttpHeaders.QueryAdvice]
             last_response_headers[http_constants.HttpHeaders.QueryAdvice] = get_query_advice_info(query_advice_raw)
-        if response_headers_list is not None:
-            response_headers_list.append(last_response_headers.copy())
+        if response_headers is not None:
+            response_headers.clear()
+            response_headers.update(last_response_headers)
         if response_hook:
             response_hook(last_response_headers, result)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
@@ -11,7 +11,7 @@ from azure.core.utils import CaseInsensitiveDict
 class CosmosItemPaged(ItemPaged[dict[str, Any]]):
     """A custom ItemPaged class that provides access to response headers from query operations.
 
-    This class wraps the standard ItemPaged and provides thread-safe access to the most recent
+    This class wraps the standard ItemPaged and provides access to the most recent
     response headers captured during pagination via a shared dict populated by __QueryFeed.
     """
 
@@ -31,7 +31,7 @@ class CosmosItemPaged(ItemPaged[dict[str, Any]]):
 class CosmosAsyncItemPaged(AsyncItemPaged[dict[str, Any]]):
     """A custom AsyncItemPaged class that provides access to response headers from async query operations.
 
-    This class wraps the standard AsyncItemPaged and provides thread-safe access to the most recent
+    This class wraps the standard AsyncItemPaged and provides access to the most recent
     response headers captured during pagination via a shared dict populated by __QueryFeed.
     """
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
@@ -16,7 +16,8 @@ class CosmosItemPaged(ItemPaged[dict[str, Any]]):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._response_headers: CaseInsensitiveDict = kwargs.pop('response_headers', CaseInsensitiveDict())
+        popped = kwargs.pop('response_headers', None)
+        self._response_headers: CaseInsensitiveDict = popped if popped is not None else CaseInsensitiveDict()
         super().__init__(*args, **kwargs)
 
     def get_response_headers(self) -> CaseInsensitiveDict:
@@ -36,7 +37,8 @@ class CosmosAsyncItemPaged(AsyncItemPaged[dict[str, Any]]):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._response_headers: CaseInsensitiveDict = kwargs.pop('response_headers', CaseInsensitiveDict())
+        popped = kwargs.pop('response_headers', None)
+        self._response_headers: CaseInsensitiveDict = popped if popped is not None else CaseInsensitiveDict()
         super().__init__(*args, **kwargs)
 
     def get_response_headers(self) -> CaseInsensitiveDict:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_responses.py
@@ -1,7 +1,7 @@
 # The MIT License (MIT)
 # Copyright (c) 2024 Microsoft Corporation
 
-from typing import Any, AsyncIterator, Iterator, Iterable, List, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.paging import ItemPaged
@@ -11,95 +11,41 @@ from azure.core.utils import CaseInsensitiveDict
 class CosmosItemPaged(ItemPaged[dict[str, Any]]):
     """A custom ItemPaged class that provides access to response headers from query operations.
 
-    This class wraps the standard ItemPaged and provides thread-safe access to response
-    headers captured during pagination via a shared list populated by __QueryFeed.
+    This class wraps the standard ItemPaged and provides thread-safe access to the most recent
+    response headers captured during pagination via a shared dict populated by __QueryFeed.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._response_headers_list: Optional[List[CaseInsensitiveDict]] = kwargs.pop('response_headers_list', None)
+        self._response_headers: CaseInsensitiveDict = kwargs.pop('response_headers', CaseInsensitiveDict())
         super().__init__(*args, **kwargs)
-        self._query_iterable: Optional[Any] = None
 
-    def by_page(self, continuation_token: Optional[str] = None) -> Iterator[Iterator[dict[str, Any]]]:
-        """Get an iterator of pages of objects.
-
-        :param str continuation_token: An opaque continuation token.
-        :returns: An iterator of pages (themselves iterator of objects)
-        :rtype: iterator[iterator[dict[str, Any]]]
-        """
-        # Call the parent's by_page to get the QueryIterable and store reference for header access
-        self._query_iterable = super().by_page(continuation_token)
-        return self._query_iterable
-
-    def get_response_headers(self) -> List[CaseInsensitiveDict]:
-        """Returns a list of response headers captured from each page of results.
-
-        Each element in the list corresponds to the headers from one page fetch.
-        Headers are captured as pages are fetched during iteration.
-
-        :return: List of response headers from each page
-        :rtype: List[~azure.core.utils.CaseInsensitiveDict]
-        """
-        if self._response_headers_list is not None:
-            return [h.copy() for h in self._response_headers_list]
-        return []
-
-    def get_last_response_headers(self) -> CaseInsensitiveDict:
-        """Returns the response headers from the most recent page fetch.
+    def get_response_headers(self) -> CaseInsensitiveDict:
+        """Returns a copy of the response headers from the most recent page fetch.
 
         :return: Response headers from the last page, or empty dict if no pages have been fetched
         :rtype: ~azure.core.utils.CaseInsensitiveDict
         """
-        if self._response_headers_list and len(self._response_headers_list) > 0:
-            return self._response_headers_list[-1].copy()
-        return CaseInsensitiveDict()
+        return self._response_headers.copy()
 
 
 class CosmosAsyncItemPaged(AsyncItemPaged[dict[str, Any]]):
     """A custom AsyncItemPaged class that provides access to response headers from async query operations.
 
-    This class wraps the standard AsyncItemPaged and provides thread-safe access to response
-    headers captured during pagination via a shared list populated by __QueryFeed.
+    This class wraps the standard AsyncItemPaged and provides thread-safe access to the most recent
+    response headers captured during pagination via a shared dict populated by __QueryFeed.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._response_headers_list: Optional[List[CaseInsensitiveDict]] = kwargs.pop('response_headers_list', None)
+        self._response_headers: CaseInsensitiveDict = kwargs.pop('response_headers', CaseInsensitiveDict())
         super().__init__(*args, **kwargs)
-        self._query_iterable: Optional[Any] = None
 
-    def by_page(self, continuation_token: Optional[str] = None) -> AsyncIterator[AsyncIterator[dict[str, Any]]]:
-        """Get an async iterator of pages of objects.
-
-        :param str continuation_token: An opaque continuation token.
-        :returns: An async iterator of pages (themselves async iterator of objects)
-        :rtype: AsyncIterator[AsyncIterator[dict[str, Any]]]
-        """
-        # Call the parent's by_page to get the QueryIterable and store reference for header access
-        self._query_iterable = super().by_page(continuation_token)
-        return self._query_iterable
-
-    def get_response_headers(self) -> List[CaseInsensitiveDict]:
-        """Returns a list of response headers captured from each page of results.
-
-        Each element in the list corresponds to the headers from one page fetch.
-        Headers are captured as pages are fetched during iteration.
-
-        :return: List of response headers from each page
-        :rtype: List[~azure.core.utils.CaseInsensitiveDict]
-        """
-        if self._response_headers_list is not None:
-            return [h.copy() for h in self._response_headers_list]
-        return []
-
-    def get_last_response_headers(self) -> CaseInsensitiveDict:
-        """Returns the response headers from the most recent page fetch.
+    def get_response_headers(self) -> CaseInsensitiveDict:
+        """Returns a copy of the response headers from the most recent page fetch.
 
         :return: Response headers from the last page, or empty dict if no pages have been fetched
         :rtype: ~azure.core.utils.CaseInsensitiveDict
         """
-        if self._response_headers_list and len(self._response_headers_list) > 0:
-            return self._response_headers_list[-1].copy()
-        return CaseInsensitiveDict()
+        return self._response_headers.copy()
 
 
 class CosmosDict(dict[str, Any]):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2400,8 +2400,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         path = base.GetPathFromLink(database_or_container_link, http_constants.ResourceType.Document)
         collection_id = base.GetResourceIdOrFullNameFromLink(database_or_container_link)
 
-        # Create shared list for thread-safe header capture
-        response_headers_list: list[CaseInsensitiveDict] = []
+        # Shared dict for thread-safe header capture — overwritten each page fetch
+        response_headers: CaseInsensitiveDict = CaseInsensitiveDict()
 
         async def fetch_fn(options: Mapping[str, Any]) -> Tuple[list[dict[str, Any]], CaseInsensitiveDict]:
             await kwargs["containerProperties"](options)
@@ -2417,7 +2417,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                     query,
                     new_options,
                     response_hook=response_hook,
-                    response_headers_list=response_headers_list,
+                    response_headers=response_headers,
                     **kwargs
                 ),
                 self.last_response_headers,
@@ -2433,7 +2433,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             response_hook=response_hook,
             raw_response_hook=kwargs.get('raw_response_hook'),
             resource_type=http_constants.ResourceType.Document,
-            response_headers_list=response_headers_list
+            response_headers=response_headers
         )
 
     def QueryItemsChangeFeed(
@@ -2993,7 +2993,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         partition_key_range_id: Optional[str] = None,
         response_hook: Optional[Callable[[Mapping[str, Any], dict[str, Any]], None]] = None,
         is_query_plan: bool = False,
-        response_headers_list: Optional[list[CaseInsensitiveDict]] = None,
+        response_headers: Optional[CaseInsensitiveDict] = None,
         **kwargs: Any
     ) -> list[dict[str, Any]]:
         """Query for more than one Azure Cosmos resources.
@@ -3012,8 +3012,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         :type response_hook: Callable[[Mapping[str, Any], dict[str, Any]], None]
         :param bool is_query_plan:
             Specifies if the call is to fetch query plan
-        :param response_headers_list: Optional list to capture response headers from each page fetch.
-        :type response_headers_list: Optional[list[CaseInsensitiveDict]]
+        :param response_headers: Optional dict to capture response headers from the most recent page fetch.
+        :type response_headers: Optional[CaseInsensitiveDict]
         :returns: A list of the queried resources.
         :rtype: list
         :raises SystemError: If the query compatibility mode is undefined.
@@ -3089,8 +3089,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                 internal_headers_capture.clear()
                 internal_headers_capture.update(last_response_headers)
             self._UpdateSessionIfRequired(headers, result, last_response_headers)
-            if response_headers_list is not None:
-                response_headers_list.append(last_response_headers.copy())
+            if response_headers is not None:
+                response_headers.clear()
+                response_headers.update(last_response_headers)
             if response_hook:
                 response_hook(self.last_response_headers, result)
             return __GetBodiesFromQueryResult(result)
@@ -3196,8 +3197,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                     else:
                         results = partial_result
 
-                if response_headers_list is not None:
-                    response_headers_list.append(last_response_headers.copy())
+                if response_headers is not None:
+                    response_headers.clear()
+                    response_headers.update(last_response_headers)
                 if response_hook:
                     response_hook(self.last_response_headers, partial_result)
             # if the prefix partition query has results lets return it
@@ -3227,8 +3229,9 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         if self.last_response_headers.get(http_constants.HttpHeaders.QueryAdvice) is not None:
             query_advice_raw = self.last_response_headers[http_constants.HttpHeaders.QueryAdvice]
             self.last_response_headers[http_constants.HttpHeaders.QueryAdvice] = get_query_advice_info(query_advice_raw)
-        if response_headers_list is not None:
-            response_headers_list.append(last_response_headers.copy())
+        if response_headers is not None:
+            response_headers.clear()
+            response_headers.update(last_response_headers)
         if response_hook:
             response_hook(self.last_response_headers, result)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2400,7 +2400,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         path = base.GetPathFromLink(database_or_container_link, http_constants.ResourceType.Document)
         collection_id = base.GetResourceIdOrFullNameFromLink(database_or_container_link)
 
-        # Shared dict for thread-safe header capture — overwritten each page fetch
+        # Shared dict for header capture — overwritten each page fetch
         response_headers: CaseInsensitiveDict = CaseInsensitiveDict()
 
         async def fetch_fn(options: Mapping[str, Any]) -> Tuple[list[dict[str, Any]], CaseInsensitiveDict]:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
@@ -30,7 +30,7 @@ from azure.cosmos import CosmosDict
 
 from ._cosmos_client_connection import CosmosClientConnection
 from ._base import build_options
-from ._constants import _Constants as Constants
+from ._constants import _Constants
 from .partition_key import NonePartitionKeyValue, _return_undefined_or_empty_partition_key, PartitionKeyType
 
 # pylint: disable=protected-access
@@ -65,11 +65,11 @@ class ScriptsProxy:
         return script_or_id["_self"]
 
     def _ensure_container_rid(self, options: dict[str, Any]) -> None:
-        if Constants.ContainerRID in options:
+        if _Constants.ContainerRID in options:
             return
         if self.container_link not in self.client_connection._container_properties_cache:
             self.client_connection._refresh_container_properties_cache(self.container_link)
-        options[Constants.ContainerRID] = self.client_connection._container_properties_cache[
+        options[_Constants.ContainerRID] = self.client_connection._container_properties_cache[
             self.container_link
         ]["_rid"]
 

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
@@ -76,23 +76,17 @@ class TestQueryResponseHeaders(unittest.TestCase):
             # Verify response headers were captured
             response_headers = query_iterable.get_response_headers()
             self.assertIsNotNone(response_headers)
-            self.assertGreater(len(response_headers), 0)
+            self.assertIsInstance(response_headers, dict)
 
             # Verify headers contain expected fields
-            first_page_headers = response_headers[0]
-            self.assertIn("x-ms-request-charge", first_page_headers)
-            self.assertIn("x-ms-activity-id", first_page_headers)
-
-            # Verify get_last_response_headers works
-            last_headers = query_iterable.get_last_response_headers()
-            self.assertIsNotNone(last_headers)
-            self.assertIn("x-ms-request-charge", last_headers)
+            self.assertIn("x-ms-request-charge", response_headers)
+            self.assertIn("x-ms-activity-id", response_headers)
 
         finally:
             self._delete_container_for_test(container_id)
 
     def test_query_response_headers_multiple_pages(self):
-        """Test that response headers are captured for each page in a paginated query."""
+        """Test that response headers reflect the last page in a paginated query."""
         container_id = "test_headers_multi_" + str(uuid.uuid4())
         created_collection = self._create_container_for_test(container_id, PartitionKey(path="/pk"))
         try:
@@ -118,21 +112,11 @@ class TestQueryResponseHeaders(unittest.TestCase):
             # Verify all items were returned
             self.assertEqual(len(items), num_items)
 
-            # Verify response headers were captured for multiple pages
+            # Verify response headers contain the last page's headers
             response_headers = query_iterable.get_response_headers()
             self.assertIsNotNone(response_headers)
-            # With 15 items and max_item_count=5, we expect at least 3 pages
-            self.assertGreaterEqual(len(response_headers), 3)
-
-            # Verify each page has headers
-            for i, headers in enumerate(response_headers):
-                self.assertIn("x-ms-request-charge", headers, f"Page {i} missing request charge header")
-                self.assertIn("x-ms-activity-id", headers, f"Page {i} missing activity id header")
-
-            # Each page should have a different activity ID
-            activity_ids = [h.get("x-ms-activity-id") for h in response_headers]
-            # Note: Activity IDs might be the same for some edge cases, but generally should differ
-            self.assertEqual(len(activity_ids), len(response_headers))
+            self.assertIn("x-ms-request-charge", response_headers)
+            self.assertIn("x-ms-activity-id", response_headers)
 
         finally:
             self._delete_container_for_test(container_id)
@@ -160,15 +144,9 @@ class TestQueryResponseHeaders(unittest.TestCase):
             # Verify no items were returned
             self.assertEqual(len(items), 0)
 
-            # Response headers may or may not be captured depending on implementation
             # The key is that the method doesn't throw an error
             response_headers = query_iterable.get_response_headers()
             self.assertIsNotNone(response_headers)
-
-            # get_last_response_headers should return None or headers depending on if a request was made
-            last_headers = query_iterable.get_last_response_headers()
-            # This can be None if no request was made, or headers if at least one request was made
-            # Both are valid behaviors
 
         finally:
             self._delete_container_for_test(container_id)
@@ -199,15 +177,14 @@ class TestQueryResponseHeaders(unittest.TestCase):
 
             # Verify response headers contain query metrics
             response_headers = query_iterable.get_response_headers()
-            self.assertGreater(len(response_headers), 0)
+            self.assertIsNotNone(response_headers)
 
             # Check for query metrics header
             metrics_header_name = "x-ms-documentdb-query-metrics"
-            first_page_headers = response_headers[0]
-            self.assertIn(metrics_header_name, first_page_headers)
+            self.assertIn(metrics_header_name, response_headers)
 
             # Validate metrics header is well-formed
-            metrics_header = first_page_headers[metrics_header_name]
+            metrics_header = response_headers[metrics_header_name]
             metrics = metrics_header.split(";")
             self.assertGreater(len(metrics), 1)
             self.assertTrue(all("=" in x for x in metrics))
@@ -216,12 +193,12 @@ class TestQueryResponseHeaders(unittest.TestCase):
             self._delete_container_for_test(container_id)
 
     def test_query_response_headers_by_page_iteration(self):
-        """Test response headers when using by_page() iteration."""
+        """Test response headers update per page, verified via x-ms-item-count."""
         container_id = "test_headers_by_page_" + str(uuid.uuid4())
         created_collection = self._create_container_for_test(container_id, PartitionKey(path="/pk"))
         try:
-            # Create items
-            num_items = 10
+            # 7 items with max_item_count=3 gives pages of 3, 3, 1
+            num_items = 7
             for i in range(num_items):
                 created_collection.create_item(body={"pk": "test", "id": f"item_{i}", "value": i})
 
@@ -230,28 +207,29 @@ class TestQueryResponseHeaders(unittest.TestCase):
                 query=query,
                 parameters=[{"name": "@pk", "value": "test"}],
                 partition_key="test",
-                max_item_count=3  # Force multiple pages
+                max_item_count=3
             )
 
-            # Iterate by page
+            # Iterate by page, tracking item counts from headers
             all_items = []
-            page_count = 0
+            item_counts = []
             for page in query_iterable.by_page():
                 page_items = list(page)
                 all_items.extend(page_items)
-                page_count += 1
 
-                # After each page, we can check the last response headers
-                last_headers = query_iterable.get_last_response_headers()
-                self.assertIsNotNone(last_headers)
-                self.assertIn("x-ms-request-charge", last_headers)
+                headers = query_iterable.get_response_headers()
+                self.assertIsNotNone(headers)
+                self.assertIn("x-ms-item-count", headers)
+                item_counts.append(int(headers["x-ms-item-count"]))
 
             # Verify all items retrieved
             self.assertEqual(len(all_items), num_items)
 
-            # Verify we got headers for each page (at least as many as page_count)
-            response_headers = query_iterable.get_response_headers()
-            self.assertGreaterEqual(len(response_headers), page_count)
+            # The last page should have fewer items than the page size,
+            # proving headers are overwritten per page
+            self.assertEqual(item_counts[-1], 1)
+            for count in item_counts[:-1]:
+                self.assertEqual(count, 3)
 
         finally:
             self._delete_container_for_test(container_id)
@@ -277,12 +255,9 @@ class TestQueryResponseHeaders(unittest.TestCase):
             headers1 = query_iterable.get_response_headers()
             headers2 = query_iterable.get_response_headers()
 
-            # They should be equal but not the same object
-            self.assertEqual(len(headers1), len(headers2))
-            if len(headers1) > 0:
-                # Modifying one should not affect the other
-                headers1[0]["test-key"] = "test-value"
-                self.assertNotIn("test-key", headers2[0])
+            # Modifying one should not affect the other
+            headers1["test-key"] = "test-value"
+            self.assertNotIn("test-key", headers2)
 
         finally:
             self._delete_container_for_test(container_id)
@@ -330,7 +305,6 @@ class TestQueryResponseHeaders(unittest.TestCase):
                         results[thread_id] = {
                             "partition_key": partition_key,
                             "item_count": len(items),
-                            "header_count": len(headers),
                             "headers": headers
                         }
                 except Exception as e:
@@ -359,25 +333,8 @@ class TestQueryResponseHeaders(unittest.TestCase):
             for thread_id, result in results.items():
                 self.assertEqual(result["item_count"], items_per_partition,
                     f"Thread {thread_id} got wrong item count")
-                self.assertGreater(result["header_count"], 0,
-                    f"Thread {thread_id} should have captured headers")
-                
-                # Verify headers contain expected keys (basic sanity check)
-                for header_dict in result["headers"]:
-                    self.assertIn("x-ms-request-charge", header_dict,
-                        f"Thread {thread_id} headers missing x-ms-request-charge")
-
-            # Verify that different threads have independent header lists
-            # (modifying one doesn't affect others)
-            if len(results) >= 2:
-                thread_ids = list(results.keys())
-                headers_0 = results[thread_ids[0]]["headers"]
-                headers_1 = results[thread_ids[1]]["headers"]
-                
-                # They should be different objects
-                self.assertIsNot(headers_0, headers_1)
-                if len(headers_0) > 0 and len(headers_1) > 0:
-                    self.assertIsNot(headers_0[0], headers_1[0])
+                self.assertIn("x-ms-request-charge", result["headers"],
+                    f"Thread {thread_id} headers missing x-ms-request-charge")
 
         finally:
             self._delete_container_for_test(container_id)
@@ -419,10 +376,7 @@ class TestQueryResponseHeaders(unittest.TestCase):
                 with lock:
                     results[thread_id] = {
                         "item_count": len(items),
-                        "header_count": len(headers),
-                        "request_charges": [
-                            float(h.get("x-ms-request-charge", 0)) for h in headers
-                        ]
+                        "request_charge": float(headers.get("x-ms-request-charge", 0))
                     }
 
             threads = []
@@ -439,12 +393,8 @@ class TestQueryResponseHeaders(unittest.TestCase):
             for thread_id, result in results.items():
                 self.assertEqual(result["item_count"], 50,
                     f"Thread {thread_id} should have gotten all 50 items")
-                self.assertGreater(result["header_count"], 0,
-                    f"Thread {thread_id} should have captured headers")
-                # Each request should have a positive request charge
-                for charge in result["request_charges"]:
-                    self.assertGreater(charge, 0,
-                        f"Thread {thread_id} should have positive request charges")
+                self.assertGreater(result["request_charge"], 0,
+                    f"Thread {thread_id} should have positive request charge")
 
         finally:
             self._delete_container_for_test(container_id)

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
@@ -145,8 +145,9 @@ class TestQueryResponseHeaders(unittest.TestCase):
             self.assertEqual(len(items), 0)
 
             # The key is that the method doesn't throw an error
+            # and the headers are populated since an HTTP request was made
             response_headers = query_iterable.get_response_headers()
-            self.assertIsNotNone(response_headers)
+            self.assertIn("x-ms-request-charge", response_headers)
 
         finally:
             self._delete_container_for_test(container_id)
@@ -226,10 +227,11 @@ class TestQueryResponseHeaders(unittest.TestCase):
             self.assertEqual(len(all_items), num_items)
 
             # The last page should have fewer items than the page size,
-            # proving headers are overwritten per page
-            self.assertEqual(item_counts[-1], 1)
-            for count in item_counts[:-1]:
-                self.assertEqual(count, 3)
+            # proving headers are overwritten per page.
+            # max_item_count is a hint, so pages may have fewer items than requested.
+            self.assertGreater(len(item_counts), 1)
+            self.assertEqual(sum(item_counts), num_items)
+            self.assertLess(item_counts[-1], item_counts[0])
 
         finally:
             self._delete_container_for_test(container_id)
@@ -254,6 +256,9 @@ class TestQueryResponseHeaders(unittest.TestCase):
             # Get headers twice
             headers1 = query_iterable.get_response_headers()
             headers2 = query_iterable.get_response_headers()
+
+            # They should be distinct objects
+            self.assertIsNot(headers1, headers2)
 
             # Modifying one should not affect the other
             headers1["test-key"] = "test-value"
@@ -335,6 +340,12 @@ class TestQueryResponseHeaders(unittest.TestCase):
                     f"Thread {thread_id} got wrong item count")
                 self.assertIn("x-ms-request-charge", result["headers"],
                     f"Thread {thread_id} headers missing x-ms-request-charge")
+
+            # Verify that different threads have independent header dicts
+            thread_ids = list(results.keys())
+            if len(thread_ids) >= 2:
+                self.assertIsNot(results[thread_ids[0]]["headers"],
+                    results[thread_ids[1]]["headers"])
 
         finally:
             self._delete_container_for_test(container_id)

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers.py
@@ -76,7 +76,6 @@ class TestQueryResponseHeaders(unittest.TestCase):
             # Verify response headers were captured
             response_headers = query_iterable.get_response_headers()
             self.assertIsNotNone(response_headers)
-            self.assertIsInstance(response_headers, dict)
 
             # Verify headers contain expected fields
             self.assertIn("x-ms-request-charge", response_headers)

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
@@ -88,7 +88,6 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             # Verify response headers were captured
             response_headers = query_iterable.get_response_headers()
             assert response_headers is not None
-            assert isinstance(response_headers, dict)
 
             # Verify headers contain expected fields
             assert "x-ms-request-charge" in response_headers

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
@@ -159,8 +159,9 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             assert len(items) == 0
 
             # The key is that the method doesn't throw an error
+            # and the headers are populated since an HTTP request was made
             response_headers = query_iterable.get_response_headers()
-            assert response_headers is not None
+            assert "x-ms-request-charge" in response_headers
 
         finally:
             await self._delete_container_for_test(cid)
@@ -242,10 +243,11 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             assert len(all_items) == num_items
 
             # The last page should have fewer items than the page size,
-            # proving headers are overwritten per page
-            assert item_counts[-1] == 1
-            for count in item_counts[:-1]:
-                assert count == 3
+            # proving headers are overwritten per page.
+            # max_item_count is a hint, so pages may have fewer items than requested.
+            assert len(item_counts) > 1
+            assert sum(item_counts) == num_items
+            assert item_counts[-1] < item_counts[0]
 
         finally:
             await self._delete_container_for_test(cid)
@@ -271,6 +273,9 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             # Get headers twice
             headers1 = query_iterable.get_response_headers()
             headers2 = query_iterable.get_response_headers()
+
+            # They should be distinct objects
+            assert headers1 is not headers2
 
             # Modifying one should not affect the other
             headers1["test-key"] = "test-value"
@@ -338,6 +343,10 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
                     f"Query {result['query_id']} got wrong item count"
                 assert "x-ms-request-charge" in result["headers"], \
                     f"Query {result['query_id']} headers missing x-ms-request-charge"
+
+            # Verify that different queries have independent header dicts
+            if len(results) >= 2:
+                assert results[0]["headers"] is not results[1]["headers"]
 
         finally:
             await self._delete_container_for_test(cid)

--- a/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_query_response_headers_async.py
@@ -88,28 +88,17 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             # Verify response headers were captured
             response_headers = query_iterable.get_response_headers()
             assert response_headers is not None
-            assert len(response_headers) > 0
+            assert isinstance(response_headers, dict)
 
             # Verify headers contain expected fields
-            first_page_headers = response_headers[0]
-            assert "x-ms-request-charge" in first_page_headers
-            assert "x-ms-activity-id" in first_page_headers
-
-            # Verify get_last_response_headers works
-            last_headers = query_iterable.get_last_response_headers()
-            assert last_headers is not None
-            assert "x-ms-request-charge" in last_headers
-
-            # Verify that the last headers match the first page in response_headers
-            # (since this is a single page query, they should be the same)
-            assert last_headers.get("x-ms-activity-id") == first_page_headers.get("x-ms-activity-id")
-            assert last_headers.get("x-ms-request-charge") == first_page_headers.get("x-ms-request-charge")
+            assert "x-ms-request-charge" in response_headers
+            assert "x-ms-activity-id" in response_headers
 
         finally:
             await self._delete_container_for_test(cid)
 
     async def test_query_response_headers_multiple_pages_async(self):
-        """Test that response headers are captured for each page in a paginated query."""
+        """Test that response headers reflect the last page in a paginated query."""
         cid = "test_headers_multi_async_" + str(uuid.uuid4())
 
         created_collection = await self._create_container_for_test(cid, PartitionKey(path="/pk"))
@@ -136,20 +125,11 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             # Verify all items were returned
             assert len(items) == num_items
 
-            # Verify response headers were captured for multiple pages
+            # Verify response headers contain the last page's headers
             response_headers = query_iterable.get_response_headers()
             assert response_headers is not None
-            # With 15 items and max_item_count=5, we expect at least 3 pages
-            assert len(response_headers) >= 3
-
-            # Verify each page has headers
-            for i, headers in enumerate(response_headers):
-                assert "x-ms-request-charge" in headers, f"Page {i} missing request charge header"
-                assert "x-ms-activity-id" in headers, f"Page {i} missing activity id header"
-
-            # Each page should have activity IDs
-            activity_ids = [h.get("x-ms-activity-id") for h in response_headers]
-            assert len(activity_ids) == len(response_headers)
+            assert "x-ms-request-charge" in response_headers
+            assert "x-ms-activity-id" in response_headers
 
         finally:
             await self._delete_container_for_test(cid)
@@ -178,14 +158,9 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             # Verify no items were returned
             assert len(items) == 0
 
-            # Response headers may or may not be captured depending on implementation
             # The key is that the method doesn't throw an error
             response_headers = query_iterable.get_response_headers()
             assert response_headers is not None
-
-            # get_last_response_headers should return None or headers depending on if a request was made
-            last_headers = query_iterable.get_last_response_headers()
-            # This can be None if no request was made, or headers if at least one request was made
 
         finally:
             await self._delete_container_for_test(cid)
@@ -217,15 +192,14 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
 
             # Verify response headers contain query metrics
             response_headers = query_iterable.get_response_headers()
-            assert len(response_headers) > 0
+            assert response_headers is not None
 
             # Check for query metrics header
             metrics_header_name = "x-ms-documentdb-query-metrics"
-            first_page_headers = response_headers[0]
-            assert metrics_header_name in first_page_headers
+            assert metrics_header_name in response_headers
 
             # Validate metrics header is well-formed
-            metrics_header = first_page_headers[metrics_header_name]
+            metrics_header = response_headers[metrics_header_name]
             metrics = metrics_header.split(";")
             assert len(metrics) > 1
             assert all("=" in x for x in metrics)
@@ -234,13 +208,13 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             await self._delete_container_for_test(cid)
 
     async def test_query_response_headers_by_page_iteration_async(self):
-        """Test response headers when using by_page() iteration."""
+        """Test response headers update per page, verified via x-ms-item-count."""
         cid = "test_headers_by_page_async_" + str(uuid.uuid4())
 
         created_collection = await self._create_container_for_test(cid, PartitionKey(path="/pk"))
         try:
-            # Create items
-            num_items = 10
+            # 7 items with max_item_count=3 gives pages of 3, 3, 1
+            num_items = 7
             for i in range(num_items):
                 await created_collection.create_item(body={"pk": "test", "id": f"item_{i}", "value": i})
 
@@ -249,28 +223,29 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
                 query=query,
                 parameters=[{"name": "@pk", "value": "test"}],
                 partition_key="test",
-                max_item_count=3  # Force multiple pages
+                max_item_count=3
             )
 
-            # Iterate by page
+            # Iterate by page, tracking item counts from headers
             all_items = []
-            page_count = 0
+            item_counts = []
             async for page in query_iterable.by_page():
                 page_items = [item async for item in page]
                 all_items.extend(page_items)
-                page_count += 1
 
-                # After each page, we can check the last response headers
-                last_headers = query_iterable.get_last_response_headers()
-                assert last_headers is not None
-                assert "x-ms-request-charge" in last_headers
+                headers = query_iterable.get_response_headers()
+                assert headers is not None
+                assert "x-ms-item-count" in headers
+                item_counts.append(int(headers["x-ms-item-count"]))
 
             # Verify all items retrieved
             assert len(all_items) == num_items
 
-            # Verify we got headers for each page (at least as many as page_count)
-            response_headers = query_iterable.get_response_headers()
-            assert len(response_headers) >= page_count
+            # The last page should have fewer items than the page size,
+            # proving headers are overwritten per page
+            assert item_counts[-1] == 1
+            for count in item_counts[:-1]:
+                assert count == 3
 
         finally:
             await self._delete_container_for_test(cid)
@@ -297,12 +272,9 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             headers1 = query_iterable.get_response_headers()
             headers2 = query_iterable.get_response_headers()
 
-            # They should be equal but not the same object
-            assert len(headers1) == len(headers2)
-            if len(headers1) > 0:
-                # Modifying one should not affect the other
-                headers1[0]["test-key"] = "test-value"
-                assert "test-key" not in headers2[0]
+            # Modifying one should not affect the other
+            headers1["test-key"] = "test-value"
+            assert "test-key" not in headers2
 
         finally:
             await self._delete_container_for_test(cid)
@@ -345,7 +317,6 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
                     "query_id": query_id,
                     "partition_key": partition_key,
                     "item_count": len(items),
-                    "header_count": len(headers),
                     "headers": headers
                 }
 
@@ -365,23 +336,8 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             for result in results:
                 assert result["item_count"] == items_per_partition, \
                     f"Query {result['query_id']} got wrong item count"
-                assert result["header_count"] > 0, \
-                    f"Query {result['query_id']} should have captured headers"
-                
-                # Verify headers contain expected keys
-                for header_dict in result["headers"]:
-                    assert "x-ms-request-charge" in header_dict, \
-                        f"Query {result['query_id']} headers missing x-ms-request-charge"
-
-            # Verify that different queries have independent header lists
-            if len(results) >= 2:
-                headers_0 = results[0]["headers"]
-                headers_1 = results[1]["headers"]
-                
-                # They should be different objects
-                assert headers_0 is not headers_1
-                if len(headers_0) > 0 and len(headers_1) > 0:
-                    assert headers_0[0] is not headers_1[0]
+                assert "x-ms-request-charge" in result["headers"], \
+                    f"Query {result['query_id']} headers missing x-ms-request-charge"
 
         finally:
             await self._delete_container_for_test(cid)
@@ -425,10 +381,7 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
                 return {
                     "query_id": query_id,
                     "item_count": len(items),
-                    "header_count": len(headers),
-                    "request_charges": [
-                        float(h.get("x-ms-request-charge", 0)) for h in headers
-                    ]
+                    "request_charge": float(headers.get("x-ms-request-charge", 0))
                 }
 
             # Create tasks but don't start fetching yet
@@ -452,12 +405,8 @@ class TestQueryResponseHeadersAsync(unittest.IsolatedAsyncioTestCase):
             for result in results:
                 assert result["item_count"] == 50, \
                     f"Query {result['query_id']} should have gotten all 50 items"
-                assert result["header_count"] > 0, \
-                    f"Query {result['query_id']} should have captured headers"
-                # Each request should have a positive request charge
-                for charge in result["request_charges"]:
-                    assert charge > 0, \
-                        f"Query {result['query_id']} should have positive request charges"
+                assert result["request_charge"] > 0, \
+                    f"Query {result['query_id']} should have positive request charge"
 
         finally:
             await self._delete_container_for_test(cid)


### PR DESCRIPTION
Simplify query response headers to last-page-only

Replaces the unbounded list[CaseInsensitiveDict] accumulated per page with a single CaseInsensitiveDict that is overwritten on each page fetch. This avoids memory growth for queries spanning thousands of pages.

Changes

 - _cosmos_responses.py — Removed get_last_response_headers() and the by_page() override from CosmosItemPaged/CosmosAsyncItemPaged. get_response_headers() now returns a copy of the most recent page's headers (consistent with CosmosDict/CosmosList).
 - _cosmos_client_connection.py / _cosmos_client_connection_async.py — Changed __QueryFeed from appending to a shared list to overwriting a shared dict via clear() + update().
 - Tests — Updated all assertions and added per-page x-ms-item-count validation to prove headers refresh each page.
 - CHANGELOG — Added breaking change entry under 4.16.0b3.