### PR TITLE
[confidentialledger] Enforce stricter redirect destination policy

### DIFF
--- a/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
+++ b/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Added redirect URL caching for write operations (POST/PUT/PATCH/DELETE). After the first redirect from the load balancer, subsequent writes go directly to the primary node, significantly reducing latency.
-- Enforced a stricter redirect destination policy: redirects are only followed when the target host is the original ledger host or one of its subdomains (e.g. an individual node). Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are now rejected and never followed or cached.
+- Enforced a stricter redirect destination policy: redirects are only followed when the target uses HTTPS, has the same effective port, and the host is the original ledger host or one of its subdomains (e.g. an individual node). Redirects that downgrade to HTTP, change the port, or point to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are now rejected and never followed or cached.
 
 ### Bugs Fixed
 

--- a/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
+++ b/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b3 (Unreleased)
+## 2.0.0b3 (2026-06-05)
 
 ### Features Added
 

--- a/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
+++ b/sdk/confidentialledger/azure-confidentialledger/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added redirect URL caching for write operations (POST/PUT/PATCH/DELETE). After the first redirect from the load balancer, subsequent writes go directly to the primary node, significantly reducing latency.
+- Enforced a stricter redirect destination policy: redirects are only followed when the target host is the original ledger host or one of its subdomains (e.g. an individual node). Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are now rejected and never followed or cached.
 
 ### Bugs Fixed
 

--- a/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
+++ b/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
@@ -15,6 +15,15 @@ and always go through the load-balancer.
 The cache is invalidated on 5xx responses or transport errors so that a
 failover is respected on the next write.
 
