### PR TITLE
[ContentUnderstanding] Set 1.2.0b2 release date to 2026-06-10

### DIFF
--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0b2 (Unreleased)
+## 1.2.0b2 (2026-06-10)
 
 ### Bugs Fixed
 - Filtered service-emitted `LLMStats:` telemetry entries from the rendered `rai_warnings` front matter.


### PR DESCRIPTION
Updates the `azure-ai-contentunderstanding` CHANGELOG header from `## 1.2.0b2 (Unreleased)` to `## 1.2.0b2 (2026-06-10)` so the release pipeline ([python - contentunderstanding](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8029)) will accept the release.

Companion to #47326 (which contains the actual `to_llm_input` changes for 1.2.0b2).