### PR TITLE
Cherrypick- Fix BatchEndpoint.defaults regression: restore attribute-access object from get()

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bugs Fixed
 
+
+- Fixed `datastore create` failing with `TypeError: Object of type Datastore is not JSON serializable`. The datastore operation was migrated to the TypeSpec client while the datastore entity still produced a legacy msrest model; the request body is now serialized to its wire form before being sent, keeping the on-the-wire request unchanged.
 - Fixed cross-tenant registry endpoint resolution for deployment template operations by using the registry discovery API instead of ARM calls.
 - Fixed deployment template update failing with immutable field errors by ensuring `allowedInstanceType` and `allowedEnvironmentVariableOverrides` are properly round-tripped during serialization.
 

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.34.1 (2026-06-30)
+## 1.34.1 (2026-07-09)
 
 ### Bugs Fixed
 - Fixed `BatchEndpoint` defaults serialization regression where `deployment_name` was sent to the service as snake_case instead of camelCase (`deploymentName`), causing `begin_create_or_update` to fail with "Could not find member 'deployment_name' on object of type 'BatchEndpointDefaults'". Serialization now emits the correct camelCase wire format, while `BatchEndpoint.defaults` returned from `get()` continues to expose an object that supports attribute access (e.g. `endpoint.defaults.deployment_name`), preserving backward compatibility with existing code and samples.

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.34.1 (2026-06-30)
 
 ### Bugs Fixed
-- Fixed `BatchEndpoint` defaults serialization regression where `deployment_name` was sent to the service as snake_case instead of camelCase (`deploymentName`), causing `begin_create_or_update` to fail with "Could not find member 'deployment_name' on object of type 'BatchEndpointDefaults'". `BatchEndpoint.defaults` is now consistently exposed as a snake_case dict to users and converted to the correct wire format on serialization.
+- Fixed `BatchEndpoint` defaults serialization regression where `deployment_name` was sent to the service as snake_case instead of camelCase (`deploymentName`), causing `begin_create_or_update` to fail with "Could not find member 'deployment_name' on object of type 'BatchEndpointDefaults'". Serialization now emits the correct camelCase wire format, while `BatchEndpoint.defaults` returned from `get()` continues to expose an object that supports attribute access (e.g. `endpoint.defaults.deployment_name`), preserving backward compatibility with existing code and samples.
 
 ## 1.34.0 (2026-06-11)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint_defaults.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint_defaults.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from marshmallow import fields, post_load
 
+from azure.ai.ml._restclient.arm_ml_service.models import BatchEndpointDefaults
 from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 
 module_logger = logging.getLogger(__name__)
