### PR TITLE
[Evaluation] Normalize evaluator validation errors to EvaluationException with USER_ERROR blame

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Bugs Fixed
 
+- Evaluators now raise `EvaluationException` (instead of bare `ValueError`/`TypeError`) for input and
+  configuration validation failures, and consistently set `blame=ErrorBlame.USER_ERROR` with an
+  appropriate `category` and `target`. Affected evaluators include `ContentSafetyEvaluator`,
+  `QAEvaluator`, `RougeScoreEvaluator`, `DocumentRetrievalEvaluator`, the task navigation efficiency
+  evaluator, and the shared evaluator base (conversation/tool-call input validation).
+
 - Fixed `RedTeam.scan()` storing decoded plaintext instead of the actual
   encoded payload for converter-based attack strategies (Base64, Flip,
   Morse, ROT13, etc.) in `evaluation_results.json` / `results.json`. The

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_eval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_base_eval.py
@@ -355,11 +355,17 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                 raise EvaluationException(
                     message="Mismatched number of user and assistant messages.",
                     internal_message=("Mismatched number of user and assistant messages."),
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.CONVERSATION,
                 )
             if len(assistant_messages) > 1:
                 raise EvaluationException(
                     message="Conversation can have only one assistant message.",
                     internal_message=("Conversation can have only one assistant message."),
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.CONVERSATION,
                 )
             eval_conv_inputs = []
             for user_msg, assist_msg in zip(user_messages, assistant_messages):
@@ -555,7 +561,8 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                     "Tool call must be a dictionary.",
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
-                    category=ErrorCategory.UNKNOWN,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
             if tool_call.get("type") != "tool_call":
                 raise EvaluationException(
@@ -563,6 +570,7 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
                     category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             if "name" not in tool_call:
@@ -571,6 +579,7 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
                     category=ErrorCategory.MISSING_FIELD,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             tool_name = str(tool_call["name"]).strip()
@@ -593,6 +602,7 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                             internal_message=str(tool_call),
                             target=ErrorTarget.EVALUATE,
                             category=ErrorCategory.INVALID_VALUE,
+                            blame=ErrorBlame.USER_ERROR,
                         )
 
             tool_name_param_pairs.append((tool_name, parameters))
@@ -639,6 +649,7 @@ class EvaluatorBase(ABC, Generic[T_EvalValue]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_validators/_task_navigation_efficiency_validator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_validators/_task_navigation_efficiency_validator.py
@@ -143,7 +143,7 @@ class TaskNavigationEfficiencyValidator(ValidatorInterface):
             return EvaluationException(
                 message="'ground_truth' parameter is required and cannot be None or empty.",
                 blame=ErrorBlame.USER_ERROR,
-                category=ErrorCategory.MISSING_FIELD,
+                category=ErrorCategory.INVALID_VALUE,
                 target=self.error_target,
             )
 

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_content_safety/_content_safety.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_content_safety/_content_safety.py
@@ -8,6 +8,7 @@ from typing_extensions import overload, override
 from azure.ai.evaluation._evaluators._common import MultiEvaluatorBase
 from azure.ai.evaluation._model_configurations import Conversation
 from azure.ai.evaluation._common._experimental import experimental
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 from ._hate_unfairness import HateUnfairnessEvaluator
 from ._self_harm import SelfHarmEvaluator
@@ -91,7 +92,12 @@ class ContentSafetyEvaluator(MultiEvaluatorBase[Union[str, float]]):
             ("hate_unfairness_threshold", hate_unfairness_threshold),
         ]:
             if not isinstance(value, int):