+Redirect destination policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Redirects are only followed when the target host is the original request host
+or one of its subdomains (e.g. an individual ledger node). Redirects to sibling
+ledgers, parent domains, unrelated hosts, or look-alike suffix domains are
+rejected and never followed or cached. This prevents a misconfigured or
+malicious load-balancer from redirecting requests (and their sensitive headers)
+to an unintended destination.
+
 Thread-safety
 ~~~~~~~~~~~~~
 * Reads of the cached value are lock-free (CPython GIL guarantees atomic
@@ -94,6 +103,29 @@ def _is_redirect(status_code: int) -> bool:
     return status_code in _REDIRECT_STATUS_CODES
 
 
+def _is_allowed_redirect_target(original_url: str, target_url: str) -> bool:
+    """Return whether *target_url* is an allowed redirect destination.
+
+    A redirect is permitted only when the target host is identical to the
+    original request host or is a subdomain of it.  All other targets — sibling
+    hosts, parent domains, unrelated hosts, and look-alike suffix domains — are
+    rejected.  Comparison is case-insensitive and ignores any port.
+
+    :param str original_url: The URL of the original request.
+    :param str target_url: The redirect target URL (e.g. from a ``Location`` header).
+    :return: True if the redirect target is permitted, otherwise False.
+    :rtype: bool
+    """
+    original_host = (urlparse(original_url).hostname or "").lower()
+    target_host = (urlparse(target_url).hostname or "").lower()
+
+    # Fail safe: if either host cannot be determined, do not follow the redirect.
+    if not original_host or not target_host:
+        return False
+
+    return target_host == original_host or target_host.endswith("." + original_host)
+
+
 class RedirectCachingPolicy(HTTPPolicy):
     """Synchronous redirect policy with write-URL caching.
 
@@ -121,6 +153,10 @@ class RedirectCachingPolicy(HTTPPolicy):
     def send(self, request: PipelineRequest) -> PipelineResponse:
         method = request.http_request.method.upper()
         is_write = method in _WRITE_METHODS
+
+        # Capture the pristine request host (before any cache rewrite) so that
+        # redirect targets are validated against the original ledger endpoint.
+        original_url = request.http_request.url
 
         # For writes, rewrite the URL to the cached primary (if warm).
         if is_write:
@@ -155,6 +191,15 @@ class RedirectCachingPolicy(HTTPPolicy):
         ):
             redirect_url = response.http_response.headers.get("Location")
             if not redirect_url:
+                break
+
+            # Enforce the redirect destination policy: only the original host or
+            # one of its subdomains may be followed.
+            if not _is_allowed_redirect_target(original_url, redirect_url):
+                _LOGGER.warning(
+                    "Refusing to follow redirect to disallowed target: %s",
+                    redirect_url,
+                )
                 break
 
             # Only cache for write methods.
@@ -205,6 +250,10 @@ class AsyncRedirectCachingPolicy(AsyncHTTPPolicy):
         method = request.http_request.method.upper()
         is_write = method in _WRITE_METHODS
 
+        # Capture the pristine request host (before any cache rewrite) so that
+        # redirect targets are validated against the original ledger endpoint.
+        original_url = request.http_request.url
+
         if is_write:
             cached = self._cache.get()
             if cached:
@@ -235,6 +284,15 @@ class AsyncRedirectCachingPolicy(AsyncHTTPPolicy):
         ):
             redirect_url = response.http_response.headers.get("Location")
             if not redirect_url:
+                break
+
+            # Enforce the redirect destination policy: only the original host or
+            # one of its subdomains may be followed.
+            if not _is_allowed_redirect_target(original_url, redirect_url):
+                _LOGGER.warning(
+                    "Refusing to follow redirect to disallowed target: %s",
+                    redirect_url,
+                )
                 break
 
             if is_write:

--- a/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
+++ b/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
@@ -44,7 +44,7 @@ Thread-safety
 import logging
 import threading
 from typing import FrozenSet, Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy, HTTPPolicy
@@ -111,10 +111,11 @@ def _is_redirect(status_code: int) -> bool:
     return status_code in _REDIRECT_STATUS_CODES
 
 
-def _effective_port(parsed) -> Optional[int]:
+def _effective_port(parsed: ParseResult) -> Optional[int]:
     """Return the effective port for a parsed URL, applying the scheme default.
 
     :param parsed: A :func:`urllib.parse.urlparse` result.
+    :type parsed: ~urllib.parse.ParseResult
     :return: The explicit port, or the scheme default (443 for ``https``,
         80 for ``http``), or ``None`` if it cannot be determined.
     :rtype: Optional[int]

--- a/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
+++ b/sdk/confidentialledger/azure-confidentialledger/azure/confidentialledger/_redirect_caching_policy.py
@@ -17,12 +17,20 @@ failover is respected on the next write.
 
 Redirect destination policy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Redirects are only followed when the target host is the original request host
-or one of its subdomains (e.g. an individual ledger node). Redirects to sibling
-ledgers, parent domains, unrelated hosts, or look-alike suffix domains are
-rejected and never followed or cached. This prevents a misconfigured or
-malicious load-balancer from redirecting requests (and their sensitive headers)
-to an unintended destination.
+A redirect is only followed when **all** of the following hold for the target:
+
+* the scheme is ``https`` (an ``https`` -> ``http`` downgrade is rejected so the
+  bearer token can never travel over cleartext);
+* the effective port matches the original request's effective port (the scheme
+  default — 443 for ``https`` — is used when no port is given); and
+* the host is the original request host or one of its subdomains (e.g. an
+  individual ledger node).
+
+Redirects to sibling ledgers, parent domains, unrelated hosts, look-alike suffix
+domains, downgraded (``http``) schemes, or different ports are rejected and never
+followed or cached. This prevents a misconfigured or malicious load-balancer from
+redirecting requests (and their sensitive headers, including the ``Authorization``
+bearer token which is *not* stripped on redirect) to an unintended destination.
 
 Thread-safety
 ~~~~~~~~~~~~~
@@ -103,26 +111,71 @@ def _is_redirect(status_code: int) -> bool:
     return status_code in _REDIRECT_STATUS_CODES
 
 
