### PR TITLE
Fix misleading application_properties docstring for received messages

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -66,7 +66,10 @@ class ServiceBusMessage(object):  # pylint: disable=too-many-instance-attributes
     :type body: Optional[Union[str, bytes]]
 
     :keyword application_properties: The user defined properties on the message.
-    :paramtype application_properties: Dict[str, Union[int or float or bool or
+     When sending, string keys are accepted. When receiving, application property keys and string values
+     are returned as bytes due to the underlying AMQP protocol. Use bytes keys to access properties
+     on received messages, e.g., ``message.application_properties[b"my_key"]``.
+    :paramtype application_properties: Dict[str or bytes, Union[int or float or bool or
      bytes or str or uuid.UUID or datetime or None]]
     :keyword Optional[str] session_id: The session identifier of the message for a sessionful entity.
     :keyword Optional[str] message_id: The id to identify the message.
@@ -288,6 +291,12 @@ class ServiceBusMessage(object):  # pylint: disable=too-many-instance-attributes
     @property
     def application_properties(self) -> Optional[Dict[Union[str, bytes], PrimitiveTypes]]:
         """The user defined properties on the message.
+
+        .. note::
+            When receiving messages, application property keys and string values are returned
+            as bytes, not strings, due to the underlying AMQP protocol. Use bytes keys to access
+            properties on received messages:
+            ``message.application_properties.get(b"my_key")``
 
         :rtype: dict[str or bytes, PrimitiveTypes] or None
         """


### PR DESCRIPTION
## Summary

- Update the `application_properties` constructor docstring to clarify that keys can be `str or bytes`, not just `str`
- Add a `.. note::` block to the `application_properties` property docstring explaining that received messages return bytes keys and string values as bytes due to the AMQP protocol
- Provide usage example: `message.application_properties.get(b"my_key")`

## Problem

The current documentation specifies `Dict[str, ...]` for `application_properties`, but when receiving messages, the AMQP layer returns keys and string values as bytes. This causes users to get unexpected `None` when accessing properties with string keys:

```python
# Sending (string keys work)
message.application_properties = {"order_id": "12345"}

# Receiving (bytes keys returned)
props = received.application_properties
props.get("order_id")    # Returns None (unexpected!)
props.get(b"order_id")   # Returns b"12345" (actual behavior)
```

The SDK's own tests already use bytes keys (e.g., `test_message.py` line 884), confirming this is known behavior that needs documentation.

## Test Plan

- [ ] No functional changes — documentation-only fix
- [ ] Verified the docstring renders correctly with Sphinx `.. note::` directive

Fixes #45082

🤖 Generated with [Claude Code](https://claude.com/claude-code)