### PR TITLE
[azure-ai-projects] Emit SDK from TypeSpec (update to commit 10482dd)

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -211,7 +211,9 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         return None
 
     @distributed_trace
-    def get_openai_client(self, *, agent_name: Optional[str] = None, **kwargs: Any) -> OpenAI:  # pylint: disable=too-many-branches
+    def get_openai_client(
+        self, *, agent_name: Optional[str] = None, **kwargs: Any
+    ) -> OpenAI:  # pylint: disable=too-many-branches
         """Get an authenticated OpenAI client from the `openai` package.
 
         Keyword arguments are passed to the OpenAI client constructor.

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.py
@@ -136,7 +136,9 @@ class AIProjectClient(AIProjectClientGenerated):  # pylint: disable=too-many-ins
         return None
 
     @distributed_trace
-    def get_openai_client(self, *, agent_name: Optional[str] = None, **kwargs: Any) -> AsyncOpenAI:  # pylint: disable=too-many-branches
+    def get_openai_client(
+        self, *, agent_name: Optional[str] = None, **kwargs: Any
+    ) -> AsyncOpenAI:  # pylint: disable=too-many-branches
         """Get an authenticated AsyncOpenAI client from the `openai` package.
 
         Keyword arguments are passed to the AsyncOpenAI client constructor.

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_models_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_models_async.py
@@ -170,8 +170,7 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
         polling_timeout: float = 300.0,
         polling_interval: float = 2.0,
         **kwargs: Any,
