### PR TITLE
Fix PR #47020 CI failures: drop Input-instance default and TRITON_MODEL

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs Fixed
 
+- `load_component` now accepts a `default` value for asset-type inputs (`uri_file`, `uri_folder`, `mltable`, `mlflow_model`, `custom_model`), matching the public CLI v2 YAML schema. Previously this raised `UserErrorException: Non-primitive type Input has no default value.`
+
 ### Other Changes
 
 ## 1.32.0 (unreleased)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_entry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_entry.py
@@ -94,6 +94,7 @@ class ModelInputSchema(InputSchema):
     )
     path = generate_path_property(azureml_type=AzureMLResourceType.MODEL)
     datastore = generate_datastore_property()
+    default = generate_path_property(azureml_type=AzureMLResourceType.MODEL)
 
 
 class DataInputSchema(InputSchema):
@@ -114,6 +115,7 @@ class DataInputSchema(InputSchema):
     path = generate_path_property(azureml_type=AzureMLResourceType.DATA)
     path_on_compute = generate_path_on_compute_property(azureml_type=AzureMLResourceType.DATA)
     datastore = generate_datastore_property()
+    default = generate_path_property(azureml_type=AzureMLResourceType.DATA)
 
 
 class MLTableInputSchema(InputSchema):
@@ -131,6 +133,7 @@ class MLTableInputSchema(InputSchema):
     path = generate_path_property(azureml_type=AzureMLResourceType.DATA)
     path_on_compute = generate_path_on_compute_property(azureml_type=AzureMLResourceType.DATA)
     datastore = generate_datastore_property()
+    default = generate_path_property(azureml_type=AzureMLResourceType.DATA)
 
 
 class InputLiteralValueSchema(metaclass=PatchedSchemaMeta):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_component.py
