### PR TITLE
[AI Projects] Remove pinned preview api_version from rubric evaluator samples

### DIFF
--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_all_sources.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_all_sources.py
@@ -82,14 +82,7 @@ traces_evaluator_version = ""
 
 with (
     DefaultAzureCredential() as credential,
-    # `allow_preview` and `api_version` are required for the evaluator
-    # generation endpoints in this preview.
-    AIProjectClient(
-        endpoint=endpoint,
-        credential=credential,
-        allow_preview=True,
-        api_version="2025-11-15-preview",
-    ) as project_client,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
 ):
     # 1. Combined Prompt + Agent + Dataset generation job.
     multi_sources: List[Dict[str, Any]] = [

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_basic.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_basic.py
@@ -81,14 +81,7 @@ TERMINAL_RUN_STATUSES = {"completed", "failed", "canceled"}
 
 with (
     DefaultAzureCredential() as credential,
-    # `allow_preview` and `api_version` are required for the evaluator
-    # generation endpoints in this preview.
-    AIProjectClient(
-        endpoint=endpoint,
-        credential=credential,
-        allow_preview=True,
-        api_version="2025-11-15-preview",
-    ) as project_client,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
     project_client.get_openai_client() as openai_client,
 ):
     # 1. Generate an evaluator from a single `Prompt` source.

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_iterate.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_iterate.py
@@ -68,14 +68,7 @@ TERMINAL_STATUSES = {JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED}
 
 with (
     DefaultAzureCredential() as credential,
-    # `allow_preview` and `api_version` are required for the evaluator
-    # generation endpoints in this preview.
-    AIProjectClient(
-        endpoint=endpoint,
-        credential=credential,
-        allow_preview=True,
-        api_version="2025-11-15-preview",
-    ) as project_client,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
 ):
     # 1. Generate v1 of the evaluator from a single `Prompt` source.
     job = project_client.beta.evaluators.create_generation_job(

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_lifecycle.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_lifecycle.py
@@ -83,14 +83,7 @@ job_body = {
 
 with (
     DefaultAzureCredential() as credential,
-    # `allow_preview` and `api_version` are required for the evaluator
-    # generation endpoints in this preview.
-    AIProjectClient(
-        endpoint=endpoint,
-        credential=credential,
-        allow_preview=True,
-        api_version="2025-11-15-preview",
-    ) as project_client,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
 ):
     # 1. Create the generation job. `operation_id` makes the call idempotent -
     # re-submitting with the same id returns the existing job.

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_lifecycle.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_lifecycle.py
@@ -39,6 +39,7 @@ USAGE:
 """
 
 import os
+import itertools
 import time
 import uuid
 from datetime import datetime, timezone
@@ -109,8 +110,11 @@ with (
     print(f"Generated evaluator `{evaluator.name}` version `{evaluator.version}`.")
 
     # 3. List the 5 most recent generation jobs in this project.
+    #    `limit` controls the page size; use `itertools.islice` to cap the total.
     print("Recent generation jobs:")
-    for entry in project_client.beta.evaluators.list_generation_jobs(limit=5, order=PageOrder.DESC):
+    for entry in itertools.islice(
+        project_client.beta.evaluators.list_generation_jobs(limit=5, order=PageOrder.DESC), 5
+    ):
         entry_name = entry.inputs.evaluator_name if entry.inputs is not None else "<unknown>"
         print(f"  - id=`{entry.id}` status=`{cast(JobStatus, entry.status).value}` evaluator_name=`{entry_name}`")
 


### PR DESCRIPTION
## Summary
Remove the pinned preview `api_version` override (and the now-unnecessary `allow_preview=True`) from the four `sample_rubric_evaluator_generation_*.py` samples in `sdk/ai/azure-ai-projects`.

## Why
- The samples hard-coded `api_version="2025-11-15-preview"` on `AIProjectClient`. This was a temporary workaround for the rubric evaluator generation endpoints. Removing it lets the samples use the client's default `api_version`, ready for the backend change that supports evaluator generation on the default version. (Backend change is not live yet — this PR prepares the SDK side.)
- `allow_preview=True` was also dropped because rubric evaluator generation goes through `project_client.beta.evaluators.*`. Per `AIProjectClient` docstring in `azure/ai/projects/_patch.py`: *"Methods on the `.beta` sub-client ... do not require setting `allow_preview=True` since it's implied by the sub-client name."* The stale comment above the constructor was removed.

## Files
- `samples/evaluations/sample_rubric_evaluator_generation_all_sources.py`
- `samples/evaluations/sample_rubric_evaluator_generation_basic.py`
- `samples/evaluations/sample_rubric_evaluator_generation_iterate.py`
- `samples/evaluations/sample_rubric_evaluator_generation_lifecycle.py`

## Scope check
Grepped all of `sdk/ai/azure-ai-projects/samples` for `2025-11-15-preview` / `api_version=` on `AIProjectClient`. No other sample (red team, datasets, etc.) was affected. `sample_rubric_evaluator_manual.py` already used the simple constructor and needed no change.
