### PR TITLE
Fix pylint 4.0.4 linting errors in azure-ai-contentsafety

### DIFF
--- a/sdk/contentsafety/azure-ai-contentsafety/samples/sample_manage_blocklist.py
+++ b/sdk/contentsafety/azure-ai-contentsafety/samples/sample_manage_blocklist.py
@@ -71,7 +71,8 @@ def add_block_items():
         )
         for block_item in result.blocklist_items:
             print(
-                f"BlockItemId: {block_item.blocklist_item_id}, Text: {block_item.text}, Description: {block_item.description}"
+                f"BlockItemId: {block_item.blocklist_item_id}, Text: {block_item.text}, "
+                f"Description: {block_item.description}"
             )
     except HttpResponseError as e:
         print("\nAdd block items failed: ")
@@ -104,7 +105,8 @@ def analyze_text_with_blocklists():
     input_text = "I h*te you and I want to k*ll you."
 
     try:
-        # After you edit your blocklist, it usually takes effect in 5 minutes, please wait some time before analyzing with blocklist after editing.
+        # After you edit your blocklist, it usually takes effect in 5 minutes,
+        # please wait some time before analyzing with blocklist after editing.
         analysis_result = client.analyze_text(
             AnalyzeTextOptions(text=input_text, blocklist_names=[blocklist_name], halt_on_blocklist_hit=False)
         )
@@ -261,7 +263,8 @@ def get_block_item():
         block_item = client.get_text_blocklist_item(blocklist_name=blocklist_name, blocklist_item_id=block_item_id)
         print("\nGet blockitem: ")
         print(
-            f"BlockItemId: {block_item.blocklist_item_id}, Text: {block_item.text}, Description: {block_item.description}"
+            f"BlockItemId: {block_item.blocklist_item_id}, Text: {block_item.text}, "
+            f"Description: {block_item.description}"
         )
     except HttpResponseError as e:
         print("\nGet block item failed: ")

--- a/sdk/contentsafety/azure-ai-contentsafety/tests/test_blocklist.py
+++ b/sdk/contentsafety/azure-ai-contentsafety/tests/test_blocklist.py
@@ -4,16 +4,16 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-from azure.core.exceptions import HttpResponseError
 from devtools_testutils import recorded_by_proxy
+from test_case import ContentSafetyTest, ContentSafetyPreparer
 
 from azure.ai.contentsafety.models import (
-    TextBlocklist,
-    TextBlocklistItem,
     AddOrUpdateTextBlocklistItemsOptions,
     RemoveTextBlocklistItemsOptions,
+    TextBlocklist,
+    TextBlocklistItem,
 )
-from test_case import ContentSafetyTest, ContentSafetyPreparer
+from azure.core.exceptions import HttpResponseError
 
 
 class TestBlocklistCase(ContentSafetyTest):

--- a/sdk/contentsafety/azure-ai-contentsafety/tests/test_case.py
+++ b/sdk/contentsafety/azure-ai-contentsafety/tests/test_case.py
@@ -5,10 +5,10 @@
 # ------------------------------------
 import functools
 
-from azure.core.credentials import AzureKeyCredential
 from devtools_testutils import AzureRecordedTestCase, is_live, FakeTokenCredential, EnvironmentVariableLoader
 
-from azure.ai.contentsafety import ContentSafetyClient, BlocklistClient
+from azure.ai.contentsafety import BlocklistClient, ContentSafetyClient
+from azure.core.credentials import AzureKeyCredential
 
 
 class ContentSafetyTest(AzureRecordedTestCase):

--- a/sdk/contentsafety/azure-ai-contentsafety/tests/test_content_safety.py
+++ b/sdk/contentsafety/azure-ai-contentsafety/tests/test_content_safety.py
@@ -7,17 +7,17 @@
 import os
 
 from devtools_testutils import recorded_by_proxy
+from test_case import ContentSafetyTest, ContentSafetyPreparer
 
 from azure.ai.contentsafety.models import (
+    AddOrUpdateTextBlocklistItemsOptions,
+    AnalyzeImageOptions,
     AnalyzeTextOptions,
     ImageData,
-    AnalyzeImageOptions,
-    TextCategory,
     TextBlocklist,
     TextBlocklistItem,
-    AddOrUpdateTextBlocklistItemsOptions,
+    TextCategory,
 )
-from test_case import ContentSafetyTest, ContentSafetyPreparer
 
 
 class TestContentSafetyCase(ContentSafetyTest):


### PR DESCRIPTION
## Summary
Fix pylint errors in `azure-ai-contentsafety` for the upcoming pylint 4.0.4 upgrade (deadline: 2026-07-13).

### Changes
- **tests/test_blocklist.py**: Fix import order — place third-party imports (`devtools_testutils`, `test_case`) before first-party imports (`azure.*`). Group `azure` imports together. (C0411, C0412)
- **tests/test_case.py**: Fix import order — place third-party imports before first-party imports. Group `azure` imports together. (C0411, C0412)
- **tests/test_content_safety.py**: Fix import order — place third-party imports before first-party imports. (C0411)
- **samples/sample_manage_blocklist.py**: Break 3 lines exceeding 120-char limit into multiple lines. (C0301)

Fixes #33222

🤖 Generated with [Claude Code](https://claude.com/claude-code)