@@ -133,11 +133,11 @@ class IOConstants:
     }
     # For validation, indicates specific parameters combination for each type
     INPUT_TYPE_COMBINATION = {
-        "uri_folder": ["path", "mode"],
-        "uri_file": ["path", "mode"],
-        "mltable": ["path", "mode"],
-        "mlflow_model": ["path", "mode"],
-        "custom_model": ["path", "mode"],
+        "uri_folder": ["path", "mode", "default"],
+        "uri_file": ["path", "mode", "default"],
+        "mltable": ["path", "mode", "default"],
+        "mlflow_model": ["path", "mode", "default"],
+        "custom_model": ["path", "mode", "default"],
         "integer": ["default", "min", "max"],
         "number": ["default", "min", "max"],
         "string": ["default"],

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -7,10 +7,11 @@
 
 import math
 from inspect import Parameter
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, Dict, List, Optional, Set, Union, overload
 
 from typing_extensions import Literal
 
+from azure.ai.ml.constants._common import AssetTypes
 from azure.ai.ml.constants._component import ComponentParameterTypes, IOConstants
 from azure.ai.ml.entities._assets.intellectual_property import IntellectualProperty
 from azure.ai.ml.exceptions import (
@@ -23,6 +24,15 @@ from azure.ai.ml.exceptions import (
 
 from .base import _InputOutputBase
 from .utils import _get_param_with_standard_annotation, _remove_empty_values
+
+_ASSET_TYPES: Set[str] = {
+    AssetTypes.URI_FILE,
+    AssetTypes.URI_FOLDER,
+    AssetTypes.MLTABLE,
+    AssetTypes.MLFLOW_MODEL,
+    AssetTypes.CUSTOM_MODEL,
+    AssetTypes.TRITON_MODEL,
+}
 
 
 class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
@@ -373,6 +383,20 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
         msg_prefix = f"Default value of Input {name}"
 
         if not self._is_primitive_type and default_value is not None:
+            # Asset-type inputs accept a string (e.g. "azureml:", "https://", local path)
+            # or another Input instance as their default value.
+            if not self._multiple_types and self.type in _ASSET_TYPES:
+                if isinstance(default_value, str):
+                    self.default = default_value
+                    return
+                if isinstance(default_value, Input):
+                    self.default = default_value
+                    return
+                msg = (
+                    f"{msg_prefix}cannot be set: default for type '{self.type}' must be a "
+                    f"string asset reference or an azure.ai.ml.Input, got '{type(default_value)}'."
+                )
+                raise UserErrorException(msg)
             msg = f"{msg_prefix}cannot be set: Non-primitive type Input has no default value."
             raise UserErrorException(msg)
         if isinstance(default_value, float) and not math.isfinite(default_value):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -31,7 +31,6 @@ _ASSET_TYPES: Set[str] = {
     AssetTypes.MLTABLE,
     AssetTypes.MLFLOW_MODEL,
     AssetTypes.CUSTOM_MODEL,
-    AssetTypes.TRITON_MODEL,
 }
 
 
@@ -383,18 +382,15 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
         msg_prefix = f"Default value of Input {name}"
 
         if not self._is_primitive_type and default_value is not None:
-            # Asset-type inputs accept a string (e.g. "azureml:", "https://", local path)
-            # or another Input instance as their default value.
+            # Asset-type inputs accept a string default value (e.g. "azureml:", "https://",
+            # local path) matching the public CLI v2 YAML schema.
             if not self._multiple_types and self.type in _ASSET_TYPES:
                 if isinstance(default_value, str):
                     self.default = default_value
                     return
-                if isinstance(default_value, Input):
-                    self.default = default_value
-                    return
                 msg = (
                     f"{msg_prefix}cannot be set: default for type '{self.type}' must be a "
-                    f"string asset reference or an azure.ai.ml.Input, got '{type(default_value)}'."
+                    f"string asset reference, got '{type(default_value)}'."
                 )
                 raise UserErrorException(msg)
             msg = f"{msg_prefix}cannot be set: Non-primitive type Input has no default value."

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_pipeline_component_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_pipeline_component_entity.py
@@ -465,3 +465,94 @@ class TestPipelineComponentEntity:
         # all leaf nodes in last layer
         # 2 leaf node of the same node name
         assert get_layer_node_name_set(layers[2]) == {"command_component", "component_a_job"}
+
+    def test_pipeline_component_asset_type_defaults(self) -> None:
+        """load_component must succeed for pipeline-component YAMLs with default: on asset-type inputs."""
+        component_path = "./tests/test_configs/components/pipeline_component_with_asset_defaults.yml"
+        component: PipelineComponent = load_component(source=component_path)
+        inputs = component.inputs
+
+        # uri_file with azureml: reference
+        assert inputs["spaceship_data"].type == "uri_file"
+        assert inputs["spaceship_data"].default == "azureml:test_dataset:1"
+
+        # uri_folder with https:// URI
+        assert inputs["folder_data"].type == "uri_folder"
+        assert inputs["folder_data"].default == "https://example.com/data"
+
+        # mltable
+        assert inputs["table_data"].type == "mltable"
+        assert inputs["table_data"].default == "azureml:test_mltable:1"
+
+        # mlflow_model
+        assert inputs["model_input"].type == "mlflow_model"
+        assert inputs["model_input"].default == "azureml:test_model:1"
+
+        # custom_model
+        assert inputs["custom_model_input"].type == "custom_model"
+        assert inputs["custom_model_input"].default == "azureml:test_custom_model:1"
+
+        # input without default is unaffected
+        assert inputs["pilot_data"].default is None
+
+    def test_pipeline_component_asset_default_round_trip(self) -> None:
+        """Dumping a loaded component with asset-type defaults must preserve the default values."""
+        component_path = "./tests/test_configs/components/pipeline_component_with_asset_defaults.yml"
+        component: PipelineComponent = load_component(source=component_path)
+        component_dict = component._to_dict()
+
+        assert component_dict["inputs"]["spaceship_data"]["default"] == "azureml:test_dataset:1"
+        assert component_dict["inputs"]["folder_data"]["default"] == "https://example.com/data"
+        assert component_dict["inputs"]["table_data"]["default"] == "azureml:test_mltable:1"
+        assert component_dict["inputs"]["model_input"]["default"] == "azureml:test_model:1"
+        assert component_dict["inputs"]["custom_model_input"]["default"] == "azureml:test_custom_model:1"
+        assert "default" not in component_dict["inputs"]["pilot_data"]
+
+    def test_pipeline_component_asset_default_rest_round_trip(self) -> None:
+        """Asset-type defaults must survive a REST serialization / deserialization round-trip."""
+        component_path = "./tests/test_configs/components/pipeline_component_with_asset_defaults.yml"
+        component: PipelineComponent = load_component(source=component_path)
+
+        rest_obj = component._to_rest_object()
+        restored = PipelineComponent._from_rest_object(rest_obj)
+
+        assert restored.inputs["spaceship_data"].default == "azureml:test_dataset:1"
+        assert restored.inputs["folder_data"].default == "https://example.com/data"
+        assert restored.inputs["table_data"].default == "azureml:test_mltable:1"
+
+    def test_pipeline_component_asset_default_inline(self) -> None:
+        """Input() constructor must accept a string default for asset types."""
+        uri_file_input = Input(type="uri_file", default="azureml:my_dataset:1", mode="ro_mount")
+        assert uri_file_input.default == "azureml:my_dataset:1"
+
+        uri_folder_input = Input(type="uri_folder", default="https://example.com/folder")
+        assert uri_folder_input.default == "https://example.com/folder"
+
+        mltable_input = Input(type="mltable", default="azureml:my_table:2")
+        assert mltable_input.default == "azureml:my_table:2"
+
+        mlflow_input = Input(type="mlflow_model", default="azureml:my_model:3")
+        assert mlflow_input.default == "azureml:my_model:3"
+
+        custom_input = Input(type="custom_model", default="azureml:my_custom:4")
+        assert custom_input.default == "azureml:my_custom:4"
+
+    def test_pipeline_component_asset_default_invalid_type_raises(self) -> None:
+        """Passing a non-string, non-Input value as default for an asset type must still raise."""
+        from azure.ai.ml.exceptions import UserErrorException
+
+        with pytest.raises(UserErrorException, match="default for type 'uri_file' must be"):
+            Input(type="uri_file", default=42)  # type: ignore[arg-type]
+
+    def test_pipeline_component_non_asset_default_still_raises(self) -> None:
+        """Non-asset non-primitive types must still raise the original error."""
+        from azure.ai.ml.exceptions import UserErrorException
+
+        # Provide a type that is not primitive and not in _ASSET_TYPES.
+        # We simulate this by creating an Input with an unknown type via kwargs.
+        inp = Input.__new__(Input)
+        inp.type = "unknown_type"
+        inp._port_name = "test_input"
+
+        with pytest.raises(UserErrorException, match="Non-primitive type Input has no default value"):
+            inp._update_default("some_value")  # type: ignore[arg-type]

--- a/sdk/ml/azure-ai-ml/tests/test_configs/components/pipeline_component_with_asset_defaults.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/components/pipeline_component_with_asset_defaults.yml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
+name: test_pipeline_component_asset_defaults
+type: pipeline
+display_name: "Test Pipeline Component with Asset-type Defaults"
+inputs:
+  year:
+    type: integer
+  spaceship_data:
+    type: uri_file
+    mode: ro_mount
+    default: azureml:test_dataset:1
+  folder_data:
+    type: uri_folder
+    mode: ro_mount
+    default: https://example.com/data
+  table_data:
+    type: mltable
+    default: azureml:test_mltable:1
+  model_input:
+    type: mlflow_model
+    default: azureml:test_model:1
+  custom_model_input:
+    type: custom_model
+    default: azureml:test_custom_model:1
+  pilot_data:
+    type: uri_file
+    mode: ro_mount
+outputs:
+  pilot_rosta:
+    type: uri_file
+    mode: rw_mount
+jobs: {}


### PR DESCRIPTION
Fixes failing CI checks on #47020.

## Problem

PR #47020 broke `test_dsl_group.py::TestDSLGroup::test_group_port_defaults`. The new `_update_default` branch silently accepted an `Input` instance as a default value, so `Input = Input(path=""in1"")` (used as a `@group` field default) no longer raised — but the test asserts it must.

Both issues fixed here were also flagged by the Copilot review on the original PR.

## Changes

In `sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py`:

- Remove the `isinstance(default_value, Input)` branch in `Input._update_default`. Asset-type defaults are now strings only, matching the public CLI v2 YAML schema and the CHANGELOG entry. `Input`-instance defaults remain rejected (which is what the DSL group code, schemas, and round-trip serialization rely on).
- Remove `AssetTypes.TRITON_MODEL` from `_ASSET_TYPES` to stay consistent with `IOConstants.INPUT_TYPE_COMBINATION` (which has no `triton_model` entry) and the CHANGELOG.
- Update the invalid-type error message accordingly.

## Verification

618 tests pass locally across `tests/dsl/unittests`, `tests/pipeline_job/unittests`, and `tests/component/unittests`, including:

- The previously-failing `test_group_port_defaults`
- All 6 new asset-default tests added in #47020

## Notes

This branch is stacked on top of #47020. Once merged (or if #47020 is updated with this commit), the failing checks should turn green.
