### PR TITLE
Fix apiview reqs install on Python 3.13 and update version calculation logic

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -57,7 +57,10 @@ def get_version_info(package_name: str, tag_is_stable: bool = False) -> Tuple[st
 
     try:
         client = PyPIClient()
-        ordered_versions = client.get_ordered_versions(package_name)
+        # Ignore 0.0.0 when it appears on PyPI as a placeholder or name-reservation version.
+        ordered_versions = [v for v in client.get_ordered_versions(package_name) if v.base_version != "0.0.0"]
+        if not ordered_versions:
+            return "", ""
         last_release = ordered_versions[-1]
         stable_releases = [x for x in ordered_versions if not x.is_prerelease]
         last_stable_version = str(stable_releases[-1] if stable_releases else "")
@@ -84,10 +87,6 @@ def get_version_info(package_name: str, tag_is_stable: bool = False) -> Tuple[st
         _LOGGER.warning(f"Failed to get version info from PyPI for {package_name}: {e}")
         last_version = ""
         last_stable_version = ""
-
-    # Ignore 0.0.0 when it appears on PyPI as a placeholder or name-reservation version.
-    if last_version and Version(last_version).base_version == "0.0.0":
-        return "", ""
 
     return last_version, last_stable_version
 

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -316,6 +316,29 @@ def main(generate_input, generate_output):
                 apiview_start_time = time.time()
                 try:
                     _LOGGER.info(f"install apiview generation tool")
+                    # Workaround for Python 3.13: lazy-object-proxy==1.10.0 (pinned in
+                    # eng/apiview_reqs.txt) ships no cp313 wheel, so pip builds it from
+                    # source. The isolated build environment fails to fetch its build deps
+                    # (setuptools_scm) from the azure-sdk private feed (401 -> interactive
+                    # prompt -> EOFError), which breaks the whole install. Pre-install the
+                    # build deps from PyPI and disable build isolation so the source build
+                    # uses them instead of reaching out to the private feed.
+                    # TODO: revert this logic once it works on Python 3.13 (e.g. once
+                    # lazy-object-proxy ships a cp313 wheel on the feed).
+                    check_call(
+                        [
+                            "python",
+                            "-m",
+                            "pip",
+                            "install",
+                            "setuptools>=64",
+                            "setuptools_scm>=8",
+                            "wheel",
+                            "--index-url=https://pypi.org/simple/",
+                        ],
+                        timeout=600,
+                        stderr=None if data.get("runMode") == "release" else subprocess.DEVNULL,
+                    )
                     check_call(
                         [
                             "python",
@@ -325,6 +348,7 @@ def main(generate_input, generate_output):
                             "-r",
                             "eng/apiview_reqs.txt",
                             "--index-url=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/",
+                            "--no-build-isolation",
                         ],
                         timeout=600,
                         stderr=None if data.get("runMode") == "release" else subprocess.DEVNULL,


### PR DESCRIPTION
### Problem
ApiView token generation fails in `spec-pull-request`/`release` runs on Python 3.13. `eng/apiview_reqs.txt` pins `lazy-object-proxy==1.10.0`, which has **no cp313 wheel**, so pip builds it from source. The isolated build environment then fails to fetch its build dependency `setuptools_scm` from the azure-sdk private feed (401 -> interactive `User for pkgs.dev.azure.com:` prompt -> `EOFError: EOF when reading a line`), aborting the install.

### Fix
Without modifying `eng/apiview_reqs.txt`, pre-install the build deps (`setuptools`, `setuptools_scm`, `wheel`) from PyPI and install the reqs with `--no-build-isolation` so the source build uses the already-installed deps instead of reaching the private feed.

A comment documents this as a temporary workaround that can be reverted once `lazy-object-proxy` works on Python 3.13 (i.e. ships a cp313 wheel on the feed).

### Test

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6468481&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692