### PR TITLE
Record @typespec/http-client-python version in generated metadata

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -629,10 +629,14 @@ def gen_typespec(
 
         raise e
 
+    http_client_python = "@typespec/http-client-python"
     with open(Path("eng/emitter-package.json"), "r") as file_in:
         data = json.load(file_in)
         npm_package_version = {
             "emitterVersion": data["dependencies"][typespec_python],
         }
+        http_client_python_version = data.get("devDependencies", {}).get(http_client_python)
+        if http_client_python_version:
+            npm_package_version[http_client_python] = http_client_python_version
 
     return npm_package_version

--- a/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/generate_utils.py
@@ -637,6 +637,6 @@ def gen_typespec(
         }
         http_client_python_version = data.get("devDependencies", {}).get(http_client_python)
         if http_client_python_version:
-            npm_package_version[http_client_python] = http_client_python_version
+            npm_package_version["httpClientPythonVersion"] = http_client_python_version
 
     return npm_package_version


### PR DESCRIPTION
## Description

In addition to `emitterVersion` (`@azure-tools/typespec-python`), this change also records the `@typespec/http-client-python` version from `eng/emitter-package.json` in the generated npm package version metadata.

The version is read from `devDependencies` in `eng/emitter-package.json` and only added when present, so behavior is unchanged when the dependency is absent.