### PR TITLE
match foundry project endpoint host by suffix not substring

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0b3 (Unreleased)
+
+### Bugs Fixed
+
+- `_derive_resource_url_from_project_endpoint` now matches the project endpoint host by suffix instead of substring, so a look-alike host (e.g. `<name>.services.ai.azure.com.example`) no longer derives an attacker-controlled resource URL.
+
 ## 1.0.0b2 (2026-04-24)
 
 ### Breaking Changes

--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
@@ -128,7 +128,7 @@ def _derive_resource_url_from_project_endpoint(project_endpoint: str) -> str:
         (".services.ai.azure.cn", ".cognitiveservices.azure.cn"),
         (".services.ai.azure.us", ".cognitiveservices.azure.us"),
     ]:
-        if hostname.endswith(project_pat):
+        if len(hostname) > len(project_pat) and hostname.endswith(project_pat):
             resource_host = hostname[: -len(project_pat)] + resource_pat
             return f"https://{resource_host}"
 

--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_copilot_adapter.py
@@ -128,8 +128,9 @@ def _derive_resource_url_from_project_endpoint(project_endpoint: str) -> str:
         (".services.ai.azure.cn", ".cognitiveservices.azure.cn"),
         (".services.ai.azure.us", ".cognitiveservices.azure.us"),
     ]:
-        if project_pat in hostname:
-            return f"https://{hostname.replace(project_pat, resource_pat)}"
+        if hostname.endswith(project_pat):
+            resource_host = hostname[: -len(project_pat)] + resource_pat
+            return f"https://{resource_host}"
 
     raise ValueError(f"Cannot derive RESOURCE_URL from: {project_endpoint}")
 

--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/azure/ai/agentserver/githubcopilot/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------
 
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"

--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/tests/unit_tests/test_replat_features.py
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/tests/unit_tests/test_replat_features.py
@@ -268,6 +268,13 @@ class TestUrlDerivation:
         with pytest.raises(ValueError, match="Cannot derive"):
             _derive_resource_url_from_project_endpoint("https://unknown.example.com/foo")
 
+    def test_derive_resource_url_rejects_lookalike_host(self):
+        """A look-alike host that only contains the suffix is rejected."""
+        with pytest.raises(ValueError, match="Cannot derive"):
+            _derive_resource_url_from_project_endpoint(
+                "https://victim.services.ai.azure.com.attacker.example/api/projects/myproject"
+            )
+
     def test_get_project_endpoint_new_var(self):
         """Prefers FOUNDRY_PROJECT_ENDPOINT over legacy name."""
         with patch.dict(os.environ, {

--- a/sdk/agentserver/azure-ai-agentserver-ghcopilot/tests/unit_tests/test_replat_features.py
+++ b/sdk/agentserver/azure-ai-agentserver-ghcopilot/tests/unit_tests/test_replat_features.py
@@ -275,6 +275,13 @@ class TestUrlDerivation:
                 "https://victim.services.ai.azure.com.attacker.example/api/projects/myproject"
             )
 
+    def test_derive_resource_url_rejects_bare_suffix_host(self):
+        """A host that is exactly the suffix (no resource label) is rejected."""
+        with pytest.raises(ValueError, match="Cannot derive"):
+            _derive_resource_url_from_project_endpoint(
+                "https://.services.ai.azure.com/api/projects/myproject"
+            )
+
     def test_get_project_endpoint_new_var(self):
         """Prefers FOUNDRY_PROJECT_ENDPOINT over legacy name."""
         with patch.dict(os.environ, {


### PR DESCRIPTION
# Description

`_derive_resource_url_from_project_endpoint` derives the Foundry resource URL that later receives a Managed Identity token (`cognitiveservices.azure.com` scope) as the bearer token, so the host it returns is where that credential is sent.

Repro: point the project endpoint host at `victim.services.ai.azure.com.attacker.example`.
Cause: the host is matched with `project_pat in hostname` (substring) and rewritten via `str.replace`, so a look-alike host that merely contains `.services.ai.azure.com` passes and yields `victim.cognitiveservices.azure.com.attacker.example`, an attacker-controlled domain.
Fix: require the host to end with the expected suffix and rewrite only that trailing suffix, so the derived resource host stays under the intended domain. Legitimate endpoints derive the same URL as before.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
