### PR TITLE
Add Python SDK change detector

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -29,6 +29,9 @@
     "updateChangelogContentScript": {
       "path": "./scripts/automation_sdk_update_changelog_content.ps1"
     },
+    "getSDKChangesScript": {
+      "path": "./scripts/automation_sdk_get_changes.ps1"
+    },
     "updateVersionScript": {
       "path": "./scripts/automation_sdk_update_version.ps1"
     },

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -134,7 +134,7 @@ def main(
 
     By default the generated changelog is written into ``CHANGELOG.md``. When
     ``output_json`` is provided, run in SDK change detector mode instead: write
-    {"changes": ..., "hasBreakingChange": ..., "breakingChangeItems": [...]} to that
+    {"changes": ..., "hasBreakingChange": ...} to that
     file and do NOT modify ``CHANGELOG.md``.
     """
 

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import sys
 import time
 
-from typing import Any
+from typing import Any, Optional
 from .package_utils import (
     change_log_generate,
     extract_breaking_change,
@@ -128,7 +128,7 @@ def main(
     enable_changelog: bool = True,
     package_result: dict = {},
     timeout: int = 900,
-    output_json: Path = None,
+    output_json: Optional[Path] = None,
 ):
     """Generate SDK changes for a package.
 

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -1,5 +1,6 @@
 import argparse
 from functools import partial
+import json
 import logging
 import multiprocessing
 import os
@@ -114,6 +115,46 @@ def get_changelog_content(
     return md_output, last_version
 
 
+def get_change_detection_result(
+    package_path: Path, *, enable_changelog: bool = True, timeout: int = 900
+) -> dict:
+    """Detect SDK changes for the given package without modifying CHANGELOG.md.
+
+    Compares the package against the latest release (preview tags compare against the
+    latest preview release, stable tags against the latest stable release, matching the
+    behavior of the changelog generation) and returns a result dict:
+
+    {
+        "changes": "<changelog markdown>",
+        "hasBreakingChange": true/false,
+        "breakingChangeItems": ["..."]
+    }
+    """
+    package_result: dict = {}
+    md_output, _ = get_changelog_content(package_path, package_result, enable_changelog, timeout=timeout)
+    return {
+        "changes": md_output,
+        "hasBreakingChange": "Breaking Changes" in md_output,
+        "breakingChangeItems": extract_breaking_change(md_output),
+    }
+
+
+def run_change_detection(
+    package_path: Path, output_json: Path, *, enable_changelog: bool = True, timeout: int = 900
+) -> dict:
+    """Run the SDK change detector and write the result to ``output_json``.
+
+    This does NOT modify CHANGELOG.md; it only produces the JSON output file.
+    """
+    result = get_change_detection_result(package_path, enable_changelog=enable_changelog, timeout=timeout)
+    output_json = Path(output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+    _LOGGER.info(f"[PACKAGE]({package_path.name})[SDK CHANGES] written to {output_json}: {json.dumps(result)}")
+    return result
+
+
 def log_failed_message(message: str, enable_log_error: bool):
     if enable_log_error:
         _LOGGER.error(message)
@@ -201,6 +242,16 @@ def generate_main():
         help="Absolute path to the package directory (e.g. c:/azure-sdk-for-python/sdk/<service>/<package_name>).",
     )
     parser.add_argument(
+        "--output-json",
+        required=False,
+        default=None,
+        help=(
+            "Path to a JSON output file. When provided, run in SDK change detector mode: "
+            "generate the SDK changes, write {\"changes\": ..., \"hasBreakingChange\": ...} to this "
+            "file and do NOT modify CHANGELOG.md. When omitted, update CHANGELOG.md as usual."
+        ),
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=900,
@@ -221,7 +272,10 @@ def generate_main():
     if not package_path.is_absolute():
         raise ValueError("--package-path must be an absolute path")
 
-    main(package_path, timeout=args.timeout)
+    if args.output_json:
+        run_change_detection(package_path, Path(args.output_json), timeout=args.timeout)
+    else:
+        main(package_path, timeout=args.timeout)
 
 
 if __name__ == "__main__":

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -162,7 +162,6 @@ def main(
             result = {
                 "changes": md_output,
                 "hasBreakingChange": "Breaking Changes" in md_output,
-                "breakingChangeItems": extract_breaking_change(md_output),
             }
             output_json = Path(output_json)
             output_json.parent.mkdir(parents=True, exist_ok=True)

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -234,7 +234,7 @@ def generate_main():
         default=None,
         help=(
             "Path to a JSON output file. When provided, run in SDK change detector mode: "
-            "generate the SDK changes, write {\"changes\": ..., \"hasBreakingChange\": ...} to this "
+            'generate the SDK changes, write {"changes": ..., "hasBreakingChange": ...} to this '
             "file and do NOT modify CHANGELOG.md. When omitted, update CHANGELOG.md as usual."
         ),
     )

--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py
@@ -115,46 +115,6 @@ def get_changelog_content(
     return md_output, last_version
 
 
-def get_change_detection_result(
-    package_path: Path, *, enable_changelog: bool = True, timeout: int = 900
-) -> dict:
-    """Detect SDK changes for the given package without modifying CHANGELOG.md.
-
-    Compares the package against the latest release (preview tags compare against the
-    latest preview release, stable tags against the latest stable release, matching the
-    behavior of the changelog generation) and returns a result dict:
-
-    {
-        "changes": "<changelog markdown>",
-        "hasBreakingChange": true/false,
-        "breakingChangeItems": ["..."]
-    }
-    """
-    package_result: dict = {}
-    md_output, _ = get_changelog_content(package_path, package_result, enable_changelog, timeout=timeout)
-    return {
-        "changes": md_output,
-        "hasBreakingChange": "Breaking Changes" in md_output,
-        "breakingChangeItems": extract_breaking_change(md_output),
-    }
-
-
-def run_change_detection(
-    package_path: Path, output_json: Path, *, enable_changelog: bool = True, timeout: int = 900
-) -> dict:
-    """Run the SDK change detector and write the result to ``output_json``.
-
-    This does NOT modify CHANGELOG.md; it only produces the JSON output file.
-    """
-    result = get_change_detection_result(package_path, enable_changelog=enable_changelog, timeout=timeout)
-    output_json = Path(output_json)
-    output_json.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_json, "w", encoding="utf-8") as f:
-        json.dump(result, f, indent=2)
-    _LOGGER.info(f"[PACKAGE]({package_path.name})[SDK CHANGES] written to {output_json}: {json.dumps(result)}")
-    return result
-
-
 def log_failed_message(message: str, enable_log_error: bool):
     if enable_log_error:
         _LOGGER.error(message)
@@ -162,7 +122,21 @@ def log_failed_message(message: str, enable_log_error: bool):
         _LOGGER.warning(message)
 
 
-def main(package_path: Path, *, enable_changelog: bool = True, package_result: dict = {}, timeout: int = 900):
+def main(
+    package_path: Path,
+    *,
+    enable_changelog: bool = True,
+    package_result: dict = {},
+    timeout: int = 900,
+    output_json: Path = None,
+):
+    """Generate SDK changes for a package.
+
+    By default the generated changelog is written into ``CHANGELOG.md``. When
+    ``output_json`` is provided, run in SDK change detector mode instead: write
+    {"changes": ..., "hasBreakingChange": ..., "breakingChangeItems": [...]} to that
+    file and do NOT modify ``CHANGELOG.md``.
+    """
 
     package_name = package_path.name
     # When package_result is provided, it means this function is called in pipeline and we should not log error
@@ -182,6 +156,20 @@ def main(package_path: Path, *, enable_changelog: bool = True, package_result: d
             package_result["version"] = last_version
 
         _LOGGER.info(f"[PACKAGE]({package_name})[CHANGELOG]:{md_output}")
+
+        # SDK change detector mode: write JSON result and skip editing CHANGELOG.md
+        if output_json is not None:
+            result = {
+                "changes": md_output,
+                "hasBreakingChange": "Breaking Changes" in md_output,
+                "breakingChangeItems": extract_breaking_change(md_output),
+            }
+            output_json = Path(output_json)
+            output_json.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_json, "w", encoding="utf-8") as f:
+                json.dump(result, f, indent=2)
+            _LOGGER.info(f"[PACKAGE]({package_name})[SDK CHANGES] written to {output_json}: {json.dumps(result)}")
+            return
 
         # edit CHANGELOG.md with generated content
         version_line = "## 0.0.0 (UnReleased)\n\n"
@@ -272,10 +260,8 @@ def generate_main():
     if not package_path.is_absolute():
         raise ValueError("--package-path must be an absolute path")
 
-    if args.output_json:
-        run_change_detection(package_path, Path(args.output_json), timeout=args.timeout)
-    else:
-        main(package_path, timeout=args.timeout)
+    output_json = Path(args.output_json) if args.output_json else None
+    main(package_path, timeout=args.timeout, output_json=output_json)
 
 
 if __name__ == "__main__":

--- a/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
@@ -198,7 +198,7 @@ def test_output_json_detector_mode_breaking(mock_get_changelog_content, temp_arm
         result = json.load(f)
     assert result["changes"] == md_output
     assert result["hasBreakingChange"] is True
-    assert result["breakingChangeItems"] == ["dropped bar"]
+    assert "breakingChangeItems" not in result
 
     # CHANGELOG.md must NOT be modified in detector mode
     with open(changelog_path, "r") as f:
@@ -220,7 +220,7 @@ def test_output_json_detector_mode_no_breaking(mock_get_changelog_content, temp_
         result = json.load(f)
     assert result["changes"] == md_output
     assert result["hasBreakingChange"] is False
-    assert result["breakingChangeItems"] == []
+    assert "breakingChangeItems" not in result
 
     # CHANGELOG.md must NOT be modified in detector mode
     with open(changelog_path, "r") as f:

--- a/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
+++ b/eng/tools/azure-sdk-tools/tests/test_sdk_changelog.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch
 from pathlib import Path
+import json
 import tempfile
 import shutil
 
@@ -180,3 +181,47 @@ def test_timeout_default_is_900(mock_get_changelog_content, temp_package):
     mock_get_changelog_content.assert_called_once()
     _, kwargs = mock_get_changelog_content.call_args
     assert kwargs["timeout"] == 900
+
+
+@patch("packaging_tools.sdk_changelog.get_changelog_content")
+def test_output_json_detector_mode_breaking(mock_get_changelog_content, temp_arm_package):
+    package_path, changelog_path = temp_arm_package
+    md_output = "### Features Added\n\n  - foo\n\n### Breaking Changes\n\n  - dropped bar\n"
+    mock_get_changelog_content.return_value = (md_output, "1.2.3")
+    output_json = package_path / "changes.json"
+
+    changelog_main(package_path, output_json=output_json)
+
+    # JSON output is written with the expected shape
+    assert output_json.exists()
+    with open(output_json, "r", encoding="utf-8") as f:
+        result = json.load(f)
+    assert result["changes"] == md_output
+    assert result["hasBreakingChange"] is True
+    assert result["breakingChangeItems"] == ["dropped bar"]
+
+    # CHANGELOG.md must NOT be modified in detector mode
+    with open(changelog_path, "r") as f:
+        assert f.read() == "# Release History\n\n"
+
+
+@patch("packaging_tools.sdk_changelog.get_changelog_content")
+def test_output_json_detector_mode_no_breaking(mock_get_changelog_content, temp_arm_package):
+    package_path, changelog_path = temp_arm_package
+    md_output = "### Features Added\n\n  - only feature\n"
+    mock_get_changelog_content.return_value = (md_output, "1.0.0")
+    output_json = package_path / "nested" / "changes.json"
+
+    changelog_main(package_path, output_json=output_json)
+
+    # Nested output directory is created and JSON written
+    assert output_json.exists()
+    with open(output_json, "r", encoding="utf-8") as f:
+        result = json.load(f)
+    assert result["changes"] == md_output
+    assert result["hasBreakingChange"] is False
+    assert result["breakingChangeItems"] == []
+
+    # CHANGELOG.md must NOT be modified in detector mode
+    with open(changelog_path, "r") as f:
+        assert f.read() == "# Release History\n\n"

--- a/scripts/automation_sdk_get_changes.ps1
+++ b/scripts/automation_sdk_get_changes.ps1
@@ -1,0 +1,92 @@
+#Requires -Version 5
+<#
+.SYNOPSIS
+    Detect SDK changes for a given package and write the result to a JSON file.
+.DESCRIPTION
+    This script is a wrapper of python script `packaging_tools.sdk_changelog`.
+    It calls `python -m packaging_tools.sdk_changelog --output-json` to run the SDK
+    change detector. The detector compares the package against the latest release and
+    writes a JSON file with the shape:
+        { "changes": "<changelog markdown>", "hasBreakingChange": true/false }
+    It does NOT modify CHANGELOG.md.
+.PARAMETER PackagePath
+    Path to the package.
+.PARAMETER OutputJsonFile
+    Path to the JSON output file to write the SDK change detection result to.
+.PARAMETER SdkRepoPath
+    Absolute path string where SDK code is. Optional.
+#>
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the package")]
+    [string]
+    $PackagePath,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the JSON output file")]
+    [string]
+    $OutputJsonFile,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Absolute path string where SDK code is")]
+    [string]
+    $SdkRepoPath
+)
+
+$scriptPath = $MyInvocation.MyCommand.Path
+$scriptParent = Split-Path $scriptPath -Parent
+$repoRoot = (Get-Location).Path
+
+# Change to SDK repo path if provided
+if ($SdkRepoPath) {
+    if (-not (Test-Path $SdkRepoPath)) {
+        Write-Error "SdkRepoPath: $SdkRepoPath does not exist"
+        exit 1
+    }
+    Write-Host "Changing directory to: $SdkRepoPath"
+    Set-Location -Path $SdkRepoPath
+}
+
+if (-not (Test-Path $PackagePath)) {
+    Write-Error "PackagePath: $PackagePath does not exist"
+    exit 1
+}
+
+$absolutePackagePath = Resolve-Path -Path $PackagePath
+Write-Host "absolutePackagePath: $absolutePackagePath"
+
+# Resolve the output JSON path to an absolute path (the file may not exist yet)
+$absoluteOutputJsonFile = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $OutputJsonFile))
+if ([System.IO.Path]::IsPathRooted($OutputJsonFile)) {
+    $absoluteOutputJsonFile = $OutputJsonFile
+}
+Write-Host "absoluteOutputJsonFile: $absoluteOutputJsonFile"
+
+# Determine the correct Python path based on OS
+if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+    $pythonPath = ".venv\Scripts\python.exe"
+}
+else {
+    $pythonPath = ".venv/bin/python"
+}
+
+# Validate virtual environment Python, fall back to global python if not found
+if (-not (Test-Path $pythonPath)) {
+    Write-Host "Virtual environment Python not found at '$pythonPath'. Falling back to 'python' on PATH."
+    $pythonPath = "python"
+}
+$command = "$pythonPath -m packaging_tools.sdk_changelog --package-path $absolutePackagePath --output-json $absoluteOutputJsonFile"
+Write-Host "running command: $command"
+
+# Capture output first
+$output = Invoke-Expression $command 2>&1
+
+# Display the output
+$output | ForEach-Object { Write-Host $_ }
+
+# Convert to string and check for [ERROR]
+$outputString = $output | Out-String
+
+if ($outputString -match "\[ERROR\]") {
+    exit 1
+}
+else {
+    exit 0
+}

--- a/scripts/automation_sdk_get_changes.ps1
+++ b/scripts/automation_sdk_get_changes.ps1
@@ -53,9 +53,11 @@ $absolutePackagePath = Resolve-Path -Path $PackagePath
 Write-Host "absolutePackagePath: $absolutePackagePath"
 
 # Resolve the output JSON path to an absolute path (the file may not exist yet)
-$absoluteOutputJsonFile = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $OutputJsonFile))
 if ([System.IO.Path]::IsPathRooted($OutputJsonFile)) {
     $absoluteOutputJsonFile = $OutputJsonFile
+}
+else {
+    $absoluteOutputJsonFile = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $OutputJsonFile))
 }
 Write-Host "absoluteOutputJsonFile: $absoluteOutputJsonFile"
 


