### PR TITLE
[Key Vault] Remove stale no-op insecure_domain_change pop for parity with azure-core #45518

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed a stale, no-op line from the internal challenge authentication policy for parity with the `azure-core` fix in [#45518](https://github.com/Azure/azure-sdk-for-python/pull/45518). This is an internal cleanup with no functional impact.
+
 ## 4.8.0b1 (2026-05-29)
 
 ### Features Added

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -135,10 +135,6 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
             request_authorized = await self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = await self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -148,10 +148,6 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
             request_authorized = self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed a stale, no-op line from the internal challenge authentication policy for parity with the `azure-core` fix in [#45518](https://github.com/Azure/azure-sdk-for-python/pull/45518). This is an internal cleanup with no functional impact.
+
 ## 4.11.1 (2026-04-29)
 
 ### Bugs Fixed

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -138,10 +138,6 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
             request_authorized = await self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = await self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -148,10 +148,6 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
             request_authorized = self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed a stale, no-op line from the internal challenge authentication policy for parity with the `azure-core` fix in [#45518](https://github.com/Azure/azure-sdk-for-python/pull/45518). This is an internal cleanup with no functional impact.
+
 ## 4.12.0b2 (2026-05-29)
 
 ### Features Added

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -135,10 +135,6 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
             request_authorized = await self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = await self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -148,10 +148,6 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
             request_authorized = self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -138,10 +138,6 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
             request_authorized = await self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = await self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -148,10 +148,6 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
             request_authorized = self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-securitydomain/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-securitydomain/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Other Changes
 
+- Removed a stale, no-op line from the internal challenge authentication policy for parity with the `azure-core` fix in [#45518](https://github.com/Azure/azure-sdk-for-python/pull/45518). This is an internal cleanup with no functional impact.
+
 - Key Vault API version `2025-07-01` is now the default
 
 ## 1.0.0b1 (2025-05-07)

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/async_challenge_auth_policy.py
@@ -135,10 +135,6 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
             request_authorized = await self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = await self.next.send(request)
                 except Exception:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_internal/challenge_auth_policy.py
@@ -148,10 +148,6 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
             request_authorized = self.on_challenge(request, response)
             if request_authorized:
-                # if we receive a challenge response, we retrieve a new token
-                # which matches the new target. In this case, we don't want to remove
-                # token from the request so clear the 'insecure_domain_change' tag
-                request.context.options.pop("insecure_domain_change", False)
                 try:
                     response = self.next.send(request)
                 except Exception:  # pylint:disable=broad-except


### PR DESCRIPTION
# Description

[#45518](https://github.com/Azure/azure-sdk-for-python/pull/45518) fixed the cross-domain redirect `Authorization`-header strip in `azure-core` by persisting the `insecure_domain_change` flag on `request.context` (a `Dict` subclass) instead of the ephemeral `request.context.options` kwargs dict. As part of that fix it removed the now-obsolete line from `azure-core`'s `BearerTokenCredentialPolicy`:

```python
request.context.options.pop("insecure_domain_change", False)
```

The Key Vault packages each carry an **independent forked copy** of the challenge-authentication policy (`challenge_auth_policy.py` + its async variant under `_shared/` or `_internal/`) that still contained that exact line. Because the live flag now lives on `request.context` and `.options` is the stale kwargs dict, the `pop` is a **no-op**. This PR removes it (sync + async) for parity with the `azure-core` fix.

This mirrors `azure-core` exactly: the surrounding block now goes straight from `if request_authorized:` to the `try:` that re-sends the request, identical to [`_authentication.py`](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py) after #45518.

**No functional change** — the removed line had no effect once the flag moved off `request.context.options`.

### Files (5 packages, sync + async = 10)
- `azure-keyvault-keys` — `_shared/challenge_auth_policy.py`, `_shared/async_challenge_auth_policy.py`
- `azure-keyvault-secrets` — same pair under `_shared/`
- `azure-keyvault-certificates` — same pair under `_shared/`
- `azure-keyvault-administration` — same pair under `_internal/`
- `azure-keyvault-securitydomain` — same pair under `_internal/`

### CHANGELOG
Added an *Other Changes* note to the four packages with an open `(Unreleased)` section (administration, certificates, keys, securitydomain). `azure-keyvault-secrets` currently has no open unreleased version (top entry is the released `4.11.0`), so no changelog entry was added there to avoid an unwarranted version bump for an internal no-op — happy to add one if maintainers prefer.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce breaking changes**
- [x] **CHANGELOG is updated** for the four packages with an open unreleased version (see note above re: `secrets`).
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] A single, informatively-messaged commit.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes. — N/A: dead-code removal with no behavioral change; the existing challenge-authentication tests continue to exercise the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