@@ -24,4 +25,4 @@ class BatchEndpointsDefaultsSchema(metaclass=PatchedSchemaMeta):
 
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:
-        return dict(data)
+        return BatchEndpointDefaults(**data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
@@ -97,14 +97,12 @@ class BatchEndpoint(Endpoint):
 
     @classmethod
     def _from_rest_object(cls, obj: BatchEndpointData) -> "BatchEndpoint":
-        defaults: Optional[Dict[str, str]] = None
-        rest_defaults = obj.properties.defaults
-        if isinstance(rest_defaults, RestBatchEndpointDefaults):
-            if rest_defaults.deployment_name is not None:
-                defaults = {"deployment_name": rest_defaults.deployment_name}
-        elif isinstance(rest_defaults, dict):
-            defaults = dict(rest_defaults) if rest_defaults else None
-
+        # Pass the REST ``BatchEndpointDefaults`` object through unchanged so that
+        # ``endpoint.defaults.deployment_name`` remains gettable/settable. Callers
+        # (including the published batch-endpoint sample notebooks) rely on being
+        # able to do ``endpoint.defaults.deployment_name = <name>`` after a get().
+        # Serialization back to camelCase wire format is handled in
+        # ``_to_rest_batch_endpoint`` via the ``RestBatchEndpointDefaults`` branch.
         return BatchEndpoint(
             id=obj.id,
             name=obj.name,
@@ -113,7 +111,7 @@ class BatchEndpoint(Endpoint):
             auth_mode=camel_to_snake(obj.properties.auth_mode),
             description=obj.properties.description,
             location=obj.location,
-            defaults=defaults,
+            defaults=obj.properties.defaults,
             provisioning_state=obj.properties.provisioning_state,
             scoring_uri=obj.properties.scoring_uri,
             openapi_uri=obj.properties.swagger_uri,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -228,11 +228,16 @@ class DatastoreOperations(_ScopeDependentOperations):
         """
         try:
             ds_request = datastore._to_rest_object()
+            # ``_to_rest_object`` builds a legacy msrest (v2023_04) Datastore model, but ``self._operation`` is the
+            # TypeSpec/arm_ml_service datastores client whose ``SdkJSONEncoder`` only serializes hybrid models — a
+            # msrest model raises ``TypeError: Object of type Datastore is not JSON serializable`` (ICM 829788361,
+            # regressed in 1.34.0). Serialize the msrest model to its camelCase wire dict first; the operation accepts
+            # ``Union[Datastore, JSON, IO[bytes]]`` and a plain dict serializes cleanly. Byte-identical to 1.33.0.
             datastore_resource = self._operation.create_or_update(
                 name=datastore.name,
                 resource_group_name=self._operation_scope.resource_group_name,
                 workspace_name=self._workspace_name,
-                body=ds_request,
+                body=ds_request.serialize(),
                 skip_validation=True,
             )
             return Datastore._from_rest_object(datastore_resource)

--- a/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_endpoint_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_online_common/unittests/test_endpoint_entity.py
@@ -205,14 +205,31 @@ class TestBatchEndpointYAML:
 
         assert rest_batch_endpoint.properties.defaults is None
 
-    def test_from_rest_object_defaults_returned_as_snake_case_dict(self) -> None:
+    def test_from_rest_object_defaults_supports_attribute_access(self) -> None:
         with open(TestBatchEndpointYAML.BATCH_ENDPOINT_REST, "r") as f:
             batch_endpoint_rest = _deserialize(BatchEndpointData, json.load(f))
 
         batch_endpoint = BatchEndpoint._from_rest_object(batch_endpoint_rest)
 
-        assert batch_endpoint.defaults == {"deployment_name": "hello-world-1"}
-        assert batch_endpoint.defaults["deployment_name"] == "hello-world-1"
+        # ``endpoint.defaults`` must remain an object that supports attribute
+        # get/set so the published sample pattern keeps working:
+        #     endpoint.defaults.deployment_name = deployment.name
+        assert batch_endpoint.defaults.deployment_name == "hello-world-1"
+
+    def test_from_rest_object_defaults_roundtrips_to_camel_case(self) -> None:
+        with open(TestBatchEndpointYAML.BATCH_ENDPOINT_REST, "r") as f:
+            batch_endpoint_rest = _deserialize(BatchEndpointData, json.load(f))
+
+        batch_endpoint = BatchEndpoint._from_rest_object(batch_endpoint_rest)
+
+        # Emulate the sample notebook flow: mutate the default deployment on the
+        # object returned by get() and serialize it back to the wire format.
+        batch_endpoint.defaults.deployment_name = "hello-world-2"
+        rest_batch_endpoint = batch_endpoint._to_rest_batch_endpoint("eastus")
+
+        rest_defaults = rest_batch_endpoint.properties.defaults
+        assert rest_defaults.deployment_name == "hello-world-2"
+        assert rest_defaults.as_dict() == {"deploymentName": "hello-world-2"}
 
 
 class TestKubernetesOnlineEndopint:

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
@@ -73,6 +73,35 @@ class TestDatastoreOperations:
         mock_datastore_operation.create_or_update(ds)
         mock_datastore_operation._operation.create_or_update.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "blob_store.yml",
+            "file_store.yml",
+            "adls_gen1.yml",
+            "adls_gen2.yml",
+            "one_lake.yml",
+            "credential_less_one_lake.yml",
+        ],
+    )
+    def test_create_body_is_json_serializable(
+        self, mock_from_rest, mock_datastore_operation: DatastoreOperations, path
+    ) -> None:
+        # Regression test (regressed in 1.34.0): the datastore operation was switched to the
+        # TypeSpec/arm_ml_service client, whose ``SdkJSONEncoder`` only serializes hybrid models. The entity
+        # ``_to_rest_object()`` still builds a legacy msrest Datastore model, so passing it as the request body
+        # raised ``TypeError: Object of type Datastore is not JSON serializable`` on every ``datastore create``.
+        # Guard: the body handed to the operation must serialize cleanly with the same encoder the client uses.
+        import json
+
+        from azure.ai.ml._restclient.arm_ml_service._utils.model_base import SdkJSONEncoder
+
+        ds = load_datastore(f"./tests/test_configs/datastore/{path}")
+        mock_datastore_operation.create_or_update(ds)
+        body = mock_datastore_operation._operation.create_or_update.call_args.kwargs["body"]
+        # Must not raise ``TypeError: Object of type Datastore is not JSON serializable``.
+        json.dumps(body, cls=SdkJSONEncoder, exclude_readonly=True)
+
     @pytest.mark.skipif(
         (IS_CPYTHON and sys.version_info >= (3, 13)) or (IS_PYPY and sys.version_info >= (3, 10)),
         reason="Skipping because CPython version is >=3.13 or PyPy version is >=3.10. azureml.dataprep.rslex do not support it",


### PR DESCRIPTION
Cherry-pick of #47813 onto release/azure-ai-ml/1.34.1.

Restores attribute-access object returned from BatchEndpoint.defaults.get() to fix regression.