+def _effective_port(parsed) -> Optional[int]:
+    """Return the effective port for a parsed URL, applying the scheme default.
+
+    :param parsed: A :func:`urllib.parse.urlparse` result.
+    :return: The explicit port, or the scheme default (443 for ``https``,
+        80 for ``http``), or ``None`` if it cannot be determined.
+    :rtype: Optional[int]
+    """
+    try:
+        explicit = parsed.port
+    except ValueError:
+        # An invalid (out-of-range) port in the URL.
+        return None
+    if explicit is not None:
+        return explicit
+    scheme = (parsed.scheme or "").lower()
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    return None
+
+
 def _is_allowed_redirect_target(original_url: str, target_url: str) -> bool:
     """Return whether *target_url* is an allowed redirect destination.
 
-    A redirect is permitted only when the target host is identical to the
-    original request host or is a subdomain of it.  All other targets — sibling
-    hosts, parent domains, unrelated hosts, and look-alike suffix domains — are
-    rejected.  Comparison is case-insensitive and ignores any port.
+    A redirect is permitted only when **all** of these hold:
+
+    * the target scheme is ``https`` (no downgrade — the bearer token must never
+      travel over cleartext);
+    * the target's effective port equals the original request's effective port
+      (the scheme default is used when no port is present); and
+    * the target host is identical to the original request host or is a subdomain
+      of it.
+
+    All other targets — sibling hosts, parent domains, unrelated hosts, look-alike
+    suffix domains, downgraded schemes, and different ports — are rejected. Host
+    comparison is case-insensitive.
 
     :param str original_url: The URL of the original request.
     :param str target_url: The redirect target URL (e.g. from a ``Location`` header).
     :return: True if the redirect target is permitted, otherwise False.
     :rtype: bool
     """
-    original_host = (urlparse(original_url).hostname or "").lower()
-    target_host = (urlparse(target_url).hostname or "").lower()
+    original = urlparse(original_url)
+    target = urlparse(target_url)
+
+    original_host = (original.hostname or "").lower()
+    target_host = (target.hostname or "").lower()
 
     # Fail safe: if either host cannot be determined, do not follow the redirect.
     if not original_host or not target_host:
         return False
 
+    # Require HTTPS on the target so the bearer token is never sent over cleartext.
+    if (target.scheme or "").lower() != "https":
+        return False
+
+    # Require the same effective port (scheme default applied when absent).
+    original_port = _effective_port(original)
+    target_port = _effective_port(target)
+    if original_port is None or target_port is None or original_port != target_port:
+        return False
+
+    # Require the same host or a subdomain of the original host.
     return target_host == original_host or target_host.endswith("." + original_host)
 
 

--- a/sdk/confidentialledger/azure-confidentialledger/tests/test_redirect_caching_policy.py
+++ b/sdk/confidentialledger/azure-confidentialledger/tests/test_redirect_caching_policy.py
@@ -32,6 +32,11 @@ SIBLING_URL = "https://other-ledger.confidential-ledger.azure.com/app/transactio
 PARENT_URL = "https://confidential-ledger.azure.com/app/transactions"
 UNRELATED_URL = "https://evil.example.com/app/transactions"
 SUFFIX_LOOKALIKE_URL = "https://test-ledger.confidential-ledger.azure.com.evil.com/app/transactions"
+# Scheme downgrade and port-mismatch variants of otherwise-valid hosts.
+DOWNGRADE_SAME_HOST_URL = "http://test-ledger.confidential-ledger.azure.com/app/transactions"
+DOWNGRADE_NODE_URL = "http://node3.test-ledger.confidential-ledger.azure.com/app/transactions"
+DIFFERENT_PORT_HOST_URL = "https://test-ledger.confidential-ledger.azure.com:8443/app/transactions"
+DIFFERENT_PORT_NODE_URL = "https://node3.test-ledger.confidential-ledger.azure.com:8443/app/transactions"
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -113,7 +118,9 @@ class TestIsAllowedRedirectTarget:
             is True
         )
 
-    def test_same_host_ignores_port(self):
+    def test_same_host_explicit_default_port_allowed(self):
+        # Original has an implicit 443; an explicit :443 target is the same
+        # effective port and must be allowed.
         assert (
             _is_allowed_redirect_target(
                 LEDGER_URL,
@@ -121,6 +128,27 @@ class TestIsAllowedRedirectTarget:
             )
             is True
         )
