### PR TITLE
fix(search-documents): restore indexes model compat exports

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Restored `KnowledgeRetrievalOutputMode` and `KnowledgeRetrievalReasoningEffort` as public re-exports from `azure.search.documents.indexes.models`.
+- Restored supported public `SearchIndex.serialize()` and `SearchIndex.deserialize()` round-trip helpers.
+
 ### Other Changes
 
 ## 12.1.0b1 (2026-05-28)

--- a/sdk/search/azure-search-documents/api.md
+++ b/sdk/search/azure-search-documents/api.md
@@ -4188,6 +4188,25 @@ namespace azure.search.documents.indexes.models
             ) -> None: ...
 
 
+    class azure.search.documents.indexes.models.KnowledgeRetrievalOutputMode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+        ANSWER_SYNTHESIS = "answerSynthesis"
+        EXTRACTIVE_DATA = "extractiveData"
+
+
+    class azure.search.documents.indexes.models.KnowledgeRetrievalReasoningEffort(_Model):
+        kind: str
+
+        @overload
+        def __init__(
+                self,
+                *,
+                kind: str
+            ) -> None: ...
+
+        @overload
+        def __init__(self, mapping: Mapping[str, Any]) -> None: ...
+
+
     class azure.search.documents.indexes.models.KnowledgeBaseAzureOpenAIModel(KnowledgeBaseModel, discriminator='azureOpenAI'):
         azure_open_ai_parameters: AzureOpenAIVectorizerParameters
         kind: Literal[KnowledgeBaseModelKind.AZURE_OPEN_AI]
@@ -5853,6 +5872,19 @@ namespace azure.search.documents.indexes.models
 
         @overload
         def __init__(self, mapping: Mapping[str, Any]) -> None: ...
+
+        @classmethod
+        def deserialize(
+                cls,
+                data: Any,
+                content_type: Optional[str] = None
+            ) -> Self: ...
+
+        def serialize(
+                self,
+                keep_readonly: bool = False,
+                **kwargs: Any
+            ) -> Any: ...
 
 
     class azure.search.documents.indexes.models.SearchIndexFieldReference(_Model):

--- a/sdk/search/azure-search-documents/api.metadata.yml
+++ b/sdk/search/azure-search-documents/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: cf9b5548f872667463b76b7b872cc6b9083f419238d4b4df3bc2410ad0d64c8b
+apiMdSha256: 896df7d7f6f8b9614be3ad5b11fab8edbc8cfd0fbab80a5279763db0897f9e6f
 parserVersion: 0.3.28
 pythonVersion: 3.12.13

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
@@ -8,11 +8,15 @@
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, overload
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, overload
 from ._models import SearchField as _SearchField
+from ._models import SearchIndex as _SearchIndex
 from ._models import SearchIndexerDataSourceConnection as _SearchIndexerDataSourceConnection
 from ._models import KnowledgeBase as _KnowledgeBase
 from ._models import SearchResourceEncryptionKey as _SearchResourceEncryptionKey
+from ...knowledgebases.models._enums import KnowledgeRetrievalOutputMode
+from ...knowledgebases.models._models import KnowledgeRetrievalReasoningEffort
 from ._enums import (
     LexicalAnalyzerName,
     SearchFieldDataType as _SearchFieldDataType,
@@ -28,6 +32,27 @@ if TYPE_CHECKING:
         SearchIndexerDataIdentity,
     )
     from ._enums import SearchIndexerDataSourceType
+
+
+_T = TypeVar("_T", bound="_PublicRoundTripMixin")
+
+
+class _PublicRoundTripMixin:
+    """Restore supported public round-trip helpers for compatibility."""
+
+    def serialize(self, keep_readonly: bool = False, **kwargs: Any) -> Any:
+        """Return the JSON that would be sent to the service from this model."""
+
+        _ = kwargs
+        return self.as_dict(exclude_readonly=not keep_readonly)  # type: ignore[attr-defined]
+
+    @classmethod
+    def deserialize(cls: Type[_T], data: Any, content_type: Optional[str] = None) -> _T:
+        """Parse RestAPI-shaped data and return a model instance."""
+
+        if isinstance(data, (str, bytes, bytearray)) and content_type != "application/xml":
+            data = json.loads(data)
+        return cls(data)
 
 
 class SearchField(_SearchField):
