### PR TITLE
[API Review] azure-storage-blob 12.31.0b1 (base 12.29.0)

### DIFF
--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -52,6 +52,7 @@ namespace azure.storage.blob
             content_type: Optional[str] = ..., 
             correlation_id: Optional[str] = ..., 
             encryption_scope: Optional[str] = ..., 
+            is_directory: Optional[bool] = ..., 
             protocol: Optional[str] = ..., 
             request_headers: Optional[Dict[str, str]] = ..., 
             request_query_params: Optional[Dict[str, str]] = ..., 
@@ -469,7 +470,7 @@ namespace azure.storage.blob
                 match_condition: Optional[MatchConditions] = ..., 
                 maxsize_condition: Optional[int] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Union[str, datetime, int]]: ...
 
@@ -930,7 +931,7 @@ namespace azure.storage.blob
                 encryption_scope: Optional[str] = ..., 
                 lease: Union[BlobLeaseClient, str] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Any]: ...
 
@@ -1021,7 +1022,7 @@ namespace azure.storage.blob
                 standard_blob_tier: Optional[StandardBlobTier] = ..., 
                 tags: dict(str, str) = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Any]: ...
 
@@ -1075,7 +1076,7 @@ namespace azure.storage.blob
                 lease: Union[BlobLeaseClient, str] = ..., 
                 match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Union[str, datetime]]: ...
 
@@ -1289,6 +1290,7 @@ namespace azure.storage.blob
         request_server_encrypted: Optional[bool]
         server_encrypted: bool
         size: int
+        smart_access_tier: Optional[str]
         snapshot: Optional[str]
         tag_count: Optional[int]
         tags: Optional[Dict[str, str]]
@@ -1648,10 +1650,8 @@ namespace azure.storage.blob
                 lease_duration: int = -1, 
                 lease_id: Optional[str] = None, 
                 *, 
-                etag: Optional[str] = ..., 
                 if_modified_since: Optional[datetime] = ..., 
                 if_unmodified_since: Optional[datetime] = ..., 
-                match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
                 **kwargs: Any
             ) -> BlobLeaseClient: ...
@@ -1704,11 +1704,9 @@ namespace azure.storage.blob
         def delete_container(
                 self, 
                 *, 
-                etag: Optional[str] = ..., 
                 if_modified_since: Optional[datetime] = ..., 
                 if_unmodified_since: Optional[datetime] = ..., 
                 lease: Union[BlobLeaseClient, str] = ..., 
-                match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
                 **kwargs: Any
             ) -> None: ...
@@ -1818,9 +1816,7 @@ namespace azure.storage.blob
                 self, 
                 metadata: Optional[Dict[str, str]] = None, 
                 *, 
-                etag: Optional[str] = ..., 
                 if_modified_since: Optional[datetime] = ..., 
-                if_unmodified_since: Optional[datetime] = ..., 
                 lease: Union[BlobLeaseClient, str] = ..., 
                 timeout: Optional[int] = ..., 
                 **kwargs: Any
@@ -1876,7 +1872,7 @@ namespace azure.storage.blob
                 progress_hook: Callable[[int, Optional[int]], None] = ..., 
                 standard_blob_tier: Optional[StandardBlobTier] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs
             ) -> BlobClient: ...
 
@@ -2873,6 +2869,7 @@ namespace azure.storage.blob
         COLD = "Cold"
         COOL = "Cool"
         HOT = "Hot"
+        SMART = "Smart"
 
 
     class azure.storage.blob.StaticWebsite(GeneratedStaticWebsite):
@@ -3114,7 +3111,7 @@ namespace azure.storage.blob
                 config: StorageConfiguration = None, 
                 start_range: Optional[int] = None, 
                 end_range: Optional[int] = None, 
-                validate_content: bool = None, 
+                validate_content: CV_TYPE_PARSED = None, 
                 encryption_options: Dict[str, Any] = None, 
                 max_concurrency: Optional[int] = None, 
                 name: str = None, 
@@ -3128,18 +3125,18 @@ namespace azure.storage.blob
 
         def chunks(self) -> Iterator[bytes]: ...
 
-        def content_as_bytes(self, max_concurrency: int = None) -> bytes: ...
+        def content_as_bytes(self, max_concurrency: Optional[int] = None) -> bytes: ...
 
         def content_as_text(
                 self, 
-                max_concurrency: int = None, 
+                max_concurrency: Optional[int] = None, 
                 encoding: str = "UTF-8"
             ) -> str: ...
 
         def download_to_stream(
                 self, 
                 stream: IO[T], 
-                max_concurrency: int = None
+                max_concurrency: Optional[int] = None
             ) -> Any: ...
 
         @overload