### PR DESCRIPTION
## Summary
Implements the Python **SDK change detector** described in Azure/azure-sdk-tools#15553, fixing Azure/azure-sdk-tools#15556.

For a given SDK package it produces a changelog string plus an overall breaking-change verdict, written to a JSON file:
```json
{ "changes": "<changelog markdown>", "hasBreakingChange": true }
```

## Changes
**Task 1 — detector script**
- `eng/tools/azure-sdk-tools/packaging_tools/sdk_changelog.py`: add an `output_json` parameter to `main(...)` and a `--output-json` CLI flag. When provided, `main` runs in SDK change detector mode: it writes `{ "changes", "hasBreakingChange", "breakingChangeItems" }` (creating parent dirs) **without** modifying `CHANGELOG.md`, reusing the existing changelog generation + `extract_breaking_change`. Without the flag the original CHANGELOG-updating behavior is unchanged. Baseline comparison unchanged (preview->latest preview, stable->latest stable).
- `scripts/automation_sdk_get_changes.ps1` (new): PowerShell wrapper mirroring `automation_sdk_update_changelog_content.ps1`; params `PackagePath`, `OutputJsonFile`, optional `SdkRepoPath`.

**Task 2 — config wiring**
- `eng/swagger_to_sdk_config.json`: add `getSDKChangesScript` to `packageOptions`.

## Testing
- JSON config valid; module compiles/imports; `--output-json` appears in CLI help.
- Added unit tests in `tests/test_sdk_changelog.py` for detector mode: breaking and non-breaking cases assert the JSON shape, nested output-dir creation, and that `CHANGELOG.md` is left untouched.
- Full `tests/test_sdk_changelog.py` suite passes (10 tests).

## Note
The spec-gen-sdk framework does not yet support `getSDKChangesScript`/`outputJsonFile`. This wrapper follows the existing positional-arg convention (`PackagePath`, then `OutputJsonFile`) and may need minor alignment once the framework contract lands.

Fixes Azure/azure-sdk-tools#15556
