### PR TITLE
[Evaluation] Fix App Insights emission silently dropping all events when evaluator definition has no "metrics"

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed row classification where rows with empty or missing results lists were incorrectly counted as "passed" (the condition `passed_count == len(results) - error_count` evaluated `0 == 0` as True).
 - Fixed `_get_metric_result` prefix matching where shorter metric names (e.g., `xpia`) could match before longer, more-specific ones (e.g., `xpia_manipulated_content`). Now sorts by length descending for correct longest-prefix matching.
 - Fixed non-dict `_properties` values from evaluators causing downstream issues. Values that are not dicts are now logged and dropped gracefully.
+- Fixed App Insights emission silently dropping every `gen_ai.evaluation.result` event when an evaluator definition (e.g., a rubric evaluator registered without metric metadata, sent as `{"type": "rubric"}`) lacked a `metrics` dict. `_build_internal_log_attributes` raised `AttributeError: 'NoneType' object has no attribute 'get'`, which was swallowed by the per-event try/except in `_log_events_to_app_insights`, resulting in zero events being emitted to App Insights for the affected run. The helper now tolerates missing or non-dict `metrics` sections and still emits the event with the base evaluator attributes.
 
 ### Other Changes
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate.py
@@ -1136,7 +1136,11 @@ def _build_internal_log_attributes(
                 internal_log_attributes["gen_ai.evaluator.id"] = str(evaluator_id)
 
             if evaluator_definition := testing_criteria_config.get("_evaluator_definition"):
-                metric_config_detail = evaluator_definition.get("metrics").get(metric_name)
+                metrics_section = evaluator_definition.get("metrics")
+                if isinstance(metrics_section, dict):
+                    metric_config_detail = metrics_section.get(metric_name)
+                else:
+                    metric_config_detail = None
 
                 if metric_config_detail:
                     if metric_config_detail.get("min_value") is not None:

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluate.py
@@ -2162,6 +2162,96 @@ class TestBuildInternalLogAttributesThreshold:
 
 
 @pytest.mark.unittest
+class TestBuildInternalLogAttributesEvaluatorDefinition:
+    """Tests for _build_internal_log_attributes handling of malformed/missing evaluator metrics.
+
+    Regression: rubric evaluators registered without a `metrics` field on the evaluator
+    definition (RAISvc sends bare ``{"type": "rubric"}``) used to crash this helper with
+    ``AttributeError: 'NoneType' object has no attribute 'get'``. That exception was
+    silently swallowed by the per-event try/except in ``_log_events_to_app_insights``
+    and resulted in zero events being emitted to App Insights for the entire run.
+    """
+
+    def test_definition_without_metrics_key_does_not_raise(self):
+        """Evaluator definition lacking 'metrics' (e.g. rubric ``{"type": "rubric"}``)
+        must not raise. Base evaluator attributes should still be populated."""
+        event_data = {"name": "rubric-manual-260526043804-e45a09"}
+        evaluator_config = {
+            "rubric-manual-260526043804-e45a09": {
+                "_evaluator_name": "rubric-manual-260526043804-e45a09",
+                "_evaluator_version": "1",
+                "_evaluator_definition": {"type": "rubric"},
+            }
+        }
+        attrs = _build_internal_log_attributes(event_data, "rubric-manual-260526043804-e45a09", evaluator_config, {})
+        assert attrs["gen_ai.evaluation.testing_criteria.name"] == "rubric-manual-260526043804-e45a09"
+        assert attrs["gen_ai.evaluator.name"] == "rubric-manual-260526043804-e45a09"
+        assert attrs["gen_ai.evaluator.version"] == "1"
+        assert "gen_ai.evaluation.min_value" not in attrs
+        assert "gen_ai.evaluation.max_value" not in attrs
+        assert "gen_ai.evaluation.desirable_direction" not in attrs
+        assert "gen_ai.evaluation.type" not in attrs
+
+    def test_definition_with_metrics_none_does_not_raise(self):
+        """Evaluator definition with metrics=None must not raise."""
+        event_data = {"name": "my_grader"}
+        evaluator_config = {
+            "my_grader": {
+                "_evaluator_definition": {"type": "rubric", "metrics": None},
+            }
+        }
+        attrs = _build_internal_log_attributes(event_data, "my_grader", evaluator_config, {})
+        assert "gen_ai.evaluation.min_value" not in attrs
+
+    def test_definition_with_metrics_empty_dict_does_not_raise(self):
+        """Evaluator definition with metrics={} must not raise."""
+        event_data = {"name": "my_grader"}
+        evaluator_config = {
+            "my_grader": {
+                "_evaluator_definition": {"type": "rubric", "metrics": {}},
+            }
+        }
+        attrs = _build_internal_log_attributes(event_data, "my_grader", evaluator_config, {})
+        assert "gen_ai.evaluation.min_value" not in attrs
+
+    def test_definition_with_metrics_list_does_not_raise(self):
+        """Evaluator definition with malformed metrics (e.g. list) must not raise."""
+        event_data = {"name": "my_grader"}
+        evaluator_config = {
+            "my_grader": {
+                "_evaluator_definition": {"type": "rubric", "metrics": ["score"]},
+            }
+        }
+        attrs = _build_internal_log_attributes(event_data, "my_grader", evaluator_config, {})
+        assert "gen_ai.evaluation.min_value" not in attrs
+
+    def test_definition_with_metric_metadata_still_populates_attributes(self):
+        """When evaluator definition does contain matching metric metadata, the
+        min/max/desirable_direction/type attributes should still be emitted."""
+        event_data = {"name": "my_grader"}
+        evaluator_config = {
+            "my_grader": {
+                "_evaluator_definition": {
+                    "type": "prompt",
+                    "metrics": {
+                        "score": {
+                            "min_value": 1.0,
+                            "max_value": 5.0,
+                            "desirable_direction": "increase",
+                            "type": "ordinal",
+                        }
+                    },
+                },
+            }
+        }
+        attrs = _build_internal_log_attributes(event_data, "score", evaluator_config, {})
+        assert attrs["gen_ai.evaluation.min_value"] == "1.0"
+        assert attrs["gen_ai.evaluation.max_value"] == "5.0"
+        assert attrs["gen_ai.evaluation.desirable_direction"] == "increase"
+        assert attrs["gen_ai.evaluation.type"] == "ordinal"
+
+
+@pytest.mark.unittest
 class TestExtractTestingCriteriaMetadataPassThreshold:
     """Tests for pass_threshold propagation in _extract_testing_criteria_metadata."""
 


### PR DESCRIPTION
## Summary

Fixes a silent App Insights emission bug where rubric evaluators registered without metric metadata produced **zero** `gen_ai.evaluation.result` events for the entire run, even though the eval itself completed successfully.

## Root cause

In `_build_internal_log_attributes` (`_evaluate.py:1138`):

```python
if evaluator_definition := testing_criteria_config.get("_evaluator_definition"):
    metric_config_detail = evaluator_definition.get("metrics").get(metric_name)
```

RAISvc's `RubricBasedEvaluatorDefinition.Metrics` defaults to empty and is not required by `Validate()`, so a rubric registered without metric metadata is sent as `{"type": "rubric"}` — no `metrics` key at all. `evaluator_definition.get("metrics")` returns `None`, then `None.get(...)` raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

That exception is caught by the per-event `try/except` at `_log_events_to_app_insights` line 1287 and silently swallowed before `event_logger.emit()` is reached. Because every event in the run hits the same code path with the same evaluator definition, **every** event is dropped — App Insights receives nothing.

Observed in production: rubric eval `rubric-manual-260526043804-e45a09` in the westus2 bug bash project had zero AppInsights events while other rubric evals in the same workspace (e.g., `aprilk-repro`) that had populated metric metadata emitted normally.

## Fix

Guard the metrics lookup with `isinstance(metrics_section, dict)` so a single misshapen definition does not abort emission for the entire run. The event is still emitted; only the optional `min_value` / `max_value` / `desirable_direction` / `type` attributes are absent for evaluators that did not register them.

## Tests

Added `TestBuildInternalLogAttributesEvaluatorDefinition` with 5 regression cases:

- `test_definition_without_metrics_key_does_not_raise` — the exact failing payload (`{"type": "rubric"}`)
- `test_definition_with_metrics_none_does_not_raise`
- `test_definition_with_metrics_empty_dict_does_not_raise`
- `test_definition_with_metrics_list_does_not_raise` — defensive against future malformed types
- `test_definition_with_metric_metadata_still_populates_attributes` — happy path unchanged

All 10 tests in `TestBuildInternalLogAttributesThreshold` + `TestBuildInternalLogAttributesEvaluatorDefinition` pass.

## Validation

- `tox run -e black -c ../../../eng/tox/tox.ini --root .` — clean
- `pytest tests/unittests/test_evaluate.py::TestBuildInternalLogAttributesEvaluatorDefinition tests/unittests/test_evaluate.py::TestBuildInternalLogAttributesThreshold -v` — 10 passed
- Reproduced the original crash with a 2-line repro before the fix; confirmed the fix prevents it.