-    ) -> ModelVersion:
-        ...
+    ) -> ModelVersion: ...
 
     @overload
     async def create(
@@ -188,8 +187,7 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
         polling_timeout: float = 300.0,
         polling_interval: float = 2.0,
         **kwargs: Any,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @distributed_trace_async
     async def create(
@@ -323,7 +321,8 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
                 last_exc = ex
                 if time.monotonic() >= deadline:
                     raise RuntimeError(
-                        f"Model {name!r}@{version!r} did not appear within " f"{polling_timeout}s after pending_create_version."
+                        f"Model {name!r}@{version!r} did not appear within "
+                        f"{polling_timeout}s after pending_create_version."
                     ) from last_exc
                 await asyncio.sleep(polling_interval)
 

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_models.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_models.py
@@ -205,8 +205,7 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
         polling_timeout: float = 300.0,
         polling_interval: float = 2.0,
         **kwargs: Any,
-    ) -> ModelVersion:
-        ...
+    ) -> ModelVersion: ...
 
     @overload
     def create(
@@ -224,8 +223,7 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
         polling_timeout: float = 300.0,
         polling_interval: float = 2.0,
         **kwargs: Any,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @distributed_trace
     def create(
@@ -362,7 +360,8 @@ class BetaModelsOperations(BetaModelsOperationsGenerated):
                 last_exc = ex
                 if time.monotonic() >= deadline:
                     raise RuntimeError(
-                        f"Model {name!r}@{version!r} did not appear within " f"{polling_timeout}s after pending_create_version."
+                        f"Model {name!r}@{version!r} did not appear within "
+                        f"{polling_timeout}s after pending_create_version."
                     ) from last_exc
                 time.sleep(polling_interval)
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_iterate.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_iterate.py
@@ -115,7 +115,9 @@ with (
     assert v1 is not None
     v1_definition = v1.definition
     assert isinstance(v1_definition, RubricBasedEvaluatorDefinition)
-    print(f"v1 created with {len(v1_definition.dimensions)} dimensions: {', '.join(d.id for d in v1_definition.dimensions)}")
+    print(
+        f"v1 created with {len(v1_definition.dimensions)} dimensions: {', '.join(d.id for d in v1_definition.dimensions)}"
+    )
 
     # 2. Edit dimensions locally.
     # Domain-expert edits:
@@ -182,7 +184,9 @@ with (
     )
     v2_definition = v2.definition
     assert isinstance(v2_definition, RubricBasedEvaluatorDefinition)
-    print(f"v2 created with {len(v2_definition.dimensions)} dimensions: {', '.join(d.id for d in v2_definition.dimensions)}")
+    print(
+        f"v2 created with {len(v2_definition.dimensions)} dimensions: {', '.join(d.id for d in v2_definition.dimensions)}"
+    )
 
     # 4. List all versions of the evaluator.
     print(f"All versions of `{evaluator_name}`:")

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_manual.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_manual.py
@@ -130,7 +130,9 @@ with (
     # `isinstance` narrows the discriminated `definition` to the rubric subtype.
     definition = evaluator.definition
     assert isinstance(definition, RubricBasedEvaluatorDefinition)
-    print(f"Created evaluator `{evaluator.name}` version `{evaluator.version}` with {len(definition.dimensions)} dimensions.")
+    print(
+        f"Created evaluator `{evaluator.name}` version `{evaluator.version}` with {len(definition.dimensions)} dimensions."
+    )
 
     # 2. Create an OpenAI evaluation that uses the rubric as a testing criterion.
     eval_object = openai_client.evals.create(

--- a/sdk/ai/azure-ai-projects/tests/foundry_features_header/foundry_features_header_test_base.py
+++ b/sdk/ai/azure-ai-projects/tests/foundry_features_header/foundry_features_header_test_base.py
@@ -67,7 +67,9 @@ EXPECTED_FOUNDRY_FEATURES: dict[str, str] = {
 #
 # Format: { "<sub_client_name>": frozenset({"<method_name>", ...}) }
 EXCLUDED_BETA_METHODS: dict[str, frozenset] = {
-    "models": frozenset({"create"}),  # multi-step helper: validate -> pending_upload -> azcopy -> pending_create_version -> poll get
+    "models": frozenset(
+        {"create"}
+    ),  # multi-step helper: validate -> pending_upload -> azcopy -> pending_create_version -> poll get
 }
 
 # Shared test cases for non-beta methods that optionally send the Foundry-Features header.

--- a/sdk/ai/azure-ai-projects/tests/models/test_patch_models.py
+++ b/sdk/ai/azure-ai-projects/tests/models/test_patch_models.py
@@ -398,17 +398,13 @@ class TestValidateCreateVersionInputs:
     def test_non_positive_polling_timeout_raises(self, tmp_path, bad_timeout):
         (tmp_path / "weights.bin").write_bytes(b"x")
         with pytest.raises(ValueError, match="polling_timeout"):
-            BetaModelsOperations._validate_create_inputs(
-                **self._kwargs(source=tmp_path, polling_timeout=bad_timeout)
-            )
+            BetaModelsOperations._validate_create_inputs(**self._kwargs(source=tmp_path, polling_timeout=bad_timeout))
 
     @pytest.mark.parametrize("bad_interval", [0, -1.0])
     def test_non_positive_polling_interval_raises(self, tmp_path, bad_interval):
         (tmp_path / "weights.bin").write_bytes(b"x")
         with pytest.raises(ValueError, match="polling_interval"):
-            BetaModelsOperations._validate_create_inputs(
-                **self._kwargs(source=tmp_path, polling_interval=bad_interval)
-            )
+            BetaModelsOperations._validate_create_inputs(**self._kwargs(source=tmp_path, polling_interval=bad_interval))
 
     def test_polling_params_skipped_when_wait_for_commit_false(self, tmp_path):
         (tmp_path / "weights.bin").write_bytes(b"x")

--- a/sdk/ai/azure-ai-projects/tests/samples/llm_instructions.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/llm_instructions.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 from typing import Final
 
-agent_tools_instructions: Final[str] = """
+agent_tools_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct for a tool-driven assistant workflow.
 
@@ -43,9 +44,11 @@ even if it also asks follow-up questions.
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-memories_instructions: Final[str] = """
+memories_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct for a memories workflow.
 
@@ -70,9 +73,11 @@ memory behavior, even if no memory matches are found.
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-agents_instructions: Final[str] = """
+agents_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct.
 
@@ -103,9 +108,11 @@ agent behavior, including reasonable correspondence between input prompt(s) and 
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-chat_completions_instructions: Final[str] = """
+chat_completions_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct for Chat Completions scenarios.
 
@@ -124,9 +131,11 @@ responds to the printed prompt, even if the exact wording varies.
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-resource_management_instructions: Final[str] = """
+resource_management_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct for resource-management samples (for example
 connections, files, and deployments).
@@ -152,9 +161,11 @@ resource-management behavior.
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-fine_tuning_instructions: Final[str] = """
+fine_tuning_instructions: Final[str] = (
+    """
 We just ran Python code and captured print/log output in an attached log file (TXT).
 Validate whether sample execution/output is correct for a fine-tuning workflow.
 
@@ -178,9 +189,11 @@ the intended fine-tuning workflow.
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
-evaluations_instructions: Final[str] = """
+evaluations_instructions: Final[str] = (
+    """
 We just ran Python code for an evaluation sample and captured print/log output in an attached log file (TXT).
 Your job: determine if the sample code executed to completion WITHOUT throwing an unhandled exception.
 
@@ -202,9 +215,11 @@ Respond FALSE (correct=false) ONLY if:
 
 Always respond with `reason` indicating the reason for the response.
 """.strip()
+)
 
 
-hosted_agents_instructions: Final[str] = """
+hosted_agents_instructions: Final[str] = (
+    """
 We just ran Python code for a hosted-agent sample and captured print/log output in an attached log file (TXT).
 Validate whether the sample executed correctly.
 
@@ -226,6 +241,7 @@ Mark `correct = true` when execution succeeds and output is consistent with the 
 
 Always include `reason` with a concise explanation tied to the observed print output.
 """.strip()
+)
 
 
 # Folder (under samples/) -> instructions.

--- a/sdk/ai/azure-ai-projects/tsp-location.yaml
+++ b/sdk/ai/azure-ai-projects/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai-foundry/data-plane/Foundry
-commit: 53fbe53ff36e1d41dc9d12dbfd949182b07a88bf
+commit: 10482dd2682575c752d61f48a21c5e2cbcb27ebe
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
## Summary

Updated azure-ai-projects SDK TypeSpec source to latest commit on feature/foundry-release branch.

**TypeSpec source:** Azure/azure-rest-api-specs@10482dd2682575c752d61f48a21c5e2cbcb27ebe (branch: feature/foundry-release)

## Changes

- Updated tsp-location.yaml commit hash to 10482dd2682575c752d61f48a21c5e2cbcb27ebe
- Applied post-emitter-fixes (black formatting, enum renames, multipart loop reorder, Sphinx docstring fixes)
- No new API changes - generated code is identical to the base branch
