### PR TITLE
[API Review] azure-keyvault-keys 4.12.0b3 (base 4.11.1)

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/api.md
+++ b/sdk/keyvault/azure-keyvault-keys/api.md
@@ -4,6 +4,7 @@ namespace azure.keyvault.keys
     class azure.keyvault.keys.ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
         V2016_10_01 = "2016-10-01"
         V2025_07_01 = "2025-07-01"
+        V2026_01_01_PREVIEW = "2026-01-01-preview"
         V7_0 = "7.0"
         V7_1 = "7.1"
         V7_2 = "7.2"
@@ -31,6 +32,17 @@ namespace azure.keyvault.keys
                 recovery_id: Optional[str] = None, 
                 scheduled_purge_date: Optional[datetime] = None, 
                 **kwargs: Any
+            ) -> None: ...
+
+        def __repr__(self) -> str: ...
+
+
+    class azure.keyvault.keys.ExternalKey:
+
+        def __init__(
+                self, 
+                *, 
+                id: str
             ) -> None: ...
 
         def __repr__(self) -> str: ...
@@ -126,6 +138,20 @@ namespace azure.keyvault.keys
                 exportable: Optional[bool] = ..., 
                 hardware_protected: Optional[bool] = False, 
                 key_operations: Optional[List[Union[str, KeyOperation]]] = ..., 
+                not_before: Optional[datetime] = ..., 
+                release_policy: Optional[KeyReleasePolicy] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultKey: ...
+
+        @distributed_trace
+        def create_external_key(
+                self, 
+                name: str, 
+                external_key: ExternalKey, 
+                *, 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
                 not_before: Optional[datetime] = ..., 
                 release_policy: Optional[KeyReleasePolicy] = ..., 
                 tags: Optional[Dict[str, str]] = ..., 
@@ -359,8 +385,10 @@ namespace azure.keyvault.keys
         property enabled: Optional[bool]    # Read-only
         property expires_on: Optional[datetime]    # Read-only
         property exportable: Optional[bool]    # Read-only
+        property external_key: Optional[ExternalKey]    # Read-only
         property hsm_platform: Optional[str]    # Read-only
         property id: str    # Read-only
+        property key_size: Optional[int]    # Read-only
         property managed: Optional[bool]    # Read-only
         property name: str    # Read-only
         property not_before: Optional[datetime]    # Read-only
@@ -502,6 +530,20 @@ namespace azure.keyvault.keys.aio
                 exportable: Optional[bool] = ..., 
                 hardware_protected: Optional[bool] = False, 
                 key_operations: Optional[List[Union[str, KeyOperation]]] = ..., 
+                not_before: Optional[datetime] = ..., 
+                release_policy: Optional[KeyReleasePolicy] = ..., 
+                tags: Optional[Dict[str, str]] = ..., 
+                **kwargs: Any
+            ) -> KeyVaultKey: ...
+
+        @distributed_trace_async
+        async def create_external_key(
+                self, 
+                name: str, 
+                external_key: ExternalKey, 
+                *, 
+                enabled: Optional[bool] = ..., 
+                expires_on: Optional[datetime] = ..., 
                 not_before: Optional[datetime] = ..., 
                 release_policy: Optional[KeyReleasePolicy] = ..., 
                 tags: Optional[Dict[str, str]] = ..., 

--- a/sdk/keyvault/azure-keyvault-keys/api.metadata.yml
+++ b/sdk/keyvault/azure-keyvault-keys/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: 81afb80fc423bf72aca4bf217228bd93c2b2215c37ae30f15d4c2ec0690922a2
+apiMdSha256: 05e3c49b61c87d61acec04ec97bd251f05ed4d256c62153c9905d4cad25dd6da
 parserVersion: 0.3.28
 pythonVersion: 3.12.9


### PR DESCRIPTION
Automated API review PR for azure-keyvault-keys.

- **Working branch:** [branch `main`](https://github.com/Azure/azure-sdk-for-python/tree/main) (version 4.12.0b3)
- **Baseline:** [tag `azure-keyvault-keys_4.11.1`](https://github.com/Azure/azure-sdk-for-python/commit/18e7c83822d6c4ab36100a52024d7791f5ce99d6) (version 4.11.1)

Generated by scripts/api_md_workflow/create_api_review_pr.js.

<!-- api-md-review-sync
DO NOT MODIFY THESE CONTENTS!
{
  "schemaVersion": 1,
  "repository": "Azure/azure-sdk-for-python",
  "packageName": "azure-keyvault-keys",
  "packageDir": "sdk/keyvault/azure-keyvault-keys",
  "baseBranch": "apireview/base_azure-keyvault-keys_4.11.1",
  "reviewBranch": "apireview/review_azure-keyvault-keys_4.12.0b3",
  "workingOwner": "Azure",
  "workingBranch": "main",
  "workingPrNumber": null
}
-->