### PR TITLE
[Storage] Fix sync list_shares test leaking shares due to wrong cleanup prefix

### DIFF
--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -953,7 +953,7 @@ class TestStorageShare(StorageRecordedTestCase):
         assert len(shares2) == 2
         self.assertNamedItemInContainer(shares2, share_names[2])
         self.assertNamedItemInContainer(shares2, share_names[3])
-        self._delete_shares()
+        self._delete_shares(prefix)
 
     @FileSharePreparer()
     @recorded_by_proxy


### PR DESCRIPTION
`test_list_shares_with_num_results_and_marker` created shares with the `"listshare"` prefix but called `self._delete_shares()` with no argument, which defaults to `TEST_SHARE_PREFIX` ("share"). Since `"listshare*"` names do not start with `"share"`, the cleanup matched nothing and leaked the shares onto the account.

Pass the `"listshare"` prefix to `_delete_shares()` so the test removes the shares it created, matching the async version.