### PR TITLE
Remove link verification from ci job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -236,16 +236,6 @@ jobs:
       parameters:
         ContinueOnError: false
 
-    - template: /eng/common/pipelines/templates/steps/verify-links.yml
-      parameters:
-        ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-          Directory: ''
-          Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-          Directory: sdk/${{ parameters.ServiceDirectory }}
-        CheckLinkGuidance: $true
-        Condition: succeededOrFailed()
-
     - task: DownloadPipelineArtifact@2
       condition: succeededOrFailed()
       inputs:


### PR DESCRIPTION
This pull request removes the link verification step from the CI pipeline configuration. The `verify-links.yml` template, which checked for valid links in markdown files, will no longer run as part of the pipeline.

Pipeline configuration changes:

* Removed the inclusion of the `verify-links.yml` template step from the CI pipeline, eliminating automated link verification for markdown files during CI runs.