### PR TITLE
ci: Create PR instead of auto-merging for TypeSpec regeneration

### DIFF
--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -165,12 +165,15 @@ jobs:
           set -euo pipefail
           TARGET_BRANCH="typespec-python-generated-tests"
           RUN_ID="${{ github.run_id }}"
-          SOURCE_BRANCH="regen/typespec-python-${RUN_ID}"
+          RUN_ATTEMPT="${{ github.run_attempt }}"
+          SOURCE_BRANCH="regen/typespec-python-${RUN_ID}-${RUN_ATTEMPT}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          GENERATED_DIR="eng/tools/azure-sdk-tools/emitter/generated"
+
           # Quick check: skip if regeneration produced no changes vs HEAD.
-          if [ -z "$(git status --porcelain -- eng/tools/azure-sdk-tools/emitter/generated/)" ]; then
+          if [ -z "$(git status --porcelain -- "$GENERATED_DIR")" ]; then
             echo "No changes to commit"
             exit 0
           fi
@@ -182,6 +185,11 @@ jobs:
             SOURCE_LABEL="microsoft/typespec@main"
           fi
 
+          # Save regenerated files to a temp dir before switching branches,
+          # since they are untracked and would be lost on checkout.
+          TMPDIR=$(mktemp -d)
+          cp -r "$GENERATED_DIR"/. "$TMPDIR"
+
           # Ensure the target branch exists; create from origin/main if not.
           git fetch --no-tags --depth=1 origin main
           if ! git fetch --no-tags --depth=1 origin "$TARGET_BRANCH" 2>/dev/null; then
@@ -192,9 +200,12 @@ jobs:
           # Create source branch based on the target branch.
           git checkout -B "$SOURCE_BRANCH" "origin/$TARGET_BRANCH"
 
