### PR TITLE
[Discovery] Fix release pipeline for batched tsp-location.yaml

### DIFF
--- a/sdk/discovery/azure-ai-discovery/tsp-location.yaml
+++ b/sdk/discovery/azure-ai-discovery/tsp-location.yaml
@@ -1,3 +1,4 @@
 batch:
   - ./azure/ai/discovery/_workspace
   - ./azure/ai/discovery/_bookshelf
+directory: specification/discovery


### PR DESCRIPTION
One-line addition to `sdk/discovery/azure-ai-discovery/tsp-location.yaml` — adds a `directory:` key alongside `batch:` to unblock the release pipeline.

`eng/common/scripts/Package-Properties.ps1` accesses `$tspLocation.directory` under `Set-StrictMode -Version 3`, which throws on batched `tsp-location.yaml` files (which only have `batch:`, no `directory:`). The script iterates all packages in the service directory, so this blocks releases for both `azure-ai-discovery` and `azure-mgmt-discovery`.

Failed build: [6384515](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6384515)