-                raise TypeError(f"{name} must be an int, got {type(value)}")
+                raise EvaluationException(
+                    message=f"{name} must be an int, got {type(value)}",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.CONTENT_SAFETY_CHAT_EVALUATOR,
+                )
 
         # Extract evaluate_query from kwargs if present
         evaluate_query_kwargs = {}

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_document_retrieval/_document_retrieval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_document_retrieval/_document_retrieval.py
@@ -7,7 +7,7 @@ from itertools import starmap
 from typing import Any, Dict, List, TypedDict, Tuple, Optional, Union
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
-from azure.ai.evaluation._exceptions import EvaluationException
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 from typing_extensions import override, overload
 
 RetrievalGroundTruthDocument = TypedDict(
@@ -71,14 +71,27 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
 
         if ground_truth_label_min >= ground_truth_label_max:
             raise EvaluationException(
-                "The ground truth label maximum must be strictly greater than the ground truth label minimum."
+                message="The ground truth label maximum must be strictly greater than the ground truth label minimum.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
             )
 
         if not isinstance(ground_truth_label_min, int):
-            raise EvaluationException("The ground truth label minimum must be an integer value.")
+            raise EvaluationException(
+                message="The ground truth label minimum must be an integer value.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+            )
 
         if not isinstance(ground_truth_label_max, int):
-            raise EvaluationException("The ground truth label maximum must be an integer value.")
+            raise EvaluationException(
+                message="The ground truth label maximum must be an integer value.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+            )
 
         self.ground_truth_label_min = ground_truth_label_min
         self.ground_truth_label_max = ground_truth_label_max
@@ -229,7 +242,12 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                 result[f"{metric_name}_higher_is_better"] = False
 
             else:
-                raise ValueError(f"No threshold set for metric '{metric_name}'")
+                raise EvaluationException(
+                    message=f"No threshold set for metric '{metric_name}'",
+                    blame=ErrorBlame.SYSTEM_ERROR,
+                    category=ErrorCategory.FAILED_EXECUTION,
+                    target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+                )
 
         return result
 
@@ -249,10 +267,13 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
         # if the qrels are empty, no meaningful evaluation is possible
         if not retrieval_ground_truth:
             raise EvaluationException(
-                (
+                message=(
                     "'retrieval_ground_truth' parameter must contain at least one item. "
                     "Check your data input to be sure that each input record has ground truth defined."
-                )
+                ),
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.MISSING_FIELD,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
             )
 
         qrels = []
@@ -264,32 +285,46 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
 
             if document_id is None or query_relevance_label is None:
                 raise EvaluationException(
-                    (
+                    message=(
                         "Invalid input data was found in the retrieval ground truth. "
                         "Ensure that all items in the 'retrieval_ground_truth' array contain "
                         "'document_id' and 'query_relevance_label' properties."
-                    )
+                    ),
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.MISSING_FIELD,
+                    target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
                 )
 
             if not isinstance(query_relevance_label, int):
-                raise EvaluationException("Query relevance labels must be integer values.")
+                raise EvaluationException(
+                    message="Query relevance labels must be integer values.",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+                )
 
             if query_relevance_label < self.ground_truth_label_min:
                 raise EvaluationException(
-                    (
+                    message=(
                         "A query relevance label less than the configured minimum value was detected in the evaluation input data. "
                         "Check the range of ground truth label values in the input data and set the value of ground_truth_label_min to "
                         "the appropriate value for your data."
-                    )
+                    ),
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
                 )
 
             if query_relevance_label > self.ground_truth_label_max:
                 raise EvaluationException(
-                    (
+                    message=(
                         "A query relevance label greater than the configured maximum value was detected in the evaluation input data. "
                         "Check the range of ground truth label values in the input data and set the value of ground_truth_label_max to "
                         "the appropriate value for your data."
-                    )
+                    ),
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
                 )
 
             qrels.append(qrel)
@@ -304,21 +339,32 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
 
                 if document_id is None or relevance_score is None:
                     raise EvaluationException(
-                        (
+                        message=(
                             "Invalid input data was found in the retrieved documents. "
                             "Ensure that all items in the 'retrieved_documents' array contain "
                             "'document_id' and 'relevance_score' properties."
-                        )
+                        ),
+                        blame=ErrorBlame.USER_ERROR,
+                        category=ErrorCategory.MISSING_FIELD,
+                        target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
                     )
 
                 if not isinstance(relevance_score, float) and not isinstance(relevance_score, int):
-                    raise EvaluationException("Retrieved document relevance score must be a numerical value.")
+                    raise EvaluationException(
+                        message="Retrieved document relevance score must be a numerical value.",
+                        blame=ErrorBlame.USER_ERROR,
+                        category=ErrorCategory.INVALID_VALUE,
+                        target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+                    )
 
                 results.append(result)
 
         if len(qrels) > 10000 or len(results) > 10000:
             raise EvaluationException(
-                "'retrieval_ground_truth' and 'retrieved_documents' inputs should contain no more than 10000 items."
+                message="'retrieval_ground_truth' and 'retrieved_documents' inputs should contain no more than 10000 items.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
             )
 
         return qrels, results

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_document_retrieval/_document_retrieval.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_document_retrieval/_document_retrieval.py
@@ -69,14 +69,6 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
         self.k = 3
         self.xdcg_discount_factor = 0.6
 
-        if ground_truth_label_min >= ground_truth_label_max:
-            raise EvaluationException(
-                message="The ground truth label maximum must be strictly greater than the ground truth label minimum.",
-                blame=ErrorBlame.USER_ERROR,
-                category=ErrorCategory.INVALID_VALUE,
-                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
-            )
-
         if not isinstance(ground_truth_label_min, int):
             raise EvaluationException(
                 message="The ground truth label minimum must be an integer value.",
@@ -88,6 +80,14 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
         if not isinstance(ground_truth_label_max, int):
             raise EvaluationException(
                 message="The ground truth label maximum must be an integer value.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,
+            )
+
+        if ground_truth_label_min >= ground_truth_label_max:
+            raise EvaluationException(
+                message="The ground truth label maximum must be strictly greater than the ground truth label minimum.",
                 blame=ErrorBlame.USER_ERROR,
                 category=ErrorCategory.INVALID_VALUE,
                 target=ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_qa/_qa.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_qa/_qa.py
@@ -7,6 +7,7 @@ from typing import Union
 from typing_extensions import overload, override
 
 from azure.ai.evaluation._evaluators._common import MultiEvaluatorBase
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 from .._coherence import CoherenceEvaluator
 from .._f1_score import F1ScoreEvaluator
@@ -99,7 +100,12 @@ class QAEvaluator(MultiEvaluatorBase[Union[str, float]]):
             ("f1_score_threshold", f1_score_threshold),
         ]:
             if not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be an int or float, got {type(value)}")
+                raise EvaluationException(
+                    message=f"{name} must be an int or float, got {type(value)}",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.QA_EVALUATOR,
+                )
 
         # Extract is_reasoning_model from kwargs to pass to LLM-based evaluators
         is_reasoning_model = kwargs.get("is_reasoning_model", False)

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_rouge/_rouge.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_rouge/_rouge.py
@@ -9,6 +9,7 @@ from typing_extensions import overload, override
 from azure.ai.evaluation._vendor.rouge_score import rouge_scorer
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 import math
 
 
@@ -113,7 +114,12 @@ class RougeScoreEvaluator(EvaluatorBase):
             ("f1_score_threshold", f1_score_threshold),
         ]:
             if not isinstance(value, float):
-                raise TypeError(f"{name} must be a float, got {type(value)}")
+                raise EvaluationException(
+                    message=f"{name} must be a float, got {type(value)}",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.ROUGE_EVALUATOR,
+                )
 
         self._threshold = {
             "precision": precision_threshold,

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_navigation_efficiency/_task_navigation_efficiency.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_task_navigation_efficiency/_task_navigation_efficiency.py
@@ -11,6 +11,7 @@ from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._evaluators._common._validators import TaskNavigationEfficiencyValidator, ValidatorInterface
 from azure.ai.evaluation._exceptions import (
+    ErrorBlame,
     ErrorCategory,
     ErrorTarget,
     EvaluationException,
@@ -119,8 +120,11 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             try:
                 self.matching_mode = _TaskNavigationEfficiencyMatchingMode(matching_mode)
             except ValueError:
-                raise ValueError(
-                    f"matching_mode must be one of {[m.value for m in _TaskNavigationEfficiencyMatchingMode]}, got '{matching_mode}'"
+                raise EvaluationException(
+                    message=f"matching_mode must be one of {[m.value for m in _TaskNavigationEfficiencyMatchingMode]}, got '{matching_mode}'",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 )
         elif isinstance(matching_mode, _TaskNavigationEfficiencyMatchingMode):
             self.matching_mode = matching_mode
@@ -128,6 +132,7 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             raise EvaluationException(
                 f"matching_mode must be a string with one of {[m.value for m in _TaskNavigationEfficiencyMatchingMode]} or _TaskNavigationEfficiencyMatchingMode enum, got {type(matching_mode)}",
                 internal_message=str(matching_mode),
+                blame=ErrorBlame.USER_ERROR,
                 target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 category=ErrorCategory.INVALID_VALUE,
             )
@@ -306,7 +311,12 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
 
         # Value and type checking for ground truth steps
         if not ground_truth:
-            raise ValueError("ground_truth cannot be empty")
+            raise EvaluationException(
+                message="ground_truth cannot be empty",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+            )
 
         # Check if ground_truth is a tuple (tool names + parameters) or list (tool names only)
         use_parameter_matching = False
@@ -318,27 +328,53 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             tool_names_list, params_dict = ground_truth
 
             if not isinstance(tool_names_list, list) or not all(isinstance(name, str) for name in tool_names_list):
-                raise TypeError("ground_truth tuple first element must be a list of strings (tool names)")
+                raise EvaluationException(
+                    message="ground_truth tuple first element must be a list of strings (tool names)",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                )
 
             if not isinstance(params_dict, dict):
-                raise TypeError(
-                    "ground_truth tuple second element must be a dictionary mapping tool names to parameters"
+                raise EvaluationException(
+                    message="ground_truth tuple second element must be a dictionary mapping tool names to parameters",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 )
 
             # Validate that all values in params_dict are dictionaries with string keys and values
             for tool_name, params in params_dict.items():
                 if not isinstance(tool_name, str):
-                    raise TypeError("ground_truth parameters dictionary keys must be strings (tool names)")
+                    raise EvaluationException(
+                        message="ground_truth parameters dictionary keys must be strings (tool names)",
+                        blame=ErrorBlame.USER_ERROR,
+                        category=ErrorCategory.INVALID_VALUE,
+                        target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                    )
                 if not isinstance(params, dict):
-                    raise TypeError(f"ground_truth parameters for tool '{tool_name}' must be a dictionary")
+                    raise EvaluationException(
+                        message=f"ground_truth parameters for tool '{tool_name}' must be a dictionary",
+                        blame=ErrorBlame.USER_ERROR,
+                        category=ErrorCategory.INVALID_VALUE,
+                        target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                    )
                 for k, v in params.items():
                     if not isinstance(k, str):
-                        raise TypeError(f"ground_truth parameters for tool '{tool_name}' must have string keys")
+                        raise EvaluationException(
+                            message=f"ground_truth parameters for tool '{tool_name}' must have string keys",
+                            blame=ErrorBlame.USER_ERROR,
+                            category=ErrorCategory.INVALID_VALUE,
+                            target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                        )
                     try:
                         json.dumps(v)
                     except (TypeError, ValueError):
-                        raise TypeError(
-                            f"ground_truth parameters for tool '{tool_name}' must have JSON-serializable values (got type {type(v)} for key '{k}')"
+                        raise EvaluationException(
+                            message=f"ground_truth parameters for tool '{tool_name}' must have JSON-serializable values (got type {type(v)} for key '{k}')",
+                            blame=ErrorBlame.USER_ERROR,
+                            category=ErrorCategory.INVALID_VALUE,
+                            target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                         )
 
             ground_truth_names = [name.strip() for name in tool_names_list]
@@ -349,8 +385,11 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             ground_truth_names = [step.strip() for step in ground_truth]
             use_parameter_matching = False
         else:
-            raise TypeError(
-                "ground_truth must be a list of strings or a tuple of (list[str], dict[str, dict[str, str]])"
+            raise EvaluationException(
+                message="ground_truth must be a list of strings or a tuple of (list[str], dict[str, dict[str, str]])",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
             )
 
         # Extract tool information from the response
@@ -393,6 +432,7 @@ class _TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                 internal_message=str(self.matching_mode),
                 target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
     @overload

--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_exceptions.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_exceptions.py
@@ -104,6 +104,9 @@ class ErrorTarget(Enum):
     AOAI_GRADER = "AoaiGrader"
     CONVERSATION_HISTORY_PARSING = "_get_conversation_history"
     TOOL_OUTPUT_UTILIZATION_EVALUATOR = "ToolOutputUtilizationEvaluator"
+    QA_EVALUATOR = "QAEvaluator"
+    ROUGE_EVALUATOR = "RougeScoreEvaluator"
+    DOCUMENT_RETRIEVAL_EVALUATOR = "DocumentRetrievalEvaluator"
 
 
 class EvaluationException(AzureError):

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_defect_rate.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_content_safety_defect_rate.py
@@ -6,6 +6,7 @@ import pytest
 
 from azure.ai.evaluation import ContentSafetyEvaluator
 from azure.ai.evaluation._evaluate._evaluate import _aggregate_metrics
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 
 def _get_file(name):
@@ -23,3 +24,22 @@ class TestContentSafetyDefectRate:
         metrics = _aggregate_metrics(df, {"content_safety": ContentSafetyEvaluator})
 
         assert metrics["content_safety.hate_unfairness_defect_rate"] == 0.33
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"violence_threshold": 0.5},
+            {"sexual_threshold": "3"},
+            {"self_harm_threshold": None},
+            {"hate_unfairness_threshold": [3]},
+        ],
+    )
+    def test_invalid_threshold_type_error_metadata(self, kwargs):
+        """Test that a non-int threshold raises EvaluationException with correct metadata."""
+        with pytest.raises(EvaluationException) as exc_info:
+            ContentSafetyEvaluator(credential=None, azure_ai_project=None, **kwargs)  # type: ignore
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.CONTENT_SAFETY_CHAT_EVALUATOR

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_document_retrieval_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_document_retrieval_evaluator.py
@@ -427,6 +427,4 @@ def test_missing_threshold_error_metadata():
     with pytest.raises(EvaluationException) as exc_info:
         evaluator._get_binary_result(unknown_metric=1.0)
 
-    _assert_exception_metadata(
-        exc_info.value, category=ErrorCategory.FAILED_EXECUTION, blame=ErrorBlame.SYSTEM_ERROR
-    )
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.FAILED_EXECUTION, blame=ErrorBlame.SYSTEM_ERROR)

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_document_retrieval_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_document_retrieval_evaluator.py
@@ -7,12 +7,14 @@ import json
 import pathlib
 import random
 from azure.ai.evaluation import evaluate
-from azure.ai.evaluation._exceptions import EvaluationException
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 from azure.ai.evaluation._evaluators._document_retrieval import (
     DocumentRetrievalEvaluator,
     RetrievalGroundTruthDocument,
     RetrievedDocument,
 )
+
+random.seed(42)
 
 
 def _get_file(name):
@@ -288,3 +290,143 @@ def test_no_labeled_retrieved_documents():
     properties = result["document_retrieval_properties"]
     assert properties["ndcg@3"] == 0
     assert properties["holes"] == len(retrieved_docs)
+
+
+def _assert_exception_metadata(exc, *, category, blame=ErrorBlame.USER_ERROR):
+    """Assert that an EvaluationException has the expected blame, category, and target populated."""
+    assert exc.blame == blame
+    assert exc.category == category
+    assert exc.target == ErrorTarget.DOCUMENT_RETRIEVAL_EVALUATOR
+
+
+def test_init_label_min_not_int_error_metadata():
+    with pytest.raises(EvaluationException) as exc_info:
+        DocumentRetrievalEvaluator(ground_truth_label_min=0.5, ground_truth_label_max=4)  # type: ignore
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_init_label_max_not_int_error_metadata():
+    with pytest.raises(EvaluationException) as exc_info:
+        DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=4.5)  # type: ignore
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_init_label_min_gte_max_error_metadata():
+    with pytest.raises(EvaluationException) as exc_info:
+        DocumentRetrievalEvaluator(ground_truth_label_min=2, ground_truth_label_max=1)
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_empty_ground_truth_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(retrieval_ground_truth=[], retrieved_documents=[])
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.MISSING_FIELD)
+
+
+def test_missing_ground_truth_fields_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0"}],
+            retrieved_documents=[{"document_id": "doc_0", "relevance_score": 1.0}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.MISSING_FIELD)
+
+
+def test_non_integer_query_relevance_label_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0", "query_relevance_label": 1.5}],
+            retrieved_documents=[{"document_id": "doc_0", "relevance_score": 1.0}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_query_relevance_label_below_min_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=1, ground_truth_label_max=4)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0", "query_relevance_label": 0}],
+            retrieved_documents=[{"document_id": "doc_0", "relevance_score": 1.0}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_query_relevance_label_above_max_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0", "query_relevance_label": 5}],
+            retrieved_documents=[{"document_id": "doc_0", "relevance_score": 1.0}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_missing_retrieved_document_fields_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0", "query_relevance_label": 1}],
+            retrieved_documents=[{"document_id": "doc_0"}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.MISSING_FIELD)
+
+
+def test_non_numeric_relevance_score_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(
+            retrieval_ground_truth=[{"document_id": "doc_0", "query_relevance_label": 1}],
+            retrieved_documents=[{"document_id": "doc_0", "relevance_score": "not-a-number"}],
+        )
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_too_many_documents_error_metadata():
+    groundtruth_docs = [
+        RetrievalGroundTruthDocument(
+            {"document_id": f"doc_{x}", "query_relevance_label": random.choice([0, 1, 2, 3, 4])}
+        )
+        for x in range(0, 10001)
+    ]
+    retrieved_docs = [
+        RetrievedDocument({"document_id": f"doc_{x}", "relevance_score": random.uniform(-10, 10)})
+        for x in range(0, 10001)
+    ]
+
+    evaluator = DocumentRetrievalEvaluator()
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator(retrieval_ground_truth=groundtruth_docs, retrieved_documents=retrieved_docs)
+
+    _assert_exception_metadata(exc_info.value, category=ErrorCategory.INVALID_VALUE)
+
+
+def test_missing_threshold_error_metadata():
+    evaluator = DocumentRetrievalEvaluator(ground_truth_label_min=0, ground_truth_label_max=2)
+
+    with pytest.raises(EvaluationException) as exc_info:
+        evaluator._get_binary_result(unknown_metric=1.0)
+
+    _assert_exception_metadata(
+        exc_info.value, category=ErrorCategory.FAILED_EXECUTION, blame=ErrorBlame.SYSTEM_ERROR
+    )

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluators/test_threshold_behavior.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_evaluators/test_threshold_behavior.py
@@ -11,6 +11,7 @@ from azure.ai.evaluation._evaluators._rouge._rouge import RougeScoreEvaluator, R
 from azure.ai.evaluation._evaluators._gleu._gleu import GleuScoreEvaluator
 from azure.ai.evaluation._evaluators._meteor._meteor import MeteorScoreEvaluator
 from azure.ai.evaluation._evaluators._f1_score._f1_score import F1ScoreEvaluator
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 
 @pytest.mark.unittest
@@ -202,6 +203,24 @@ class TestRougeThresholdBehavior:
         assert mock_result["rouge_precision_result"] == EVALUATION_PASS_FAIL_MAPPING[True]
         assert mock_result["rouge_recall_result"] == EVALUATION_PASS_FAIL_MAPPING[True]
         assert mock_result["rouge_f1_score_result"] == EVALUATION_PASS_FAIL_MAPPING[True]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"precision_threshold": 1},
+            {"recall_threshold": "0.5"},
+            {"f1_score_threshold": None},
+        ],
+    )
+    def test_rouge_invalid_threshold_type_error_metadata(self, kwargs):
+        """Test that a non-float threshold raises EvaluationException with correct metadata."""
+        with pytest.raises(EvaluationException) as exc_info:
+            RougeScoreEvaluator(rouge_type=RougeType.ROUGE_L, **kwargs)  # type: ignore
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.ROUGE_EVALUATOR
 
 
 @pytest.mark.unittest

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_qa_evaluator.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_qa_evaluator.py
@@ -1,5 +1,6 @@
 import pytest
 from azure.ai.evaluation import QAEvaluator
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 
 @pytest.mark.usefixtures("mock_model_config")
@@ -27,3 +28,13 @@ class TestQAEvaluator:
                 assert (
                     evaluator._is_reasoning_model is False
                 ), f"{type(evaluator).__name__} did not default to is_reasoning_model=False"
+
+    def test_invalid_threshold_type_error_metadata(self, mock_model_config):
+        """Test that an invalid threshold type raises EvaluationException with correct metadata."""
+        with pytest.raises(EvaluationException) as exc_info:
+            QAEvaluator(model_config=mock_model_config, groundedness_threshold="not-a-number")  # type: ignore
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.QA_EVALUATOR

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_task_navigation_efficiency_evaluators.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_task_navigation_efficiency_evaluators.py
@@ -5,7 +5,7 @@ from azure.ai.evaluation._evaluators._task_navigation_efficiency import (
     _TaskNavigationEfficiencyEvaluator,
     _TaskNavigationEfficiencyMatchingMode,
 )
-from azure.ai.evaluation._exceptions import EvaluationException
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 
 @pytest.mark.unittest
@@ -404,6 +404,64 @@ class TestTaskNavigationEfficiencyEvaluator:
         # Test invalid type for mode
         with pytest.raises(EvaluationException):
             _TaskNavigationEfficiencyEvaluator(matching_mode=123)  # type: ignore
+
+    def test_matching_mode_validation_error_metadata(self):
+        """Test that invalid matching_mode raises EvaluationException with correct metadata."""
+        # Invalid string mode
+        with pytest.raises(EvaluationException) as exc_info:
+            _TaskNavigationEfficiencyEvaluator(matching_mode="invalid_mode")
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR
+
+        # Invalid type for mode
+        with pytest.raises(EvaluationException) as exc_info:
+            _TaskNavigationEfficiencyEvaluator(matching_mode=123)  # type: ignore
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR
+
+    def test_empty_ground_truth_error_metadata(self):
+        """Test that empty ground_truth raises EvaluationException with correct metadata."""
+        evaluator = _TaskNavigationEfficiencyEvaluator(matching_mode=_TaskNavigationEfficiencyMatchingMode.EXACT_MATCH)
+
+        response = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_call", "tool_call_id": "call_1", "name": "search", "arguments": {}}],
+            },
+        ]
+
+        with pytest.raises(EvaluationException) as exc_info:
+            evaluator(response=response, ground_truth=[])
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR
+
+    def test_invalid_ground_truth_type_error_metadata(self):
+        """Test that an invalid ground_truth type raises EvaluationException with correct metadata."""
+        evaluator = _TaskNavigationEfficiencyEvaluator(matching_mode=_TaskNavigationEfficiencyMatchingMode.EXACT_MATCH)
+
+        response = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_call", "tool_call_id": "call_1", "name": "search", "arguments": {}}],
+            },
+        ]
+
+        with pytest.raises(EvaluationException) as exc_info:
+            evaluator(response=response, ground_truth="not-a-valid-ground-truth")  # type: ignore
+
+        exc = exc_info.value
+        assert exc.blame == ErrorBlame.USER_ERROR
+        assert exc.category == ErrorCategory.INVALID_VALUE
+        assert exc.target == ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR
 
     # ==================== ALIAS INPUT NORMALIZATION TESTS ====================
 

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_task_navigation_efficiency_evaluators.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_task_navigation_efficiency_evaluators.py
@@ -398,11 +398,11 @@ class TestTaskNavigationEfficiencyEvaluator:
         assert evaluator2.matching_mode == _TaskNavigationEfficiencyMatchingMode.IN_ORDER_MATCH
 
         # Test invalid string mode
