### PR TITLE
sanitise the invocation id path param with a safe fallback

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0b6 (Unreleased)
+
+### Bugs Fixed
+
+- `GET /invocations/{id}` and `POST /invocations/{id}/cancel` no longer reflect a malformed `invocation_id` path parameter (illegal characters or longer than `_MAX_ID_LENGTH`) into the `x-agent-invocation-id` response header and the request-scoped log and span fields. The id is now validated with a generated fallback, matching the create path.
+
 ## 1.0.0b5 (2026-06-12)
 
 ### Bugs Fixed

--- a/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_invocation.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_invocation.py
@@ -496,7 +496,7 @@ class InvocationAgentServerHost(_WSHandlerMixin, AgentServerHost):
         dispatch: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         raw_invocation_id = request.path_params["invocation_id"]
-        invocation_id = _sanitize_id(raw_invocation_id, raw_invocation_id)
+        invocation_id = _sanitize_id(raw_invocation_id, str(uuid.uuid4()))
         request.state.invocation_id = invocation_id
 
         raw_session_id = request.query_params.get("agent_session_id", "")

--- a/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.0.0b5"
+VERSION = "1.0.0b6"

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
@@ -5,6 +5,8 @@
 reflected into the ``x-agent-invocation-id`` response header. Both
 ``GET /invocations/{id}`` and ``POST /invocations/{id}/cancel`` run through
 the same traced endpoint, so each scenario is exercised on both routes."""
+import uuid
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
@@ -12,7 +14,6 @@ from starlette.responses import Response
 
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 from azure.ai.agentserver.invocations._constants import InvocationConstants
-from azure.ai.agentserver.invocations._invocation import _MAX_ID_LENGTH, _VALID_ID_RE
 
 _HEADER = InvocationConstants.INVOCATION_ID_HEADER
 
@@ -21,6 +22,17 @@ _ENDPOINTS = [
     ("GET", "/invocations/{id}"),
     ("POST", "/invocations/{id}/cancel"),
 ]
+
+
+def _is_uuid(value: str) -> bool:
+    """A rejected id falls back to a freshly generated UUID, so the safe
+    replacement is observable from the header alone without reaching into
+    the package internals."""
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
 
 
 def _build_app() -> InvocationAgentServerHost:
@@ -59,16 +71,17 @@ async def test_invalid_char_id_not_reflected_in_header(method, template):
     safe fallback rather than echoed back verbatim."""
     echoed = await _echoed_id(method, template.format(id="bad~id"))
     assert echoed != "bad~id"
-    assert _VALID_ID_RE.match(echoed)
+    assert _is_uuid(echoed)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method,template", _ENDPOINTS)
 async def test_overlong_id_not_reflected_in_header(method, template):
