### PR TITLE
Update multipart file type variant tests

### DIFF
--- a/sdk/ai/azure-ai-projects/tests/models/test_models.py
+++ b/sdk/ai/azure-ai-projects/tests/models/test_models.py
@@ -91,7 +91,7 @@ class TestModels(TestBase):
             creds = project_client.beta.models.get_credentials(
                 name=model_name,
                 version=model_version,
-                body=ModelCredentialRequest(blob_uri=registered.blob_uri),
+                credential_request=ModelCredentialRequest(blob_uri=registered.blob_uri),
             )
             blob_ref = getattr(creds, "blob_reference_for_consumption", None) or getattr(creds, "blob_reference", None)
             assert blob_ref is not None, f"no blob reference in credentials response: {creds!r}"
@@ -129,7 +129,7 @@ class TestModels(TestBase):
             pending = project_client.beta.models.pending_upload(
                 name=model_name,
                 version=model_version,
-                body=ModelPendingUploadRequest(
+                pending_upload_request=ModelPendingUploadRequest(
                     pending_upload_type=PendingUploadType.TEMPORARY_BLOB_REFERENCE,
                 ),
             )

--- a/sdk/ai/azure-ai-projects/tests/models/test_multipart_filetype_variants.py
+++ b/sdk/ai/azure-ai-projects/tests/models/test_multipart_filetype_variants.py
@@ -39,7 +39,7 @@ def _read(value):
 def _canonicalize(prepared):
     """Reduce the helper's output to ``(field, filename, content_bytes, content_type)``.
 
-    ``content_type`` defaults to ``"application/zip"`` so that 2-tuple and
+    ``content_type`` defaults to ``"application/octet-stream"`` so that 2-tuple and
     3-tuple variants compare equal when the caller relied on the default.
     """
     assert len(prepared) == 1, f"expected a single multipart entry, got {prepared!r}"
@@ -47,10 +47,10 @@ def _canonicalize(prepared):
     assert isinstance(entry, tuple), f"helper must wrap entry as a tuple, got {entry!r}"
     if len(entry) == 2:
         filename, content = entry
-        content_type = "application/zip"
+        content_type = "application/octet-stream"
     elif len(entry) == 3:
         filename, content, content_type = entry
-        content_type = content_type or "application/zip"
+        content_type = content_type or "application/octet-stream"
     else:
         raise AssertionError(f"unexpected tuple arity: {entry!r}")
     return (field, filename, _read(content), content_type)
@@ -67,7 +67,7 @@ def _variants(tmp_path):
     yield ("IO[bytes] (from open)", [_variant_io_bytes(tmp_path)])
     yield ("(filename, bytes)", [(FILENAME, CONTENT)])
     yield ("(filename, IO[bytes])", [(FILENAME, io.BytesIO(CONTENT))])
-    yield ("(filename, bytes, content_type)", [(FILENAME, CONTENT, "application/zip")])
+    yield ("(filename, bytes, content_type)", [(FILENAME, CONTENT, "application/octet-stream")])
 
 
 def test_filetype_variants_produce_equivalent_request_body(tmp_path):
@@ -77,7 +77,7 @@ def test_filetype_variants_produce_equivalent_request_body(tmp_path):
         prepared = prepare_multipart_form_data({"files": files_value}, ["files"], [])
         canonical_by_variant[label] = _canonicalize(prepared)
 
-    expected = (FIELD, FILENAME, CONTENT, "application/zip")
+    expected = (FIELD, FILENAME, CONTENT, "application/octet-stream")
     for label, canonical in canonical_by_variant.items():
         assert canonical == expected, f"variant {label!r} produced {canonical!r}, expected {expected!r}"
 
@@ -88,7 +88,7 @@ def test_filetype_variants_produce_equivalent_request_body(tmp_path):
         ("IO[bytes] (from open)", lambda tmp_path: [_variant_io_bytes(tmp_path)]),
         ("(filename, bytes)", lambda _tmp_path: [(FILENAME, CONTENT)]),
         ("(filename, IO[bytes])", lambda _tmp_path: [(FILENAME, io.BytesIO(CONTENT))]),
-        ("(filename, bytes, content_type)", lambda _tmp_path: [(FILENAME, CONTENT, "application/zip")]),
+        ("(filename, bytes, content_type)", lambda _tmp_path: [(FILENAME, CONTENT, "application/octet-stream")]),
     ],
 )
 def test_filetype_variant_normalized_entry(tmp_path, label, files_value_factory):

--- a/sdk/ai/azure-ai-projects/tests/models/test_multipart_filetype_variants.py
+++ b/sdk/ai/azure-ai-projects/tests/models/test_multipart_filetype_variants.py
@@ -22,6 +22,7 @@ from azure.ai.projects._utils.utils import prepare_multipart_form_data
 FILENAME = "canvas-design.zip"
 CONTENT = b"PK\x03\x04 fake zip body"
 FIELD = "files"
+CONTENT_TYPE = "application/octet-stream"
 
 
 def _read(value):