@@ -3298,7 +3295,7 @@ namespace azure.storage.blob.aio
                 match_condition: Optional[MatchConditions] = ..., 
                 maxsize_condition: Optional[int] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Union[str, datetime, int]]: ...
 
@@ -3758,7 +3755,7 @@ namespace azure.storage.blob.aio
                 encryption_scope: Optional[str] = ..., 
                 lease: Union[BlobLeaseClient, str] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Any]: ...
 
@@ -3850,7 +3847,7 @@ namespace azure.storage.blob.aio
                 standard_blob_tier: Optional[StandardBlobTier] = ..., 
                 tags: dict(str, str) = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Any]: ...
 
@@ -3904,7 +3901,7 @@ namespace azure.storage.blob.aio
                 lease: Union[BlobLeaseClient, str] = ..., 
                 match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs: Any
             ) -> Dict[str, Union[str, datetime]]: ...
 
@@ -4299,10 +4296,8 @@ namespace azure.storage.blob.aio
                 lease_duration: int = -1, 
                 lease_id: Optional[str] = None, 
                 *, 
-                etag: Optional[str] = ..., 
                 if_modified_since: Optional[datetime] = ..., 
                 if_unmodified_since: Optional[datetime] = ..., 
-                match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
                 **kwargs: Any
             ) -> BlobLeaseClient: ...
@@ -4355,11 +4350,9 @@ namespace azure.storage.blob.aio
         async def delete_container(
                 self, 
                 *, 
-                etag: Optional[str] = ..., 
                 if_modified_since: Optional[datetime] = ..., 
                 if_unmodified_since: Optional[datetime] = ..., 
                 lease: Union[BlobLeaseClient, str] = ..., 
-                match_condition: Optional[MatchConditions] = ..., 
                 timeout: Optional[int] = ..., 
                 **kwargs: Any
             ) -> None: ...
@@ -4525,7 +4518,7 @@ namespace azure.storage.blob.aio
                 progress_hook: Callable[[int, Optional[int]], Awaitable[None]] = ..., 
                 standard_blob_tier: Optional[StandardBlobTier] = ..., 
                 timeout: Optional[int] = ..., 
-                validate_content: Optional[bool] = ..., 
+                validate_content: Union[bool, Literal[auto, crc64, md5]] = ..., 
                 **kwargs
             ) -> BlobClient: ...
 
@@ -4624,7 +4617,7 @@ namespace azure.storage.blob.aio
                 config: StorageConfiguration = None, 
                 start_range: Optional[int] = None, 
                 end_range: Optional[int] = None, 
-                validate_content: bool = None, 
+                validate_content: CV_TYPE_PARSED = None, 
                 encryption_options: Dict[str, Any] = None, 
                 max_concurrency: Optional[int] = None, 
                 name: str = None, 
@@ -4638,18 +4631,18 @@ namespace azure.storage.blob.aio
 
         def chunks(self) -> AsyncIterator[bytes]: ...
 
-        async def content_as_bytes(self, max_concurrency: int = None) -> bytes: ...
+        async def content_as_bytes(self, max_concurrency: Optional[int] = None) -> bytes: ...
 
         async def content_as_text(
                 self, 
-                max_concurrency: int = None, 
+                max_concurrency: Optional[int] = None, 
                 encoding: str = "UTF-8"
             ) -> str: ...
 
         async def download_to_stream(
                 self, 
                 stream: IO[T], 
-                max_concurrency: int = None
+                max_concurrency: Optional[int] = None
             ) -> Any: ...
 
         @overload

--- a/sdk/storage/azure-storage-blob/api.metadata.yml
+++ b/sdk/storage/azure-storage-blob/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: 9010619c987cb7f6cd5a839bd39fe61f7efbdc22a09e86ec39757adeff28fd93
+apiMdSha256: 38a660f5d55527fe389aaf9017736875f51f1f564acd4ea8aaaa547552b820b2
 parserVersion: 0.3.28
 pythonVersion: 3.12.9


### PR DESCRIPTION
Automated API review PR for azure-storage-blob.

- **Working branch:** [branch `GenerateAPITextScript`](https://github.com/Azure/azure-sdk-for-python/tree/GenerateAPITextScript) (version 12.31.0b1)
- **Baseline:** [tag `azure-storage-blob_12.29.0`](https://github.com/Azure/azure-sdk-for-python/commit/e73548b8a2e8fa20c3ae9114e94b548cb69a309e) (version 12.29.0)

Generated by scripts/api_md_workflow/create_api_review_pr.js.