### PR TITLE
Update AAD reference to Microsoft Entra in packaging README template

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/README.md
+++ b/eng/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/README.md
@@ -24,7 +24,7 @@ pip install azure-identity
 
 ### Authentication
 
-By default, [Azure Active Directory](https://aka.ms/awps/aad) token authentication depends on correct configuration of the following environment variables.
+By default, [Microsoft Entra](https://learn.microsoft.com/entra/fundamentals/what-is-entra) token authentication depends on correct configuration of the following environment variables.
 
 - `AZURE_CLIENT_ID` for Azure client ID.
 - `AZURE_TENANT_ID` for Azure tenant ID.


### PR DESCRIPTION
Updates the `Authentication` section of the packaging README template at `eng/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/README.md` to reflect current branding.

- Link text: `Azure Active Directory` -> `Microsoft Entra`
- Link URL: `https://aka.ms/awps/aad` -> `https://learn.microsoft.com/entra/fundamentals/what-is-entra`

This template is used by packaging tooling to generate package READMEs, so the change will propagate to future generated READMEs.