@@ -39,7 +40,7 @@ def _read(value):
 def _canonicalize(prepared):
     """Reduce the helper's output to ``(field, filename, content_bytes, content_type)``.
 
-    ``content_type`` defaults to ``"application/octet-stream"`` so that 2-tuple and
+    ``content_type`` defaults to ``CONTENT_TYPE`` so that 2-tuple and
     3-tuple variants compare equal when the caller relied on the default.
     """
     assert len(prepared) == 1, f"expected a single multipart entry, got {prepared!r}"
@@ -47,10 +48,10 @@ def _canonicalize(prepared):
     assert isinstance(entry, tuple), f"helper must wrap entry as a tuple, got {entry!r}"
     if len(entry) == 2:
         filename, content = entry
-        content_type = "application/octet-stream"
+        content_type = CONTENT_TYPE
     elif len(entry) == 3:
         filename, content, content_type = entry
-        content_type = content_type or "application/octet-stream"
+        content_type = content_type or CONTENT_TYPE
     else:
         raise AssertionError(f"unexpected tuple arity: {entry!r}")
     return (field, filename, _read(content), content_type)
@@ -67,7 +68,7 @@ def _variants(tmp_path):
     yield ("IO[bytes] (from open)", [_variant_io_bytes(tmp_path)])
     yield ("(filename, bytes)", [(FILENAME, CONTENT)])
     yield ("(filename, IO[bytes])", [(FILENAME, io.BytesIO(CONTENT))])
-    yield ("(filename, bytes, content_type)", [(FILENAME, CONTENT, "application/octet-stream")])
+    yield ("(filename, bytes, content_type)", [(FILENAME, CONTENT, CONTENT_TYPE)])
 
 
 def test_filetype_variants_produce_equivalent_request_body(tmp_path):
@@ -77,7 +78,7 @@ def test_filetype_variants_produce_equivalent_request_body(tmp_path):
         prepared = prepare_multipart_form_data({"files": files_value}, ["files"], [])
         canonical_by_variant[label] = _canonicalize(prepared)
 
-    expected = (FIELD, FILENAME, CONTENT, "application/octet-stream")
+    expected = (FIELD, FILENAME, CONTENT, CONTENT_TYPE)
     for label, canonical in canonical_by_variant.items():
         assert canonical == expected, f"variant {label!r} produced {canonical!r}, expected {expected!r}"
 
@@ -88,17 +89,18 @@ def test_filetype_variants_produce_equivalent_request_body(tmp_path):
         ("IO[bytes] (from open)", lambda tmp_path: [_variant_io_bytes(tmp_path)]),
         ("(filename, bytes)", lambda _tmp_path: [(FILENAME, CONTENT)]),
         ("(filename, IO[bytes])", lambda _tmp_path: [(FILENAME, io.BytesIO(CONTENT))]),
-        ("(filename, bytes, content_type)", lambda _tmp_path: [(FILENAME, CONTENT, "application/octet-stream")]),
+        ("(filename, bytes, content_type)", lambda _tmp_path: [(FILENAME, CONTENT, CONTENT_TYPE)]),
     ],
 )
 def test_filetype_variant_normalized_entry(tmp_path, label, files_value_factory):
     """Per-variant sanity: the helper emits a single ``files`` part with the
     expected filename and content."""
     prepared = prepare_multipart_form_data({"files": files_value_factory(tmp_path)}, ["files"], [])
-    field, filename, content, _content_type = _canonicalize(prepared)
+    field, filename, content, content_type = _canonicalize(prepared)
     assert field == FIELD, label
     assert filename == FILENAME, label
     assert content == CONTENT, label
+    assert content_type == CONTENT_TYPE, label
 
 
 def test_data_field_precedes_file_parts(tmp_path):


### PR DESCRIPTION
The method `_normalize_multipart_file_entry` in `azure\ai\projects\_utils\utils.py` now uses "application/octet-stream" as the content type default, as seen here: https://github.com/Azure/azure-sdk-for-python/blob/feature/azure-ai-projects/2.3.0/sdk/ai/azure-ai-projects/azure/ai/projects/_utils/utils.py#L66 . This is a result of an emitter change. There was no default before (see this commit, which added this new default following using new emitter: https://github.com/Azure/azure-sdk-for-python/commit/7f2a28c4291b33b4f5d7980c841b187c961e3634#diff-956744d63fbe9ee2ad5d51c6959f9f17f7d173656de8fabad16753ce7fe156cfR66 )

Update unit-tests to reflect that change in default value.


This was the original CoPilot comment in the PR: https://github.com/Azure/azure-sdk-for-python/pull/47500
This helper now injects an explicit content-type ("application/octet-stream") when normalizing bare file values, which changes the normalized multipart tuples produced by prepare_multipart_form_data. The offline unit tests in tests/models/test_multipart_filetype_variants.py currently assume that variants normalize to an equivalent representation when the caller did not explicitly provide a content-type; with this change they will need to be updated accordingly (e.g., update the expected/default content-type and/or the explicit content-type variant).
