### PR TITLE
Deprecate azure-mgmt-deploymentmanager

### DIFF
--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/CHANGELOG.md
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b1.post1 (2026-06-04)
+## 2.0.0b2 (2026-06-04)
 
 ### Other Changes
 

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/CHANGELOG.md
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0b1.post1 (2026-06-04)
+
+### Other Changes
+
+  - This package has been deprecated and will no longer be maintained after 07-31-2023. This package will only receive security fixes until 07-31-2023.
+
 ## 2.0.0b1 (2022-11-01)
 
 ### Features Added

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/README.md
@@ -1,28 +1,4 @@
 # Microsoft Azure SDK for Python
 
-This is the Microsoft Azure Deployment Manager Client Library.
-This package has been tested with Python 3.7+.
-For a more complete view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).
-
-## _Disclaimer_
-
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
-# Usage
-
-
-To learn how to use this package, see the [quickstart guide](https://aka.ms/azsdk/python/mgmt)
- 
-For docs and references, see [Python SDK References](https://docs.microsoft.com/python/api/overview/azure/)
-Code samples for this package can be found at [Deployment Manager](https://docs.microsoft.com/samples/browse/?languages=python&term=Getting%20started%20-%20Managing&terms=Getting%20started%20-%20Managing) on docs.microsoft.com.
-Additional code samples for different Azure services are available at [Samples Repo](https://aka.ms/azsdk/python/mgmt/samples)
-
-
-# Provide Feedback
-
-If you encounter any bugs or have suggestions, please file an issue in the
-[Issues](https://github.com/Azure/azure-sdk-for-python/issues)
-section of the project. 
-
-
+This package has been deprecated and will no longer be maintained after 07-31-2023. This package will only receive security fixes until 07-31-2023.
 

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/azure/mgmt/deploymentmanager/_version.py
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/azure/mgmt/deploymentmanager/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "2.0.0b1.post1"
+VERSION = "2.0.0b2"

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/azure/mgmt/deploymentmanager/_version.py
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/azure/mgmt/deploymentmanager/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "2.0.0b1"
+VERSION = "2.0.0b1.post1"

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/sdk_packaging.toml
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/sdk_packaging.toml
@@ -5,3 +5,4 @@ package_doc_id = ""
 is_stable = false
 is_arm = true
 title = "AzureDeploymentManager"
+auto_update = false

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/setup.py
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/setup.py
@@ -47,7 +47,7 @@ setup(
     url='https://github.com/Azure/azure-sdk-for-python',
     keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 7 - Inactive',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Azure Deployment Manager is being decommissioned and its REST API specs were deleted in Azure/azure-rest-api-specs#26818. This PR deprecates the `azure-mgmt-deploymentmanager` Python SDK package following the [Python SDK deprecation process](https://aka.ms/azsdk/python/deprecation-process).

There is **no replacement package** (full service retirement, EOL **07-31-2023**).

### Step 1 changes (this PR)
- **README.md**: replaced contents with the no-replacement deprecation disclaimer.
- **CHANGELOG.md**: added `2.0.0b1.post1` entry with the deprecation disclaimer.
- **_version.py**: `2.0.0b1` -> `2.0.0b1.post1` (metadata-only post-release, no code changes).
- **sdk_packaging.toml**: added `auto_update = false`.
- **setup.py**: `Development Status :: 7 - Inactive`.
- pyproject.toml verified to not contain `ci_enabled = false`; ci.yml already lists the package under Artifacts.

### Remaining process steps (follow-up, not in this PR)
- Resolve open issues/PRs for the library.
- Trigger the release pipeline to publish `2.0.0b1.post1` to PyPI.
- Create a follow-up PR to remove the package source from `main`.
- Update MS Learn / azure.github.io API docs.