### PR TITLE
[sdk generation pipeline] Update package metadata title unconditionally

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -232,7 +232,7 @@ class CheckFile:
                 toml_data = toml.load(fd)
             if "packaging" not in toml_data:
                 toml_data["packaging"] = {}
-            if title and not toml_data["packaging"].get("title"):
+            if title:
                 toml_data["packaging"]["title"] = title
             toml_data["packaging"]["is_stable"] = is_stable
             with open(pyproject_toml, "wb") as fd:


### PR DESCRIPTION
## Summary
- Update packaging metadata generation to write the provided title whenever one is supplied.
- This allows generated pyproject packaging titles to be refreshed instead of preserving a previous value.

## Validation
- Confirmed branch diff contains only `eng/tools/azure-sdk-tools/packaging_tools/package_utils.py`.
- Confirmed working tree was clean before pushing.