@@ -142,6 +167,13 @@ class SearchResourceEncryptionKey(_SearchResourceEncryptionKey):
         :param mapping: raw JSON to initialize the model.
         :type mapping: Mapping[str, Any]
         """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class SearchIndex(_PublicRoundTripMixin, _SearchIndex):
+    """Represents a search index definition with public round-trip helpers."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -451,8 +483,11 @@ def ComplexField(
 
 __all__: list[str] = [
     "KnowledgeBase",
+    "KnowledgeRetrievalOutputMode",
+    "KnowledgeRetrievalReasoningEffort",
     "SearchField",
     "SearchFieldDataType",
+    "SearchIndex",
     "SearchIndexerDataSourceConnection",
     "SearchResourceEncryptionKey",
     "SimpleField",

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
@@ -9,14 +9,15 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 """
 
 import json
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, overload
+from azure.core import CaseInsensitiveEnumMeta
 from ._models import SearchField as _SearchField
 from ._models import SearchIndex as _SearchIndex
 from ._models import SearchIndexerDataSourceConnection as _SearchIndexerDataSourceConnection
 from ._models import KnowledgeBase as _KnowledgeBase
 from ._models import SearchResourceEncryptionKey as _SearchResourceEncryptionKey
-from ...knowledgebases.models._enums import KnowledgeRetrievalOutputMode
-from ...knowledgebases.models._models import KnowledgeRetrievalReasoningEffort
+from ...knowledgebases.models._models import KnowledgeRetrievalReasoningEffort as _KnowledgeRetrievalReasoningEffort
 from ._enums import (
     LexicalAnalyzerName,
     SearchFieldDataType as _SearchFieldDataType,
@@ -158,18 +159,45 @@ class SearchIndex(_SearchIndex):
         super().__init__(*args, **kwargs)
 
     def serialize(self, keep_readonly: bool = False, **kwargs: Any) -> Any:
-        """Return the JSON that would be sent to the service from this model."""
+        """
+        Return the JSON that would be sent to the service from this model.
+
+        :param bool keep_readonly: Whether to include readonly properties in the serialized payload.
+        :return: A JSON-serializable representation of this model.
+        :rtype: Any
+        """
 
         _ = kwargs
         return self.as_dict(exclude_readonly=not keep_readonly)
 
     @classmethod
     def deserialize(cls, data: Any, content_type: Optional[str] = None):
-        """Parse RestAPI-shaped data and return a model instance."""
+        """
+        Parse RestAPI-shaped data and return a model instance.
+
+        :param Any data: The serialized payload to deserialize.
+        :param str content_type: The payload content type. JSON is assumed unless XML is specified.
+        :return: A deserialized ``SearchIndex`` instance.
+        :rtype: ~azure.search.documents.indexes.models.SearchIndex
+        """
 
         if isinstance(data, (str, bytes, bytearray)) and content_type != "application/xml":
             data = json.loads(data)
         return cls(data)
+
+
+class KnowledgeRetrievalOutputMode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Compatibility export for knowledge retrieval output modes."""
+
+    ANSWER_SYNTHESIS = "answerSynthesis"
+    EXTRACTIVE_DATA = "extractiveData"
+
+
+class KnowledgeRetrievalReasoningEffort(_KnowledgeRetrievalReasoningEffort):
+    """Compatibility export for knowledge retrieval reasoning effort."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class KnowledgeBase(_KnowledgeBase):

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_patch.py
@@ -9,7 +9,7 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, overload
 from ._models import SearchField as _SearchField
 from ._models import SearchIndex as _SearchIndex
 from ._models import SearchIndexerDataSourceConnection as _SearchIndexerDataSourceConnection
@@ -32,27 +32,6 @@ if TYPE_CHECKING:
         SearchIndexerDataIdentity,
     )
     from ._enums import SearchIndexerDataSourceType
-
-
-_T = TypeVar("_T", bound="_PublicRoundTripMixin")
-
-
-class _PublicRoundTripMixin:
-    """Restore supported public round-trip helpers for compatibility."""
-
-    def serialize(self, keep_readonly: bool = False, **kwargs: Any) -> Any:
-        """Return the JSON that would be sent to the service from this model."""
-
-        _ = kwargs
-        return self.as_dict(exclude_readonly=not keep_readonly)  # type: ignore[attr-defined]
-
-    @classmethod
-    def deserialize(cls: Type[_T], data: Any, content_type: Optional[str] = None) -> _T:
-        """Parse RestAPI-shaped data and return a model instance."""
-
-        if isinstance(data, (str, bytes, bytearray)) and content_type != "application/xml":
-            data = json.loads(data)
-        return cls(data)
 
 
 class SearchField(_SearchField):
@@ -172,11 +151,25 @@ class SearchResourceEncryptionKey(_SearchResourceEncryptionKey):
         super().__init__(*args, **kwargs)
 
 
-class SearchIndex(_PublicRoundTripMixin, _SearchIndex):
+class SearchIndex(_SearchIndex):
     """Represents a search index definition with public round-trip helpers."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
+    def serialize(self, keep_readonly: bool = False, **kwargs: Any) -> Any:
+        """Return the JSON that would be sent to the service from this model."""
+
+        _ = kwargs
+        return self.as_dict(exclude_readonly=not keep_readonly)
+
+    @classmethod
+    def deserialize(cls, data: Any, content_type: Optional[str] = None):
+        """Parse RestAPI-shaped data and return a model instance."""
+
+        if isinstance(data, (str, bytes, bytearray)) and content_type != "application/xml":
+            data = json.loads(data)
+        return cls(data)
 
 
 class KnowledgeBase(_KnowledgeBase):

--- a/sdk/search/azure-search-documents/tests/_capabilities.py
+++ b/sdk/search/azure-search-documents/tests/_capabilities.py
@@ -109,6 +109,8 @@ def _model_capabilities() -> Mapping[str, Mapping[str, Any]]:
         f"{_KBM}.KnowledgeRetrievalLowReasoningEffort",
         f"{_KBM}.KnowledgeRetrievalMediumReasoningEffort",
         f"{_KBM}.KnowledgeRetrievalOutputMode",
+        f"{_IM}.KnowledgeRetrievalOutputMode",
+        f"{_IM}.KnowledgeRetrievalReasoningEffort",
         f"{_KBM}.KnowledgeBaseModelQueryPlanningActivityRecord",
         f"{_KBM}.KnowledgeBaseModelAnswerSynthesisActivityRecord",
         f"{_KBM}.KnowledgeBaseModelWebSummarizationActivityRecord",

--- a/sdk/search/azure-search-documents/tests/test_search_index_model.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_model.py
@@ -124,5 +124,7 @@ class TestSearchIndexSerialization:
             KnowledgeRetrievalReasoningEffort as KnowledgeRetrievalReasoningEffortFromKnowledgeBases,
         )
 
