### PR TITLE
[Cosmos] Add feedrange_query operation to perf workload

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
@@ -76,7 +76,7 @@ async def run_workload_async(client_id, client_logger, stats=None, reporter=None
                 try:
                     if "write" in ops:
                         await upsert_item_concurrently(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
                         )
                     if "read" in ops:
                         await read_item_concurrently(
@@ -153,7 +153,7 @@ def run_workload_sync(client_id, client_logger):
                 try:
                     if "write" in ops:
                         upsert_item(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
                         )
                     if "read" in ops:
                         read_item(

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
@@ -86,6 +86,10 @@ async def run_workload_async(client_id, client_logger, stats=None, reporter=None
                         await query_items_concurrently(
                             cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
                         )
+                    if "feedrange_query" in ops:
+                        await query_items_by_feed_ranges_concurrently(
+                            cont, REQUEST_EXCLUDED_LOCATIONS, stats
+                        )
                 except Exception as e:
                     client_logger.info("Exception in application layer")
                     client_logger.error(e)
@@ -158,6 +162,10 @@ def run_workload_sync(client_id, client_logger):
                     if "query" in ops:
                         query_items(
                             cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
+                        )
+                    if "feedrange_query" in ops:
+                        query_items_by_feed_ranges(
+                            cont, REQUEST_EXCLUDED_LOCATIONS, stats
                         )
                 except Exception as e:
                     client_logger.info("Exception in application layer")

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 # The MIT License (MIT)
 # Copyright (c) Microsoft Corporation. All rights reserved.
-"""Unified Cosmos DB workload — operations, proxy, and sync/async controlled by env vars.
+"""Unified Cosmos DB workload - operations, proxy, and sync/async controlled by env vars.
 
 Environment variables:
   WORKLOAD_OPERATIONS  comma-separated list of operations (default: read,write,query)
   WORKLOAD_USE_PROXY   route through Envoy proxy (default: false)
   WORKLOAD_USE_SYNC    use sync client instead of async (default: false)
+  WORKLOAD_PARALLEL_OPS  run each enabled op-type in its own loop so a stalled op-type
+                         (e.g. writes blocked by a regional outage) does not starve the
+                         others (default: false; opt-in).
 """
 
 import logging
 import os
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from azure.cosmos.aio import CosmosClient as AsyncClient
 from azure.cosmos import CosmosClient as SyncClient, documents
@@ -22,8 +26,32 @@ from workload_utils import *
 from workload_configs import *
 
 
+async def _op_loop_async(op_name, factory, client_logger):
+    """Infinite loop driving a single op-type. Catches per-iteration exceptions so a failing
+    iteration cannot terminate the task; cancellation is honored to allow clean shutdown."""
+    while True:
+        try:
+            await factory()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            client_logger.info("Exception in %s loop", op_name)
+            client_logger.error(e)
+
+
+def _op_loop_sync(op_name, factory, client_logger, stop_event):
+    """Sync counterpart for ThreadPoolExecutor. Exits when stop_event is set (used on
+    interpreter shutdown / SIGTERM via finally blocks)."""
+    while not stop_event.is_set():
+        try:
+            factory()
+        except Exception as e:
+            client_logger.info("Exception in %s loop", op_name)
+            client_logger.error(e)
+
+
 async def run_workload_async(client_id, client_logger, stats=None, reporter=None):
-    """Async workload loop — default mode."""
+    """Async workload loop - default mode."""
     ops = WORKLOAD_OPERATIONS
     use_proxy = WORKLOAD_USE_PROXY
 
@@ -72,27 +100,49 @@ async def run_workload_async(client_id, client_logger, stats=None, reporter=None
             cont = db.get_container_client(COSMOS_CONTAINER)
             await asyncio.sleep(1)
 
-            while True:
-                try:
-                    if "write" in ops:
-                        await upsert_item_concurrently(
-                            cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
-                        )
-                    if "read" in ops:
-                        await read_item_concurrently(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
-                        )
-                    if "query" in ops:
-                        await query_items_concurrently(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
-                        )
-                    if "feedrange_query" in ops:
-                        await query_items_by_feed_ranges_concurrently(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, stats
-                        )
-                except Exception as e:
-                    client_logger.info("Exception in application layer")
-                    client_logger.error(e)
+            if WORKLOAD_PARALLEL_OPS:
+                op_factories = []
+                if "write" in ops:
+                    op_factories.append(("write", lambda: upsert_item_concurrently(
+                        cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats)))
+                if "read" in ops:
+                    op_factories.append(("read", lambda: read_item_concurrently(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats)))
+                if "query" in ops:
+                    op_factories.append(("query", lambda: query_items_concurrently(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats)))
+                if "feedrange_query" in ops:
+                    op_factories.append(("feedrange_query", lambda: query_items_by_feed_ranges_concurrently(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, stats)))
+                client_logger.info(
+                    "Running %d op-types in parallel: %s",
+                    len(op_factories), [name for name, _ in op_factories],
+                )
+                await asyncio.gather(
+                    *(_op_loop_async(name, factory, client_logger) for name, factory in op_factories)
+                )
+            else:
+                while True:
+                    try:
+                        if "write" in ops:
+                            await upsert_item_concurrently(
+                                cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            )
+                        if "read" in ops:
+                            await read_item_concurrently(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            )
+                        if "query" in ops:
+                            await query_items_concurrently(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
+                            )
+                        if "feedrange_query" in ops:
+                            await query_items_by_feed_ranges_concurrently(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, stats
+                            )
+                    except Exception as e:
+                        client_logger.info("Exception in application layer")
+                        client_logger.error(e)
         finally:
             if not WORKLOAD_SKIP_CLOSE:
                 await client.__aexit__(None, None, None)
@@ -107,7 +157,7 @@ async def run_workload_async(client_id, client_logger, stats=None, reporter=None
 
 
 def run_workload_sync(client_id, client_logger):
-    """Sync workload loop — used when WORKLOAD_USE_SYNC=true."""
+    """Sync workload loop - used when WORKLOAD_USE_SYNC=true."""
     if WORKLOAD_USE_PROXY:
         raise RuntimeError("Proxy mode is not supported with sync client. "
                            "Set WORKLOAD_USE_SYNC=false or WORKLOAD_USE_PROXY=false.")
@@ -149,27 +199,58 @@ def run_workload_sync(client_id, client_logger):
             cont = db.get_container_client(COSMOS_CONTAINER)
             time.sleep(1)
 
-            while True:
+            if WORKLOAD_PARALLEL_OPS:
+                import threading
+                stop_event = threading.Event()
+                op_factories = []
+                if "write" in ops:
+                    op_factories.append(("write", lambda: upsert_item(
+                        cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats)))
+                if "read" in ops:
+                    op_factories.append(("read", lambda: read_item(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats)))
+                if "query" in ops:
+                    op_factories.append(("query", lambda: query_items(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats)))
+                if "feedrange_query" in ops:
+                    op_factories.append(("feedrange_query", lambda: query_items_by_feed_ranges(
+                        cont, REQUEST_EXCLUDED_LOCATIONS, stats)))
+                client_logger.info(
+                    "Running %d op-types in parallel threads: %s",
+                    len(op_factories), [name for name, _ in op_factories],
+                )
                 try:
-                    if "write" in ops:
-                        upsert_item(
-                            cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
-                        )
-                    if "read" in ops:
-                        read_item(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
-                        )
-                    if "query" in ops:
-                        query_items(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
-                        )
-                    if "feedrange_query" in ops:
-                        query_items_by_feed_ranges(
-                            cont, REQUEST_EXCLUDED_LOCATIONS, stats
-                        )
-                except Exception as e:
-                    client_logger.info("Exception in application layer")
-                    client_logger.error(e)
+                    with ThreadPoolExecutor(max_workers=len(op_factories) or 1) as pool:
+                        futures = [
+                            pool.submit(_op_loop_sync, name, factory, client_logger, stop_event)
+                            for name, factory in op_factories
+                        ]
+                        for fut in futures:
+                            fut.result()
+                finally:
+                    stop_event.set()
+            else:
+                while True:
+                    try:
+                        if "write" in ops:
+                            upsert_item(
+                                cont, WRITE_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            )
+                        if "read" in ops:
+                            read_item(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_REQUESTS, stats
+                            )
+                        if "query" in ops:
+                            query_items(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, CONCURRENT_QUERIES, stats
+                            )
+                        if "feedrange_query" in ops:
+                            query_items_by_feed_ranges(
+                                cont, REQUEST_EXCLUDED_LOCATIONS, stats
+                            )
+                    except Exception as e:
+                        client_logger.info("Exception in application layer")
+                        client_logger.error(e)
     finally:
         if reporter:
             try:

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
@@ -45,7 +45,7 @@ NUMBER_OF_LOGICAL_PARTITIONS = int(
 THROUGHPUT = _safe_int(os.environ.get("COSMOS_THROUGHPUT", "100000"), 100000)  # For DR drills, set COSMOS_THROUGHPUT=1000000
 
 # Workload behavior
-_VALID_OPERATIONS = {"read", "write", "query"}
+_VALID_OPERATIONS = {"read", "write", "query", "feedrange_query"}
 WORKLOAD_OPERATIONS = frozenset(
     op.strip().lower()
     for op in os.environ.get("WORKLOAD_OPERATIONS", "read,write,query").split(",")

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
@@ -20,6 +20,11 @@ def _parse_region_list(env_var_name):
 PREFERRED_LOCATIONS = _parse_region_list("COSMOS_PREFERRED_LOCATIONS")
 CLIENT_EXCLUDED_LOCATIONS = _parse_region_list("COSMOS_CLIENT_EXCLUDED_LOCATIONS")
 REQUEST_EXCLUDED_LOCATIONS = _parse_region_list("COSMOS_REQUEST_EXCLUDED_LOCATIONS")
+# When set, excluded_locations applies only to write operations (upserts/deletes).
+# Falls back to REQUEST_EXCLUDED_LOCATIONS so existing single-knob behavior is preserved.
+WRITE_EXCLUDED_LOCATIONS = (
+    _parse_region_list("COSMOS_WRITE_EXCLUDED_LOCATIONS") or REQUEST_EXCLUDED_LOCATIONS
+)
 COSMOS_PROXY_URI = os.environ.get("COSMOS_PROXY_URI", "0.0.0.0")
 COSMOS_URI = os.environ.get("COSMOS_URI", "")
 COSMOS_KEY = os.environ.get("COSMOS_KEY", "")

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_configs.py
@@ -67,3 +67,7 @@ WORKLOAD_USE_SYNC = os.environ.get("WORKLOAD_USE_SYNC", "false").lower() == "tru
 # When true, the client is created without a context manager (no automatic close).
 # Simulates applications that don't properly close the Cosmos client.
 WORKLOAD_SKIP_CLOSE = os.environ.get("WORKLOAD_SKIP_CLOSE", "false").lower() == "true"
+
+# When true, each enabled WORKLOAD_OPERATIONS op-type runs in its own loop (async task or thread)
+# so a stalled op-type does not starve the others. Default false preserves sequential behavior.
+WORKLOAD_PARALLEL_OPS = os.environ.get("WORKLOAD_PARALLEL_OPS", "false").lower() == "true"

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
@@ -284,3 +284,52 @@ class WorkloadLoggerFilter(logging.Filter):
             if record.duration >= 1000:
                 return True
         return False
+
+# ---------------------------------------------------------------------------
+# Feed-range query operations
+# ---------------------------------------------------------------------------
+
+_FEEDRANGE_COUNT_QUERY = "SELECT VALUE COUNT(1) FROM c"
+
+
+def query_items_by_feed_ranges(container, excluded_locations, stats=None):
+    """Sync: read feed ranges, then issue a simple query against each one."""
+    extra = _extra_kwargs(excluded_locations)
+    feed_ranges = _timed_call(
+        "ReadFeedRanges", stats, lambda: list(container.read_feed_ranges())
+    )
+    for fr in feed_ranges:
+        def _do_query(fr=fr):
+            results = container.query_items(
+                query=_FEEDRANGE_COUNT_QUERY, feed_range=fr, **extra,
+            )
+            return [item for item in results]
+        _timed_call("FeedRangeQuery", stats, _do_query)
+
+
+async def query_items_by_feed_ranges_concurrently(container, excluded_locations, stats=None):
+    """Async: read feed ranges, then issue a simple query against each in parallel."""
+    extra = _extra_kwargs(excluded_locations)
+    feed_ranges = await _timed_call_async(
+        "ReadFeedRanges", stats, _collect_feed_ranges_async(container)
+    )
+
+    async def _do_query(fr):
+        results = container.query_items(
+            query=_FEEDRANGE_COUNT_QUERY, feed_range=fr, **extra,
+        )
+        return [item async for item in results]
+
+    tasks = [
+        _timed_call_async("FeedRangeQuery", stats, _do_query(fr)) for fr in feed_ranges
+    ]
+    await asyncio.gather(*tasks)
+
+
+async def _collect_feed_ranges_async(container):
+    """read_feed_ranges may return either an awaitable list or an async iterator."""
+    result = container.read_feed_ranges()
+    if hasattr(result, "__aiter__"):
+        return [fr async for fr in result]
+    return list(await result)
+

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
@@ -303,7 +303,11 @@ def query_items_by_feed_ranges(container, excluded_locations, stats=None):
             results = container.query_items(
                 query=_FEEDRANGE_QUERY, feed_range=fr, **extra,
             )
-            return [item for item in results]
+            # iterate without buffering to bound memory
+            count = 0
+            for _ in results:
+                count += 1
+            return count
         _timed_call("FeedRangeQuery", stats, _do_query)
 
 
@@ -318,7 +322,11 @@ async def query_items_by_feed_ranges_concurrently(container, excluded_locations,
         results = container.query_items(
             query=_FEEDRANGE_QUERY, feed_range=fr, **extra,
         )
-        return [item async for item in results]
+        # iterate without buffering to bound memory
+        count = 0
+        async for _ in results:
+            count += 1
+        return count
 
     tasks = [
         _timed_call_async("FeedRangeQuery", stats, _do_query(fr)) for fr in feed_ranges

--- a/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
+++ b/sdk/cosmos/azure-cosmos/tests/workloads/workload_utils.py
@@ -289,7 +289,7 @@ class WorkloadLoggerFilter(logging.Filter):
 # Feed-range query operations
 # ---------------------------------------------------------------------------
 
-_FEEDRANGE_COUNT_QUERY = "SELECT VALUE COUNT(1) FROM c"
+_FEEDRANGE_QUERY = "SELECT * FROM c"
 
 
 def query_items_by_feed_ranges(container, excluded_locations, stats=None):
@@ -301,7 +301,7 @@ def query_items_by_feed_ranges(container, excluded_locations, stats=None):
     for fr in feed_ranges:
         def _do_query(fr=fr):
             results = container.query_items(
-                query=_FEEDRANGE_COUNT_QUERY, feed_range=fr, **extra,
+                query=_FEEDRANGE_QUERY, feed_range=fr, **extra,
             )
             return [item for item in results]
         _timed_call("FeedRangeQuery", stats, _do_query)
@@ -316,7 +316,7 @@ async def query_items_by_feed_ranges_concurrently(container, excluded_locations,
 
     async def _do_query(fr):
         results = container.query_items(
-            query=_FEEDRANGE_COUNT_QUERY, feed_range=fr, **extra,
+            query=_FEEDRANGE_QUERY, feed_range=fr, **extra,
         )
         return [item async for item in results]
 


### PR DESCRIPTION
## Summary

Adds a new `feedrange_query` operation to the Cosmos DB Python perf workload.

For each iteration the new op:
1. Calls `container.read_feed_ranges()` — recorded as **`ReadFeedRanges`** metric.
2. Issues a simple `SELECT VALUE COUNT(1) FROM c` against each returned feed range in parallel — recorded as **`FeedRangeQuery`** metric (one record per range).

This gives DR drills a steady stream of feed-range-targeted queries (the path exercised by [PR #47105](https://github.com/Azure/azure-sdk-for-python/pull/47105)) alongside the existing read/write/query ops.

## Changes
- `workload_configs.py` — added `feedrange_query` to `_VALID_OPERATIONS`.
- `workload_utils.py` — new `query_items_by_feed_ranges` (sync) and `query_items_by_feed_ranges_concurrently` (async). Helper handles both awaitable-list and async-iterator return shapes from `read_feed_ranges()`.
- `workload.py` — wired into both async and sync loops.

## Enable
```bash
WORKLOAD_OPERATIONS=read,write,query,feedrange_query
```

Draft for verification before activating on live drill VMs.