### PR TITLE
[cherry-pick] DT operation fixes (#47284) to release/azure-ai-ml/1.34.0

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/_client.py
@@ -59,7 +59,7 @@ class MachineLearningServicesClient:
         credential: "TokenCredential",
         **kwargs: Any
     ) -> None:
-        _endpoint = "{endpoint}/genericasset/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices"
+        _endpoint = "{endpoint}/genericasset/v2.0/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices"
         self._config = MachineLearningServicesClientConfiguration(
             endpoint=endpoint,
             subscription_id=subscription_id,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/_configuration.py
@@ -44,7 +44,7 @@ class MachineLearningServicesClientConfiguration:  # pylint: disable=too-many-in
         credential: "TokenCredential",
         **kwargs: Any
     ) -> None:
-        api_version: str = kwargs.pop("api_version", "2024-04-01-preview")
+        api_version: str = kwargs.pop("api_version", "2026-05-01-preview")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/aio/_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/aio/_client.py
@@ -59,7 +59,7 @@ class MachineLearningServicesClient:
         credential: "AsyncTokenCredential",
         **kwargs: Any
     ) -> None:
-        _endpoint = "{endpoint}/genericasset/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices"
+        _endpoint = "{endpoint}/genericasset/v2.0/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices"
         self._config = MachineLearningServicesClientConfiguration(
             endpoint=endpoint,
             subscription_id=subscription_id,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/aio/_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/aio/_configuration.py
@@ -44,7 +44,7 @@ class MachineLearningServicesClientConfiguration:  # pylint: disable=too-many-in
         credential: "AsyncTokenCredential",
         **kwargs: Any
     ) -> None:
-        api_version: str = kwargs.pop("api_version", "2024-04-01-preview")
+        api_version: str = kwargs.pop("api_version", "2026-05-01-preview")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/operations/_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/azure_ai_assets_v2024_04_01/azureaiassetsv20240401/operations/_operations.py
@@ -89,7 +89,7 @@ def build_deployment_templates_create_request(  # pylint: disable=name-too-long
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
-    _url = "/registries/{registryName}/{name}/versions/{version}"
+    _url = "/registries/{registryName}/deploymenttemplates/{name}/versions/{version}"
     path_format_arguments = {
         "registryName": _SERIALIZER.url("registry_name", registry_name, "str"),
         "name": _SERIALIZER.url("name", name, "str"),

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_template.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_template.py
@@ -564,11 +564,10 @@ class DeploymentTemplate(Resource, RestTranslatableMixin):  # pylint: disable=to
             "version": self.version,
         }
 
-        # Always include type field
-        if hasattr(self, "type") and self.type:
-            result["type"] = self.type
-        else:
-            result["type"] = "deploymenttemplates"  # Default type if not specified
+        # Always use "deploymenttemplates" as the type value for the API wire format.
+        # YAML schema uses "deployment_template" as the entity type identifier, but the
+        # service validates that the type in the body matches the route ("deploymenttemplates").
+        result["type"] = "deploymenttemplates"
 
         # Add optional basic fields
         if self.display_name:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_deployment_template_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_deployment_template_operations.py
@@ -56,12 +56,18 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
         """
         if self.__service_client is None:
             endpoint = self._get_registry_endpoint()
+            # Only pass through kwargs that the TypeSpec-generated AzureAiAssetsClient
+            # can handle. MLClient injects kwargs like 'cloud', 'credential_scopes',
+            # 'client_request_id', 'request_id' which break the client's HTTP pipeline
+            # when passed through to its policies.
+            _allowed_kwargs = ("user_agent", "logging_enable")
+            client_kwargs = {k: v for k, v in self._service_client_kwargs.items() if k in _allowed_kwargs}
             self.__service_client = AzureAiAssetsClient(
                 endpoint=endpoint,
                 subscription_id=self._operation_scope.subscription_id,
                 resource_group_name=self._operation_scope.resource_group_name,
                 credential=self._credential,
-                **self._service_client_kwargs,
+                **client_kwargs,
             )
         return self.__service_client
 
@@ -84,17 +90,12 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
                 RegistryDiscoveryClient as ServiceClientRegistryDiscovery,
             )
 
-            # Try to get credential from service client or operation config
-            credential = None
-            if hasattr(self._service_client, "_config") and hasattr(self._service_client._config, "credential"):
-                credential = self._service_client._config.credential
-            elif hasattr(self._operation_config, "credential"):
-                credential = self._operation_config.credential
-
-            if credential and self._operation_scope.registry_name:
+            if self._credential and self._operation_scope.registry_name:
                 # Use registry discovery API to get the primary region
                 discovery_base_url = _get_registry_discovery_endpoint_from_metadata(_get_default_cloud_name())
-                discovery_client = ServiceClientRegistryDiscovery(credential=credential, base_url=discovery_base_url)
+                discovery_client = ServiceClientRegistryDiscovery(
+                    credential=self._credential, base_url=discovery_base_url
+                )
                 response = discovery_client.registry_management_non_workspace.get_registry_management_non_workspace(
                     self._operation_scope.registry_name
                 )
@@ -106,7 +107,7 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
             module_logger.debug("Could not determine registry region dynamically: %s. Using default.", e)
 
         # Fallback to default region if unable to determine dynamically
-        return "https://int.experiments.azureml-test.net"
+        return "https://eastus.api.azureml.ms"
 
     def _convert_dict_to_deployment_template(self, dict_data: Dict[str, Any]) -> DeploymentTemplate:
         """Convert dictionary format to DeploymentTemplate object.
@@ -367,9 +368,15 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
             name=deployment_template.name,
             version=deployment_template.version,
             body=rest_object,
+            polling=False,
             **kwargs,
         )
