### PR TITLE
Cosmos: update casing for telemetry

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
@@ -221,7 +221,7 @@ class HttpHeaders:
 
     # Change feed
     AIM = "A-IM"
-    IncrementalFeedHeaderValue = "Incremental feed"
+    IncrementalFeedHeaderValue = "Incremental Feed"
     FullFidelityFeedHeaderValue = "Full-Fidelity Feed"
     ChangeFeedWireFormatVersion = "x-ms-cosmos-changefeed-wire-format-version"
 


### PR DESCRIPTION
Internal telemetry uses proper casing - fixing this here for our internal visibility.