+
+    def test_subdomain_explicit_default_port_allowed(self):
+        assert (
+            _is_allowed_redirect_target(
+                LEDGER_URL,
+                "https://node3.test-ledger.confidential-ledger.azure.com:443/app",
+            )
+            is True
+        )
+
+    def test_http_downgrade_same_host_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, DOWNGRADE_SAME_HOST_URL) is False
+
+    def test_http_downgrade_subdomain_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, DOWNGRADE_NODE_URL) is False
+
+    def test_different_port_same_host_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, DIFFERENT_PORT_HOST_URL) is False
+
+    def test_different_port_subdomain_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, DIFFERENT_PORT_NODE_URL) is False
 
     def test_case_insensitive(self):
         assert (
@@ -246,7 +274,17 @@ class TestRedirectCachingPolicy:
         assert policy._cache.get() is None
 
     @pytest.mark.parametrize(
-        "target", [SIBLING_URL, PARENT_URL, UNRELATED_URL, SUFFIX_LOOKALIKE_URL]
+        "target",
+        [
+            SIBLING_URL,
+            PARENT_URL,
+            UNRELATED_URL,
+            SUFFIX_LOOKALIKE_URL,
+            DOWNGRADE_SAME_HOST_URL,
+            DOWNGRADE_NODE_URL,
+            DIFFERENT_PORT_HOST_URL,
+            DIFFERENT_PORT_NODE_URL,
+        ],
     )
     def test_disallowed_redirect_not_followed(self, target):
         redirect_resp = _make_response(307, {"Location": target})
@@ -369,7 +407,17 @@ class TestAsyncRedirectCachingPolicy:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "target", [SIBLING_URL, PARENT_URL, UNRELATED_URL, SUFFIX_LOOKALIKE_URL]
+        "target",
+        [
+            SIBLING_URL,
+            PARENT_URL,
+            UNRELATED_URL,
+            SUFFIX_LOOKALIKE_URL,
+            DOWNGRADE_SAME_HOST_URL,
+            DOWNGRADE_NODE_URL,
+            DIFFERENT_PORT_HOST_URL,
+            DIFFERENT_PORT_NODE_URL,
+        ],
     )
     async def test_disallowed_redirect_not_followed(self, target):
         redirect_resp = _make_response(307, {"Location": target})

