### PR TITLE
[API Review] azure-keyvault-secrets 4.11.0 (base none)

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/API.md
+++ b/sdk/keyvault/azure-keyvault-secrets/API.md
@@ -1,0 +1,332 @@
+```py
+# Package is parsed using apiview-stub-generator(version:0.3.28), Python version: 3.12.9
+
+
+namespace azure.keyvault.secrets
+
+    class azure.keyvault.secrets.ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+        V2016_10_01 = "2016-10-01"
+        V2025_07_01 = "2025-07-01"
+        V7_0 = "7.0"
+        V7_1 = "7.1"
+        V7_2 = "7.2"
+        V7_3 = "7.3"
+        V7_4 = "7.4"
+        V7_5 = "7.5"
+        V7_6 = "7.6"
+
+
+    class azure.keyvault.secrets.ContentType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+        PEM = "application/x-pem-file"
+        PFX = "application/x-pkcs12"
+
+
+    class azure.keyvault.secrets.DeletedSecret:
+        property deleted_date: Optional[datetime]    # Read-only
+        property id: Optional[str]    # Read-only
+        property name: Optional[str]    # Read-only
+        property properties: SecretProperties    # Read-only
+        property recovery_id: Optional[str]    # Read-only
+        property scheduled_purge_date: Optional[datetime]    # Read-only
+
+        def __init__(
+                self, 
+                properties: SecretProperties, 
+                deleted_date: Optional[datetime] = None, 
+                recovery_id: Optional[str] = None, 
+                scheduled_purge_date: Optional[datetime] = None
+            ) -> None: ...
+
+        def __repr__(self) -> str: ...
+
+
+    class azure.keyvault.secrets.KeyVaultSecret:
+        property id: Optional[str]    # Read-only
+        property name: Optional[str]    # Read-only
+        property properties: SecretProperties    # Read-only
+        property value: Optional[str]    # Read-only
+
+        def __init__(
+                self, 
+                properties: SecretProperties, 
+                value: Optional[str]
+            ) -> None: ...
+
+        def __repr__(self) -> str: ...
+
+
+    class azure.keyvault.secrets.KeyVaultSecretIdentifier:
+        property name: str    # Read-only
+        property source_id: str    # Read-only
+        property vault_url: str    # Read-only
+        property version: Optional[str]    # Read-only
+
+        def __init__(self, source_id: str) -> None: ...
+
+
+    class azure.keyvault.secrets.SecretClient(KeyVaultClientBase): implements ContextManager 
+        property vault_url: str    # Read-only
+
+        def __init__(
+                self, 
+                vault_url: str, 
+                credential: TokenCredential, 
+                *, 
+                api_version: Union[ApiVersion, str] = ..., 
+                verify_challenge_resource: Optional[bool] = ..., 
+                **kwargs: Any
+            ) -> None: ...
+
+        @distributed_trace
+        def backup_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> bytes: ...
+
+        @distributed_trace
+        def begin_delete_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> LROPoller[DeletedSecret]: ...
+
+        @distributed_trace
+        def begin_recover_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> LROPoller[SecretProperties]: ...
+
+        def close(self) -> None: ...
+
+        @distributed_trace
+        def get_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> DeletedSecret: ...
+
+        @distributed_trace
+        def get_secret(
+                self, 
+                name: str, 
+                version: Optional[str] = None, 
+                *, 
+                out_content_type: Optional[Union[str, ContentType]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultSecret: ...
+
+        @distributed_trace
+        def list_deleted_secrets(self, **kwargs: Any) -> ItemPaged[DeletedSecret]: ...
+
+        @distributed_trace
+        def list_properties_of_secret_versions(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> ItemPaged[SecretProperties]: ...
+
+        @distributed_trace
+        def list_properties_of_secrets(self, **kwargs: Any) -> ItemPaged[SecretProperties]: ...
+
+        @distributed_trace
+        def purge_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> None: ...
+
+        @distributed_trace
+        def restore_secret_backup(
+                self, 
+                backup: bytes, 
+                **kwargs: Any
+            ) -> SecretProperties: ...
+
+        @distributed_trace
+        def send_request(
+                self, 
+                request: HttpRequest, 
+                *, 
+                stream: bool = False, 
+                **kwargs: Any
+            ) -> HttpResponse: ...
+
+        @distributed_trace
+        def set_secret(
+                self, 
+                name: str, 
+                value: str, 
+                *, 
+                content_type: Optional[str] = ..., 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
+                not_before: Optional[datetime] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultSecret: ...
+
+        @distributed_trace
+        def update_secret_properties(
+                self, 
+                name: str, 
+                version: Optional[str] = None, 
+                *, 
+                content_type: Optional[str] = ..., 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
+                not_before: Optional[datetime] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> SecretProperties: ...
+
+
+    class azure.keyvault.secrets.SecretProperties:
+        property content_type: Optional[str]    # Read-only
+        property created_on: Optional[datetime]    # Read-only
+        property enabled: Optional[bool]    # Read-only
+        property expires_on: Optional[datetime]    # Read-only
+        property id: Optional[str]    # Read-only
+        property key_id: Optional[str]    # Read-only
+        property managed: Optional[bool]    # Read-only
+        property name: Optional[str]    # Read-only
+        property not_before: Optional[datetime]    # Read-only
+        property previous_version: Optional[str]    # Read-only
+        property recoverable_days: Optional[int]    # Read-only
+        property recovery_level: Optional[str]    # Read-only
+        property tags: Optional[Dict[str, str]]    # Read-only
+        property updated_on: Optional[datetime]    # Read-only
+        property vault_url: Optional[str]    # Read-only
+        property version: Optional[str]    # Read-only
+
+        def __init__(
+                self, 
+                *args: Any, 
+                **kwargs: Any
+            ) -> None: ...
+
+        def __repr__(self) -> str: ...
+
+
+namespace azure.keyvault.secrets.aio
+
+    class azure.keyvault.secrets.aio.SecretClient(AsyncKeyVaultClientBase): implements AsyncContextManager 
+        property vault_url: str    # Read-only
+
+        def __init__(
+                self, 
+                vault_url: str, 
+                credential: AsyncTokenCredential, 
+                *, 
+                api_version: Union[ApiVersion, str] = ..., 
+                verify_challenge_resource: Optional[bool] = ..., 
+                **kwargs: Any
+            ) -> None: ...
+
+        @distributed_trace_async
+        async def backup_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> bytes: ...
+
+        async def close(self) -> None: ...
+
+        @distributed_trace_async
+        async def delete_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> DeletedSecret: ...
+
+        @distributed_trace_async
+        async def get_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> DeletedSecret: ...
+
+        @distributed_trace_async
+        async def get_secret(
+                self, 
+                name: str, 
+                version: Optional[str] = None, 
+                *, 
+                out_content_type: Optional[Union[str, ContentType]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultSecret: ...
+
+        @distributed_trace
+        def list_deleted_secrets(self, **kwargs: Any) -> AsyncItemPaged[DeletedSecret]: ...
+
+        @distributed_trace
+        def list_properties_of_secret_versions(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> AsyncItemPaged[SecretProperties]: ...
+
+        @distributed_trace
+        def list_properties_of_secrets(self, **kwargs: Any) -> AsyncItemPaged[SecretProperties]: ...
+
+        @distributed_trace_async
+        async def purge_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> None: ...
+
+        @distributed_trace_async
+        async def recover_deleted_secret(
+                self, 
+                name: str, 
+                **kwargs: Any
+            ) -> SecretProperties: ...
+
+        @distributed_trace_async
+        async def restore_secret_backup(
+                self, 
+                backup: bytes, 
+                **kwargs: Any
+            ) -> SecretProperties: ...
+
+        @distributed_trace_async
+        def send_request(
+                self, 
+                request: HttpRequest, 
+                *, 
+                stream: bool = False, 
+                **kwargs: Any
+            ) -> Awaitable[AsyncHttpResponse]: ...
+
+        @distributed_trace_async
+        async def set_secret(
+                self, 
+                name: str, 
+                value: str, 
+                *, 
+                content_type: Optional[str] = ..., 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
+                not_before: Optional[datetime] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultSecret: ...
+
+        @distributed_trace_async
+        async def update_secret_properties(
+                self, 
+                name: str, 
+                version: Optional[str] = None, 
+                *, 
+                content_type: Optional[str] = ..., 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
+                not_before: Optional[datetime] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> SecretProperties: ...
+
+
+```


### PR DESCRIPTION
Automated API review PR for `azure-keyvault-secrets`.

- **Target:** `origin/main` (version `4.11.0`)
- **Baseline:** _empty_ (version `none`)

Generated by `scripts/create_api_review_pr.py`.