### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -818,7 +818,7 @@
 /.github/CODEOWNERS                                                  @lmazuel @kashifkhan @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                     @l0lawrence @praveenkuttappan @maririos
 /.github/prompts/                                                    @mccoyp @l0lawrence @benbp
-/.github/skills/                                                     @mccoyp @l0lawrence @benbp
+/.github/skills/                                                     @mccoyp @l0lawrence @benbp @Azure/azsdk-cli
 /sdk/pullrequest.yml                                                 @danieljurek @mikeharder @benbp
 
 /.config/1espt/                                                      @benbp @mikeharder


### PR DESCRIPTION
Adds `@Azure/azsdk-cli` to the owners list for `/.github/skills/` in `.github/CODEOWNERS`, alongside the existing owners (`@mccoyp @l0lawrence @benbp`).

This assigns shared ownership of skill definitions under `.github/skills/` to the `@Azure/azsdk-cli` team so they can review changes to those files.