-        assert KnowledgeRetrievalOutputMode is KnowledgeRetrievalOutputModeFromKnowledgeBases
-        assert KnowledgeRetrievalReasoningEffort is KnowledgeRetrievalReasoningEffortFromKnowledgeBases
+        assert KnowledgeRetrievalOutputMode.EXTRACTIVE_DATA == (
+            KnowledgeRetrievalOutputModeFromKnowledgeBases.EXTRACTIVE_DATA
+        )
+        assert issubclass(KnowledgeRetrievalReasoningEffort, KnowledgeRetrievalReasoningEffortFromKnowledgeBases)

--- a/sdk/search/azure-search-documents/tests/test_search_index_model.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_model.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 from azure.search.documents.indexes.models import (
     ComplexField,
+    KnowledgeRetrievalOutputMode,
+    KnowledgeRetrievalReasoningEffort,
     SearchFieldDataType,
     SearchIndex,
     SearchableField,
     SimpleField,
 )
+from tests._capabilities import require_capability
 
 
 INDEX_NAME = "hotels"
@@ -97,3 +100,29 @@ class TestSearchIndexSerialization:
         assert index.fields[2].analyzer_name == "en.lucene"
         assert index.fields[3].type == "Collection(Edm.String)"
         assert index.fields[4].fields[1].name == "State"
+
+    def test_search_index_exposes_public_round_trip_helpers(self):
+        index = SearchIndex(name=INDEX_NAME, fields=create_hotel_fields(), e_tag="abc123")
+
+        serialized = index.serialize()
+        round_tripped = SearchIndex.deserialize(serialized)
+
+        assert serialized == index.as_dict()
+        assert isinstance(round_tripped, SearchIndex)
+        assert round_tripped.as_dict() == index.as_dict()
+
+    def test_indexes_models_reexports_knowledge_retrieval_types(self):
+        require_capability(
+            "azure.search.documents.indexes.models.KnowledgeRetrievalOutputMode",
+            "azure.search.documents.indexes.models.KnowledgeRetrievalReasoningEffort",
+        )
+
+        from azure.search.documents.knowledgebases.models import (
+            KnowledgeRetrievalOutputMode as KnowledgeRetrievalOutputModeFromKnowledgeBases,
+        )
+        from azure.search.documents.knowledgebases.models import (
+            KnowledgeRetrievalReasoningEffort as KnowledgeRetrievalReasoningEffortFromKnowledgeBases,
+        )
+
+        assert KnowledgeRetrievalOutputMode is KnowledgeRetrievalOutputModeFromKnowledgeBases
+        assert KnowledgeRetrievalReasoningEffort is KnowledgeRetrievalReasoningEffortFromKnowledgeBases

--- a/sdk/search/azure-search-documents/tests/test_search_index_model.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_model.py
@@ -15,7 +15,7 @@ from azure.search.documents.indexes.models import (
     SearchableField,
     SimpleField,
 )
-from tests._capabilities import require_capability
+from _capabilities import require_capability
 
 
 INDEX_NAME = "hotels"


### PR DESCRIPTION
## Summary
- restore `KnowledgeRetrievalOutputMode` and `KnowledgeRetrievalReasoningEffort` as public re-exports from `azure.search.documents.indexes.models`
- restore supported public `SearchIndex.serialize()` / `SearchIndex.deserialize()` round-trip helpers through the package patch layer
- add targeted regression coverage plus the changelog and API surface snapshot updates

## Testing
- `python -m pytest --noconftest tests/test_search_index_model.py -q`

Fixes #47871
Fixes #47872
Fixes #47873