-        return deployment_template
+        # Fire the LRO but don't wait for polling — the asset is available immediately.
+        # Fetch the created/updated resource to return the server-side state.
+        try:
+            return self.get(deployment_template.name, deployment_template.version)
+        except Exception:
+            return deployment_template
 
     @distributed_trace
     @monitor_with_telemetry_mixin(ops_logger, "DeploymentTemplate.Delete", ActivityType.PUBLICAPI)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_index_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_index_operations.py
@@ -117,8 +117,16 @@ class IndexOperations(_ScopeDependentOperations):
                 resource_group_name=self._operation_scope.resource_group_name,
                 workspace_name=self._operation_scope.workspace_name,
                 credential=self._credential,
+                api_version="2024-04-01-preview",
                 **self._service_client_kwargs,
             )
+
+            # Index operations require the legacy /genericasset/ path (without v2.0).
+            # The TypeSpec-generated client defaults to /genericasset/v2.0/ which is needed
+            # for DeploymentTemplate operations, but the Index service returns HTTP 500 on
+            # the v2.0 path for write operations. Override the base URL to use the legacy path.
+            base_url = self.__azure_ai_assets_client._client._base_url
+            self.__azure_ai_assets_client._client._base_url = base_url.replace("/genericasset/v2.0/", "/genericasset/")
 
         return self.__azure_ai_assets_client
 


### PR DESCRIPTION
Cherry-pick of bd8971095778ebcaf41e47404ff5f85755480737 (DT operation fixes #47284) to release branch.

## Changes
- Restclient: use /genericasset/v2.0/ path and 2026-05-01-preview API version (required by DT service)
- Fix create URL: add missing 'deploymenttemplates' segment in request builder
- Fix _get_registry_endpoint: remove recursive self._service_client call, use self._credential directly
- Fix create_or_update: use polling=False to avoid LRO hang, fetch result via get()
- Fix DT type field: always use 'deploymenttemplates' in REST body to match service route validation
- Fix pylint and black formatting
- Index operations: override base URL to /genericasset/ and pin api_version=2024-04-01-preview