### PR TITLE
Move Storage Extension to Use Pyproject.toml

### DIFF
--- a/sdk/storage/azure-storage-extensions/azure/storage/extensions/checksums/crc64/crc64module.c
+++ b/sdk/storage/azure-storage-extensions/azure/storage/extensions/checksums/crc64/crc64module.c
@@ -7,13 +7,22 @@
 #include "helpers.h"
 
 PyObject* compute(PyObject* self, PyObject* args) {
-    const unsigned char* src;
-    Py_ssize_t length;
+    PyObject* data;
     uint64_t uCrc;
 
-    // Parse the bytes input, length, and initial CRC
-    if (!PyArg_ParseTuple(args, "y#K", &src, &length, &uCrc))
+    // Parse as object + unsigned long long. We use "OK" instead of "y#K"
+    // because y# requires _PyArg_ParseTuple_SizeT symbol which is not
+    // reliably available in the stable/limited ABI on all platforms.
+    if (!PyArg_ParseTuple(args, "OK", &data, &uCrc))
         return NULL;
+
+    if (!PyBytes_Check(data)) {
+        PyErr_SetString(PyExc_TypeError, "a bytes-like object is required, not '...'");
+        return NULL;
+    }
+
+    const unsigned char* src = (const unsigned char*)PyBytes_AsString(data);
+    Py_ssize_t length = PyBytes_Size(data);
 
     uint64_t pData = 0;
     uint64_t uSize = (uint64_t)length;

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -72,6 +72,8 @@ environment = "CFLAGS='-Wno-implicit-function-declaration'"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 aarch64"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.macos]
 archs = "arm64"

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -65,7 +65,8 @@ suppressed_skip_warnings = ["*"]
 in_bundle = false
 
 [tool.cibuildwheel]
-build = "cp310*"
+build = ["cp310*", "pp*"]
+enable = ["pypy"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 environment = "CFLAGS='-Wno-implicit-function-declaration'"

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.10"
+dependencies = []
 keywords = ["azure", "azure sdk"]
 dynamic = ["version", "readme"]
 
@@ -64,17 +65,16 @@ suppressed_skip_warnings = ["*"]
 in_bundle = false
 
 [tool.cibuildwheel]
-build = ["cp310*", "pp310*", "pp311*"]
+build = "cp310*"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
-test-skip = "*-macosx_arm64"
 environment = "CFLAGS='-Wno-implicit-function-declaration'"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 aarch64"
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 arm64"
+archs = "arm64"
 
 [tool.cibuildwheel.windows]
-archs = "AMD64"
+archs = "AMD64 ARM64"

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -1,3 +1,54 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------
+
+[build-system]
+requires = ["setuptools>=77.0.3", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "azure-storage-extensions"
+authors = [
+  { name = "Microsoft Corporation", email = "ascl@microsoft.com" },
+]
+description = "Azure Storage Extensions"
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+requires-python = ">=3.10"
+keywords = ["azure", "azure sdk"]
+dynamic = ["version", "readme"]
+
+[project.urls]
+repository = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-extensions"
+
+[tool.setuptools.dynamic]
+version = { attr = "azure.storage.extensions.checksums._version.VERSION" }
+readme = { file = ["README.md"], content-type = "text/markdown" }
+
+[tool.setuptools.packages.find]
+exclude = [
+    "tests*",
+    "samples*",
+    "doc*",
+    "azure",
+    "azure.storage",
+    "azure.storage.extensions",
+]
+
+[tool.setuptools.package-data]
+"azure.storage.extensions.checksums" = ["py.typed", "*.pyi"]
+
 [tool.azure-sdk-build]
 mypy = false
 pyright = false
@@ -12,9 +63,8 @@ breaking = false
 # these can be any number of suppressions. note that * present means that ALL warnings will be suppressed for this package
 suppressed_skip_warnings = ["*"]
 
-[build-system]
-# cibuildwheel is NOT a build-system dependency; it is the outer orchestration tool
-requires = ["setuptools", "wheel"]
+[tool.azure-sdk-conda]
+in_bundle = false
 
 [tool.cibuildwheel]
 build = ["cp310*", "pp310*", "pp311*"]

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -46,9 +46,6 @@ exclude = [
     "azure.storage.extensions",
 ]
 
-[tool.setuptools.package-data]
-"azure.storage.extensions.checksums" = ["py.typed", "*.pyi"]
-
 [tool.azure-sdk-build]
 mypy = false
 pyright = false

--- a/sdk/storage/azure-storage-extensions/setup.py
+++ b/sdk/storage/azure-storage-extensions/setup.py
@@ -23,7 +23,7 @@ setup(
         Extension(
             "crc64",
             ["azure/storage/extensions/checksums/crc64/crc64module.c"],
-            define_macros=[("Py_LIMITED_API", "3")],
+            define_macros=[("Py_LIMITED_API", "0x030A0000")],
             py_limited_api=True,
         ),
     ],

--- a/sdk/storage/azure-storage-extensions/setup.py
+++ b/sdk/storage/azure-storage-extensions/setup.py
@@ -4,10 +4,15 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import os
-import re
+# This file remains only for two things that setuptools cannot yet express
+# declaratively in pyproject.toml without opting into experimental config:
+#   1. Compiling the limited-API C extension(s).
+#   2. Overriding bdist_wheel so wheels built against Py_LIMITED_API are
+#      tagged abi3 and become reusable across CPython 3.x versions.
+# Can be removed once experimental is removed from https://github.com/pypa/setuptools/blob/84ed5913724df5a12dc804e1d5efe12508e706d2/setuptools/config/pyprojecttoml.py#L135
+
 from setuptools import setup, Extension
-from wheel.bdist_wheel import bdist_wheel
+from setuptools.command.bdist_wheel import bdist_wheel
 
 
 class bdist_wheel_abi3(bdist_wheel):
@@ -21,51 +26,12 @@ class bdist_wheel_abi3(bdist_wheel):
         return python, abi, plat
 
 
-PACKAGE_NAME = "azure-storage-extensions"
-PACKAGE_PPRINT_NAME = "Azure Storage Extensions"
-
-package_folder_path = PACKAGE_NAME.replace("-", "/")
-
-# Version extraction inspired from 'requests'
-with open(os.path.join(package_folder_path, "checksums", "_version.py"), "r") as fd:
-    version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
-
-if not version:
-    raise RuntimeError("Cannot find version information")
-
 setup(
-    name=PACKAGE_NAME,
-    version=version,
-    description=PACKAGE_PPRINT_NAME,
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    license="MIT",
-    author="Microsoft Corporation",
-    author_email="ascl@microsoft.com",
-    url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-extensions",
-    keywords="azure, azure sdk",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "License :: OSI Approved :: MIT License",
-    ],
-    zip_safe=False,
-    python_requires=">=3.10",
-    packages=[
-        "azure.storage.extensions.checksums",
-    ],
     ext_package="azure.storage.extensions.checksums",
     ext_modules=[
         Extension(
             "crc64",
-            [os.path.join(package_folder_path, "checksums", "crc64", "crc64module.c")],
+            ["azure/storage/extensions/checksums/crc64/crc64module.c"],
             define_macros=[("Py_LIMITED_API", "3")],
             py_limited_api=True,
         ),

--- a/sdk/storage/azure-storage-extensions/setup.py
+++ b/sdk/storage/azure-storage-extensions/setup.py
@@ -14,10 +14,26 @@
 # This file can be removed once both experimental gates are dropped in
 # https://github.com/pypa/setuptools/blob/84ed5913724df5a12dc804e1d5efe12508e706d2/setuptools/config/pyprojecttoml.py#L135
 
+import re
+from pathlib import Path
+
 from setuptools import setup, Extension
+
+PACKAGE_NAME = "azure-storage-extensions"
+
+# `name` and `version` are declared in pyproject.toml (version dynamically via
+# [tool.setuptools.dynamic]). They are repeated in the setup() call below only
+# because doc-warden's README verification parses setup.py and requires both
+# kwargs to be present. The version is read from _version.py rather than
+# imported so it works under doc-warden's AST exec as well as a normal build;
+# both run with the working directory set to the package root.
+version_text = Path("azure", "storage", "extensions", "checksums", "_version.py").read_text()
+version = re.search(r'VERSION = "(.*?)"', version_text).group(1)
 
 
 setup(
+    name=PACKAGE_NAME,
+    version=version,
     ext_package="azure.storage.extensions.checksums",
     ext_modules=[
         Extension(

--- a/sdk/storage/azure-storage-extensions/setup.py
+++ b/sdk/storage/azure-storage-extensions/setup.py
@@ -4,26 +4,17 @@
 # license information.
 # --------------------------------------------------------------------------
 
-# This file remains only for two things that setuptools cannot yet express
-# declaratively in pyproject.toml without opting into experimental config:
-#   1. Compiling the limited-API C extension(s).
-#   2. Overriding bdist_wheel so wheels built against Py_LIMITED_API are
-#      tagged abi3 and become reusable across CPython 3.x versions.
-# Can be removed once experimental is removed from https://github.com/pypa/setuptools/blob/84ed5913724df5a12dc804e1d5efe12508e706d2/setuptools/config/pyprojecttoml.py#L135
+# This file remains for two pieces of config that setuptools cannot yet
+# express declaratively in pyproject.toml without opting into experimental
+# config:
+#   1. The limited-API C extension(s) — [tool.setuptools.ext-modules] is
+#      still experimental.
+#   2. The abi3 wheel tag (py_limited_api) — the equivalent
+#      [tool.distutils.bdist_wheel] table is also still experimental.
+# This file can be removed once both experimental gates are dropped in
+# https://github.com/pypa/setuptools/blob/84ed5913724df5a12dc804e1d5efe12508e706d2/setuptools/config/pyprojecttoml.py#L135
 
 from setuptools import setup, Extension
-from setuptools.command.bdist_wheel import bdist_wheel
-
-
-class bdist_wheel_abi3(bdist_wheel):
-    """Override bdist_wheel tag behavior to add abi3 tag."""
-
-    def get_tag(self):
-        python, abi, plat = super().get_tag()
-
-        if python.startswith("cp"):
-            return python, "abi3", plat
-        return python, abi, plat
 
 
 setup(
@@ -36,5 +27,5 @@ setup(
             py_limited_api=True,
         ),
     ],
-    cmdclass={"bdist_wheel": bdist_wheel_abi3},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )


### PR DESCRIPTION
Moving storage extensions to use pyproject.toml. `setup.py` remains since building extensions is marked as experiment for pyproject.toml