### PR TITLE
Don't use sparse chekout for private repos

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -88,29 +88,11 @@ jobs:
 
     - ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
       - checkout: self
-        displayName: 'Sparse checkout eng/common/scripts for GitHub login'
-        path: s/_login_scripts
-        sparseCheckoutDirectories: eng/common/scripts
-        fetchDepth: 1
-  
-      - pwsh: |
-          $source = "$(Build.SourcesDirectory)/_login_scripts/eng"
-          $dest = "$(Agent.TempDirectory)"
-          Copy-Item -Recurse -Force $source $dest
-          Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/*" -ErrorAction SilentlyContinue
-          Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/.git" -ErrorAction SilentlyContinue
-        displayName: Copy and clean repo checkout folder
-      
-      - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    - ${{ else }}:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
-          ScriptDirectory: "$(Agent.TempDirectory)/eng/common/scripts"
-
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
-        ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
-          TokenToUseForAuth: $(GH_TOKEN)
-        Paths:
-          - '**'
+          Paths:
+            - '**'
 
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -142,12 +142,13 @@ jobs:
       os: linux
 
     steps:
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
-        ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
-          TokenToUseForAuth: $(azuresdk-github-pat)
-        Paths:
-          - '**'
+    - ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
+      - checkout: self
+    - ${{ else }}:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          Paths:
+            - '**'
 
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 
@@ -181,12 +182,13 @@ jobs:
       os: linux
 
     steps:
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
-        ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
-          TokenToUseForAuth: $(azuresdk-github-pat)
-        Paths:
-          - '**'
+    - ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
+      - checkout: self
+    - ${{ else }}:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          Paths:
+            - '**'
 
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml
 

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -109,29 +109,11 @@ jobs:
     steps:
       - ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
         - checkout: self
-          displayName: 'Sparse checkout eng/common/scripts for GitHub login'
-          path: s/_login_scripts
-          sparseCheckoutDirectories: eng/common/scripts
-          fetchDepth: 1
-    
-        - pwsh: |
-            $source = "$(Build.SourcesDirectory)/_login_scripts/eng"
-            $dest = "$(Agent.TempDirectory)"
-            Copy-Item -Recurse -Force $source $dest
-            Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/*" -ErrorAction SilentlyContinue
-            Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/.git" -ErrorAction SilentlyContinue
-          displayName: Copy and clean repo checkout folder
-        
-        - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+      - ${{ else }}:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
-            ScriptDirectory: "$(Agent.TempDirectory)/eng/common/scripts"
-
-      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-        parameters:
-          ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
-            TokenToUseForAuth: $(GH_TOKEN)
-          Paths:
-            - '**'
+            Paths:
+              - '**'
 
       - ${{ parameters.PreSteps }}
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -27,29 +27,11 @@ parameters:
 steps:
   - ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
     - checkout: self
-      displayName: 'Sparse checkout eng/common/scripts for GitHub login'
-      path: s/_login_scripts
-      sparseCheckoutDirectories: eng/common/scripts
-      fetchDepth: 1
-
-    - pwsh: |
-        $source = "$(Build.SourcesDirectory)/_login_scripts/eng"
-        $dest = "$(Agent.TempDirectory)"
-        Copy-Item -Recurse -Force $source $dest
-        Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/*" -ErrorAction SilentlyContinue
-        Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/.git" -ErrorAction SilentlyContinue
-      displayName: Copy and clean repo checkout folder
-    
-    - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+  - ${{ else }}:
+    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
       parameters:
-        ScriptDirectory: "$(Agent.TempDirectory)/eng/common/scripts"
-
-  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-    parameters:
-      ${{ if endsWith(variables['Build.Repository.Name'], '-pr') }}:
-        TokenToUseForAuth: $(GH_TOKEN)
-      Paths:
-        - '**'
+        Paths:
+          - '**'
 
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'


### PR DESCRIPTION
This pull request simplifies the Azure DevOps pipeline templates by removing custom sparse checkout and GitHub login steps for pull request builds. Instead, it now relies on a unified approach using the existing `sparse-checkout.yml` template for non-PR builds, reducing duplication and complexity in the pipeline configuration.

**Pipeline simplification and cleanup:**

* Removed custom PowerShell steps and manual sparse checkout logic for PR builds in `ci.tests.yml`, `live.tests.yml`, and `build-package-artifacts.yml`, including copying scripts and cleaning the checkout folder. [[1]](diffhunk://#diff-9a817977293f806ff99e282fb84005c9d7d96a314a112fd977f42685fec32edaL91-L111) [[2]](diffhunk://#diff-0ea764226e5dbbb822624683595ddec3033905225c0290d45dcf2c514f677373L112-L132) [[3]](diffhunk://#diff-7bcc194306293552e9a915d90831f1338d2e5d86ffd42a6d0009394c49a85be8L30-L50)
* Eliminated the use of the `login-to-github.yml` template and associated script directory parameter for PR builds, further streamlining the pipeline steps. [[1]](diffhunk://#diff-9a817977293f806ff99e282fb84005c9d7d96a314a112fd977f42685fec32edaL91-L111) [[2]](diffhunk://#diff-0ea764226e5dbbb822624683595ddec3033905225c0290d45dcf2c514f677373L112-L132) [[3]](diffhunk://#diff-7bcc194306293552e9a915d90831f1338d2e5d86ffd42a6d0009394c49a85be8L30-L50)
* Consolidated the checkout and sparse checkout logic to use the standard `sparse-checkout.yml` template for non-PR builds, reducing conditional complexity. [[1]](diffhunk://#diff-9a817977293f806ff99e282fb84005c9d7d96a314a112fd977f42685fec32edaL91-L111) [[2]](diffhunk://#diff-0ea764226e5dbbb822624683595ddec3033905225c0290d45dcf2c514f677373L112-L132) [[3]](diffhunk://#diff-7bcc194306293552e9a915d90831f1338d2e5d86ffd42a6d0009394c49a85be8L30-L50)


[python - voicelive](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6688461&view=results)