### PR TITLE
API Review Process: Add ADO Work Item metadata and assign architects to Review PRs at creation time

### DIFF
--- a/.github/ARCHITECTS
+++ b/.github/ARCHITECTS
@@ -1,6 +1,7 @@
 # Instructions for ARCHITECTS file format:
 # This file follows the CODEOWNERS pattern style. Each non-comment line maps a
-# repository path pattern to the GitHub user responsible for API architecture review.
+# repository path pattern to the GitHub user or team responsible for API architecture review.
+# Owners may be individual users like @octocat or teams like @Azure/sdk-arch.
 
 ###########
 # SDK

--- a/.github/ARCHITECTS
+++ b/.github/ARCHITECTS
@@ -1,0 +1,10 @@
+# Instructions for ARCHITECTS file format:
+# This file follows the CODEOWNERS pattern style. Each non-comment line maps a
+# repository path pattern to the GitHub user responsible for API architecture review.
+
+###########
+# SDK
+###########
+
+# Catch all
+/sdk/ @kashifkhan

--- a/.github/skills/create-api-review-pr/SKILL.md
+++ b/.github/skills/create-api-review-pr/SKILL.md
@@ -18,6 +18,7 @@ If the user asks to create an API review PR for a new package, explain that new 
 3. Python 3.10 or later must be available.
 4. `azpysdk` must be installed (`pip install -e ./eng/tools/azure-sdk-tools`).
 5. ApiView stub generator dependencies must be installed (`pip install -r ./eng/apiview_reqs.txt`).
+6. `azsdk` CLI may be needed for package work item lookup. Do not proactively check or install it before running `create_api_review_pr.py`; the script detects supported install locations and reports when installation or update is necessary.
 
 ## Information to Gather
 
@@ -46,6 +47,8 @@ Before running the script:
 2. **Validate the baseline tag**: Run `git tag -l "<tag>"` to confirm the tag exists. If the user provided a version like `12.29.0`, construct the full tag as `<package-name>_<version>` and validate that.
 3. **Validate the target tag when applicable**: If the user provided a target version or tag, construct or validate the full tag as `<package-name>_<version>` and run `git tag -l "<tag>"`.
 4. **Confirm the working tree is clean**: Run `git status --porcelain` and warn if there are uncommitted changes.
+
+Do not proactively run `azsdk --help`, `azsdk package find-work-item --help`, or the `azure-sdk-mcp.ps1` installer as a validation step. If `create_api_review_pr.py` fails with an error saying the `azsdk` CLI is not found or the `package find-work-item` command is unavailable, then run `pwsh ./eng/common/mcp/azure-sdk-mcp.ps1` from the repository root to install or update it, and rerun the same `create_api_review_pr.py` command once. If the script still reports an `azsdk` error after that, stop and report the failure.
 
 ## Execution
 

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -363,6 +363,7 @@
     "oauthlib",
     "objs",
     "odata",
+    "octocat",
     "oidc",
     "onboarded",
     "onmicrosoft",

--- a/scripts/api_md_workflow/create_api_review_pr.py
+++ b/scripts/api_md_workflow/create_api_review_pr.py
@@ -24,6 +24,7 @@ MAIN_REF = f"{REMOTE}/main"
 SYNC_METADATA_MARKER = "api-md-review-sync"
 SYNC_METADATA_WARNING = "DO NOT MODIFY THESE CONTENTS!"
 GITHUB_API_TIMEOUT_SECONDS = 30
+AZSDK_INSTALL_SCRIPT = REPO_ROOT / "eng" / "common" / "mcp" / "azure-sdk-mcp.ps1"
 
 
 class GitHubApiError(Exception):
