### PR TITLE
[azpysdk] Refactor apistub so that API consistency files are the default output

### DIFF
--- a/.github/skills/generate-api-markdown/SKILL.md
+++ b/.github/skills/generate-api-markdown/SKILL.md
@@ -19,6 +19,7 @@ description: Generate an API markdown file and token file using ApiView. Use thi
 1. Navigate to the desired package directory
 2. Run the command:
    ```bash
-   azpysdk apistub --md --extract-metadata --install-deps --dest-dir . .
+   azpysdk apistub .
    ```
-3. The command outputs the location of the generated markdown file. Provide this file to the user for review.
+3. The command generates `api.md` and `api.metadata.yml` in the package directory, which are the files needed to pass the API consistency check. Provide these files to the user for review.
+4. If the user explicitly asks for the raw APIView token file, run `azpysdk apistub . --token-file` instead.

--- a/.github/workflows/src/api-md-consistency/adapters/python.js
+++ b/.github/workflows/src/api-md-consistency/adapters/python.js
@@ -131,7 +131,7 @@ function generateApiForPackage({
     const pythonExecutable = runtimeExecutable || process.env.RUNTIME_EXECUTABLE;
     run(
       pythonExecutable,
-      ["-m", "azpysdk.main", "apistub", "--md", "--extract-metadata", "--dest-dir", packageDir, packageName],
+      ["-m", "azpysdk.main", "apistub", "--dest-dir", packageDir, packageName],
       {
         cwd: repoRoot,
         check: true,
@@ -141,7 +141,7 @@ function generateApiForPackage({
     return;
   }
 
-  run("azpysdk", ["apistub", "--md", "--extract-metadata", "--dest-dir", packageDir, packageName], {
+  run("azpysdk", ["apistub", "--dest-dir", packageDir, packageName], {
     cwd: repoRoot,
     check: true,
     logger: activeLogger,

--- a/.github/workflows/src/api-md-consistency/adapters/python.js
+++ b/.github/workflows/src/api-md-consistency/adapters/python.js
@@ -131,7 +131,7 @@ function generateApiForPackage({
     const pythonExecutable = runtimeExecutable || process.env.RUNTIME_EXECUTABLE;
     run(
       pythonExecutable,
-      ["-m", "azpysdk.main", "apistub", "--dest-dir", packageDir, packageName],
+      ["-m", "azpysdk.main", "apistub", packageName],
       {
         cwd: repoRoot,
         check: true,
@@ -141,7 +141,7 @@ function generateApiForPackage({
     return;
   }
 
-  run("azpysdk", ["apistub", "--dest-dir", packageDir, packageName], {
+  run("azpysdk", ["apistub", packageName], {
     cwd: repoRoot,
     check: true,
     logger: activeLogger,

--- a/.github/workflows/src/api-md-consistency/api-md-consistency.js
+++ b/.github/workflows/src/api-md-consistency/api-md-consistency.js
@@ -47,7 +47,7 @@ function formatIssueSection(title, apiFiles) {
     lines.push(styleLog(`PACKAGE: ${packageName}`, ANSI.bold, ANSI.cyan));
     lines.push(`PATH:    ${packageDir}`);
     lines.push(`API FILE: ${apiFile}`);
-    lines.push(styleLog(`Regenerate from the ${packageName} pacakge root:`, ANSI.bold, ANSI.yellow));
+    lines.push(styleLog(`Regenerate from the ${packageName} package root:`, ANSI.bold, ANSI.yellow));
     lines.push(styleLog(`  azpysdk apistub .`, ANSI.bold, ANSI.yellow));
     lines.push("============================================================");
   }

--- a/.github/workflows/src/api-md-consistency/api-md-consistency.js
+++ b/.github/workflows/src/api-md-consistency/api-md-consistency.js
@@ -47,8 +47,8 @@ function formatIssueSection(title, apiFiles) {
     lines.push(styleLog(`PACKAGE: ${packageName}`, ANSI.bold, ANSI.cyan));
     lines.push(`PATH:    ${packageDir}`);
     lines.push(`API FILE: ${apiFile}`);
-    lines.push(styleLog("Regenerate from the repository root:", ANSI.bold, ANSI.yellow));
-    lines.push(styleLog(`  azpysdk apistub --md --extract-metadata ${packageName} --dest-dir .`, ANSI.bold, ANSI.yellow));
+    lines.push(styleLog(`Regenerate from the ${packageName} pacakge root:`, ANSI.bold, ANSI.yellow));
+    lines.push(styleLog(`  azpysdk apistub .`, ANSI.bold, ANSI.yellow));
     lines.push("============================================================");
   }
   lines.push("");
@@ -97,7 +97,7 @@ export default async function apiMdConsistency({ core }) {
       "",
       formatIssueSection("Mismatched packages:", mismatches),
       formatIssueSection("Missing required API files:", missing),
-      "To regenerate api.md locally, run the command shown for each package from the repository root.",
+      "To regenerate api.md and api.metadata.yml locally, run the command shown for each package from the repository root.",
     ].filter((part) => part !== "");
 
     core.setFailed(messageParts.join("\n"));

--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -147,7 +147,7 @@ A quick description of the commands above:
 - verifywhl: verifies the wheel contents and manifest
 - verifysdist: verifies the sdist contents and manifest
 - samples: runs all of the samples in the `samples` directory and verifies they are working correctly
-- apistub: runs the [apistubgenerator](https://github.com/Azure/azure-sdk-tools/tree/main/packages/python-packages/apiview-stub-generator) tool on your code
+- apistub: runs the [apistubgenerator](https://github.com/Azure/azure-sdk-tools/tree/main/packages/python-packages/apiview-stub-generator) tool on your code. By default, generates `api.md` and `api.metadata.yml` in the package directory, which are the files needed to pass the API consistency check. Use `--dest-dir <path>` to write these files somewhere else, or `--token-file` to generate only the raw APIView token file.
 
 ## The `devtools_testutils` package
 

--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -147,7 +147,7 @@ A quick description of the commands above:
 - verifywhl: verifies the wheel contents and manifest
 - verifysdist: verifies the sdist contents and manifest
 - samples: runs all of the samples in the `samples` directory and verifies they are working correctly
-- apistub: runs the [apistubgenerator](https://github.com/Azure/azure-sdk-tools/tree/main/packages/python-packages/apiview-stub-generator) tool on your code. By default, generates `api.md` and `api.metadata.yml` in the package directory, which are the files needed to pass the API consistency check. Use `--dest-dir <path>` to write these files somewhere else, or `--token-file` to generate only the raw APIView token file.
+- apistub: runs the [apistubgenerator](https://github.com/Azure/azure-sdk-tools/tree/main/packages/python-packages/apiview-stub-generator) tool on your code. By default, generates `api.md` and `api.metadata.yml` in the package directory, which are the files needed to pass the API consistency check. Use `--token-file` to generate only the raw APIView token file.
 
 ## The `devtools_testutils` package
 

--- a/doc/tool_usage_guide.md
+++ b/doc/tool_usage_guide.md
@@ -21,7 +21,7 @@ The following checks are available via the `azpysdk` entrypoint.
 |`pyright`| Runs `pyright` checks or `next-pyright` checks. (based on presence of `--next` argument) | `azpysdk pyright .` |
 |`black`| Runs `black` checks. | `azpysdk black .` |
 |`verifytypes`| Runs `verifytypes` checks. | `azpysdk verifytypes .` |
-|`apistub`| Generates an api stub for the package. | `azpysdk apistub .` |
+|`apistub`| Generates `api.md`, API metadata, or APIView token files for the package. | `azpysdk apistub .` |
 |`bandit`| Runs `bandit` checks, which detect common security issues. | `azpysdk bandit .` |
 |`verifywhl`| Verifies that the root directory in whl is azure, and verifies manifest so that all directories in source are included in sdist. | `azpysdk verifywhl .` |
 |`verifysdist`| Verify directories included in sdist and contents in manifest file. Also ensures that py.typed configuration is correct within the setup.py. | `azpysdk verifysdist .` |

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -57,12 +57,6 @@ class apistub(Check):
             "apistub", parents=parents, help="Run the apistub check to generate an API stub for a package"
         )
         p.add_argument(
-            "--dest-dir",
-            dest="dest_dir",
-            default=None,
-            help="Destination directory for generated API stub token files. Defaults to the package directory.",
-        )
-        p.add_argument(
             "--token-file",
             dest="token_file",
             default=False,
@@ -152,11 +146,7 @@ class apistub(Check):
             pkg_path = get_package_wheel_path(package_dir)
             pkg_path = os.path.abspath(pkg_path)
 
-            dest_dir = getattr(args, "dest_dir", None)
-            if dest_dir:
-                out_token_path = os.path.abspath(dest_dir)
-            else:
-                out_token_path = os.path.abspath(package_dir)
+            out_token_path = os.path.abspath(package_dir)
             os.makedirs(out_token_path, exist_ok=True)
 
             cross_language_mapping_path = get_cross_language_mapping_path(package_dir)

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -60,21 +60,14 @@ class apistub(Check):
             "--dest-dir",
             dest="dest_dir",
             default=None,
-            help="Destination directory for generated API stub token files.",
+            help="Destination directory for generated API stub token files. Defaults to the package directory.",
         )
         p.add_argument(
-            "--md",
-            dest="generate_md",
+            "--token-file",
+            dest="token_file",
             default=False,
             action="store_true",
-            help="Generate api.md from the JSON token file using Export-APIViewMarkdown.ps1. Output directory for api.md is the same as the generated token file.",
-        )
-        p.add_argument(
-            "--extract-metadata",
-            dest="extract_metadata",
-            default=False,
-            action="store_true",
-            help="Extract language-specific metadata from generated api.md into api.metadata.yml and remove metadata header from api.md.",
+            help="Generate only the raw APIView token file.",
         )
         p.add_argument(
             "--install-deps",
@@ -106,9 +99,8 @@ class apistub(Check):
         """Run the apistub check command."""
         logger.info("Running apistub check...")
 
-        if getattr(args, "extract_metadata", False) and not getattr(args, "generate_md", False):
-            logger.error("--extract-metadata requires --md.")
-            return 1
+        token_file = getattr(args, "token_file", False)
+        generate_markdown = not token_file
 
         set_envvar_defaults()
         targeted = self.get_targeted_directories(args)
@@ -163,9 +155,9 @@ class apistub(Check):
             dest_dir = getattr(args, "dest_dir", None)
             if dest_dir:
                 out_token_path = os.path.abspath(dest_dir)
-                os.makedirs(out_token_path, exist_ok=True)
             else:
-                out_token_path = os.path.abspath(staging_directory)
+                out_token_path = os.path.abspath(package_dir)
+            os.makedirs(out_token_path, exist_ok=True)
 
             cross_language_mapping_path = get_cross_language_mapping_path(package_dir)
 
@@ -178,15 +170,21 @@ class apistub(Check):
                 cmds.extend(["--out-path", out_token_path])
             if cross_language_mapping_path:
                 cmds.extend(["--mapping-path", cross_language_mapping_path])
-            if getattr(args, "generate_md", False):
+            if generate_markdown:
                 cmds.append("--skip-pylint")
 
             logger.info("Running apistub {}.".format(cmds))
 
             try:
                 self.run_venv_command(executable, cmds, cwd=staging_directory, check=True, immediately_dump=True)
-                if getattr(args, "generate_md", False):
-                    token_json_path = os.path.join(out_token_path, f"{package_name}_python.json")
+                token_json_path = os.path.join(out_token_path, f"{package_name}_python.json")
+                if token_file:
+                    if os.path.exists(token_json_path):
+                        logger.info(f"Generated APIView token file: {token_json_path}")
+                    else:
+                        logger.error(f"Expected APIView token file was not generated: {token_json_path}")
+                        results.append(1)
+                else:
                     md_script = os.path.join(REPO_ROOT, "eng", "common", "scripts", "Export-APIViewMarkdown.ps1")
                     metadata_script = os.path.join(REPO_ROOT, "eng", "scripts", "Extract-APIViewMetadata-Python.ps1")
                     logger.info(f"Generating api.md for {package_name}")
@@ -201,16 +199,15 @@ class apistub(Check):
                         if result.stdout:
                             logger.info(result.stdout)
 
-                        if getattr(args, "extract_metadata", False):
-                            logger.info(f"Extracting API metadata for {package_name}")
-                            metadata_result = run(
-                                ["pwsh", metadata_script, "-OutputPath", out_token_path],
-                                check=True,
-                                capture_output=True,
-                                text=True,
-                            )
-                            if metadata_result.stdout:
-                                logger.info(metadata_result.stdout)
+                        logger.info(f"Extracting API metadata for {package_name}")
+                        metadata_result = run(
+                            ["pwsh", metadata_script, "-OutputPath", out_token_path],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        )
+                        if metadata_result.stdout:
+                            logger.info(metadata_result.stdout)
                     except FileNotFoundError:
                         logger.error("Failed to generate api.md: pwsh (PowerShell) is not installed or not on PATH.")
                         results.append(1)

--- a/eng/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/functions.py
@@ -182,15 +182,19 @@ def glob_packages(glob_string: str, target_root_dir: str) -> List[str]:
     collected_top_level_directories = []
 
     for glob_string in individual_globs:
-        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "setup.py"), recursive=True) + glob.glob(
-            os.path.join(target_root_dir, "sdk/*/", glob_string, "setup.py")
+        globbed = (
+            glob.glob(os.path.join(target_root_dir, glob_string, "setup.py"), recursive=True)
+            + glob.glob(os.path.join(target_root_dir, "*/", glob_string, "setup.py"))
+            + glob.glob(os.path.join(target_root_dir, "sdk/*/", glob_string, "setup.py"))
         )
         collected_top_level_directories.extend([os.path.dirname(p) for p in globbed])
 
     # handle pyproject.toml separately, as we need to filter them by the presence of a `[project]` section
     for glob_string in individual_globs:
-        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "pyproject.toml"), recursive=True) + glob.glob(
-            os.path.join(target_root_dir, "sdk/*/", glob_string, "pyproject.toml")
+        globbed = (
+            glob.glob(os.path.join(target_root_dir, glob_string, "pyproject.toml"), recursive=True)
+            + glob.glob(os.path.join(target_root_dir, "*/", glob_string, "pyproject.toml"))
+            + glob.glob(os.path.join(target_root_dir, "sdk/*/", glob_string, "pyproject.toml"))
         )
         for p in globbed:
             if get_pyproject(os.path.dirname(p)):

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -336,8 +336,6 @@ def main(generate_input, generate_output):
                         "azpysdk",
                         "apistub",
                         package_name,
-                        "--dest-dir",
-                        package_path.absolute().as_posix(),
                     ]
                     _LOGGER.info(f"generate apiview file for package {package_name}")
                     check_call(

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -335,8 +335,6 @@ def main(generate_input, generate_output):
                     cmds = [
                         "azpysdk",
                         "apistub",
-                        "--md",
-                        "--extract-metadata",
                         package_name,
                         "--dest-dir",
                         package_path.absolute().as_posix(),

--- a/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
+++ b/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
@@ -70,6 +70,22 @@ def test_discovery_single_package():
     ]
 
 
+def test_discovery_single_package_from_sdk_root():
+    results = discover_targeted_packages("azure-template", sdk_root, filter_type="Build")
+
+    assert [os.path.basename(result) for result in results] == [
+        "azure-template",
+    ]
+
+
+def test_discovery_single_package_from_repo_root():
+    results = discover_targeted_packages("azure-template", repo_root, filter_type="Build")
+
+    assert [os.path.basename(result) for result in results] == [
+        "azure-template",
+    ]
+
+
 def test_discovery_omit_regression():
     results = discover_targeted_packages("*", core_service_root, filter_type="Regression")
 

--- a/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
+++ b/eng/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
@@ -3,7 +3,6 @@ import os
 from ci_tools.parsing import ParsedSetup
 from ci_tools.functions import discover_targeted_packages
 
-
 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
 sdk_root = os.path.join(repo_root, "sdk")
 core_service_root = os.path.join(sdk_root, "core")

--- a/eng/tools/azure-sdk-tools/tests/test_apistub.py
+++ b/eng/tools/azure-sdk-tools/tests/test_apistub.py
@@ -73,14 +73,20 @@ class TestGetPackageWheelPath:
 class TestRunOutputDirectory:
     """Verify that dest_dir controls where the output token path ends up."""
 
-    def _make_args(self, dest_dir=None, generate_md=False, isolate=False, install_deps=False):
+    def _make_args(
+        self,
+        dest_dir=None,
+        token_file=False,
+        isolate=False,
+        install_deps=False,
+    ):
         return argparse.Namespace(
             target=".",
             isolate=isolate,
             command="apistub",
             service=None,
             dest_dir=dest_dir,
-            generate_md=generate_md,
+            token_file=token_file,
             install_deps=install_deps,
         )
 
@@ -111,7 +117,7 @@ class TestRunOutputDirectory:
         ) as pip_freeze, patch.object(
             stub, "run_venv_command"
         ):
-            stub.run(self._make_args(isolate=True))
+            stub.run(self._make_args(isolate=True, token_file=True))
 
         install_dev_reqs.assert_not_called()
         install_into_venv.assert_not_called()
@@ -144,7 +150,7 @@ class TestRunOutputDirectory:
         ) as pip_freeze, patch.object(
             stub, "run_venv_command"
         ):
-            args = self._make_args(install_deps=True)
+            args = self._make_args(install_deps=True, token_file=True)
             stub.run(args)
 
         install_dev_reqs.assert_called_once_with(sys.executable, args, str(tmp_path))
@@ -242,10 +248,12 @@ class TestRunOutputDirectory:
             open(os.path.join(out_dir, "azure-core_python.json"), "w").close()
 
         def fake_pwsh(cmd, **kwargs):
-            # Simulate pwsh generating api.md
             out_idx = cmd.index("-OutputPath")
             out_dir = cmd[out_idx + 1]
-            open(os.path.join(out_dir, "api.md"), "w").close()
+            if "Extract-APIViewMetadata-Python.ps1" in cmd[1]:
+                open(os.path.join(out_dir, "api.metadata.yml"), "w").close()
+            else:
+                open(os.path.join(out_dir, "api.md"), "w").close()
             return MagicMock(returncode=0)
 
         with patch.object(stub, "get_targeted_directories", return_value=[fake_parsed]), patch.object(
@@ -258,11 +266,12 @@ class TestRunOutputDirectory:
             "azpysdk.apistub.run", side_effect=fake_pwsh
         ):
 
-            stub.run(self._make_args(dest_dir=str(dest), generate_md=True))
+            stub.run(self._make_args(dest_dir=str(dest)))
 
         expected_out = str(dest)
         assert os.path.isdir(expected_out)
         assert os.path.exists(os.path.join(expected_out, "api.md"))
+        assert os.path.exists(os.path.join(expected_out, "api.metadata.yml"))
         assert os.path.exists(os.path.join(expected_out, "azure-core_python.json"))
 
     @patch(
@@ -273,8 +282,10 @@ class TestRunOutputDirectory:
     @patch("azpysdk.apistub.create_package_and_install")
     @patch("azpysdk.apistub.install_into_venv")
     @patch("azpysdk.apistub.set_envvar_defaults")
-    def test_no_dest_dir_uses_staging(self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch):
-        """When --dest-dir is not given, output path should be the staging directory."""
+    def test_no_dest_dir_uses_package_directory(
+        self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch
+    ):
+        """When --dest-dir is not given, output should go to the package directory."""
         monkeypatch.chdir(os.getcwd())
         stub = apistub()
         staging = str(tmp_path / "staging")
@@ -287,7 +298,6 @@ class TestRunOutputDirectory:
 
         def fake_apistub_run(exe, cmds, **kwargs):
             captured_cmds.append(cmds)
-            # Simulate apistub generating the token JSON
             out_idx = cmds.index("--out-path")
             out_dir = cmds[out_idx + 1]
             open(os.path.join(out_dir, "azure-core_python.json"), "w").close()
@@ -295,7 +305,10 @@ class TestRunOutputDirectory:
         def fake_pwsh(cmd, **kwargs):
             out_idx = cmd.index("-OutputPath")
             out_dir = cmd[out_idx + 1]
-            open(os.path.join(out_dir, "api.md"), "w").close()
+            if "Extract-APIViewMetadata-Python.ps1" in cmd[1]:
+                open(os.path.join(out_dir, "api.metadata.yml"), "w").close()
+            else:
+                open(os.path.join(out_dir, "api.md"), "w").close()
             return MagicMock(returncode=0)
 
         with patch.object(stub, "get_targeted_directories", return_value=[fake_parsed]), patch.object(
@@ -308,15 +321,16 @@ class TestRunOutputDirectory:
             "azpysdk.apistub.run", side_effect=fake_pwsh
         ):
 
-            stub.run(self._make_args(dest_dir=None, generate_md=True))
+            stub.run(self._make_args(dest_dir=None))
 
-        # The --out-path passed to apistub should be the staging directory
+        # The --out-path passed to apistub should be the package directory
         assert len(captured_cmds) == 1
         cmds = captured_cmds[0]
         out_idx = cmds.index("--out-path")
-        assert cmds[out_idx + 1] == os.path.abspath(staging)
-        assert os.path.exists(os.path.join(staging, "api.md"))
-        assert os.path.exists(os.path.join(staging, "azure-core_python.json"))
+        assert cmds[out_idx + 1] == os.path.abspath(str(tmp_path))
+        assert os.path.exists(os.path.join(str(tmp_path), "api.md"))
+        assert os.path.exists(os.path.join(str(tmp_path), "api.metadata.yml"))
+        assert os.path.exists(os.path.join(str(tmp_path), "azure-core_python.json"))
 
     @patch(
         "azpysdk.apistub.REPO_ROOT", os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
@@ -326,8 +340,10 @@ class TestRunOutputDirectory:
     @patch("azpysdk.apistub.create_package_and_install")
     @patch("azpysdk.apistub.install_into_venv")
     @patch("azpysdk.apistub.set_envvar_defaults")
-    def test_generate_md_adds_skip_pylint(self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch):
-        """When --md is passed (generate_md=True), --skip-pylint must be in the cmds."""
+    def test_default_generation_adds_skip_pylint(
+        self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch
+    ):
+        """By default, markdown generation should add --skip-pylint to the cmds."""
         monkeypatch.chdir(os.getcwd())
         stub = apistub()
         staging = str(tmp_path / "staging")
@@ -358,7 +374,7 @@ class TestRunOutputDirectory:
         ), patch(
             "azpysdk.apistub.run", side_effect=fake_pwsh
         ):
-            stub.run(self._make_args(generate_md=True))
+            stub.run(self._make_args())
 
         assert len(captured_cmds) == 1
         assert "--skip-pylint" in captured_cmds[0]
@@ -371,10 +387,10 @@ class TestRunOutputDirectory:
     @patch("azpysdk.apistub.create_package_and_install")
     @patch("azpysdk.apistub.install_into_venv")
     @patch("azpysdk.apistub.set_envvar_defaults")
-    def test_no_generate_md_omits_skip_pylint(
+    def test_token_file_omits_skip_pylint_and_markdown_generation(
         self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch
     ):
-        """When --md is not passed (generate_md=False), --skip-pylint must not be in the cmds."""
+        """When --token-file is passed, only the raw token file should be generated."""
         monkeypatch.chdir(os.getcwd())
         stub = apistub()
         staging = str(tmp_path / "staging")
@@ -387,6 +403,9 @@ class TestRunOutputDirectory:
 
         def fake_apistub_run(exe, cmds, **kwargs):
             captured_cmds.append(cmds)
+            out_idx = cmds.index("--out-path")
+            out_dir = cmds[out_idx + 1]
+            open(os.path.join(out_dir, "azure-core_python.json"), "w").close()
 
         with patch.object(stub, "get_targeted_directories", return_value=[fake_parsed]), patch.object(
             stub, "get_executable", return_value=(sys.executable, staging)
@@ -394,8 +413,10 @@ class TestRunOutputDirectory:
             stub, "ensure_apistub_dependencies"
         ), patch.object(
             stub, "run_venv_command", side_effect=fake_apistub_run
-        ):
-            stub.run(self._make_args(generate_md=False))
+        ), patch("azpysdk.apistub.run") as pwsh_run:
+            stub.run(self._make_args(token_file=True))
 
         assert len(captured_cmds) == 1
         assert "--skip-pylint" not in captured_cmds[0]
+        assert os.path.exists(os.path.join(str(tmp_path), "azure-core_python.json"))
+        pwsh_run.assert_not_called()

--- a/eng/tools/azure-sdk-tools/tests/test_apistub.py
+++ b/eng/tools/azure-sdk-tools/tests/test_apistub.py
@@ -71,11 +71,10 @@ class TestGetPackageWheelPath:
 
 
 class TestRunOutputDirectory:
-    """Verify that dest_dir controls where the output token path ends up."""
+    """Verify apistub output directory behavior."""
 
     def _make_args(
         self,
-        dest_dir=None,
         token_file=False,
         isolate=False,
         install_deps=False,
@@ -85,7 +84,6 @@ class TestRunOutputDirectory:
             isolate=isolate,
             command="apistub",
             service=None,
-            dest_dir=dest_dir,
             token_file=token_file,
             install_deps=install_deps,
         )
@@ -225,67 +223,10 @@ class TestRunOutputDirectory:
     @patch("azpysdk.apistub.create_package_and_install")
     @patch("azpysdk.apistub.install_into_venv")
     @patch("azpysdk.apistub.set_envvar_defaults")
-    def test_dest_dir_uses_destination_directory(
+    def test_outputs_use_package_directory(
         self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch
     ):
-        """When --dest-dir is given, output should go directly to <dest_dir>/."""
-        monkeypatch.chdir(os.getcwd())
-        dest = tmp_path / "output"
-        dest.mkdir()
-
-        stub = apistub()
-        staging = str(tmp_path / "staging")
-        os.makedirs(staging, exist_ok=True)
-        fake_parsed = MagicMock()
-        fake_parsed.folder = str(tmp_path)
-        fake_parsed.name = "azure-core"
-
-        def fake_apistub_run(exe, cmds, **kwargs):
-            # Simulate apistub generating the token JSON
-            out_idx = cmds.index("--out-path")
-            out_dir = cmds[out_idx + 1]
-            os.makedirs(out_dir, exist_ok=True)
-            open(os.path.join(out_dir, "azure-core_python.json"), "w").close()
-
-        def fake_pwsh(cmd, **kwargs):
-            out_idx = cmd.index("-OutputPath")
-            out_dir = cmd[out_idx + 1]
-            if "Extract-APIViewMetadata-Python.ps1" in cmd[1]:
-                open(os.path.join(out_dir, "api.metadata.yml"), "w").close()
-            else:
-                open(os.path.join(out_dir, "api.md"), "w").close()
-            return MagicMock(returncode=0)
-
-        with patch.object(stub, "get_targeted_directories", return_value=[fake_parsed]), patch.object(
-            stub, "get_executable", return_value=(sys.executable, staging)
-        ), patch.object(stub, "install_dev_reqs"), patch.object(stub, "pip_freeze"), patch.object(
-            stub, "ensure_apistub_dependencies"
-        ), patch.object(
-            stub, "run_venv_command", side_effect=fake_apistub_run
-        ), patch(
-            "azpysdk.apistub.run", side_effect=fake_pwsh
-        ):
-
-            stub.run(self._make_args(dest_dir=str(dest)))
-
-        expected_out = str(dest)
-        assert os.path.isdir(expected_out)
-        assert os.path.exists(os.path.join(expected_out, "api.md"))
-        assert os.path.exists(os.path.join(expected_out, "api.metadata.yml"))
-        assert os.path.exists(os.path.join(expected_out, "azure-core_python.json"))
-
-    @patch(
-        "azpysdk.apistub.REPO_ROOT", os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
-    )
-    @patch("azpysdk.apistub.get_cross_language_mapping_path", return_value=None)
-    @patch("azpysdk.apistub.get_package_wheel_path", return_value="/fake/pkg.whl")
-    @patch("azpysdk.apistub.create_package_and_install")
-    @patch("azpysdk.apistub.install_into_venv")
-    @patch("azpysdk.apistub.set_envvar_defaults")
-    def test_no_dest_dir_uses_package_directory(
-        self, _env, _install, _create, _get_whl, _get_mapping, tmp_path, monkeypatch
-    ):
-        """When --dest-dir is not given, output should go to the package directory."""
+        """Output should go to the package directory."""
         monkeypatch.chdir(os.getcwd())
         stub = apistub()
         staging = str(tmp_path / "staging")
@@ -321,7 +262,7 @@ class TestRunOutputDirectory:
             "azpysdk.apistub.run", side_effect=fake_pwsh
         ):
 
-            stub.run(self._make_args(dest_dir=None))
+            stub.run(self._make_args())
 
         # The --out-path passed to apistub should be the package directory
         assert len(captured_cmds) == 1
@@ -413,7 +354,9 @@ class TestRunOutputDirectory:
             stub, "ensure_apistub_dependencies"
         ), patch.object(
             stub, "run_venv_command", side_effect=fake_apistub_run
-        ), patch("azpysdk.apistub.run") as pwsh_run:
+        ), patch(
+            "azpysdk.apistub.run"
+        ) as pwsh_run:
             stub.run(self._make_args(token_file=True))
 
         assert len(captured_cmds) == 1

--- a/scripts/api_md_workflow/create_api_review_pr.py
+++ b/scripts/api_md_workflow/create_api_review_pr.py
@@ -521,8 +521,6 @@ def generate_api_for_package(
                 "-m",
                 "azpysdk.main",
                 "apistub",
-                "--md",
-                "--extract-metadata",
                 "--dest-dir",
                 str(package_dir),
                 package_name,
@@ -535,8 +533,6 @@ def generate_api_for_package(
         [
             "azpysdk",
             "apistub",
-            "--md",
-            "--extract-metadata",
             "--dest-dir",
             str(package_dir),
             package_name,


### PR DESCRIPTION
This PR fundamentally changes the behavior of `azpysdk apistub`. Due to the introduction of the api consistency check, the command to pass that consistency check used to be:

**Old Command**
`azpysdk apistub --md --extract-metadata --dest-dir .`

This is very inconsistent with the guidance on how to pass all other Python checks!

So now the default command is what is needed to pass the CI:

**New Command**
`azpysdk apistub .` 

This will generate the markdown and metadata file.

The previous default behavior, which generates the APIView token file, can be achieved by passing `--token-file`. 

This also updates the guidance that service teams use. 

Finally, this PR removes `--dest-dir` which was broken and has surprising results. The two usage patterns that should cover all use cases are:

**from repo root**
`azpysdk apistub {packageName}`

**from package dir**
`azpysdk apistub .`