### PR TITLE
[ml] Allow updating display_name/description/tags on existing pipeline (sweep) jobs (DRAFT)

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -710,7 +710,26 @@ class JobOperations(_ScopeDependentOperations):
         ):
             self._set_headers_with_user_aml_token(kwargs)
 
-        result = self._create_or_update_with_different_version_api(rest_job_resource=rest_job_resource, **kwargs)
+        # For a pipeline job that was previously fetched (i.e. already exists on the
+        # service), round-tripping the high-level entity through to_rest_job_object()
+        # does not produce a byte-identical REST body. MFE then sees a delta in
+        # immutable fields such as InputBindings and rejects the PUT with
+        # JobPropertyImmutable. Per the service contract, only description, tags,
+        # displayName, properties and isArchived are updatable. When this is clearly
+        # an update of an existing pipeline job, overlay just those fields onto the
+        # stored REST representation instead of sending the round-tripped body.
+        if (
+            rest_job_resource.properties.job_type == RestJobType.PIPELINE
+            and getattr(job, "creation_context", None) is not None
+            and rest_job_resource.name
+        ):
+            result = self._update_existing_pipeline_job_editable_fields(
+                rest_job_resource=rest_job_resource, **kwargs
+            )
+        else:
+            result = self._create_or_update_with_different_version_api(
+                rest_job_resource=rest_job_resource, **kwargs
+            )
 
         if is_local_run(result):
             ws_base_url = self._all_operations.all_operations[
@@ -779,6 +798,25 @@ class JobOperations(_ScopeDependentOperations):
         )
 
         return result
+
+    def _update_existing_pipeline_job_editable_fields(
+        self, rest_job_resource: JobBase, **kwargs: Any
+    ) -> JobBase:
+        """Apply an in-place update to an existing pipeline job using only the
+        editable fields. Avoids JobPropertyImmutable / InputBindings errors that
+        occur when the round-tripped REST body diverges from the stored one.
+
+        Per the service contract, only description, tags, displayName, properties
+        and isArchived are updatable on an existing job.
+        """
+        stored = self._get_job_2401(rest_job_resource.name)
+        new_props = rest_job_resource.properties
+        stored.properties.description = new_props.description
+        stored.properties.display_name = new_props.display_name
+        stored.properties.tags = new_props.tags
+        stored.properties.properties = new_props.properties
+        stored.properties.is_archived = new_props.is_archived
+        return self._create_or_update_with_different_version_api(rest_job_resource=stored, **kwargs)
 
     def _archive_or_restore(self, name: str, is_archived: bool) -> None:
         job_object = self._get_job(name)


### PR DESCRIPTION
**Draft - request for review.**

## Bug

`MLClient.jobs.create_or_update(fetched_job)` fails for an already-submitted pipeline job (incl. one containing a `sweep` step) when the caller only mutates an editable field like `display_name`:

```text
HttpResponseError: (UserError) A job with this name already exists. ...
  the existing job's InputBindings cannot be changed.
  Only description, tags, displayName, properties, and isArchived can be updated.
  InnerError: { code: Immutable / JobPropertyImmutable }
  MessageParameters: { `property`: " InputBindings" }
```

## Repro

Reproduced end-to-end in azureml-examples CI: https://github.com/Azure/azureml-examples/pull/4018`n
Minimal snippet:

```python
pipeline_job = ml_client.jobs.create_or_update(pipeline_job, experiment_name="pipeline_samples")
fetched = ml_client.jobs.get(pipeline_job.name)
fetched.display_name = f"{pipeline_job.name}_updated"
ml_client.jobs.create_or_update(fetched)   # <- raises JobPropertyImmutable / InputBindings
```

## Root cause

`JobOperations.create_or_update` always sends the full reconstructed REST body via PUT. For an existing pipeline job, `to_rest_job_object(job)` round-trips through the high-level entity and does not produce a byte-identical body to what MFE has stored. MFE then sees a delta in immutable fields such as `InputBindings` and rejects the update, even though the caller only touched an editable field.

## Fix

When `create_or_update` is clearly an update of an already-existing pipeline job (`PIPELINE` type, `creation_context` populated, `name` set), overlay only the editable fields (`description`, `tags`, `displayName`, `properties`, `isArchived` -- the set MFE explicitly enumerates) onto the **stored** REST representation fetched via `_get_job_2401` and PUT that. This mirrors what `_archive_or_restore` already does and avoids the InputBindings round-trip mismatch.

## Follow-ups (not in this PR)

- Apply the same fix to the async `JobOperations`.
- Consider extending the gate beyond `PIPELINE` once the same round-trip issue is verified or ruled out for other job types.