--- a/sdk/confidentialledger/azure-confidentialledger/tests/test_redirect_caching_policy.py
+++ b/sdk/confidentialledger/azure-confidentialledger/tests/test_redirect_caching_policy.py
@@ -6,6 +6,7 @@
 """Unit tests for RedirectCachingPolicy and AsyncRedirectCachingPolicy."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,14 +15,29 @@ from azure.confidentialledger._redirect_caching_policy import (
     AsyncRedirectCachingPolicy,
     RedirectCachingPolicy,
     _RedirectUrlCache,
+    _is_allowed_redirect_target,
     _rewrite_url,
 )
+
+
+# ── test hosts ───────────────────────────────────────────────────────────────
+# The ledger endpoint (also the load-balancer host) and a valid node subdomain.
+LEDGER_URL = "https://test-ledger.confidential-ledger.azure.com/app/transactions"
+NODE_URL = "https://node3.test-ledger.confidential-ledger.azure.com/app/transactions"
+NODE_BASE = "https://node3.test-ledger.confidential-ledger.azure.com"
+NODE_HOST = "node3.test-ledger.confidential-ledger.azure.com"
+
+# Disallowed redirect destinations.
+SIBLING_URL = "https://other-ledger.confidential-ledger.azure.com/app/transactions"
+PARENT_URL = "https://confidential-ledger.azure.com/app/transactions"
+UNRELATED_URL = "https://evil.example.com/app/transactions"
+SUFFIX_LOOKALIKE_URL = "https://test-ledger.confidential-ledger.azure.com.evil.com/app/transactions"
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
-def _make_request(method: str = "POST", url: str = "https://lb.example.com/app/transactions"):
+def _make_request(method: str = "POST", url: str = LEDGER_URL):
     """Return a fake PipelineRequest."""
     http_request = MagicMock()
     http_request.method = method
@@ -80,6 +96,60 @@ class TestRewriteUrl:
         assert result == "https://new-host:443/path"
 
 
+# ── _is_allowed_redirect_target ──────────────────────────────────────────────
+
+
+class TestIsAllowedRedirectTarget:
+    def test_same_host_allowed(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, LEDGER_URL) is True
+
+    def test_subdomain_allowed(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, NODE_URL) is True
+        assert (
+            _is_allowed_redirect_target(
+                LEDGER_URL,
+                "https://primary-1.test-ledger.confidential-ledger.azure.com/app",
+            )
+            is True
+        )
+
+    def test_same_host_ignores_port(self):
+        assert (
+            _is_allowed_redirect_target(
+                LEDGER_URL,
+                "https://test-ledger.confidential-ledger.azure.com:443/app",
+            )
+            is True
+        )
+
+    def test_case_insensitive(self):
+        assert (
+            _is_allowed_redirect_target(
+                LEDGER_URL,
+                "https://NODE3.Test-Ledger.Confidential-Ledger.Azure.Com/app",
+            )
+            is True
+        )
+
+    def test_sibling_host_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, SIBLING_URL) is False
+
+    def test_parent_domain_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, PARENT_URL) is False
+
+    def test_unrelated_host_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, UNRELATED_URL) is False
+
+    def test_suffix_lookalike_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, SUFFIX_LOOKALIKE_URL) is False
+
+    def test_missing_target_host_blocked(self):
+        assert _is_allowed_redirect_target(LEDGER_URL, "/app/transactions") is False
+
+    def test_missing_original_host_blocked(self):
+        assert _is_allowed_redirect_target("/app/transactions", NODE_URL) is False
+
+
 # ── RedirectCachingPolicy (sync) ─────────────────────────────────────────────
 
 
@@ -92,7 +162,7 @@ class TestRedirectCachingPolicy:
         return policy
 
     def test_cache_populated_on_first_redirect(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp])
 
@@ -100,40 +170,40 @@ class TestRedirectCachingPolicy:
         result = policy.send(request)
 
         assert result.http_response.status_code == 200
-        assert policy._cache.get() == "https://primary.example.com"
+        assert policy._cache.get() == NODE_BASE
 
     def test_subsequent_write_uses_cached_url(self):
         # First request: redirect populates cache
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         # Second request: should go directly
         final_resp2 = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp1, final_resp2])
 
         policy.send(_make_request("POST"))
-        req2 = _make_request("POST", "https://lb.example.com/app/transactions")
+        req2 = _make_request("POST", LEDGER_URL)
         policy.send(req2)
 
         # The request URL should have been rewritten to the cached primary
-        assert "primary.example.com" in req2.http_request.url
+        assert NODE_HOST in req2.http_request.url
 
     def test_get_never_uses_cache(self):
         # Warm the cache via a POST redirect
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         # GET request
         final_resp2 = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp1, final_resp2])
 
         policy.send(_make_request("POST"))
-        get_req = _make_request("GET", "https://lb.example.com/app/transactions")
+        get_req = _make_request("GET", LEDGER_URL)
         policy.send(get_req)
 
         # GET should NOT have been rewritten
-        assert get_req.http_request.url == "https://lb.example.com/app/transactions"
+        assert get_req.http_request.url == LEDGER_URL
 
     def test_5xx_invalidates_cache(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         error_resp = _make_response(503)
         policy = self._make_policy([redirect_resp, final_resp1, error_resp])
@@ -145,7 +215,7 @@ class TestRedirectCachingPolicy:
         assert policy._cache.get() is None
 
     def test_transport_error_invalidates_cache(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp, ConnectionError("connection lost")])
 
@@ -157,16 +227,16 @@ class TestRedirectCachingPolicy:
         assert policy._cache.get() is None
 
     def test_delete_is_a_write_method(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp])
 
         policy.send(_make_request("DELETE"))
-        assert policy._cache.get() == "https://primary.example.com"
+        assert policy._cache.get() == NODE_BASE
 
     def test_permit_redirects_false_skips_redirect(self):
         policy = RedirectCachingPolicy(permit_redirects=False)
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         policy.next = MagicMock()
         policy.next.send = MagicMock(return_value=redirect_resp)
 
@@ -174,6 +244,48 @@ class TestRedirectCachingPolicy:
         # Should return the 307 without following
         assert result.http_response.status_code == 307
         assert policy._cache.get() is None
+
+    @pytest.mark.parametrize(
+        "target", [SIBLING_URL, PARENT_URL, UNRELATED_URL, SUFFIX_LOOKALIKE_URL]
+    )
+    def test_disallowed_redirect_not_followed(self, target):
+        redirect_resp = _make_response(307, {"Location": target})
+        # Only one downstream call is expected; the redirect must not be followed.
+        policy = self._make_policy([redirect_resp])
+
+        result = policy.send(_make_request("POST"))
+
+        # The 307 is returned as-is and the disallowed target is never cached.
+        assert result.http_response.status_code == 307
+        assert policy._cache.get() is None
+        assert policy.next.send.call_count == 1
+
+    def test_subdomain_redirect_followed(self):
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
+        final_resp = _make_response(200)
+        policy = self._make_policy([redirect_resp, final_resp])
+
+        result = policy.send(_make_request("POST"))
+
+        assert result.http_response.status_code == 200
+        assert policy._cache.get() == NODE_BASE
+
+    def test_disallowed_redirect_emits_warning_log(self, caplog):
+        redirect_resp = _make_response(307, {"Location": UNRELATED_URL})
+        policy = self._make_policy([redirect_resp])
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="azure.confidentialledger._redirect_caching_policy",
+        ):
+            policy.send(_make_request("POST"))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "Refusing to follow redirect to disallowed target" in r.message
+            and UNRELATED_URL in r.message
+            for r in warnings
+        ), f"Expected a block warning for {UNRELATED_URL}, got: {[r.message for r in warnings]}"
 
 
 # ── AsyncRedirectCachingPolicy ───────────────────────────────────────────────
@@ -195,43 +307,43 @@ class TestAsyncRedirectCachingPolicy:
 
     @pytest.mark.asyncio
     async def test_cache_populated_on_first_redirect(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp])
 
         result = await policy.send(_make_request("POST"))
         assert result.http_response.status_code == 200
-        assert policy._cache.get() == "https://primary.example.com"
+        assert policy._cache.get() == NODE_BASE
 
     @pytest.mark.asyncio
     async def test_subsequent_write_uses_cached_url(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         final_resp2 = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp1, final_resp2])
 
         await policy.send(_make_request("POST"))
-        req2 = _make_request("POST", "https://lb.example.com/app/transactions")
+        req2 = _make_request("POST", LEDGER_URL)
         await policy.send(req2)
 
-        assert "primary.example.com" in req2.http_request.url
+        assert NODE_HOST in req2.http_request.url
 
     @pytest.mark.asyncio
     async def test_get_never_uses_cache(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         final_resp2 = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp1, final_resp2])
 
         await policy.send(_make_request("POST"))
-        get_req = _make_request("GET", "https://lb.example.com/app/transactions")
+        get_req = _make_request("GET", LEDGER_URL)
         await policy.send(get_req)
 
-        assert get_req.http_request.url == "https://lb.example.com/app/transactions"
+        assert get_req.http_request.url == LEDGER_URL
 
     @pytest.mark.asyncio
     async def test_5xx_invalidates_cache(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp1 = _make_response(200)
         error_resp = _make_response(503)
         policy = self._make_policy([redirect_resp, final_resp1, error_resp])
@@ -244,7 +356,7 @@ class TestAsyncRedirectCachingPolicy:
 
     @pytest.mark.asyncio
     async def test_transport_error_invalidates_cache(self):
-        redirect_resp = _make_response(307, {"Location": "https://primary.example.com/app/transactions"})
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
         final_resp = _make_response(200)
         policy = self._make_policy([redirect_resp, final_resp, ConnectionError("connection lost")])
 
@@ -254,3 +366,46 @@ class TestAsyncRedirectCachingPolicy:
         with pytest.raises(ConnectionError):
             await policy.send(_make_request("POST"))
         assert policy._cache.get() is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "target", [SIBLING_URL, PARENT_URL, UNRELATED_URL, SUFFIX_LOOKALIKE_URL]
+    )
+    async def test_disallowed_redirect_not_followed(self, target):
+        redirect_resp = _make_response(307, {"Location": target})
+        policy = self._make_policy([redirect_resp])
+
+        result = await policy.send(_make_request("POST"))
+
+        assert result.http_response.status_code == 307
+        assert policy._cache.get() is None
+        assert policy.next.send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_subdomain_redirect_followed(self):
+        redirect_resp = _make_response(307, {"Location": NODE_URL})
+        final_resp = _make_response(200)
+        policy = self._make_policy([redirect_resp, final_resp])
+
+        result = await policy.send(_make_request("POST"))
+
+        assert result.http_response.status_code == 200
+        assert policy._cache.get() == NODE_BASE
+
+    @pytest.mark.asyncio
+    async def test_disallowed_redirect_emits_warning_log(self, caplog):
+        redirect_resp = _make_response(307, {"Location": UNRELATED_URL})
+        policy = self._make_policy([redirect_resp])
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="azure.confidentialledger._redirect_caching_policy",
+        ):
+            await policy.send(_make_request("POST"))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "Refusing to follow redirect to disallowed target" in r.message
+            and UNRELATED_URL in r.message
+            for r in warnings
+        ), f"Expected a block warning for {UNRELATED_URL}, got: {[r.message for r in warnings]}"


### PR DESCRIPTION
## Summary

Hardens the data-plane redirect handling in `azure-confidentialledger` so that the client only follows HTTP redirects whose target host is the **original ledger host or one of its subdomains**. Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are now rejected, logged at `WARNING`, and never followed or cached.

Fixes **ICM 31000000622491**.

## Problem

The custom `RedirectCachingPolicy` / `AsyncRedirectCachingPolicy` (used in place of the default `RedirectPolicy`) followed **any** `Location` target returned by the service. Because Confidential Ledger intentionally disables sensitive-header cleanup on redirects (`disable_redirect_cleanup=True`) to preserve auth headers across service-managed redirects within the ledger, a misconfigured or malicious load balancer could redirect a request — **along with its sensitive headers** — to an unintended destination.

## Policy

Given an original request to `https://test-ledger.confidential-ledger.azure.com`, redirects are now evaluated as follows:

| Target | Followed? |
| --- | --- |
| `https://test-ledger.confidential-ledger.azure.com/...` (same host) | Yes |
| `https://node3.test-ledger.confidential-ledger.azure.com/...` (subdomain / node) | Yes |
| `https://primary-1.test-ledger.confidential-ledger.azure.com/...` (subdomain / node) | Yes |
| `https://other-ledger.confidential-ledger.azure.com/...` (sibling ledger) | No |
| `https://confidential-ledger.azure.com/...` (parent domain) | No |
| `https://evil.example.com/...` (unrelated host) | No |
| `https://test-ledger.confidential-ledger.azure.com.evil.com/...` (suffix look-alike) | No |

## Changes

- **New helper** `_is_allowed_redirect_target(original_url, target_url)` — host/subdomain check that is case-insensitive, ignores port, and fails safe (rejects) if either host can't be parsed. Logic: `target == original or target.endswith("." + original)`.
- **Sync + async `send()`** now capture the pristine request URL (before any cached-primary rewrite) and validate every redirect hop against it. Disallowed targets are logged (`Refusing to follow redirect to disallowed target: ...`) and the redirect loop breaks without following or caching.
- **CHANGELOG** entry added under `2.0.0b3 (Unreleased)`.

## Testing

**Unit tests** (`tests/test_redirect_caching_policy.py`) — 39 passing:
- `_is_allowed_redirect_target`: same host, subdomains, port/case variations (allowed); sibling, parent, unrelated, suffix look-alike, missing-host (blocked).
- Sync + async policy: disallowed targets are not followed (single downstream call, `307` returned as-is, cache stays empty); legitimate subdomain redirects are still followed and cached.
- `caplog` assertions that the `Refusing to follow redirect to disallowed target` warning is emitted (sync + async).

**Live validation** against a real ledger (AAD auth):
- 15/15 consecutive writes succeed end-to-end through the policy.
- A real load-balancer to node redirect to an `accledger-2.<ledger>.confidential-ledger.azure.com` **subdomain** is correctly **allowed**, followed, cached, and reused on subsequent writes — confirming the legitimate path the service depends on is preserved.
- The malicious-target path cannot be exercised live (the real service never emits a malicious redirect), so it is covered exclusively by the mock-based unit tests above.
<img width="907" height="627" alt="image" src="https://github.com/user-attachments/assets/2aab486a-023e-4b6b-af63-e92ac1c8048f" />

## Scope / notes

- This change affects only the **data-plane** `azure-confidentialledger` redirect policy. The certificate client and `azure-mgmt-confidentialledger` use the generated default `RedirectPolicy` and are out of scope.
- No public API changes; behavior change only.
