### PR TITLE
fix(engsys): vnext pipeline should not open duplicate issues when running multiple packages

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -165,7 +165,6 @@ extends:
       - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly')  }}:
         - template: /eng/pipelines/templates/stages/python-analyze-weekly.yml
           parameters:
-            BuildTargetingString: ${{ parameters.BuildTargetingString }}
+            BuildTargetingString: ${{ package }}
             ServiceDirectory: ${{ parameters.ServiceDirectory }}
             JobName: ${{ parameters.JobName }}
-


### PR DESCRIPTION
I noticed for storage https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6491369&view=results 
each storage pkg runs in parallel

Each pkg's run has its own analyze stage, but per analyze stage, pylint/pyright/etc. checks run for every single storage pkg, not just that run's intended package

this causes duplicate issues to be opened for the same packages, because each individual run opens the same issues

update BuildTargetingString passed to `python-analyze-weekly`

test run where you can see each analyze stage's azpysdk checks only target one package: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6503046&view=results (i manually canceled after verifying the pylint stages)