### PR TITLE
Install APIView generation tool dependencies in SDK generation pipeline

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -327,6 +327,7 @@ def main(generate_input, generate_output):
                             "--index-url=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/",
                         ],
                         timeout=600,
+                        stderr=None if data.get("runMode") == "release" else subprocess.DEVNULL,
                     )
 
                     _LOGGER.info("generate apiview artifacts")

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -324,16 +324,15 @@ def main(generate_input, generate_output):
                         "--extract-metadata",
                         package_name,
                         "--dest-dir",
-                        package_path.absolute(),
+                        package_path.absolute().as_posix(),
                     ]
                     _LOGGER.info(f"generate apiview file for package {package_name}")
                     check_call(
                         cmds,
                         timeout=900 if data.get("runMode") == "spec-pull-request" else 36000,
-                        cwd=".",
                         # known issue that higher python version meet install warning with lower pylint.
                         # we skip the output here to reduce confusion and will remove it after apiview tool upgrade to higher pylint version.
-                        stderr=subprocess.DEVNULL,
+                        # stderr=subprocess.DEVNULL,
                     )
                     for file in os.listdir(package_path):
                         if "_python.json" in file and package_name in file:

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -315,6 +315,20 @@ def main(generate_input, generate_output):
             if data.get("runMode") in ["spec-pull-request", "release"]:
                 apiview_start_time = time.time()
                 try:
+                    _LOGGER.info(f"install apiview generation tool")
+                    check_call(
+                        [
+                            "python",
+                            "-m",
+                            "pip",
+                            "install",
+                            "-r",
+                            "eng/apiview_reqs.txt",
+                            "--index-url=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/",
+                        ],
+                        timeout=600,
+                    )
+
                     _LOGGER.info("generate apiview artifacts")
                     package_path = Path(sdk_folder, folder_name, package_name)
                     cmds = [
@@ -332,7 +346,8 @@ def main(generate_input, generate_output):
                         timeout=900 if data.get("runMode") == "spec-pull-request" else 36000,
                         # known issue that higher python version meet install warning with lower pylint.
                         # we skip the output here to reduce confusion and will remove it after apiview tool upgrade to higher pylint version.
-                        # stderr=subprocess.DEVNULL,
+                        # in "release" mode we keep stderr so the output is visible for debugging.
+                        stderr=None if data.get("runMode") == "release" else subprocess.DEVNULL,
                     )
                     for file in os.listdir(package_path):
                         if "_python.json" in file and package_name in file:

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -3,6 +3,7 @@
 # init env
 python -m pip install -U pip > /dev/null
 python -m pip install eng/tools/azure-sdk-tools[ghtools] > /dev/null
+python -m pip install eng/apiview_reqs.txt > /dev/null
 
 # install tsp-client
 echo Install tsp-client

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -3,7 +3,6 @@
 # init env
 python -m pip install -U pip > /dev/null
 python -m pip install eng/tools/azure-sdk-tools[ghtools] > /dev/null
-python -m pip install -r eng/apiview_reqs.txt > /dev/null
 
 # install tsp-client
 echo Install tsp-client

--- a/scripts/automation_init.sh
+++ b/scripts/automation_init.sh
@@ -3,7 +3,7 @@
 # init env
 python -m pip install -U pip > /dev/null
 python -m pip install eng/tools/azure-sdk-tools[ghtools] > /dev/null
-python -m pip install eng/apiview_reqs.txt > /dev/null
+python -m pip install -r eng/apiview_reqs.txt > /dev/null
 
 # install tsp-client
 echo Install tsp-client


### PR DESCRIPTION
fix https://github.com/Azure/azure-sdk-for-python/pull/47518

I already test this PR in pipeline and result contains expected `api.md`: https://github.com/Azure/azure-sdk-for-python/pull/47520