-        with pytest.raises(ValueError):
+        with pytest.raises(EvaluationException):
             _TaskNavigationEfficiencyEvaluator(matching_mode="invalid_mode")
 
         # Test invalid type for mode
-        with pytest.raises(Exception):  # EvaluationException
+        with pytest.raises(EvaluationException):
             _TaskNavigationEfficiencyEvaluator(matching_mode=123)  # type: ignore
 
     # ==================== ALIAS INPUT NORMALIZATION TESTS ====================


### PR DESCRIPTION
## Summary

Normalizes evaluation/validation error handling in `azure-ai-evaluation` so that **user input and configuration errors are consistently raised as `EvaluationException` with `blame=ErrorBlame.USER_ERROR`** (plus an appropriate `category` and `target`).

Previously several evaluators raised bare `ValueError`/`TypeError` for input/threshold validation, and a few existing `EvaluationException` raises did not set `blame`, so they defaulted to `Unknown`/`InternalError` even though they were caused by user input.

## Changes

**Raw `ValueError`/`TypeError` → `EvaluationException(USER_ERROR)`**
- `ContentSafetyEvaluator` — threshold type check
- `QAEvaluator` — threshold type check
- `RougeScoreEvaluator` — threshold type check
- `DocumentRetrievalEvaluator` — ground-truth label and input-record validation
- Task navigation efficiency evaluator — `matching_mode` and `ground_truth` validation

**Existing `EvaluationException` missing `USER_ERROR`**
- Evaluator base (`_base_eval.py`) — conversation message mismatch, malformed tool-call parsing, and threshold-not-a-number checks now set `blame=USER_ERROR` (one `category=UNKNOWN` corrected to `INVALID_VALUE`)

**Supporting**
- Added `QA_EVALUATOR`, `ROUGE_EVALUATOR`, and `DOCUMENT_RETRIEVAL_EVALUATOR` members to `ErrorTarget`
- Updated the task navigation test to expect `EvaluationException` for an invalid `matching_mode`
- CHANGELOG entry under 1.17.1 (Unreleased)

## Intentionally left unchanged (not user errors)

- "Evaluator returned invalid output" / "Invalid score value" across the prompty and tool evaluators remain `SYSTEM_ERROR` (malformed LLM output, not user input).
- Internal/defensive checks (`_conversation_aggregators.py` `UNKNOWN`, `_base_rai_svc_eval.py` "Not implemented") are unchanged.

## Validation

- All affected unit tests pass (document retrieval, task navigation, threshold behavior, common validators, built-in & agent evaluators).
- `black` (pinned 24.4.0, repo config) passes on all modified files.