-          # Apply regenerated files on top.
-          git checkout HEAD@{1} -- eng/tools/azure-sdk-tools/emitter/generated
-          git add -f eng/tools/azure-sdk-tools/emitter/generated/
+          # Restore regenerated files from the temp dir.
+          mkdir -p "$GENERATED_DIR"
+          rm -rf "$GENERATED_DIR"/*
+          cp -r "$TMPDIR"/. "$GENERATED_DIR"
+          rm -rf "$TMPDIR"
+          git add -f "$GENERATED_DIR"/
 
           if git diff --cached --quiet; then
             echo "No changes vs $TARGET_BRANCH"

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -164,9 +164,7 @@ jobs:
         run: |
           set -euo pipefail
           TARGET_BRANCH="typespec-python-generated-tests"
-          RUN_ID="${{ github.run_id }}"
-          RUN_ATTEMPT="${{ github.run_attempt }}"
-          SOURCE_BRANCH="regen/typespec-python-${RUN_ID}-${RUN_ATTEMPT}"
+          SOURCE_BRANCH="regen/typespec-python"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -197,6 +195,11 @@ jobs:
             git fetch --no-tags --depth=1 origin "$TARGET_BRANCH"
           fi
 
+          # Check if an open regen PR already exists; reuse its branch if so.
+          EXISTING_PR=$(gh pr list --repo "${{ github.repository }}" \
+            --base "$TARGET_BRANCH" --head "$SOURCE_BRANCH" --label "typespec-python" \
+            --state open --json number -q '.[0].number')
+
           # Create source branch based on the target branch.
           git checkout -B "$SOURCE_BRANCH" "origin/$TARGET_BRANCH"
 
@@ -216,24 +219,17 @@ jobs:
           git commit -m "$COMMIT_MSG"
           git push origin "$SOURCE_BRANCH" --force-with-lease
 
-          # Close any existing open regen PRs against the target branch.
-          EXISTING_PRS=$(gh pr list --repo "${{ github.repository }}" \
-            --base "$TARGET_BRANCH" --label "typespec-python" \
-            --state open --json number -q '.[].number')
-          for pr in $EXISTING_PRS; do
-            echo "Closing superseded PR #${pr}"
-            gh pr close "$pr" --repo "${{ github.repository }}" \
-              --comment "Superseded by a newer regeneration run."
-          done
-
-          # Create a new PR.
-          gh pr create --repo "${{ github.repository }}" \
-            --base "$TARGET_BRANCH" \
-            --head "$SOURCE_BRANCH" \
-            --title "$COMMIT_MSG" \
-            --body "Automated regeneration from ${SOURCE_LABEL}." \
-            --label "typespec-python"
-          echo "::notice::Created PR for regenerated tests against $TARGET_BRANCH"
+          if [ -n "$EXISTING_PR" ]; then
+            echo "::notice::Updated existing PR #${EXISTING_PR} with new regeneration"
+          else
+            gh pr create --repo "${{ github.repository }}" \
+              --base "$TARGET_BRANCH" \
+              --head "$SOURCE_BRANCH" \
+              --title "$COMMIT_MSG" \
+              --body "Automated regeneration from ${SOURCE_LABEL}." \
+              --label "typespec-python"
+            echo "::notice::Created PR for regenerated tests against $TARGET_BRANCH"
+          fi
 
   notify-on-failure:
     name: "Notify on failure"

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -200,6 +200,9 @@ jobs:
             --base "$TARGET_BRANCH" --head "$SOURCE_BRANCH" --label "typespec-python" \
             --state open --json number -q '.[0].number')
 
+          # Clean up untracked generated files so checkout doesn't conflict.
+          rm -rf "$GENERATED_DIR"
+
           # Create source branch based on the target branch.
           git checkout -B "$SOURCE_BRANCH" "origin/$TARGET_BRANCH"
 

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 # Note: with cancel-in-progress, a newer run can cancel an older one after it
 # has force-pushed the branch but before it finishes updating the tracking
@@ -157,10 +158,14 @@ jobs:
             ! -path "$TARGET/template/*" \
             -print -exec cp -f "$TEMPLATE" {} \;
 
-      - name: Commit and push to dedicated branch
+      - name: Create regeneration PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          BRANCH="typespec-python-generated-tests"
+          TARGET_BRANCH="typespec-python-generated-tests"
+          RUN_ID="${{ github.run_id }}"
+          SOURCE_BRANCH="regen/typespec-python-${RUN_ID}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -170,8 +175,6 @@ jobs:
             exit 0
           fi
 
-          # Push regenerated files directly to the dedicated branch.
-          # This branch is machine-managed and may be force-pushed.
           PR_NUMBER="${{ steps.typespec-info.outputs.typespec_pr_number }}"
           if [ -n "$PR_NUMBER" ]; then
             SOURCE_LABEL="microsoft/typespec PR #${PR_NUMBER}"
@@ -179,23 +182,47 @@ jobs:
             SOURCE_LABEL="microsoft/typespec@main"
           fi
 
-          # Base on origin/main so the dedicated branch never inherits
-          # unrelated content from whatever ref the workflow checked out.
+          # Ensure the target branch exists; create from origin/main if not.
           git fetch --no-tags --depth=1 origin main
-          git checkout -B "$BRANCH" origin/main
+          if ! git fetch --no-tags --depth=1 origin "$TARGET_BRANCH" 2>/dev/null; then
+            git push origin "origin/main:refs/heads/$TARGET_BRANCH"
+            git fetch --no-tags --depth=1 origin "$TARGET_BRANCH"
+          fi
 
-          # Re-apply just the regenerated tree on top of origin/main.
+          # Create source branch based on the target branch.
+          git checkout -B "$SOURCE_BRANCH" "origin/$TARGET_BRANCH"
+
+          # Apply regenerated files on top.
           git checkout HEAD@{1} -- eng/tools/azure-sdk-tools/emitter/generated
           git add -f eng/tools/azure-sdk-tools/emitter/generated/
 
           if git diff --cached --quiet; then
-            echo "No changes vs origin/main"
+            echo "No changes vs $TARGET_BRANCH"
             exit 0
           fi
 
-          git commit -m "[typespec-python] Regenerate tests from ${SOURCE_LABEL}"
-          git push origin "$BRANCH" --force-with-lease
-          echo "::notice::Pushed regenerated tests to $BRANCH"
+          COMMIT_MSG="[typespec-python] Regenerate tests from ${SOURCE_LABEL}"
+          git commit -m "$COMMIT_MSG"
+          git push origin "$SOURCE_BRANCH" --force-with-lease
+
+          # Close any existing open regen PRs against the target branch.
+          EXISTING_PRS=$(gh pr list --repo "${{ github.repository }}" \
+            --base "$TARGET_BRANCH" --label "typespec-python" \
+            --state open --json number -q '.[].number')
+          for pr in $EXISTING_PRS; do
+            echo "Closing superseded PR #${pr}"
+            gh pr close "$pr" --repo "${{ github.repository }}" \
+              --comment "Superseded by a newer regeneration run."
+          done
+
+          # Create a new PR.
+          gh pr create --repo "${{ github.repository }}" \
+            --base "$TARGET_BRANCH" \
+            --head "$SOURCE_BRANCH" \
+            --title "$COMMIT_MSG" \
+            --body "Automated regeneration from ${SOURCE_LABEL}." \
+            --label "typespec-python"
+          echo "::notice::Created PR for regenerated tests against $TARGET_BRANCH"
 
   notify-on-failure:
     name: "Notify on failure"


### PR DESCRIPTION
Instead of force-pushing regenerated tests directly to `typespec-python-generated-tests`, the workflow now creates a PR against that branch for review.

Changes:
- Added `pull-requests: write` permission
- Pushes to a unique `regen/typespec-python-<run_id>` branch
- Closes any existing open regen PRs (to avoid pile-up)
- Creates a new PR against `typespec-python-generated-tests`
- Auto-creates the target branch from `origin/main` if it doesn't exist yet