@@ -87,7 +88,9 @@ def log_error(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def run(args: list[str], *, cwd: Path = REPO_ROOT, check: bool = True, capture: bool = False, shell: bool = False) -> CommandResult:
+def run(
+    args: list[str], *, cwd: Path = REPO_ROOT, check: bool = True, capture: bool = False, shell: bool = False
+) -> CommandResult:
     printable = " ".join(args)
     log_info(f"$ {printable}")
     completed = subprocess.run(
@@ -364,7 +367,9 @@ def find_package_dir(package_name: str) -> Path:
     if not matches:
         raise RuntimeError(f"ERROR: package '{package_name}' not found under sdk/*/")
     if len(matches) > 1:
-        raise RuntimeError(f"ERROR: multiple matches for '{package_name}': {', '.join(str(match) for match in matches)}")
+        raise RuntimeError(
+            f"ERROR: multiple matches for '{package_name}': {', '.join(str(match) for match in matches)}"
+        )
     return matches[0]
 
 
@@ -459,6 +464,129 @@ def parse_simple_yaml(text: str) -> dict[str, str]:
         if match:
             result[match.group(1)] = match.group(2).strip()
     return result
+
+
+def write_simple_yaml(file_path: Path, metadata: dict[str, str]) -> None:
+    existing_text = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+    line_ending = "\r\n" if "\r\n" in existing_text else "\n"
+    file_path.write_text(
+        line_ending.join(f"{key}: {metadata[key]}" for key in sorted(metadata)) + line_ending, encoding="utf-8"
+    )
+
+
+def package_version_major_minor(package_version: str) -> str:
+    match = re.match(r"^(\d+)(?:\.(\d+))?", package_version.strip())
+    if not match:
+        raise RuntimeError(f"ERROR: could not derive major/minor version from package version '{package_version}'.")
+    major = match.group(1)
+    minor = match.group(2) or "0"
+    return f"{major}.{minor}"
+
+
+def parse_package_work_item_id(output: str) -> int | None:
+    try:
+        parsed = json.loads(output)
+        if isinstance(parsed, dict):
+            value = parsed.get("work_item_id") or parsed.get("workItemId")
+            if isinstance(value, int):
+                return value
+            if isinstance(value, str) and value.isdigit():
+                return int(value)
+    except json.JSONDecodeError:
+        pass
+
+    match = re.search(r"Work Item ID:\s*(\d+)", output)
+    return int(match.group(1)) if match else None
+
+
+def find_azsdk_executable() -> str | None:
+    azsdk_from_path = shutil.which("azsdk")
+    if azsdk_from_path:
+        return azsdk_from_path
+
+    for install_dir in [Path.home() / "bin", Path.home() / ".azure-sdk-mcp"]:
+        for executable_name in ["azsdk.exe", "azsdk"]:
+            candidate = install_dir / executable_name
+            if candidate.is_file():
+                return str(candidate)
+
+    return None
+
+
+def combined_command_output(result: CommandResult) -> str:
+    return "\n".join(part.strip() for part in [result.stdout, result.stderr] if part.strip())
+
+
+def resolve_azsdk_executable() -> str:
+    azsdk_executable = find_azsdk_executable()
+    if azsdk_executable:
+        return azsdk_executable
+
+    raise RuntimeError(
+        "ERROR: azsdk CLI not found. Install it by running "
+        f"'pwsh {AZSDK_INSTALL_SCRIPT}', or run with '-UpdatePathInProfile' to add it to PATH."
+    )
+
+
+def ensure_azsdk_find_work_item_available() -> None:
+    azsdk_executable = resolve_azsdk_executable()
+    result = run([azsdk_executable, "package", "find-work-item", "--help"], check=False, capture=True)
+    if result.status == 0:
+        return
+
+    details = combined_command_output(result)
+    raise RuntimeError(
+        "ERROR: azsdk CLI is installed, but the 'package find-work-item' command is unavailable. "
+        f"Update it by running 'pwsh {AZSDK_INSTALL_SCRIPT}'." + (f"\n{details}" if details else "")
+    )
+
+
+def package_work_item_metadata_value(package_name: str, package_version: str) -> str:
+    package_version_major_minor_value = package_version_major_minor(package_version)
+    result = run(
+        [
+            resolve_azsdk_executable(),
+            "package",
+            "find-work-item",
+            "--package-name",
+            package_name,
+            "--package-version",
+            package_version_major_minor_value,
+            "--language",
+            "Python",
+        ],
+        check=False,
+        capture=True,
+    )
+    output = combined_command_output(result)
+
+    if result.status != 0:
+        metadata_value = '"Unknown"' if "No package work item found" in output else '"ERROR"'
+        log_warning(
+            f"WARNING: failed to resolve package work item ID for {package_name} {package_version_major_minor_value}. "
+            f"api.metadata.yml will use packageWorkItemId: {metadata_value}." + (f"\n{output}" if output else "")
+        )
+        return metadata_value
+
+    work_item_id = parse_package_work_item_id(result.stdout)
+    if work_item_id is None:
+        log_warning(
+            f"WARNING: azsdk package find-work-item completed for {package_name} {package_version_major_minor_value} "
+            'but did not return a work item ID. api.metadata.yml will use packageWorkItemId: "Unknown".'
+            + (f"\n{output}" if output else "")
+        )
+        return '"Unknown"'
+    return str(work_item_id)
+
+
+def add_package_work_item_metadata(package_name: str, package_version: str, package_dir: Path) -> None:
+    metadata_file = metadata_path(package_dir)
+    if not metadata_file.exists():
+        return
+
+    metadata = parse_simple_yaml(metadata_file.read_text(encoding="utf-8"))
+    metadata["packageWorkItemId"] = package_work_item_metadata_value(package_name, package_version)
+    write_simple_yaml(metadata_file, metadata)
 
 
 def metadata_sha_or_none(metadata_bytes: bytes | None) -> str | None:
@@ -573,7 +701,9 @@ def ensure_branch_state_has_metadata_sha(branch_label: str, state: BranchState) 
 
 
 def select_best_pr(prs: list[dict[str, Any]]) -> dict[str, Any] | None:
-    candidates = [pr for pr in prs if pr.get("number") is not None and pr.get("url") and pr.get("state") and pr.get("updatedAt")]
+    candidates = [
+        pr for pr in prs if pr.get("number") is not None and pr.get("url") and pr.get("state") and pr.get("updatedAt")
+    ]
     if not candidates:
         return None
     open_prs = [pr for pr in candidates if str(pr.get("state", "")).lower() == "open"]
@@ -631,7 +761,9 @@ def build_sync_metadata_object(
         "workingBranch": working_branch["branch"],
     }
     working_pr = find_open_pr_for_head(head_selector)
-    metadata["workingPrNumber"] = working_pr.get("number") if working_pr and isinstance(working_pr.get("number"), int) else None
+    metadata["workingPrNumber"] = (
+        working_pr.get("number") if working_pr and isinstance(working_pr.get("number"), int) else None
+    )
     return metadata
 
 
@@ -697,7 +829,10 @@ def ensure_pr_body_sync_metadata(pr: dict[str, Any] | None, metadata_block: str 
         log_info(f"Updated API review sync metadata on PR #{pr['number']}.")
     except Exception as error:  # pylint: disable=broad-except
         details = str(error)
-        log_warning(f"WARNING: failed to update API review sync metadata on PR #{pr['number']}." + (f"\n  {details}" if details else ""))
+        log_warning(
+            f"WARNING: failed to update API review sync metadata on PR #{pr['number']}."
+            + (f"\n  {details}" if details else "")
+        )
 
 
 def find_open_pr_for_head(head_selector: str) -> dict[str, Any] | None:
@@ -746,9 +881,18 @@ def find_open_pr_for_branches(base_branch: str, head_branch: str) -> dict[str, A
 def create_draft_pr(base_branch: str, head_branch: str, title: str, body: str) -> dict[str, Any]:
     try:
         created_pr = get_github_api().create_draft_pull_request(base_branch, head_branch, title, body)
-        return {"ok": True, "url": created_pr.get("html_url") or created_pr.get("url") or "", "stderr": "", "stdout": ""}
+        return {
+            "ok": True,
+            "url": created_pr.get("html_url") or created_pr.get("url") or "",
+            "stderr": "",
+            "stdout": "",
+        }
     except GitHubApiError as error:
         return {"ok": False, "status": error.status, "stdout": "", "stderr": str(error)}
+
+
+def single_line_output(value: Any) -> str:
+    return str(value or "").replace(chr(10), " ").replace(chr(13), " ").strip()
 
 
 def branch_reference_markdown(head_selector: str) -> str:
@@ -804,6 +948,7 @@ def generate_api_bytes_for_ref(
         if not output_path.exists():
             raise RuntimeError(f"ERROR: did not produce {output_path}")
 
+        add_package_work_item_metadata(package_name, version, package_dir)
         metadata = metadata_path(package_dir).read_bytes() if metadata_path(package_dir).exists() else None
         return ApiResult(output_path.read_bytes(), metadata, version)
     finally:
@@ -817,12 +962,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--package-name", required=True)
     parser.add_argument("--base", required=True)
     parser.add_argument("--target")
-    parser.add_argument("--python", "--runtime", dest="runtime_executable", default=os.environ.get("RUNTIME_EXECUTABLE"))
+    parser.add_argument(
+        "--python", "--runtime", dest="runtime_executable", default=os.environ.get("RUNTIME_EXECUTABLE")
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    ensure_azsdk_find_work_item_available()
+
     package_dir = find_package_dir(args.package_name)
     log_info(f"Found package at: {package_dir}")
 
@@ -965,21 +1114,18 @@ def main(argv: list[str] | None = None) -> int:
                 item
                 for item in [
                     f"Exit code: {pr_create.get('status')}",
-                    f"stderr: {str(pr_create.get('stderr') or '').replace(chr(10), ' ').replace(chr(13), ' ').strip()}"
-                    if pr_create.get("stderr")
-                    else "",
-                    f"stdout: {str(pr_create.get('stdout') or '').replace(chr(10), ' ').replace(chr(13), ' ').strip()}"
-                    if pr_create.get("stdout")
-                    else "",
-                    f"Debug repro: use the GitHub REST API endpoint POST /repos/{REPO_SLUG}/pulls with base/head/title/body/draft=true.",
+                    f"stderr: {single_line_output(pr_create.get('stderr'))}" if pr_create.get("stderr") else "",
+                    f"stdout: {single_line_output(pr_create.get('stdout'))}" if pr_create.get("stdout") else "",
+                    "Debug repro: use the GitHub REST API endpoint POST "
+                    f"/repos/{REPO_SLUG}/pulls with base/head/title/body/draft=true.",
                 ]
                 if item
             )
             log_warning(
-                "\nWARNING: GitHub PR creation failed. Both branches were pushed successfully -- open the PR manually here:\n"
+                "\nWARNING: GitHub PR creation failed. Both branches were pushed successfully -- "
+                "open the PR manually here:\n"
                 f"  {compare_url}\n"
-                f"  Title: {title}"
-                + (f"\n  {error_details}" if error_details else "")
+                f"  Title: {title}" + (f"\n  {error_details}" if error_details else "")
             )
         return 0
     finally:

--- a/scripts/api_md_workflow/create_api_review_pr.py
+++ b/scripts/api_md_workflow/create_api_review_pr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -14,7 +15,6 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_OWNER = "Azure"
 REPO_NAME = "azure-sdk-for-python"
@@ -25,6 +25,7 @@ SYNC_METADATA_MARKER = "api-md-review-sync"
 SYNC_METADATA_WARNING = "DO NOT MODIFY THESE CONTENTS!"
 GITHUB_API_TIMEOUT_SECONDS = 30
 AZSDK_INSTALL_SCRIPT = REPO_ROOT / "eng" / "common" / "mcp" / "azure-sdk-mcp.ps1"
+ARCHITECTS_PATH = REPO_ROOT / ".github" / "ARCHITECTS"
 
 
 class GitHubApiError(Exception):
@@ -89,7 +90,12 @@ def log_error(message: str) -> None:
 
 
 def run(
-    args: list[str], *, cwd: Path = REPO_ROOT, check: bool = True, capture: bool = False, shell: bool = False
+    args: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    check: bool = True,
+    capture: bool = False,
+    shell: bool = False,
 ) -> CommandResult:
     printable = " ".join(args)
     log_info(f"$ {printable}")
@@ -101,9 +107,17 @@ def run(
         text=True,
         shell=shell,
     )
-    result = CommandResult(completed.returncode, completed.stdout or "", completed.stderr or "")
+    result = CommandResult(
+        completed.returncode, completed.stdout or "", completed.stderr or ""
+    )
     if check and result.status != 0:
-        raise RuntimeError(f"Command failed ({result.status}): {printable}")
+        details = "\n".join(
+            part for part in [result.stderr.strip(), result.stdout.strip()] if part
+        )
+        raise RuntimeError(
+            f"Command failed ({result.status}): {printable}"
+            + (f"\n{details}" if details else "")
+        )
     return result
 
 
@@ -111,7 +125,9 @@ def git(args: list[str], *, check: bool = True) -> CommandResult:
     if _git_runner:
         result = _git_runner(args, check)
         if check and result.status != 0:
-            raise RuntimeError(f"Command failed ({result.status}): {' '.join(['git', *args])}")
+            raise RuntimeError(
+                f"Command failed ({result.status}): {' '.join(['git', *args])}"
+            )
         return result
     return run(["git", *args], check=check, capture=True)
 
@@ -146,12 +162,19 @@ def normalize_pull_request(pr: dict[str, Any] | None) -> dict[str, Any] | None:
         return None
 
     owner_login = None
+    author_login = None
     if isinstance(pr.get("headRepositoryOwner"), dict):
         owner_login = pr["headRepositoryOwner"].get("login")
     elif isinstance(pr.get("head"), dict):
-        repo = pr["head"].get("repo") if isinstance(pr["head"].get("repo"), dict) else {}
+        repo = (
+            pr["head"].get("repo") if isinstance(pr["head"].get("repo"), dict) else {}
+        )
         owner = repo.get("owner") if isinstance(repo.get("owner"), dict) else {}
         owner_login = owner.get("login")
+    if isinstance(pr.get("author"), dict):
+        author_login = pr["author"].get("login")
+    elif isinstance(pr.get("user"), dict):
+        author_login = pr["user"].get("login")
 
     return {
         "number": pr.get("number"),
@@ -161,6 +184,7 @@ def normalize_pull_request(pr: dict[str, Any] | None) -> dict[str, Any] | None:
         "body": pr.get("body"),
         "headRefName": pr.get("headRefName") or (pr.get("head") or {}).get("ref"),
         "headRepositoryOwner": {"login": owner_login},
+        "authorLogin": author_login,
     }
 
 
@@ -168,7 +192,9 @@ class GitHubApi:
     def __init__(self, token: str | None):
         self.token = token
 
-    def _request(self, method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    def _request(
+        self, method: str, url: str, payload: dict[str, Any] | None = None
+    ) -> Any:
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
         headers = {
             "Accept": "application/vnd.github+json",
@@ -207,7 +233,9 @@ class GitHubApi:
                 {"head": head, "state": "open", "per_page": limit},
             ),
         )
-        return [pr for pr in (normalize_pull_request(item) for item in data or []) if pr]
+        return [
+            pr for pr in (normalize_pull_request(item) for item in data or []) if pr
+        ]
 
     def search_pull_requests(self, query: str, limit: int) -> list[dict[str, Any]]:
         graphql_query = """
@@ -222,6 +250,7 @@ query($query: String!, $first: Int!) {
         body
         headRefName
         headRepositoryOwner { login }
+                author { login }
       }
     }
   }
@@ -235,24 +264,62 @@ query($query: String!, $first: Int!) {
         nodes = ((data or {}).get("data") or {}).get("search", {}).get("nodes", [])
         return [pr for pr in (normalize_pull_request(item) for item in nodes) if pr]
 
-    def list_pull_requests_by_branches(self, base: str, head: str, limit: int) -> list[dict[str, Any]]:
+    def list_pull_requests_by_branches(
+        self, base: str, head: str, limit: int
+    ) -> list[dict[str, Any]]:
         data = self._request(
             "GET",
             self._rest_url(
                 f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls",
-                {"base": base, "head": f"{REPO_OWNER}:{head}", "state": "open", "per_page": limit},
+                {
+                    "base": base,
+                    "head": f"{REPO_OWNER}:{head}",
+                    "state": "open",
+                    "per_page": limit,
+                },
             ),
         )
-        return [pr for pr in (normalize_pull_request(item) for item in data or []) if pr]
+        return [
+            pr for pr in (normalize_pull_request(item) for item in data or []) if pr
+        ]
 
     def update_pull_request_body(self, number: int, body: str) -> None:
-        self._request("PATCH", self._rest_url(f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{number}"), {"body": body})
+        self._request(
+            "PATCH",
+            self._rest_url(f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{number}"),
+            {"body": body},
+        )
 
-    def create_draft_pull_request(self, base: str, head: str, title: str, body: str) -> dict[str, Any]:
+    def create_draft_pull_request(
+        self, base: str, head: str, title: str, body: str
+    ) -> dict[str, Any]:
         return self._request(
             "POST",
             self._rest_url(f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls"),
             {"base": base, "head": head, "title": title, "body": body, "draft": True},
+        )
+
+    def request_reviewers(self, pr_number: int, reviewers: list[str]) -> None:
+        url = self._rest_url(
+            f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}/requested_reviewers"
+        )
+        log_info(
+            f"API review architect diagnostics: requesting PR reviewers at {url}: {reviewers}"
+        )
+        response = self._request(
+            "POST",
+            url,
+            {"reviewers": reviewers},
+        )
+        requested_reviewers = []
+        if isinstance(response, dict):
+            requested_reviewers = [
+                reviewer.get("login")
+                for reviewer in response.get("requested_reviewers", [])
+                if isinstance(reviewer, dict) and reviewer.get("login")
+            ]
+        log_info(
+            f"API review architect diagnostics: GitHub response requested_reviewers={requested_reviewers}"
         )
 
 
@@ -266,7 +333,9 @@ def get_github_api() -> GitHubApi:
 def ensure_clean_worktree() -> None:
     status = git_out(["status", "--porcelain"])
     if status:
-        raise RuntimeError(f"ERROR: working tree is not clean. Commit or stash changes before running.\n{status}")
+        raise RuntimeError(
+            f"ERROR: working tree is not clean. Commit or stash changes before running.\n{status}"
+        )
 
 
 def current_branch() -> str:
@@ -274,20 +343,31 @@ def current_branch() -> str:
 
 
 def tag_exists(tag: str) -> bool:
-    return git(["rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"], check=False).status == 0
+    return (
+        git(
+            ["rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"], check=False
+        ).status
+        == 0
+    )
 
 
 def validate_base_tag(package_name: str, base_tag: str) -> str:
     prefix = f"{package_name}_"
     if not base_tag.startswith(prefix):
-        raise RuntimeError(f"ERROR: --base tag '{base_tag}' must start with '{prefix}'.")
+        raise RuntimeError(
+            f"ERROR: --base tag '{base_tag}' must start with '{prefix}'."
+        )
 
     version = base_tag[len(prefix) :]
     if not version:
-        raise RuntimeError(f"ERROR: --base tag '{base_tag}' is missing the version suffix.")
+        raise RuntimeError(
+            f"ERROR: --base tag '{base_tag}' is missing the version suffix."
+        )
 
     if not tag_exists(base_tag):
-        raise RuntimeError(f"ERROR: tag '{base_tag}' does not exist in this repository.")
+        raise RuntimeError(
+            f"ERROR: tag '{base_tag}' does not exist in this repository."
+        )
 
     return version
 
@@ -334,15 +414,21 @@ def resolve_target_ref(target: str, package_name: str | None = None) -> str:
         if branch_ref:
             return branch_ref
 
-        raise RuntimeError(f"ERROR: --target '{target}' is neither a branch on {REMOTE} nor a tag in this repository.")
+        raise RuntimeError(
+            f"ERROR: --target '{target}' is neither a branch on {REMOTE} nor a tag in this repository."
+        )
 
     owner, branch = target.split(":", 1)
     if not owner or not branch:
-        raise RuntimeError(f"ERROR: invalid --target '{target}'. Expected 'tag', 'branch', or 'owner:branch'.")
+        raise RuntimeError(
+            f"ERROR: invalid --target '{target}'. Expected 'tag', 'branch', or 'owner:branch'."
+        )
 
     branch_ref = try_fork_branch_ref(owner, branch)
     if not branch_ref:
-        raise RuntimeError(f"ERROR: branch '{branch}' does not exist in fork '{owner}'.")
+        raise RuntimeError(
+            f"ERROR: branch '{branch}' does not exist in fork '{owner}'."
+        )
     return branch_ref
 
 
@@ -374,7 +460,9 @@ def find_package_dir(package_name: str) -> Path:
 
 
 def read_version(package_dir: Path) -> str:
-    version_regex = re.compile(r"^\s*VERSION\s*[:=]\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+    version_regex = re.compile(
+        r"^\s*VERSION\s*[:=]\s*[\"']([^\"']+)[\"']", re.MULTILINE
+    )
     candidates: list[Path] = []
     for file_path in walk_files(package_dir):
         if file_path.name not in {"_version.py", "version.py"}:
@@ -396,7 +484,9 @@ def read_version(package_dir: Path) -> str:
     raise RuntimeError(f"ERROR: could not find a version string in {package_dir}")
 
 
-def generate_api_for_package(package_name: str, runtime_executable: str | None, ref_label: str | None = None) -> None:
+def generate_api_for_package(
+    package_name: str, runtime_executable: str | None, ref_label: str | None = None
+) -> None:
     if ref_label:
         log_info(f"--- Generating api.md on {ref_label} ---")
 
@@ -420,7 +510,15 @@ def generate_api_for_package(package_name: str, runtime_executable: str | None, 
         return
 
     run(
-        ["azpysdk", "apistub", "--md", "--extract-metadata", "--dest-dir", str(package_dir), package_name],
+        [
+            "azpysdk",
+            "apistub",
+            "--md",
+            "--extract-metadata",
+            "--dest-dir",
+            str(package_dir),
+            package_name,
+        ],
         check=True,
         shell=sys.platform == "win32",
     )
@@ -470,14 +568,18 @@ def write_simple_yaml(file_path: Path, metadata: dict[str, str]) -> None:
     existing_text = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
     line_ending = "\r\n" if "\r\n" in existing_text else "\n"
     file_path.write_text(
-        line_ending.join(f"{key}: {metadata[key]}" for key in sorted(metadata)) + line_ending, encoding="utf-8"
+        line_ending.join(f"{key}: {metadata[key]}" for key in sorted(metadata))
+        + line_ending,
+        encoding="utf-8",
     )
 
 
 def package_version_major_minor(package_version: str) -> str:
     match = re.match(r"^(\d+)(?:\.(\d+))?", package_version.strip())
     if not match:
-        raise RuntimeError(f"ERROR: could not derive major/minor version from package version '{package_version}'.")
+        raise RuntimeError(
+            f"ERROR: could not derive major/minor version from package version '{package_version}'."
+        )
     major = match.group(1)
     minor = match.group(2) or "0"
     return f"{major}.{minor}"
@@ -514,7 +616,9 @@ def find_azsdk_executable() -> str | None:
 
 
 def combined_command_output(result: CommandResult) -> str:
-    return "\n".join(part.strip() for part in [result.stdout, result.stderr] if part.strip())
+    return "\n".join(
+        part.strip() for part in [result.stdout, result.stderr] if part.strip()
+    )
 
 
 def resolve_azsdk_executable() -> str:
@@ -530,18 +634,23 @@ def resolve_azsdk_executable() -> str:
 
 def ensure_azsdk_find_work_item_available() -> None:
     azsdk_executable = resolve_azsdk_executable()
-    result = run([azsdk_executable, "package", "find-work-item", "--help"], check=False, capture=True)
+    result = run(
+        [azsdk_executable, "package", "find-work-item", "--help"],
+        check=False,
+        capture=True,
+    )
     if result.status == 0:
         return
 
     details = combined_command_output(result)
     raise RuntimeError(
         "ERROR: azsdk CLI is installed, but the 'package find-work-item' command is unavailable. "
-        f"Update it by running 'pwsh {AZSDK_INSTALL_SCRIPT}'." + (f"\n{details}" if details else "")
+        f"Update it by running 'pwsh {AZSDK_INSTALL_SCRIPT}'."
+        + (f"\n{details}" if details else "")
     )
 
 
-def package_work_item_metadata_value(package_name: str, package_version: str) -> str:
+def package_work_item_id(package_name: str, package_version: str) -> int | None:
     package_version_major_minor_value = package_version_major_minor(package_version)
     result = run(
         [
@@ -561,32 +670,22 @@ def package_work_item_metadata_value(package_name: str, package_version: str) ->
     output = combined_command_output(result)
 
     if result.status != 0:
-        metadata_value = '"Unknown"' if "No package work item found" in output else '"ERROR"'
         log_warning(
             f"WARNING: failed to resolve package work item ID for {package_name} {package_version_major_minor_value}. "
-            f"api.metadata.yml will use packageWorkItemId: {metadata_value}." + (f"\n{output}" if output else "")
+            "PR body sync metadata will omit packageWorkItemId."
+            + (f"\n{output}" if output else "")
         )
-        return metadata_value
+        return None
 
     work_item_id = parse_package_work_item_id(result.stdout)
     if work_item_id is None:
         log_warning(
             f"WARNING: azsdk package find-work-item completed for {package_name} {package_version_major_minor_value} "
-            'but did not return a work item ID. api.metadata.yml will use packageWorkItemId: "Unknown".'
+            "but did not return a work item ID. PR body sync metadata will omit packageWorkItemId."
             + (f"\n{output}" if output else "")
         )
-        return '"Unknown"'
-    return str(work_item_id)
-
-
-def add_package_work_item_metadata(package_name: str, package_version: str, package_dir: Path) -> None:
-    metadata_file = metadata_path(package_dir)
-    if not metadata_file.exists():
-        return
-
-    metadata = parse_simple_yaml(metadata_file.read_text(encoding="utf-8"))
-    metadata["packageWorkItemId"] = package_work_item_metadata_value(package_name, package_version)
-    write_simple_yaml(metadata_file, metadata)
+        return None
+    return work_item_id
 
 
 def metadata_sha_or_none(metadata_bytes: bytes | None) -> str | None:
@@ -594,6 +693,66 @@ def metadata_sha_or_none(metadata_bytes: bytes | None) -> str | None:
         return None
     metadata = parse_simple_yaml(metadata_bytes.decode("utf-8"))
     return metadata.get("apiMdSha256")
+
+
+def codeowners_style_pattern_matches(pattern: str, path: str) -> bool:
+    normalized_path = path.replace("\\", "/").strip("/")
+    normalized_pattern = pattern.replace("\\", "/").strip()
+    if not normalized_pattern or normalized_pattern.startswith("!"):
+        return False
+    if normalized_pattern.startswith("/"):
+        normalized_pattern = normalized_pattern[1:]
+    if normalized_pattern.endswith("/"):
+        directory_pattern = normalized_pattern.rstrip("/")
+        return normalized_path == directory_pattern or normalized_path.startswith(
+            f"{directory_pattern}/"
+        )
+    return fnmatch.fnmatchcase(normalized_path, normalized_pattern)
+
+
+def github_user_from_owner(owner: str) -> str | None:
+    if not owner.startswith("@") or "/" in owner:
+        return None
+    user = owner[1:].strip()
+    return user or None
+
+
+def architects_for_package(
+    package_dir: Path | str, architects_path: Path | None = None
+) -> list[str]:
+    architects_path = architects_path or ARCHITECTS_PATH
+    package_relative = normalize_package_dir(package_dir)
+    log_info(
+        "API review architect diagnostics: "
+        f"package_dir={package_dir}, normalized={package_relative}, architects_path={architects_path}"
+    )
+    if not architects_path.exists():
+        log_warning(
+            f"API review architect diagnostics: ARCHITECTS file does not exist: {architects_path}"
+        )
+        return []
+
+    matching_architects: list[str] = []
+    for line in architects_path.read_text(encoding="utf-8").splitlines():
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith("#"):
+            continue
+        parts = stripped_line.split()
+        if len(parts) < 2:
+            continue
+        pattern = parts[0]
+        if codeowners_style_pattern_matches(pattern, package_relative):
+            matching_architects = [
+                user for owner in parts[1:] if (user := github_user_from_owner(owner))
+            ]
+            log_info(
+                "API review architect diagnostics: "
+                f"matched ARCHITECTS pattern={pattern!r}, owners={parts[1:]}, users={matching_architects}"
+            )
+    log_info(
+        f"API review architect diagnostics: resolved architects={matching_architects}"
+    )
+    return matching_architects
 
 
 def branch_remote_ref(branch: str) -> str:
@@ -631,7 +790,9 @@ def read_ref_file_bytes(ref: str, relative_path: str) -> bytes | None:
 def desired_branch_state(result: ApiResult | None) -> BranchState:
     if result is None:
         return BranchState(False, False, None)
-    return BranchState(True, bool(result.metadata), metadata_sha_or_none(result.metadata))
+    return BranchState(
+        True, bool(result.metadata), metadata_sha_or_none(result.metadata)
+    )
 
 
 def api_results_have_api_diff(base_result: ApiResult, target_result: ApiResult) -> bool:
@@ -645,7 +806,9 @@ def branch_state_matches_desired(actual: BranchState, desired: BranchState) -> b
 def read_branch_state(ref: str, api_relative: str, meta_relative: str) -> BranchState:
     metadata_bytes = read_ref_file_bytes(ref, meta_relative)
     api_md_bytes = read_ref_file_bytes(ref, api_relative)
-    return BranchState(bool(api_md_bytes), bool(metadata_bytes), metadata_sha_or_none(metadata_bytes))
+    return BranchState(
+        bool(api_md_bytes), bool(metadata_bytes), metadata_sha_or_none(metadata_bytes)
+    )
 
 
 def branch_suffix_from_index(index: int) -> str:
@@ -658,7 +821,9 @@ def branch_suffix_from_index(index: int) -> str:
             return suffix
 
 
-def next_available_branch_name(preferred_branch: str, existing_branches: set[str]) -> str:
+def next_available_branch_name(
+    preferred_branch: str, existing_branches: set[str]
+) -> str:
     if preferred_branch not in existing_branches:
         return preferred_branch
 
@@ -669,7 +834,12 @@ def next_available_branch_name(preferred_branch: str, existing_branches: set[str
 
 
 def is_ancestor_ref(ancestor_ref: str, branch_ref: str) -> bool:
-    return git(["merge-base", "--is-ancestor", ancestor_ref, branch_ref], check=False).status == 0
+    return (
+        git(
+            ["merge-base", "--is-ancestor", ancestor_ref, branch_ref], check=False
+        ).status
+        == 0
+    )
 
 
 def resolve_branch_selection(
@@ -681,28 +851,41 @@ def resolve_branch_selection(
     required_ancestor_ref: str | None = None,
 ) -> BranchSelection:
     existing_branches = set(list_remote_branches_with_prefix(preferred_branch))
-    ordered_candidates = sorted(existing_branches, key=lambda branch: (branch != preferred_branch, branch))
+    ordered_candidates = sorted(
+        existing_branches, key=lambda branch: (branch != preferred_branch, branch)
+    )
 
     for candidate_branch in ordered_candidates:
         remote_ref = fetch_remote_branch(candidate_branch)
         actual_state = read_branch_state(remote_ref, api_relative, meta_relative)
         if not branch_state_matches_desired(actual_state, desired_state):
             continue
-        if required_ancestor_ref and not is_ancestor_ref(required_ancestor_ref, remote_ref):
+        if required_ancestor_ref and not is_ancestor_ref(
+            required_ancestor_ref, remote_ref
+        ):
             continue
         return BranchSelection(candidate_branch, True, remote_ref)
 
-    return BranchSelection(next_available_branch_name(preferred_branch, existing_branches), False, None)
+    return BranchSelection(
+        next_available_branch_name(preferred_branch, existing_branches), False, None
+    )
 
 
 def ensure_branch_state_has_metadata_sha(branch_label: str, state: BranchState) -> None:
     if state.has_api_md and not state.api_md_sha256:
-        raise RuntimeError(f"ERROR: {branch_label} is missing apiMdSha256 in api.metadata.yml.")
+        raise RuntimeError(
+            f"ERROR: {branch_label} is missing apiMdSha256 in api.metadata.yml."
+        )
 
 
 def select_best_pr(prs: list[dict[str, Any]]) -> dict[str, Any] | None:
     candidates = [
-        pr for pr in prs if pr.get("number") is not None and pr.get("url") and pr.get("state") and pr.get("updatedAt")
+        pr
+        for pr in prs
+        if pr.get("number") is not None
+        and pr.get("url")
+        and pr.get("state")
+        and pr.get("updatedAt")
     ]
     if not candidates:
         return None
@@ -727,7 +910,9 @@ def target_branch_exists(head_selector: str) -> bool:
     return bool(try_fork_branch_ref(parts["owner"], parts["branch"]))
 
 
-def sync_working_branch_info(head_selector: str | None, package_name: str | None = None) -> dict[str, str] | None:
+def sync_working_branch_info(
+    head_selector: str | None, package_name: str | None = None
+) -> dict[str, str] | None:
     if not head_selector:
         return None
     if resolve_target_tag(head_selector, package_name):
@@ -745,6 +930,7 @@ def build_sync_metadata_object(
     base_branch: str,
     review_branch: str,
     head_selector: str,
+    package_work_item_id_value: int | None = None,
 ) -> dict[str, Any] | None:
     working_branch = sync_working_branch_info(head_selector, package_name)
     if not working_branch:
@@ -762,8 +948,12 @@ def build_sync_metadata_object(
     }
     working_pr = find_open_pr_for_head(head_selector)
     metadata["workingPrNumber"] = (
-        working_pr.get("number") if working_pr and isinstance(working_pr.get("number"), int) else None
+        working_pr.get("number")
+        if working_pr and isinstance(working_pr.get("number"), int)
+        else None
     )
+    if package_work_item_id_value:
+        metadata["packageWorkItemId"] = package_work_item_id_value
     return metadata
 
 
@@ -781,7 +971,9 @@ def build_sync_metadata_block(metadata: dict[str, Any] | None) -> str | None:
 
 
 def replace_sync_metadata_block(body: str | None, metadata_block: str | None) -> str:
-    cleaned_body = re.sub(rf"<!--\s*{SYNC_METADATA_MARKER}[\s\S]*?-->\s*", "", str(body or "")).rstrip()
+    cleaned_body = re.sub(
+        rf"<!--\s*{SYNC_METADATA_MARKER}[\s\S]*?-->\s*", "", str(body or "")
+    ).rstrip()
     if not metadata_block:
         return cleaned_body
     return f"{cleaned_body}\n\n{metadata_block}"
@@ -818,7 +1010,9 @@ def update_pr_body(pr_number: int, body: str) -> None:
     get_github_api().update_pull_request_body(pr_number, body)
 
 
-def ensure_pr_body_sync_metadata(pr: dict[str, Any] | None, metadata_block: str | None) -> None:
+def ensure_pr_body_sync_metadata(
+    pr: dict[str, Any] | None, metadata_block: str | None
+) -> None:
     if not metadata_block or not pr or not isinstance(pr.get("number"), int):
         return
     desired_body = replace_sync_metadata_block(pr.get("body") or "", metadata_block)
@@ -847,7 +1041,11 @@ def find_open_pr_for_head(head_selector: str) -> dict[str, Any] | None:
         pass
 
     try:
-        all_prs.extend(github.search_pull_requests(f"repo:{REPO_SLUG} is:pr is:open head:{parts['branch']}", 50))
+        all_prs.extend(
+            github.search_pull_requests(
+                f"repo:{REPO_SLUG} is:pr is:open head:{parts['branch']}", 50
+            )
+        )
     except Exception:  # pylint: disable=broad-except
         pass
 
@@ -862,7 +1060,9 @@ def find_open_pr_for_head(head_selector: str) -> dict[str, Any] | None:
     return select_best_pr(list(deduped.values()))
 
 
-def find_open_pr_for_branches(base_branch: str, head_branch: str) -> dict[str, Any] | None:
+def find_open_pr_for_branches(
+    base_branch: str, head_branch: str
+) -> dict[str, Any] | None:
     github = get_github_api()
     try:
         prs = github.list_pull_requests_by_branches(base_branch, head_branch, 20)
@@ -872,18 +1072,30 @@ def find_open_pr_for_branches(base_branch: str, head_branch: str) -> dict[str, A
         pass
 
     try:
-        prs = github.search_pull_requests(f"repo:{REPO_SLUG} is:pr is:open head:{head_branch} base:{base_branch}", 20)
+        prs = github.search_pull_requests(
+            f"repo:{REPO_SLUG} is:pr is:open head:{head_branch} base:{base_branch}", 20
+        )
         return select_best_pr(prs)
     except Exception:  # pylint: disable=broad-except
         return None
 
 
-def create_draft_pr(base_branch: str, head_branch: str, title: str, body: str) -> dict[str, Any]:
+def create_draft_pr(
+    base_branch: str, head_branch: str, title: str, body: str
+) -> dict[str, Any]:
     try:
-        created_pr = get_github_api().create_draft_pull_request(base_branch, head_branch, title, body)
+        created_pr = get_github_api().create_draft_pull_request(
+            base_branch, head_branch, title, body
+        )
         return {
             "ok": True,
+            "number": created_pr.get("number"),
             "url": created_pr.get("html_url") or created_pr.get("url") or "",
+            "authorLogin": (
+                (created_pr.get("user") or {}).get("login")
+                if isinstance(created_pr.get("user"), dict)
+                else None
+            ),
             "stderr": "",
             "stdout": "",
         }
@@ -893,6 +1105,59 @@ def create_draft_pr(base_branch: str, head_branch: str, title: str, body: str) -
 
 def single_line_output(value: Any) -> str:
     return str(value or "").replace(chr(10), " ").replace(chr(13), " ").strip()
+
+
+def assign_architects_to_pr(
+    pr_number: int | None,
+    package_dir: Path | str,
+    pr_author_login: str | None = None,
+    architects: list[str] | None = None,
+) -> None:
+    if not pr_number:
+        log_warning(
+            "API review architect diagnostics: no PR number available; skipping reviewer request"
+        )
+        return
+    architects = (
+        architects_for_package(package_dir) if architects is None else architects
+    )
+    if not architects:
+        log_warning(
+            "API review architect diagnostics: "
+            f"no architects resolved for package_dir={package_dir}; skipping reviewer request"
+        )
+        return
+    log_info(f"API review architect diagnostics: PR author login={pr_author_login}")
+    reviewers = architects
+    if pr_author_login:
+        author_login = pr_author_login.lower()
+        self_reviewers = [
+            architect for architect in architects if architect.lower() == author_login
+        ]
+        reviewers = [
+            architect for architect in architects if architect.lower() != author_login
+        ]
+        if self_reviewers:
+            log_warning(
+                "WARNING: GitHub does not allow requesting the PR author as a reviewer; "
+                f"skipping architect reviewer(s) on PR #{pr_number}: "
+                f"{', '.join('@' + user for user in self_reviewers)}"
+            )
+        if not reviewers:
+            log_warning(
+                "API review architect diagnostics: "
+                f"all resolved architects are the PR author; no reviewer request will be sent for PR #{pr_number}"
+            )
+            return
+    try:
+        get_github_api().request_reviewers(pr_number, reviewers)
+        log_info(
+            f"Requested API review from architect(s) on PR #{pr_number}: {', '.join('@' + user for user in reviewers)}"
+        )
+    except GitHubApiError as error:
+        log_warning(
+            f"WARNING: failed to request API review from architect(s) on PR #{pr_number}: {error}"
+        )
 
 
 def branch_reference_markdown(head_selector: str) -> str:
@@ -909,18 +1174,32 @@ def baseline_reference_markdown(base_tag: str | None) -> str:
     return f"[tag `{base_tag}`]({commit_url})"
 
 
-def target_reference_info(head_selector: str, package_name: str | None = None) -> dict[str, str]:
+def target_reference_info(
+    head_selector: str, package_name: str | None = None
+) -> dict[str, str]:
     target_tag = resolve_target_tag(head_selector, package_name)
     if target_tag:
-        return {"label": "Target tag", "markdown": baseline_reference_markdown(target_tag)}
+        return {
+            "label": "Target tag",
+            "markdown": baseline_reference_markdown(target_tag),
+        }
 
     if target_branch_exists(head_selector):
         pr = find_open_pr_for_head(head_selector)
         if pr:
-            return {"label": "Working PR", "markdown": f"[PR #{pr['number']}]({pr['url']})"}
-        return {"label": "Working branch", "markdown": branch_reference_markdown(head_selector)}
+            return {
+                "label": "Working PR",
+                "markdown": f"[PR #{pr['number']}]({pr['url']})",
+            }
+        return {
+            "label": "Working branch",
+            "markdown": branch_reference_markdown(head_selector),
+        }
 
-    return {"label": "Working branch", "markdown": branch_reference_markdown(head_selector)}
+    return {
+        "label": "Working branch",
+        "markdown": branch_reference_markdown(head_selector),
+    }
 
 
 def write_bytes(file_path: Path, contents: bytes) -> None:
@@ -948,8 +1227,11 @@ def generate_api_bytes_for_ref(
         if not output_path.exists():
             raise RuntimeError(f"ERROR: did not produce {output_path}")
 
-        add_package_work_item_metadata(package_name, version, package_dir)
-        metadata = metadata_path(package_dir).read_bytes() if metadata_path(package_dir).exists() else None
+        metadata = (
+            metadata_path(package_dir).read_bytes()
+            if metadata_path(package_dir).exists()
+            else None
+        )
         return ApiResult(output_path.read_bytes(), metadata, version)
     finally:
         git(["reset", "--", package_relative], check=False)
@@ -958,12 +1240,17 @@ def generate_api_bytes_for_ref(
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Create an API review PR for a Python package api.md diff.")
+    parser = argparse.ArgumentParser(
+        description="Create an API review PR for a Python package api.md diff."
+    )
     parser.add_argument("--package-name", required=True)
     parser.add_argument("--base", required=True)
     parser.add_argument("--target")
     parser.add_argument(
-        "--python", "--runtime", dest="runtime_executable", default=os.environ.get("RUNTIME_EXECUTABLE")
+        "--python",
+        "--runtime",
+        dest="runtime_executable",
+        default=os.environ.get("RUNTIME_EXECUTABLE"),
     )
     return parser.parse_args(argv)
 
@@ -974,6 +1261,7 @@ def main(argv: list[str] | None = None) -> int:
 
     package_dir = find_package_dir(args.package_name)
     log_info(f"Found package at: {package_dir}")
+    architect_reviewers = architects_for_package(package_dir)
 
     ensure_clean_worktree()
     original_branch = current_branch()
@@ -982,7 +1270,9 @@ def main(argv: list[str] | None = None) -> int:
 
     git(["fetch", REMOTE, "main"])
     base_version = validate_base_tag(args.package_name, args.base)
-    target_ref = resolve_target_ref(args.target, args.package_name) if args.target else MAIN_REF
+    target_ref = (
+        resolve_target_ref(args.target, args.package_name) if args.target else MAIN_REF
+    )
 
     try:
         log_info(f"\n=== Capturing baseline api.md from tag {args.base} ===")
@@ -1023,7 +1313,9 @@ def main(argv: list[str] | None = None) -> int:
         ensure_branch_state_has_metadata_sha("target API result", desired_review_state)
 
         base_selection = resolve_branch_selection(
-            preferred_branch=api_review_branch_name("base", args.package_name, base_version),
+            preferred_branch=api_review_branch_name(
+                "base", args.package_name, base_version
+            ),
             desired_state=desired_base_state,
             api_relative=api_relative,
             meta_relative=meta_relative,
@@ -1041,11 +1333,19 @@ def main(argv: list[str] | None = None) -> int:
             if base_result.metadata:
                 write_bytes(meta_file_path, base_result.metadata)
                 git(["add", meta_relative])
-            git(["commit", "-m", f"[API Review] Baseline api.md for {args.package_name} {base_version}"])
+            git(
+                [
+                    "commit",
+                    "-m",
+                    f"[API Review] Baseline api.md for {args.package_name} {base_version}",
+                ]
+            )
             git(["push", "--force-with-lease", REMOTE, base_branch])
 
         review_selection = resolve_branch_selection(
-            preferred_branch=api_review_branch_name("review", args.package_name, target_version),
+            preferred_branch=api_review_branch_name(
+                "review", args.package_name, target_version
+            ),
             desired_state=desired_review_state,
             api_relative=api_relative,
             meta_relative=meta_relative,
@@ -1064,19 +1364,33 @@ def main(argv: list[str] | None = None) -> int:
             if target_result.metadata:
                 write_bytes(meta_file_path, target_result.metadata)
                 git(["add", meta_relative])
-            git(["commit", "-m", f"[API Review] api.md for {args.package_name} {target_version}"])
+            git(
+                [
+                    "commit",
+                    "-m",
+                    f"[API Review] api.md for {args.package_name} {target_version}",
+                ]
+            )
             git(["push", "--force-with-lease", REMOTE, review_branch])
 
-        title = f"[API Review] {args.package_name} {target_version} (base {base_version})"
+        title = (
+            f"[API Review] {args.package_name} {target_version} (base {base_version})"
+        )
         working_selector = args.target or "main"
         working_reference = target_reference_info(working_selector, args.package_name)
         baseline_ref = baseline_reference_markdown(args.base)
+        package_work_item_id_value = None
+        if sync_working_branch_info(working_selector, args.package_name):
+            package_work_item_id_value = package_work_item_id(
+                args.package_name, target_version
+            )
         sync_metadata = build_sync_metadata_object(
             package_name=args.package_name,
             package_dir=package_dir,
             base_branch=base_branch,
             review_branch=review_branch,
             head_selector=working_selector,
+            package_work_item_id_value=package_work_item_id_value,
         )
         sync_metadata_block = build_sync_metadata_block(sync_metadata)
         body = build_review_pr_body(
@@ -1092,6 +1406,12 @@ def main(argv: list[str] | None = None) -> int:
             existing_pr = find_open_pr_for_branches(base_branch, review_branch)
             if existing_pr:
                 ensure_pr_body_sync_metadata(existing_pr, sync_metadata_block)
+                assign_architects_to_pr(
+                    existing_pr.get("number"),
+                    package_dir,
+                    existing_pr.get("authorLogin"),
+                    architect_reviewers,
+                )
                 log_info(f"\n=== Reusing existing PR #{existing_pr['number']} ===")
                 log_info(existing_pr["url"])
                 return 0
@@ -1100,12 +1420,24 @@ def main(argv: list[str] | None = None) -> int:
         compare_url = f"https://github.com/{REPO_SLUG}/compare/{base_branch}...{review_branch}?expand=1"
         pr_create = create_draft_pr(base_branch, review_branch, title, body)
         if pr_create["ok"]:
+            assign_architects_to_pr(
+                pr_create.get("number"),
+                package_dir,
+                pr_create.get("authorLogin"),
+                architect_reviewers,
+            )
             if pr_create.get("url"):
                 log_info(pr_create["url"])
         else:
             existing_pr = find_open_pr_for_branches(base_branch, review_branch)
             if existing_pr:
                 ensure_pr_body_sync_metadata(existing_pr, sync_metadata_block)
+                assign_architects_to_pr(
+                    existing_pr.get("number"),
+                    package_dir,
+                    existing_pr.get("authorLogin"),
+                    architect_reviewers,
+                )
                 log_info(f"\n=== Reusing existing PR #{existing_pr['number']} ===")
                 log_info(existing_pr["url"])
                 return 0
@@ -1114,8 +1446,16 @@ def main(argv: list[str] | None = None) -> int:
                 item
                 for item in [
                     f"Exit code: {pr_create.get('status')}",
-                    f"stderr: {single_line_output(pr_create.get('stderr'))}" if pr_create.get("stderr") else "",
-                    f"stdout: {single_line_output(pr_create.get('stdout'))}" if pr_create.get("stdout") else "",
+                    (
+                        f"stderr: {single_line_output(pr_create.get('stderr'))}"
+                        if pr_create.get("stderr")
+                        else ""
+                    ),
+                    (
+                        f"stdout: {single_line_output(pr_create.get('stdout'))}"
+                        if pr_create.get("stdout")
+                        else ""
+                    ),
                     "Debug repro: use the GitHub REST API endpoint POST "
                     f"/repos/{REPO_SLUG}/pulls with base/head/title/body/draft=true.",
                 ]

--- a/scripts/api_md_workflow/create_api_review_pr.py
+++ b/scripts/api_md_workflow/create_api_review_pr.py
@@ -564,16 +564,6 @@ def parse_simple_yaml(text: str) -> dict[str, str]:
     return result
 
 
-def write_simple_yaml(file_path: Path, metadata: dict[str, str]) -> None:
-    existing_text = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
-    line_ending = "\r\n" if "\r\n" in existing_text else "\n"
-    file_path.write_text(
-        line_ending.join(f"{key}: {metadata[key]}" for key in sorted(metadata))
-        + line_ending,
-        encoding="utf-8",
-    )
-
-
 def package_version_major_minor(package_version: str) -> str:
     match = re.match(r"^(\d+)(?:\.(\d+))?", package_version.strip())
     if not match:
@@ -650,7 +640,7 @@ def ensure_azsdk_find_work_item_available() -> None:
     )
 
 
-def package_work_item_id(package_name: str, package_version: str) -> int | None:
+def package_work_item_id(package_name: str, package_version: str) -> int | str:
     package_version_major_minor_value = package_version_major_minor(package_version)
     result = run(
         [
@@ -672,19 +662,19 @@ def package_work_item_id(package_name: str, package_version: str) -> int | None:
     if result.status != 0:
         log_warning(
             f"WARNING: failed to resolve package work item ID for {package_name} {package_version_major_minor_value}. "
-            "PR body sync metadata will omit packageWorkItemId."
+            "PR body sync metadata will set packageWorkItemId to ERROR."
             + (f"\n{output}" if output else "")
         )
-        return None
+        return "ERROR"
 
     work_item_id = parse_package_work_item_id(result.stdout)
     if work_item_id is None:
         log_warning(
             f"WARNING: azsdk package find-work-item completed for {package_name} {package_version_major_minor_value} "
-            "but did not return a work item ID. PR body sync metadata will omit packageWorkItemId."
+            "but did not return a work item ID. PR body sync metadata will set packageWorkItemId to NONE."
             + (f"\n{output}" if output else "")
         )
-        return None
+        return "NONE"
     return work_item_id
 
 
@@ -695,19 +685,86 @@ def metadata_sha_or_none(metadata_bytes: bytes | None) -> str | None:
     return metadata.get("apiMdSha256")
 
 
+def _codeowners_segment_match(
+    path_segments: list[str], pattern_segments: list[str]
+) -> bool:
+    memo: dict[tuple[int, int], bool] = {}
+
+    def match(path_index: int, pattern_index: int) -> bool:
+        key = (path_index, pattern_index)
+        if key in memo:
+            return memo[key]
+
+        # Base case: pattern exhausted
+        if pattern_index >= len(pattern_segments):
+            result = path_index >= len(path_segments)
+        # Pattern segment is **
+        elif pattern_segments[pattern_index] == "**":
+            next_pattern_index = pattern_index
+            while (
+                next_pattern_index + 1 < len(pattern_segments)
+                and pattern_segments[next_pattern_index + 1] == "**"
+            ):
+                next_pattern_index += 1
+            if next_pattern_index + 1 >= len(pattern_segments):
+                result = True
+            else:
+                result = any(
+                    match(next_path_index, next_pattern_index + 1)
+                    for next_path_index in range(path_index, len(path_segments) + 1)
+                )
+        # Path exhausted but pattern remains
+        elif path_index >= len(path_segments):
+            result = False
+        # Segment doesn't match
+        elif not fnmatch.fnmatchcase(
+            path_segments[path_index], pattern_segments[pattern_index]
+        ):
+            result = False
+        # Recurse to next segments
+        else:
+            result = match(path_index + 1, pattern_index + 1)
+
+        memo[key] = result
+        return result
+
+    return match(0, 0)
+
+
 def codeowners_style_pattern_matches(pattern: str, path: str) -> bool:
     normalized_path = path.replace("\\", "/").strip("/")
     normalized_pattern = pattern.replace("\\", "/").strip()
     if not normalized_pattern or normalized_pattern.startswith("!"):
         return False
-    if normalized_pattern.startswith("/"):
+
+    is_anchored = normalized_pattern.startswith("/")
+    if is_anchored:
         normalized_pattern = normalized_pattern[1:]
+
     if normalized_pattern.endswith("/"):
-        directory_pattern = normalized_pattern.rstrip("/")
-        return normalized_path == directory_pattern or normalized_path.startswith(
-            f"{directory_pattern}/"
+        normalized_pattern = normalized_pattern.rstrip("/")
+        normalized_pattern = f"{normalized_pattern}/**" if normalized_pattern else "**"
+
+    if not normalized_pattern:
+        return False
+
+    path_segments = [segment for segment in normalized_path.split("/") if segment]
+
+    if "/" not in normalized_pattern:
+        return any(
+            fnmatch.fnmatchcase(segment, normalized_pattern)
+            for segment in path_segments
         )
-    return fnmatch.fnmatchcase(normalized_path, normalized_pattern)
+
+    pattern_segments = [segment for segment in normalized_pattern.split("/") if segment]
+
+    if is_anchored:
+        return _codeowners_segment_match(path_segments, pattern_segments)
+
+    for start_index in range(0, len(path_segments) + 1):
+        if _codeowners_segment_match(path_segments[start_index:], pattern_segments):
+            return True
+    return False
 
 
 def github_user_from_owner(owner: str) -> str | None:
@@ -930,7 +987,7 @@ def build_sync_metadata_object(
     base_branch: str,
     review_branch: str,
     head_selector: str,
-    package_work_item_id_value: int | None = None,
+    package_work_item_id_value: int | str | None = None,
 ) -> dict[str, Any] | None:
     working_branch = sync_working_branch_info(head_selector, package_name)
     if not working_branch:
@@ -952,7 +1009,7 @@ def build_sync_metadata_object(
         if working_pr and isinstance(working_pr.get("number"), int)
         else None
     )
-    if package_work_item_id_value:
+    if package_work_item_id_value is not None:
         metadata["packageWorkItemId"] = package_work_item_id_value
     return metadata
 
@@ -1257,7 +1314,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
-    ensure_azsdk_find_work_item_available()
+    if sync_working_branch_info(args.target or "main", args.package_name):
+        ensure_azsdk_find_work_item_available()
 
     package_dir = find_package_dir(args.package_name)
     log_info(f"Found package at: {package_dir}")
@@ -1379,11 +1437,19 @@ def main(argv: list[str] | None = None) -> int:
         working_selector = args.target or "main"
         working_reference = target_reference_info(working_selector, args.package_name)
         baseline_ref = baseline_reference_markdown(args.base)
-        package_work_item_id_value = None
+        package_work_item_id_value: int | str | None = None
         if sync_working_branch_info(working_selector, args.package_name):
-            package_work_item_id_value = package_work_item_id(
-                args.package_name, target_version
-            )
+            try:
+                package_work_item_id_value = package_work_item_id(
+                    args.package_name, target_version
+                )
+            except Exception as error:  # pylint: disable=broad-except
+                package_work_item_id_value = "ERROR"
+                log_warning(
+                    "WARNING: failed to resolve package work item ID. "
+                    "PR body sync metadata will set packageWorkItemId to ERROR."
+                    + (f"\n{error}" if str(error) else "")
+                )
         sync_metadata = build_sync_metadata_object(
             package_name=args.package_name,
             package_dir=package_dir,

--- a/scripts/api_md_workflow/create_api_review_pr.py
+++ b/scripts/api_md_workflow/create_api_review_pr.py
@@ -62,6 +62,12 @@ class BranchSelection:
     remote_ref: str | None
 
 
+@dataclass
+class ArchitectReviewers:
+    users: list[str]
+    teams: list[str]
+
+
 GitRunner = Callable[[list[str], bool], CommandResult]
 _git_runner: GitRunner | None = None
 _github_api: "GitHubApi | None" = None
@@ -299,27 +305,43 @@ query($query: String!, $first: Int!) {
             {"base": base, "head": head, "title": title, "body": body, "draft": True},
         )
 
-    def request_reviewers(self, pr_number: int, reviewers: list[str]) -> None:
+    def request_reviewers(
+        self,
+        pr_number: int,
+        reviewers: list[str],
+        team_reviewers: list[str] | None = None,
+    ) -> None:
         url = self._rest_url(
             f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}/requested_reviewers"
         )
+        payload: dict[str, Any] = {"reviewers": reviewers}
+        if team_reviewers:
+            payload["team_reviewers"] = team_reviewers
         log_info(
-            f"API review architect diagnostics: requesting PR reviewers at {url}: {reviewers}"
+            "API review architect diagnostics: requesting PR reviewers at "
+            f"{url}: reviewers={reviewers}, team_reviewers={team_reviewers or []}"
         )
         response = self._request(
             "POST",
             url,
-            {"reviewers": reviewers},
+            payload,
         )
         requested_reviewers = []
+        requested_teams = []
         if isinstance(response, dict):
             requested_reviewers = [
                 reviewer.get("login")
                 for reviewer in response.get("requested_reviewers", [])
                 if isinstance(reviewer, dict) and reviewer.get("login")
             ]
+            requested_teams = [
+                team.get("slug")
+                for team in response.get("requested_teams", [])
+                if isinstance(team, dict) and team.get("slug")
+            ]
         log_info(
-            f"API review architect diagnostics: GitHub response requested_reviewers={requested_reviewers}"
+            "API review architect diagnostics: GitHub response "
+            f"requested_reviewers={requested_reviewers}, requested_teams={requested_teams}"
         )
 
 
@@ -767,11 +789,24 @@ def codeowners_style_pattern_matches(pattern: str, path: str) -> bool:
     return False
 
 
-def github_user_from_owner(owner: str) -> str | None:
-    if not owner.startswith("@") or "/" in owner:
+def github_owner_from_owner(owner: str) -> str | None:
+    if not owner.startswith("@"):
         return None
-    user = owner[1:].strip()
-    return user or None
+    github_owner = owner[1:].strip()
+    return github_owner or None
+
+
+def architect_reviewers_from_owners(owners: list[str]) -> ArchitectReviewers:
+    users: list[str] = []
+    teams: list[str] = []
+    for owner in owners:
+        if "/" in owner:
+            _, team_slug = owner.split("/", 1)
+            if team_slug:
+                teams.append(team_slug)
+            continue
+        users.append(owner)
+    return ArchitectReviewers(users=users, teams=teams)
 
 
 def architects_for_package(
@@ -800,11 +835,13 @@ def architects_for_package(
         pattern = parts[0]
         if codeowners_style_pattern_matches(pattern, package_relative):
             matching_architects = [
-                user for owner in parts[1:] if (user := github_user_from_owner(owner))
+                owner
+                for candidate in parts[1:]
+                if (owner := github_owner_from_owner(candidate))
             ]
             log_info(
                 "API review architect diagnostics: "
-                f"matched ARCHITECTS pattern={pattern!r}, owners={parts[1:]}, users={matching_architects}"
+                f"matched ARCHITECTS pattern={pattern!r}, owners={parts[1:]}, resolved={matching_architects}"
             )
     log_info(
         f"API review architect diagnostics: resolved architects={matching_architects}"
@@ -1184,15 +1221,17 @@ def assign_architects_to_pr(
             f"no architects resolved for package_dir={package_dir}; skipping reviewer request"
         )
         return
+    resolved_reviewers = architect_reviewers_from_owners(architects)
     log_info(f"API review architect diagnostics: PR author login={pr_author_login}")
-    reviewers = architects
+    reviewers = resolved_reviewers.users
+    team_reviewers = resolved_reviewers.teams
     if pr_author_login:
         author_login = pr_author_login.lower()
         self_reviewers = [
-            architect for architect in architects if architect.lower() == author_login
+            architect for architect in reviewers if architect.lower() == author_login
         ]
         reviewers = [
-            architect for architect in architects if architect.lower() != author_login
+            architect for architect in reviewers if architect.lower() != author_login
         ]
         if self_reviewers:
             log_warning(
@@ -1200,16 +1239,20 @@ def assign_architects_to_pr(
                 f"skipping architect reviewer(s) on PR #{pr_number}: "
                 f"{', '.join('@' + user for user in self_reviewers)}"
             )
-        if not reviewers:
+        if not reviewers and not team_reviewers:
             log_warning(
                 "API review architect diagnostics: "
                 f"all resolved architects are the PR author; no reviewer request will be sent for PR #{pr_number}"
             )
             return
     try:
-        get_github_api().request_reviewers(pr_number, reviewers)
+        get_github_api().request_reviewers(pr_number, reviewers, team_reviewers)
+        requested_owners = [
+            *["@" + user for user in reviewers],
+            *["@" + REPO_OWNER + "/" + team for team in team_reviewers],
+        ]
         log_info(
-            f"Requested API review from architect(s) on PR #{pr_number}: {', '.join('@' + user for user in reviewers)}"
+            f"Requested API review from architect(s) on PR #{pr_number}: {', '.join(requested_owners)}"
         )
     except GitHubApiError as error:
         log_warning(

--- a/scripts/api_md_workflow/create_api_review_pr_test.py
+++ b/scripts/api_md_workflow/create_api_review_pr_test.py
@@ -15,7 +15,11 @@ def stub_git_branches(branches):
     branch_set = set(branches)
 
     def runner(args, check):
-        if args[0] == "fetch" and len(args) > 2 and args[2].split(":", 1)[0] in branch_set:
+        if (
+            args[0] == "fetch"
+            and len(args) > 2
+            and args[2].split(":", 1)[0] in branch_set
+        ):
             return command_result()
         return command_result(status=1)
 
@@ -27,6 +31,7 @@ class StubGithubApi:
         self.head_results = head_results or []
         self.search_results = search_results or []
         self.on_lookup = on_lookup
+        self.reviewers = []
 
     def _lookup(self, results):
         if self.on_lookup:
@@ -46,7 +51,13 @@ class StubGithubApi:
         return None
 
     def create_draft_pull_request(self, _base, _head, _title, _body):
-        return {"html_url": "https://github.com/Azure/azure-sdk-for-python/pull/1"}
+        return {
+            "number": 1,
+            "html_url": "https://github.com/Azure/azure-sdk-for-python/pull/1",
+        }
+
+    def request_reviewers(self, pr_number, reviewers):
+        self.reviewers.append((pr_number, reviewers))
 
 
 class ApiReviewPrTests(unittest.TestCase):
@@ -60,14 +71,23 @@ class ApiReviewPrTests(unittest.TestCase):
         response_context = MagicMock()
         response_context.__enter__.return_value = response
 
-        with patch.object(workflow, "urlopen", return_value=response_context) as urlopen:
-            self.assertEqual(workflow.GitHubApi(None)._request("GET", "https://example.test"), {"ok": True})
+        with patch.object(
+            workflow, "urlopen", return_value=response_context
+        ) as urlopen:
+            self.assertEqual(
+                workflow.GitHubApi(None)._request("GET", "https://example.test"),
+                {"ok": True},
+            )
 
         urlopen.assert_called_once()
-        self.assertEqual(urlopen.call_args.kwargs["timeout"], workflow.GITHUB_API_TIMEOUT_SECONDS)
+        self.assertEqual(
+            urlopen.call_args.kwargs["timeout"], workflow.GITHUB_API_TIMEOUT_SECONDS
+        )
 
     def test_target_reference_info_links_matching_open_pr_from_direct_head_query(self):
-        workflow.set_command_runner_for_test(stub_git_branches(["users/example/direct-feature"]))
+        workflow.set_command_runner_for_test(
+            stub_git_branches(["users/example/direct-feature"])
+        )
         workflow.set_github_api_for_test(
             StubGithubApi(
                 head_results=[
@@ -137,7 +157,8 @@ class ApiReviewPrTests(unittest.TestCase):
             workflow.target_reference_info("azure-example_1.2.3"),
             {
                 "label": "Target tag",
-                "markdown": "[tag `azure-example_1.2.3`](https://github.com/Azure/azure-sdk-for-python/commit/abc123def456)",
+                "markdown": "[tag `azure-example_1.2.3`]"
+                "(https://github.com/Azure/azure-sdk-for-python/commit/abc123def456)",
             },
         )
         self.assertEqual(pr_lookup_count, 0)
@@ -146,11 +167,20 @@ class ApiReviewPrTests(unittest.TestCase):
         pr_lookup_count = 0
 
         def runner(args, check):
-            if args == ["rev-parse", "--verify", "--quiet", "refs/tags/azure-example_1.2.3"]:
+            if args == [
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "refs/tags/azure-example_1.2.3",
+            ]:
                 return command_result()
             if args == ["rev-list", "-n", "1", "azure-example_1.2.3"]:
                 return command_result("abc123def456\n")
-            if args == ["fetch", "origin", "azure-example_1.2.3:refs/remotes/origin/azure-example_1.2.3"]:
+            if args == [
+                "fetch",
+                "origin",
+                "azure-example_1.2.3:refs/remotes/origin/azure-example_1.2.3",
+            ]:
                 return command_result()
             return command_result(status=1)
 
@@ -161,19 +191,27 @@ class ApiReviewPrTests(unittest.TestCase):
         workflow.set_command_runner_for_test(runner)
         workflow.set_github_api_for_test(StubGithubApi(on_lookup=on_lookup))
 
-        self.assertEqual(workflow.resolve_target_ref("azure-example_1.2.3", "azure-example"), "azure-example_1.2.3")
-        self.assertIsNone(workflow.sync_working_branch_info("azure-example_1.2.3", "azure-example"))
+        self.assertEqual(
+            workflow.resolve_target_ref("azure-example_1.2.3", "azure-example"),
+            "azure-example_1.2.3",
+        )
+        self.assertIsNone(
+            workflow.sync_working_branch_info("azure-example_1.2.3", "azure-example")
+        )
         self.assertEqual(
             workflow.target_reference_info("azure-example_1.2.3", "azure-example"),
             {
                 "label": "Target tag",
-                "markdown": "[tag `azure-example_1.2.3`](https://github.com/Azure/azure-sdk-for-python/commit/abc123def456)",
+                "markdown": "[tag `azure-example_1.2.3`]"
+                "(https://github.com/Azure/azure-sdk-for-python/commit/abc123def456)",
             },
         )
         self.assertEqual(pr_lookup_count, 0)
 
     def test_build_sync_metadata_object_records_fork_owner_and_branch(self):
-        workflow.set_command_runner_for_test(stub_git_branches(["users/example/feature"]))
+        workflow.set_command_runner_for_test(
+            stub_git_branches(["users/example/feature"])
+        )
         workflow.set_github_api_for_test(
             StubGithubApi(
                 search_results=[
@@ -195,11 +233,13 @@ class ApiReviewPrTests(unittest.TestCase):
             base_branch="apireview/base_azure-example_1.0.0",
             review_branch="apireview/review_azure-example_1.1.0",
             head_selector="example:users/example/feature",
+            package_work_item_id_value=31370,
         )
 
         self.assertEqual(metadata["workingOwner"], "example")
         self.assertEqual(metadata["workingBranch"], "users/example/feature")
         self.assertEqual(metadata["workingPrNumber"], 47204)
+        self.assertEqual(metadata["packageWorkItemId"], 31370)
 
     def test_build_sync_metadata_object_omits_metadata_for_tag_targets(self):
         pr_lookup_count = 0
@@ -248,7 +288,9 @@ class ApiReviewPrTests(unittest.TestCase):
         self.assertNotIn("Update behavior", body)
         self.assertNotIn("api-md-review-sync", body)
 
-    def test_build_review_pr_body_includes_sync_metadata_for_working_branch_reviews(self):
+    def test_build_review_pr_body_includes_sync_metadata_for_working_branch_reviews(
+        self,
+    ):
         metadata_block = workflow.build_sync_metadata_block(
             {
                 "schemaVersion": 1,
@@ -260,6 +302,7 @@ class ApiReviewPrTests(unittest.TestCase):
                 "workingOwner": "Azure",
                 "workingBranch": "main",
                 "workingPrNumber": None,
+                "packageWorkItemId": "31370",
             }
         )
 
@@ -279,12 +322,17 @@ class ApiReviewPrTests(unittest.TestCase):
         self.assertNotIn("Static tag-to-tag review", body)
         self.assertIn("<!-- api-md-review-sync", body)
         self.assertIn('"workingBranch": "main"', body)
+        self.assertIn('"packageWorkItemId": "31370"', body)
 
     def test_api_results_have_api_diff_ignores_metadata_only_changes(self):
         self.assertFalse(
             workflow.api_results_have_api_diff(
-                workflow.ApiResult(b"# API\n\nclass Same\n", b"apiMdSha256: old", "1.0.0"),
-                workflow.ApiResult(b"# API\n\nclass Same\n", b"apiMdSha256: new", "1.0.1"),
+                workflow.ApiResult(
+                    b"# API\n\nclass Same\n", b"apiMdSha256: old", "1.0.0"
+                ),
+                workflow.ApiResult(
+                    b"# API\n\nclass Same\n", b"apiMdSha256: new", "1.0.1"
+                ),
             )
         )
 
@@ -293,15 +341,99 @@ class ApiReviewPrTests(unittest.TestCase):
         self.assertEqual(workflow.package_version_major_minor("12"), "12.0")
 
     def test_parse_package_work_item_id(self):
-        self.assertEqual(workflow.parse_package_work_item_id("Work Item ID: 31370\n"), 31370)
-        self.assertEqual(workflow.parse_package_work_item_id('{"work_item_id":31371}'), 31371)
+        self.assertEqual(
+            workflow.parse_package_work_item_id("Work Item ID: 31370\n"), 31370
+        )
+        self.assertEqual(
+            workflow.parse_package_work_item_id('{"work_item_id":31371}'), 31371
+        )
 
-    def test_pkg_work_item_value_no_shell(self):
+    def test_architects_for_package_uses_codeowners_style_last_match(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            architects_path = Path(temp_dir) / "ARCHITECTS"
+            architects_path.write_text(
+                "# comment\n"
+                "/sdk/ @fallback\n"
+                "/sdk/keyvault/ @keyvault-architect @Azure/ignored-team\n"
+                "/sdk/keyvault/azure-keyvault-keys/ @tjprescott\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                workflow.architects_for_package(
+                    "sdk/keyvault/azure-keyvault-keys", architects_path
+                ),
+                ["tjprescott"],
+            )
+
+    def test_assign_architects_to_pr_requests_matching_architects_as_reviewers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            architects_path = Path(temp_dir) / "ARCHITECTS"
+            architects_path.write_text(
+                "/sdk/ @kashifkhan\n/sdk/keyvault/ @tjprescott\n", encoding="utf-8"
+            )
+            github = StubGithubApi()
+            workflow.set_github_api_for_test(github)
+
+            with patch.object(workflow, "ARCHITECTS_PATH", architects_path):
+                workflow.assign_architects_to_pr(
+                    123, "sdk/keyvault/azure-keyvault-keys"
+                )
+
+            self.assertEqual(github.reviewers, [(123, ["tjprescott"])])
+
+    def test_assign_uses_cached_architects(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            github = StubGithubApi()
+            workflow.set_github_api_for_test(github)
+
+            with patch.object(
+                workflow, "ARCHITECTS_PATH", Path(temp_dir) / "ARCHITECTS"
+            ):
+                workflow.assign_architects_to_pr(
+                    123, "sdk/keyvault/azure-keyvault-keys", architects=["l0lawrence"]
+                )
+
+            self.assertEqual(github.reviewers, [(123, ["l0lawrence"])])
+
+    def test_assign_architects_to_pr_warns_when_architect_is_pr_author(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            architects_path = Path(temp_dir) / "ARCHITECTS"
+            architects_path.write_text("/sdk/keyvault/ @tjprescott\n", encoding="utf-8")
+            github = StubGithubApi()
+            workflow.set_github_api_for_test(github)
+
+            with (
+                patch.object(workflow, "ARCHITECTS_PATH", architects_path),
+                patch.object(workflow, "log_warning") as log_warning,
+            ):
+                workflow.assign_architects_to_pr(
+                    123, "sdk/keyvault/azure-keyvault-keys", "tjprescott"
+                )
+
+            self.assertEqual(github.reviewers, [])
+            self.assertTrue(
+                any(
+                    "GitHub does not allow requesting the PR author as a reviewer"
+                    in call.args[0]
+                    for call in log_warning.call_args_list
+                )
+            )
+
+    def test_package_work_item_id_no_shell(self):
         with (
-            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk") as resolve_azsdk,
-            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "Work Item ID: 31370\n")) as run,
+            patch.object(
+                workflow, "resolve_azsdk_executable", return_value="azsdk"
+            ) as resolve_azsdk,
+            patch.object(
+                workflow,
+                "run",
+                return_value=workflow.CommandResult(0, "Work Item ID: 31370\n"),
+            ) as run,
         ):
-            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), "31370")
+            self.assertEqual(
+                workflow.package_work_item_id("azure-example", "1.2.3b1"), 31370
+            )
 
         resolve_azsdk.assert_called_once_with()
         run.assert_called_once_with(
@@ -320,59 +452,90 @@ class ApiReviewPrTests(unittest.TestCase):
             capture=True,
         )
 
-    def test_pkg_work_item_value_error(self):
+    def test_package_work_item_id_error(self):
         with (
             patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
-            patch.object(workflow, "run", return_value=workflow.CommandResult(1, "", "Unexpected failure")),
+            patch.object(
+                workflow,
+                "run",
+                return_value=workflow.CommandResult(1, "", "Unexpected failure"),
+            ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"ERROR"')
+            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
 
         log_warning.assert_called_once()
-        self.assertIn('packageWorkItemId: "ERROR"', log_warning.call_args.args[0])
+        self.assertIn(
+            "PR body sync metadata will omit packageWorkItemId",
+            log_warning.call_args.args[0],
+        )
 
-    def test_pkg_work_item_value_unknown_missing(self):
+    def test_package_work_item_id_unknown_missing(self):
         with (
             patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
             patch.object(
                 workflow,
                 "run",
                 return_value=workflow.CommandResult(
-                    1, "[ERROR] No package work item found for package 'azure-example'.\n", ""
+                    1,
+                    "[ERROR] No package work item found for package 'azure-example'.\n",
+                    "",
                 ),
             ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"Unknown"')
+            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
 
         log_warning.assert_called_once()
-        self.assertIn('packageWorkItemId: "Unknown"', log_warning.call_args.args[0])
+        self.assertIn(
+            "PR body sync metadata will omit packageWorkItemId",
+            log_warning.call_args.args[0],
+        )
 
-    def test_pkg_work_item_value_unknown_no_id(self):
+    def test_package_work_item_id_unknown_no_id(self):
         with (
             patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
-            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "No package work item found\n", "")),
+            patch.object(
+                workflow,
+                "run",
+                return_value=workflow.CommandResult(
+                    0, "No package work item found\n", ""
+                ),
+            ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"Unknown"')
+            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
 
         log_warning.assert_called_once()
-        self.assertIn('packageWorkItemId: "Unknown"', log_warning.call_args.args[0])
+        self.assertIn(
+            "PR body sync metadata will omit packageWorkItemId",
+            log_warning.call_args.args[0],
+        )
 
     def test_azsdk_preflight_checks_help(self):
         with (
-            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk") as resolve_azsdk,
-            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "help")) as run,
+            patch.object(
+                workflow, "resolve_azsdk_executable", return_value="azsdk"
+            ) as resolve_azsdk,
+            patch.object(
+                workflow, "run", return_value=workflow.CommandResult(0, "help")
+            ) as run,
         ):
             workflow.ensure_azsdk_find_work_item_available()
 
         resolve_azsdk.assert_called_once_with()
-        run.assert_called_once_with(["azsdk", "package", "find-work-item", "--help"], check=False, capture=True)
+        run.assert_called_once_with(
+            ["azsdk", "package", "find-work-item", "--help"], check=False, capture=True
+        )
 
     def test_azsdk_preflight_fails_if_stale(self):
         with (
             patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
-            patch.object(workflow, "run", return_value=workflow.CommandResult(1, "", "Unknown command")),
+            patch.object(
+                workflow,
+                "run",
+                return_value=workflow.CommandResult(1, "", "Unknown command"),
+            ),
         ):
             with self.assertRaisesRegex(RuntimeError, "package find-work-item"):
                 workflow.ensure_azsdk_find_work_item_available()
@@ -380,12 +543,16 @@ class ApiReviewPrTests(unittest.TestCase):
     def test_main_preflights_azsdk_first(self):
         with (
             patch.object(
-                workflow, "ensure_azsdk_find_work_item_available", side_effect=RuntimeError("missing command")
+                workflow,
+                "ensure_azsdk_find_work_item_available",
+                side_effect=RuntimeError("missing command"),
             ),
             patch.object(workflow, "find_package_dir") as find_package_dir,
         ):
             with self.assertRaisesRegex(RuntimeError, "missing command"):
-                workflow.main(["--package-name", "azure-example", "--base", "azure-example_1.0.0"])
+                workflow.main(
+                    ["--package-name", "azure-example", "--base", "azure-example_1.0.0"]
+                )
 
         find_package_dir.assert_not_called()
 
@@ -409,7 +576,9 @@ class ApiReviewPrTests(unittest.TestCase):
 
     def test_resolve_azsdk_uses_mcp_dir(self):
         def is_file(candidate):
-            return str(candidate).replace("\\", "/").endswith("/.azure-sdk-mcp/azsdk.exe")
+            return (
+                str(candidate).replace("\\", "/").endswith("/.azure-sdk-mcp/azsdk.exe")
+            )
 
         with (
             patch.object(workflow.shutil, "which", return_value=None),
@@ -429,24 +598,6 @@ class ApiReviewPrTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "azure-sdk-mcp.ps1"):
                 workflow.resolve_azsdk_executable()
-
-    def test_add_package_work_item_metadata(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            package_dir = Path(temp_dir)
-            metadata_file = package_dir / "api.metadata.yml"
-            metadata_file.write_text(
-                "apiMdSha256: abc123\r\nparserVersion: 1.0\r\n",
-                encoding="utf-8",
-            )
-
-            with patch.object(workflow, "package_work_item_metadata_value", return_value="31370") as package_work_item:
-                workflow.add_package_work_item_metadata("azure-example", "1.2.3b1", package_dir)
-
-            package_work_item.assert_called_once_with("azure-example", "1.2.3b1")
-            self.assertEqual(
-                metadata_file.read_text(encoding="utf-8"),
-                "apiMdSha256: abc123\npackageWorkItemId: 31370\nparserVersion: 1.0\n",
-            )
 
     def test_replace_sync_metadata_block_replaces_stale_hidden_metadata(self):
         old_block = workflow.build_sync_metadata_block(
@@ -474,7 +625,9 @@ class ApiReviewPrTests(unittest.TestCase):
             }
         )
 
-        body = workflow.replace_sync_metadata_block(f"Review body\n\n{old_block}", new_block)
+        body = workflow.replace_sync_metadata_block(
+            f"Review body\n\n{old_block}", new_block
+        )
 
         self.assertTrue(body.startswith("Review body\n\n<!-- api-md-review-sync"))
         self.assertIn("DO NOT MODIFY THESE CONTENTS!", body)
@@ -483,13 +636,17 @@ class ApiReviewPrTests(unittest.TestCase):
         self.assertEqual(body.count("api-md-review-sync"), 1)
 
     def test_sync_metadata_block_json_is_parseable(self):
-        block = workflow.build_sync_metadata_block({"schemaVersion": 1, "workingPrNumber": None})
+        block = workflow.build_sync_metadata_block(
+            {"schemaVersion": 1, "workingPrNumber": None}
+        )
         json_text = (
             block.replace("<!-- api-md-review-sync\n", "")
             .replace("DO NOT MODIFY THESE CONTENTS!\n", "")
             .replace("\n-->", "")
         )
-        self.assertEqual(json.loads(json_text), {"schemaVersion": 1, "workingPrNumber": None})
+        self.assertEqual(
+            json.loads(json_text), {"schemaVersion": 1, "workingPrNumber": None}
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/api_md_workflow/create_api_review_pr_test.py
+++ b/scripts/api_md_workflow/create_api_review_pr_test.py
@@ -56,8 +56,8 @@ class StubGithubApi:
             "html_url": "https://github.com/Azure/azure-sdk-for-python/pull/1",
         }
 
-    def request_reviewers(self, pr_number, reviewers):
-        self.reviewers.append((pr_number, reviewers))
+    def request_reviewers(self, pr_number, reviewers, team_reviewers=None):
+        self.reviewers.append((pr_number, reviewers, team_reviewers or []))
 
 
 class ApiReviewPrTests(unittest.TestCase):
@@ -366,6 +366,21 @@ class ApiReviewPrTests(unittest.TestCase):
                 ["tjprescott"],
             )
 
+    def test_architects_for_package_keeps_team_owners(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            architects_path = Path(temp_dir) / "ARCHITECTS"
+            architects_path.write_text(
+                "/sdk/keyvault/ @tjprescott @Azure/keyvault-arch\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                workflow.architects_for_package(
+                    "sdk/keyvault/azure-keyvault-keys", architects_path
+                ),
+                ["tjprescott", "Azure/keyvault-arch"],
+            )
+
     def test_assign_architects_to_pr_requests_matching_architects_as_reviewers(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             architects_path = Path(temp_dir) / "ARCHITECTS"
@@ -380,7 +395,7 @@ class ApiReviewPrTests(unittest.TestCase):
                     123, "sdk/keyvault/azure-keyvault-keys"
                 )
 
-            self.assertEqual(github.reviewers, [(123, ["tjprescott"])])
+            self.assertEqual(github.reviewers, [(123, ["tjprescott"], [])])
 
     def test_assign_uses_cached_architects(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -394,7 +409,35 @@ class ApiReviewPrTests(unittest.TestCase):
                     123, "sdk/keyvault/azure-keyvault-keys", architects=["l0lawrence"]
                 )
 
-            self.assertEqual(github.reviewers, [(123, ["l0lawrence"])])
+            self.assertEqual(github.reviewers, [(123, ["l0lawrence"], [])])
+
+    def test_assign_architects_to_pr_requests_team_reviewers(self):
+        github = StubGithubApi()
+        workflow.set_github_api_for_test(github)
+
+        workflow.assign_architects_to_pr(
+            123,
+            "sdk/keyvault/azure-keyvault-keys",
+            architects=["tjprescott", "Azure/keyvault-arch"],
+        )
+
+        self.assertEqual(
+            github.reviewers,
+            [(123, ["tjprescott"], ["keyvault-arch"])],
+        )
+
+    def test_assign_architects_to_pr_keeps_team_when_author_is_user(self):
+        github = StubGithubApi()
+        workflow.set_github_api_for_test(github)
+
+        workflow.assign_architects_to_pr(
+            123,
+            "sdk/keyvault/azure-keyvault-keys",
+            "tjprescott",
+            architects=["tjprescott", "Azure/keyvault-arch"],
+        )
+
+        self.assertEqual(github.reviewers, [(123, [], ["keyvault-arch"])])
 
     def test_assign_architects_to_pr_warns_when_architect_is_pr_author(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -462,13 +505,13 @@ class ApiReviewPrTests(unittest.TestCase):
             ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-                self.assertEqual(
-                    workflow.package_work_item_id("azure-example", "1.2.3b1"), "ERROR"
-                )
+            self.assertEqual(
+                workflow.package_work_item_id("azure-example", "1.2.3b1"), "ERROR"
+            )
 
         log_warning.assert_called_once()
         self.assertIn(
-                "PR body sync metadata will set packageWorkItemId to ERROR",
+            "PR body sync metadata will set packageWorkItemId to ERROR",
             log_warning.call_args.args[0],
         )
 

--- a/scripts/api_md_workflow/create_api_review_pr_test.py
+++ b/scripts/api_md_workflow/create_api_review_pr_test.py
@@ -1,5 +1,7 @@
 import json
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from scripts.api_md_workflow import create_api_review_pr as workflow
@@ -66,18 +68,20 @@ class ApiReviewPrTests(unittest.TestCase):
 
     def test_target_reference_info_links_matching_open_pr_from_direct_head_query(self):
         workflow.set_command_runner_for_test(stub_git_branches(["users/example/direct-feature"]))
-        workflow.set_github_api_for_test(StubGithubApi(
-            head_results=[
-                {
-                    "number": 45678,
-                    "url": "https://github.com/Azure/azure-sdk-for-python/pull/45678",
-                    "state": "OPEN",
-                    "updatedAt": "2026-06-05T00:00:00Z",
-                    "headRefName": "users/example/direct-feature",
-                    "headRepositoryOwner": {"login": "example"},
-                }
-            ]
-        ))
+        workflow.set_github_api_for_test(
+            StubGithubApi(
+                head_results=[
+                    {
+                        "number": 45678,
+                        "url": "https://github.com/Azure/azure-sdk-for-python/pull/45678",
+                        "state": "OPEN",
+                        "updatedAt": "2026-06-05T00:00:00Z",
+                        "headRefName": "users/example/direct-feature",
+                        "headRepositoryOwner": {"login": "example"},
+                    }
+                ]
+            )
+        )
 
         self.assertEqual(
             workflow.target_reference_info("example:users/example/direct-feature"),
@@ -89,18 +93,20 @@ class ApiReviewPrTests(unittest.TestCase):
 
     def test_target_reference_info_keeps_origin_main_as_branch(self):
         workflow.set_command_runner_for_test(stub_git_branches(["main"]))
-        workflow.set_github_api_for_test(StubGithubApi(
-            search_results=[
-                {
-                    "number": 23456,
-                    "url": "https://github.com/Azure/azure-sdk-for-python/pull/23456",
-                    "state": "OPEN",
-                    "updatedAt": "2026-06-05T00:00:00Z",
-                    "headRefName": "main",
-                    "headRepositoryOwner": {"login": "example"},
-                }
-            ]
-        ))
+        workflow.set_github_api_for_test(
+            StubGithubApi(
+                search_results=[
+                    {
+                        "number": 23456,
+                        "url": "https://github.com/Azure/azure-sdk-for-python/pull/23456",
+                        "state": "OPEN",
+                        "updatedAt": "2026-06-05T00:00:00Z",
+                        "headRefName": "main",
+                        "headRepositoryOwner": {"login": "example"},
+                    }
+                ]
+            )
+        )
 
         self.assertEqual(
             workflow.target_reference_info("origin/main"),
@@ -168,18 +174,20 @@ class ApiReviewPrTests(unittest.TestCase):
 
     def test_build_sync_metadata_object_records_fork_owner_and_branch(self):
         workflow.set_command_runner_for_test(stub_git_branches(["users/example/feature"]))
-        workflow.set_github_api_for_test(StubGithubApi(
-            search_results=[
-                {
-                    "number": 47204,
-                    "url": "https://github.com/Azure/azure-sdk-for-python/pull/47204",
-                    "state": "OPEN",
-                    "updatedAt": "2026-06-05T00:00:00Z",
-                    "headRefName": "users/example/feature",
-                    "headRepositoryOwner": {"login": "example"},
-                }
-            ]
-        ))
+        workflow.set_github_api_for_test(
+            StubGithubApi(
+                search_results=[
+                    {
+                        "number": 47204,
+                        "url": "https://github.com/Azure/azure-sdk-for-python/pull/47204",
+                        "state": "OPEN",
+                        "updatedAt": "2026-06-05T00:00:00Z",
+                        "headRefName": "users/example/feature",
+                        "headRepositoryOwner": {"login": "example"},
+                    }
+                ]
+            )
+        )
 
         metadata = workflow.build_sync_metadata_object(
             package_name="azure-example",
@@ -280,6 +288,166 @@ class ApiReviewPrTests(unittest.TestCase):
             )
         )
 
+    def test_package_version_major_minor(self):
+        self.assertEqual(workflow.package_version_major_minor("1.2.3b1"), "1.2")
+        self.assertEqual(workflow.package_version_major_minor("12"), "12.0")
+
+    def test_parse_package_work_item_id(self):
+        self.assertEqual(workflow.parse_package_work_item_id("Work Item ID: 31370\n"), 31370)
+        self.assertEqual(workflow.parse_package_work_item_id('{"work_item_id":31371}'), 31371)
+
+    def test_pkg_work_item_value_no_shell(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk") as resolve_azsdk,
+            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "Work Item ID: 31370\n")) as run,
+        ):
+            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), "31370")
+
+        resolve_azsdk.assert_called_once_with()
+        run.assert_called_once_with(
+            [
+                "azsdk",
+                "package",
+                "find-work-item",
+                "--package-name",
+                "azure-example",
+                "--package-version",
+                "1.2",
+                "--language",
+                "Python",
+            ],
+            check=False,
+            capture=True,
+        )
+
+    def test_pkg_work_item_value_error(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
+            patch.object(workflow, "run", return_value=workflow.CommandResult(1, "", "Unexpected failure")),
+            patch.object(workflow, "log_warning") as log_warning,
+        ):
+            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"ERROR"')
+
+        log_warning.assert_called_once()
+        self.assertIn('packageWorkItemId: "ERROR"', log_warning.call_args.args[0])
+
+    def test_pkg_work_item_value_unknown_missing(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
+            patch.object(
+                workflow,
+                "run",
+                return_value=workflow.CommandResult(
+                    1, "[ERROR] No package work item found for package 'azure-example'.\n", ""
+                ),
+            ),
+            patch.object(workflow, "log_warning") as log_warning,
+        ):
+            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"Unknown"')
+
+        log_warning.assert_called_once()
+        self.assertIn('packageWorkItemId: "Unknown"', log_warning.call_args.args[0])
+
+    def test_pkg_work_item_value_unknown_no_id(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
+            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "No package work item found\n", "")),
+            patch.object(workflow, "log_warning") as log_warning,
+        ):
+            self.assertEqual(workflow.package_work_item_metadata_value("azure-example", "1.2.3b1"), '"Unknown"')
+
+        log_warning.assert_called_once()
+        self.assertIn('packageWorkItemId: "Unknown"', log_warning.call_args.args[0])
+
+    def test_azsdk_preflight_checks_help(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk") as resolve_azsdk,
+            patch.object(workflow, "run", return_value=workflow.CommandResult(0, "help")) as run,
+        ):
+            workflow.ensure_azsdk_find_work_item_available()
+
+        resolve_azsdk.assert_called_once_with()
+        run.assert_called_once_with(["azsdk", "package", "find-work-item", "--help"], check=False, capture=True)
+
+    def test_azsdk_preflight_fails_if_stale(self):
+        with (
+            patch.object(workflow, "resolve_azsdk_executable", return_value="azsdk"),
+            patch.object(workflow, "run", return_value=workflow.CommandResult(1, "", "Unknown command")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "package find-work-item"):
+                workflow.ensure_azsdk_find_work_item_available()
+
+    def test_main_preflights_azsdk_first(self):
+        with (
+            patch.object(
+                workflow, "ensure_azsdk_find_work_item_available", side_effect=RuntimeError("missing command")
+            ),
+            patch.object(workflow, "find_package_dir") as find_package_dir,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "missing command"):
+                workflow.main(["--package-name", "azure-example", "--base", "azure-example_1.0.0"])
+
+        find_package_dir.assert_not_called()
+
+    def test_resolve_azsdk_uses_path_first(self):
+        with patch.object(workflow.shutil, "which", return_value="C:/tools/azsdk.exe"):
+            self.assertEqual(workflow.resolve_azsdk_executable(), "C:/tools/azsdk.exe")
+
+    def test_resolve_azsdk_uses_common_dir(self):
+        def is_file(candidate):
+            return str(candidate).replace("\\", "/").endswith("/bin/azsdk.exe")
+
+        with (
+            patch.object(workflow.shutil, "which", return_value=None),
+            patch.object(workflow.Path, "home", return_value=Path("C:/Users/example")),
+            patch.object(workflow.Path, "is_file", is_file),
+        ):
+            self.assertEqual(
+                workflow.resolve_azsdk_executable().replace("\\", "/"),
+                "C:/Users/example/bin/azsdk.exe",
+            )
+
+    def test_resolve_azsdk_uses_mcp_dir(self):
+        def is_file(candidate):
+            return str(candidate).replace("\\", "/").endswith("/.azure-sdk-mcp/azsdk.exe")
+
+        with (
+            patch.object(workflow.shutil, "which", return_value=None),
+            patch.object(workflow.Path, "home", return_value=Path("C:/Users/example")),
+            patch.object(workflow.Path, "is_file", is_file),
+        ):
+            self.assertEqual(
+                workflow.resolve_azsdk_executable().replace("\\", "/"),
+                "C:/Users/example/.azure-sdk-mcp/azsdk.exe",
+            )
+
+    def test_resolve_azsdk_missing_errors(self):
+        with (
+            patch.object(workflow.shutil, "which", return_value=None),
+            patch.object(workflow.Path, "home", return_value=Path("C:/Users/example")),
+            patch.object(workflow.Path, "is_file", return_value=False),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "azure-sdk-mcp.ps1"):
+                workflow.resolve_azsdk_executable()
+
+    def test_add_package_work_item_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            package_dir = Path(temp_dir)
+            metadata_file = package_dir / "api.metadata.yml"
+            metadata_file.write_text(
+                "apiMdSha256: abc123\r\nparserVersion: 1.0\r\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(workflow, "package_work_item_metadata_value", return_value="31370") as package_work_item:
+                workflow.add_package_work_item_metadata("azure-example", "1.2.3b1", package_dir)
+
+            package_work_item.assert_called_once_with("azure-example", "1.2.3b1")
+            self.assertEqual(
+                metadata_file.read_text(encoding="utf-8"),
+                "apiMdSha256: abc123\npackageWorkItemId: 31370\nparserVersion: 1.0\n",
+            )
+
     def test_replace_sync_metadata_block_replaces_stale_hidden_metadata(self):
         old_block = workflow.build_sync_metadata_block(
             {
@@ -316,7 +484,11 @@ class ApiReviewPrTests(unittest.TestCase):
 
     def test_sync_metadata_block_json_is_parseable(self):
         block = workflow.build_sync_metadata_block({"schemaVersion": 1, "workingPrNumber": None})
-        json_text = block.replace("<!-- api-md-review-sync\n", "").replace("DO NOT MODIFY THESE CONTENTS!\n", "").replace("\n-->", "")
+        json_text = (
+            block.replace("<!-- api-md-review-sync\n", "")
+            .replace("DO NOT MODIFY THESE CONTENTS!\n", "")
+            .replace("\n-->", "")
+        )
         self.assertEqual(json.loads(json_text), {"schemaVersion": 1, "workingPrNumber": None})
 
 

--- a/scripts/api_md_workflow/create_api_review_pr_test.py
+++ b/scripts/api_md_workflow/create_api_review_pr_test.py
@@ -462,11 +462,13 @@ class ApiReviewPrTests(unittest.TestCase):
             ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
+                self.assertEqual(
+                    workflow.package_work_item_id("azure-example", "1.2.3b1"), "ERROR"
+                )
 
         log_warning.assert_called_once()
         self.assertIn(
-            "PR body sync metadata will omit packageWorkItemId",
+                "PR body sync metadata will set packageWorkItemId to ERROR",
             log_warning.call_args.args[0],
         )
 
@@ -484,11 +486,13 @@ class ApiReviewPrTests(unittest.TestCase):
             ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
+            self.assertEqual(
+                workflow.package_work_item_id("azure-example", "1.2.3b1"), "ERROR"
+            )
 
         log_warning.assert_called_once()
         self.assertIn(
-            "PR body sync metadata will omit packageWorkItemId",
+            "PR body sync metadata will set packageWorkItemId to ERROR",
             log_warning.call_args.args[0],
         )
 
@@ -504,11 +508,13 @@ class ApiReviewPrTests(unittest.TestCase):
             ),
             patch.object(workflow, "log_warning") as log_warning,
         ):
-            self.assertIsNone(workflow.package_work_item_id("azure-example", "1.2.3b1"))
+            self.assertEqual(
+                workflow.package_work_item_id("azure-example", "1.2.3b1"), "NONE"
+            )
 
         log_warning.assert_called_once()
         self.assertIn(
-            "PR body sync metadata will omit packageWorkItemId",
+            "PR body sync metadata will set packageWorkItemId to NONE",
             log_warning.call_args.args[0],
         )
 


### PR DESCRIPTION
This PR does two main things:

1) Retrieves the ADO Package Work Item at the time of Review PR creation and stores it in the PR metadata block. This will be used by future phases.

2) Adds an ARCHITECTS file to `.github` that functions like CODEOWNERS (same format) but is only used for assigning reviews on API Review PRs.