-    """An over-length path id does not bypass the ``_MAX_ID_LENGTH`` cap."""
-    echoed = await _echoed_id(method, template.format(id="a" * (_MAX_ID_LENGTH + 50)))
-    assert len(echoed) <= _MAX_ID_LENGTH
-    assert _VALID_ID_RE.match(echoed)
+    """An over-length path id is dropped in favour of the safe fallback."""
+    long_id = "a" * 300
+    echoed = await _echoed_id(method, template.format(id=long_id))
+    assert echoed != long_id
+    assert _is_uuid(echoed)
 
 
 @pytest.mark.asyncio

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+"""Tests that the ``{invocation_id}`` path param is sanitised before it is
+reflected into the ``x-agent-invocation-id`` response header."""
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+from starlette.responses import Response
+
+from azure.ai.agentserver.invocations import InvocationAgentServerHost
+from azure.ai.agentserver.invocations._constants import InvocationConstants
+from azure.ai.agentserver.invocations._invocation import _MAX_ID_LENGTH, _VALID_ID_RE
+
+_HEADER = InvocationConstants.INVOCATION_ID_HEADER
+
+
+def _build_app() -> InvocationAgentServerHost:
+    app = InvocationAgentServerHost()
+
+    @app.invoke_handler
+    async def handle(request: Request) -> Response:
+        return Response(content=b"ok")
+
+    @app.get_invocation_handler
+    async def get_handler(request: Request) -> Response:
+        return Response(content=b"got")
+
+    return app
+
+
+async def _echoed_id(path_id: str) -> str:
+    transport = ASGITransport(app=_build_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.get(f"/invocations/{path_id}")
+    return resp.headers[_HEADER]
+
+
+@pytest.mark.asyncio
+async def test_invalid_char_id_not_reflected_in_header():
+    """A path id with characters outside the id allow-list is replaced by a
+    safe fallback rather than echoed back verbatim."""
+    echoed = await _echoed_id("bad~id")
+    assert echoed != "bad~id"
+    assert _VALID_ID_RE.match(echoed)
+
+
+@pytest.mark.asyncio
+async def test_overlong_id_not_reflected_in_header():
+    """An over-length path id does not bypass the ``_MAX_ID_LENGTH`` cap."""
+    echoed = await _echoed_id("a" * (_MAX_ID_LENGTH + 50))
+    assert len(echoed) <= _MAX_ID_LENGTH
+    assert _VALID_ID_RE.match(echoed)
+
+
+@pytest.mark.asyncio
+async def test_valid_id_passes_through_unchanged():
+    """A well-formed path id is preserved so lookups keep working."""
+    echoed = await _echoed_id("valid-id_123.abc")
+    assert echoed == "valid-id_123.abc"

--- a/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/tests/test_invocation_id_sanitization.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 """Tests that the ``{invocation_id}`` path param is sanitised before it is
-reflected into the ``x-agent-invocation-id`` response header."""
+reflected into the ``x-agent-invocation-id`` response header. Both
+``GET /invocations/{id}`` and ``POST /invocations/{id}/cancel`` run through
+the same traced endpoint, so each scenario is exercised on both routes."""
 import pytest
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
@@ -13,6 +15,12 @@ from azure.ai.agentserver.invocations._constants import InvocationConstants
 from azure.ai.agentserver.invocations._invocation import _MAX_ID_LENGTH, _VALID_ID_RE
 
 _HEADER = InvocationConstants.INVOCATION_ID_HEADER
+
+# (method, url template) for the two endpoints that echo the id header.
+_ENDPOINTS = [
+    ("GET", "/invocations/{id}"),
+    ("POST", "/invocations/{id}/cancel"),
+]
 
 
 def _build_app() -> InvocationAgentServerHost:
@@ -26,35 +34,46 @@ def _build_app() -> InvocationAgentServerHost:
     async def get_handler(request: Request) -> Response:
         return Response(content=b"got")
 
+    @app.cancel_invocation_handler
+    async def cancel_handler(request: Request) -> Response:
+        return Response(content=b"cancelled")
+
     return app
 
 
-async def _echoed_id(path_id: str) -> str:
+async def _echoed_id(method: str, url: str) -> str:
     transport = ASGITransport(app=_build_app())
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
-        resp = await client.get(f"/invocations/{path_id}")
+        resp = await client.request(method, url)
+    # Assert the request actually succeeded and the header is present so a
+    # failure points at the real cause rather than a bare KeyError.
+    assert resp.status_code == 200, f"unexpected status {resp.status_code} for {method} {url}"
+    assert _HEADER in resp.headers, f"{_HEADER} missing from response headers"
     return resp.headers[_HEADER]
 
 
 @pytest.mark.asyncio
-async def test_invalid_char_id_not_reflected_in_header():
+@pytest.mark.parametrize("method,template", _ENDPOINTS)
+async def test_invalid_char_id_not_reflected_in_header(method, template):
     """A path id with characters outside the id allow-list is replaced by a
     safe fallback rather than echoed back verbatim."""
-    echoed = await _echoed_id("bad~id")
+    echoed = await _echoed_id(method, template.format(id="bad~id"))
     assert echoed != "bad~id"
     assert _VALID_ID_RE.match(echoed)
 
 
 @pytest.mark.asyncio
-async def test_overlong_id_not_reflected_in_header():
+@pytest.mark.parametrize("method,template", _ENDPOINTS)
+async def test_overlong_id_not_reflected_in_header(method, template):
     """An over-length path id does not bypass the ``_MAX_ID_LENGTH`` cap."""
-    echoed = await _echoed_id("a" * (_MAX_ID_LENGTH + 50))
+    echoed = await _echoed_id(method, template.format(id="a" * (_MAX_ID_LENGTH + 50)))
     assert len(echoed) <= _MAX_ID_LENGTH
     assert _VALID_ID_RE.match(echoed)
 
 
 @pytest.mark.asyncio
-async def test_valid_id_passes_through_unchanged():
+@pytest.mark.parametrize("method,template", _ENDPOINTS)
+async def test_valid_id_passes_through_unchanged(method, template):
     """A well-formed path id is preserved so lookups keep working."""
-    echoed = await _echoed_id("valid-id_123.abc")
+    echoed = await _echoed_id(method, template.format(id="valid-id_123.abc"))
     assert echoed == "valid-id_123.abc"


### PR DESCRIPTION
# Description

`GET /invocations/{id}` and the `POST /invocations/{id}/cancel` variant both run through `_traced_invocation_endpoint`, which is meant to validate the id with `_sanitize_id` before it reaches the `x-agent-invocation-id` response header and the request-scoped log and span fields.

Repro: request `GET /invocations/bad~id` (a character outside `_VALID_ID_RE`), or an id longer than `_MAX_ID_LENGTH`; the raw value comes straight back in the `x-agent-invocation-id` response header.
Cause: the call is `_sanitize_id(raw_invocation_id, raw_invocation_id)`, so the rejected value is its own fallback and the length and character checks can never drop anything. `_create_invocation_endpoint` passes a generated UUID instead.
Fix: fall back to a fresh UUID, matching the create path, so a malformed id never reaches the header or the logs. Added a regression test for the invalid-character and over-length cases plus a valid-id passthrough.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
