### PR TITLE
[Core] Improve cross-domain redirect detection

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_redirect.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_redirect.py
@@ -40,7 +40,7 @@ from azure.core.pipeline.transport import (
 )
 from azure.core.rest import HttpResponse, HttpRequest, AsyncHttpResponse
 from ._base import HTTPPolicy, RequestHistory
-from ._utils import get_domain
+from ._utils import domain_changed
 
 HTTPResponseType = TypeVar("HTTPResponseType", HttpResponse, LegacyHttpResponse)
 AllHttpResponseType = TypeVar(
@@ -54,22 +54,6 @@ HTTPRequestType = TypeVar("HTTPRequestType", HttpRequest, LegacyHttpRequest)
 ClsRedirectPolicy = TypeVar("ClsRedirectPolicy", bound="RedirectPolicyBase")
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def domain_changed(original_domain: Optional[str], url: str) -> bool:
-    """Checks if the domain has changed.
-
-    :param str original_domain: The original domain.
-    :param str url: The new url.
-    :rtype: bool
-    :return: Whether the domain has changed.
-    """
-    domain = get_domain(url)
-    if not original_domain:
-        return False
-    if original_domain == domain:
-        return False
-    return True
 
 
 class RedirectPolicyBase:
@@ -200,7 +184,7 @@ class RedirectPolicy(RedirectPolicyBase, HTTPPolicy[HTTPRequestType, HTTPRespons
         """
         retryable: bool = True
         redirect_settings = self.configure_redirects(request.context.options)
-        original_domain = get_domain(request.http_request.url) if redirect_settings["allow"] else None
+        original_domain = urlparse(request.http_request.url) if redirect_settings["allow"] else None
         while retryable:
             response = self.next.send(request)
             redirect_location = self.get_redirect_location(response)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_redirect_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_redirect_async.py
@@ -24,6 +24,7 @@
 #
 # --------------------------------------------------------------------------
 from typing import TypeVar
+from urllib.parse import urlparse
 from azure.core.exceptions import TooManyRedirectsError
 from azure.core.pipeline import PipelineResponse, PipelineRequest
 from azure.core.pipeline.transport import (
@@ -32,8 +33,8 @@ from azure.core.pipeline.transport import (
 )
 from azure.core.rest import AsyncHttpResponse, HttpRequest
 from . import AsyncHTTPPolicy
-from ._redirect import RedirectPolicyBase, domain_changed
-from ._utils import get_domain
+from ._redirect import RedirectPolicyBase
+from ._utils import domain_changed
 
 AsyncHTTPResponseType = TypeVar("AsyncHTTPResponseType", AsyncHttpResponse, LegacyAsyncHttpResponse)
 HTTPRequestType = TypeVar("HTTPRequestType", HttpRequest, LegacyHttpRequest)
@@ -71,7 +72,7 @@ class AsyncRedirectPolicy(RedirectPolicyBase, AsyncHTTPPolicy[HTTPRequestType, A
         """
         redirects_remaining = True
         redirect_settings = self.configure_redirects(request.context.options)
-        original_domain = get_domain(request.http_request.url) if redirect_settings["allow"] else None
+        original_domain = urlparse(request.http_request.url) if redirect_settings["allow"] else None
         while redirects_remaining:
             response = await self.next.send(request)
             redirect_location = self.get_redirect_location(response)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
@@ -27,7 +27,7 @@ import datetime
 import email.utils
 import urllib.parse
 from typing import Optional, Set, cast, Union, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
 
 from azure.core.pipeline.transport import (
     HttpResponse as LegacyHttpResponse,
@@ -43,6 +43,41 @@ from .. import PipelineResponse
 
 AllHttpResponseType = Union[HttpResponse, LegacyHttpResponse, AsyncHttpResponse, LegacyAsyncHttpResponse]
 HTTPRequestType = Union[HttpRequest, LegacyHttpRequest]
+
+# Default ports corresponding to a scheme.
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def domain_changed(original_domain: Optional[ParseResult], url: str) -> bool:
+    """Checks if the domain has changed between the original request and a redirect target.
+
+    The domain is considered changed if the hostname, port, or scheme differs. ``urlparse``
+    already normalizes the hostname and scheme to lowercase, so no additional normalization
+    is required. An absent port and the scheme's default port (e.g. 80 for http) are treated
+    as equivalent when the scheme is unchanged.
+
+    :param original_domain: The parsed URL of the original request, or ``None`` if redirects
+     are disabled.
+    :type original_domain: ~urllib.parse.ParseResult or None
+    :param str url: The redirect target url.
+    :rtype: bool
+    :return: Whether the domain has changed.
+    """
+    if not original_domain:
+        return False
+    redirect_domain = urlparse(url)
+    if original_domain.hostname != redirect_domain.hostname:
+        return True
+
+    changed_port = original_domain.port != redirect_domain.port
+    changed_scheme = original_domain.scheme != redirect_domain.scheme
+
+    # Treat an absent port and the scheme's default port as equivalent when the scheme matches.
+    default_port = (DEFAULT_PORTS.get(original_domain.scheme), None)
+    if not changed_scheme and original_domain.port in default_port and redirect_domain.port in default_port:
+        return False
+
+    return changed_port or changed_scheme
 
 
 def _parse_http_date(text: str) -> datetime.datetime:
@@ -94,16 +129,6 @@ def get_retry_after(response: PipelineResponse[HTTPRequestType, AllHttpResponseT
             parsed_retry_after = parse_retry_after(retry_after)
             return parsed_retry_after / 1000.0
     return None
-
-
-def get_domain(url: str) -> str:
-    """Get the domain of an url.
-
-    :param str url: The url.
-    :rtype: str
-    :return: The domain of the url.
-    """
-    return str(urlparse(url).netloc).lower()
 
 
 def get_challenge_parameter(headers, challenge_scheme: str, challenge_parameter: str) -> Optional[str]:

--- a/sdk/core/azure-core/tests/test_utils.py
+++ b/sdk/core/azure-core/tests/test_utils.py
@@ -4,11 +4,12 @@
 # ------------------------------------
 import sys
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from azure.core.utils import case_insensitive_dict
 from azure.core.utils._utils import get_running_async_lock, CaseInsensitiveSet
-from azure.core.pipeline.policies._utils import parse_retry_after, get_challenge_parameter, sanitize_url
+from azure.core.pipeline.policies._utils import parse_retry_after, get_challenge_parameter, sanitize_url, domain_changed
 
 
 @pytest.fixture()
@@ -279,6 +280,41 @@ def test_sanitize_url():
 def test_sanitize_url_with_different_placeholder():
     url = "https://www.example.com?q1=value1&q2=value2"
     assert sanitize_url(url, {"q1"}, "SANITIZED") == "https://www.example.com?q1=value1&q2=SANITIZED"
+
+
+@pytest.mark.parametrize(
+    "original,redirect,expected",
+    [
+        # Identical URLs -> no change.
+        ("https://example.com", "https://example.com", False),
+        # Same host, different path -> no change.
+        ("https://example.com/foo", "https://example.com/bar", False),
+        # Different host -> change.
+        ("https://example.com", "https://example1.com", True),
+        # Hostname comparison is case-insensitive (urlparse normalizes).
+        ("https://Example.com", "https://example.com", False),
+        # Different scheme on same host -> change.
+        ("https://example.com", "http://example.com", True),
+        # Different explicit port on same host -> change.
+        ("https://example.com:443", "https://example.com:8443", True),
+        # Same host, same explicit port -> no change.
+        ("https://example.com:8443", "https://example.com:8443", False),
+        # Default port vs absent port for https -> no change.
+        ("https://example.com:443", "https://example.com", False),
+        ("https://example.com", "https://example.com:443", False),
+        # Default port vs absent port for http -> no change.
+        ("http://example.com:80", "http://example.com", False),
+        # Default port for one scheme is not the default for a different scheme.
+        ("https://example.com:80", "https://example.com", True),
+    ],
+)
+def test_domain_changed(original, redirect, expected):
+    assert domain_changed(urlparse(original), redirect) is expected
+
+
+def test_domain_changed_no_original_domain():
+    # When redirects are disabled the original domain is None and is never considered changed.
+    assert domain_changed(None, "https://example.com") is False
 
 
 class TestCaseInsensitiveSet:


### PR DESCRIPTION
Improves the cross-domain redirect detection of `azure-core`. The implementation is based on that of `requests` seen [here](https://github.com/psf/requests/blob/c4367f231b5dc54f23f2983828562ce3a7555a8a/src/requests/sessions.py#L154-L184).
