### PR TITLE
Fix datastore create TypeError: serialize msrest body for the TypeSpec client

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugs Fixed
 
+- Fixed `datastore create` failing with `TypeError: Object of type Datastore is not JSON serializable`. The datastore operation was migrated to the TypeSpec client while the datastore entity still produced a legacy msrest model; the request body is now serialized to its wire form before being sent, keeping the on-the-wire request unchanged.
 - Fixed cross-tenant registry endpoint resolution for deployment template operations by using the registry discovery API instead of ARM calls.
 - Fixed deployment template update failing with immutable field errors by ensuring `allowedInstanceType` and `allowedEnvironmentVariableOverrides` are properly round-tripped during serialization.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -222,11 +222,16 @@ class DatastoreOperations(_ScopeDependentOperations):
         """
         try:
             ds_request = datastore._to_rest_object()
+            # ``_to_rest_object`` builds a legacy msrest (v2023_04) Datastore model, but ``self._operation`` is the
+            # TypeSpec/arm_ml_service datastores client whose ``SdkJSONEncoder`` only serializes hybrid models — a
+            # msrest model raises ``TypeError: Object of type Datastore is not JSON serializable`` (ICM 829788361,
+            # regressed in 1.34.0). Serialize the msrest model to its camelCase wire dict first; the operation accepts
+            # ``Union[Datastore, JSON, IO[bytes]]`` and a plain dict serializes cleanly. Byte-identical to 1.33.0.
             datastore_resource = self._operation.create_or_update(
                 name=datastore.name,
                 resource_group_name=self._operation_scope.resource_group_name,
                 workspace_name=self._workspace_name,
-                body=ds_request,
+                body=ds_request.serialize(),
                 skip_validation=True,
             )
             return Datastore._from_rest_object(datastore_resource)

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
@@ -87,7 +87,7 @@ class TestDatastoreOperations:
     def test_create_body_is_json_serializable(
         self, mock_from_rest, mock_datastore_operation: DatastoreOperations, path
     ) -> None:
-        # Regression for ICM 829788361 (regressed in 1.34.0): the datastore operation was switched to the
+        # Regression test (regressed in 1.34.0): the datastore operation was switched to the
         # TypeSpec/arm_ml_service client, whose ``SdkJSONEncoder`` only serializes hybrid models. The entity
         # ``_to_rest_object()`` still builds a legacy msrest Datastore model, so passing it as the request body
         # raised ``TypeError: Object of type Datastore is not JSON serializable`` on every ``datastore create``.

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
@@ -73,6 +73,35 @@ class TestDatastoreOperations:
         mock_datastore_operation.create_or_update(ds)
         mock_datastore_operation._operation.create_or_update.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "blob_store.yml",
+            "file_store.yml",
+            "adls_gen1.yml",
+            "adls_gen2.yml",
+            "one_lake.yml",
+            "credential_less_one_lake.yml",
+        ],
+    )
+    def test_create_body_is_json_serializable(
+        self, mock_from_rest, mock_datastore_operation: DatastoreOperations, path
+    ) -> None:
+        # Regression for ICM 829788361 (regressed in 1.34.0): the datastore operation was switched to the
+        # TypeSpec/arm_ml_service client, whose ``SdkJSONEncoder`` only serializes hybrid models. The entity
+        # ``_to_rest_object()`` still builds a legacy msrest Datastore model, so passing it as the request body
+        # raised ``TypeError: Object of type Datastore is not JSON serializable`` on every ``datastore create``.
+        # Guard: the body handed to the operation must serialize cleanly with the same encoder the client uses.
+        import json
+
+        from azure.ai.ml._restclient.arm_ml_service._utils.model_base import SdkJSONEncoder
+
+        ds = load_datastore(f"./tests/test_configs/datastore/{path}")
+        mock_datastore_operation.create_or_update(ds)
+        body = mock_datastore_operation._operation.create_or_update.call_args.kwargs["body"]
+        # Must not raise ``TypeError: Object of type Datastore is not JSON serializable``.
+        json.dumps(body, cls=SdkJSONEncoder, exclude_readonly=True)
+
     @pytest.mark.skipif(
         (IS_CPYTHON and sys.version_info >= (3, 13)) or (IS_PYPY and sys.version_info >= (3, 10)),
         reason="Skipping because CPython version is >=3.13 or PyPy version is >=3.10. azureml.dataprep.rslex do not support it",


### PR DESCRIPTION
# Description
`az ml datastore create` (and MLClient.datastores.create_or_update) fails on azure-ai-ml 1.34.0 with "TypeError: Object of type Datastore is not JSON serializable". It works on 1.33.0.

Root cause: the datastore operation was migrated to the TypeSpec client, whose JSON encoder only serializes the new hybrid models. The datastore entity still builds a legacy msrest model for the request body, so the body can't be serialized and the call fails before any HTTP request is made.

Fix: serialize the msrest model to its wire dict before sending it (body=ds_request.serialize()). The operation accepts a JSON body, and the on-the-wire request/response is unchanged — byte-identical to 1.33.0, verified across all datastore types and credential types (including the customer's --none case).

Testing:
- Reproduced the failure and confirmed the fix resolves it.
- Added a regression test that captures the request body and asserts it is JSON-serializable with the client's encoder. It fails on the unfixed code (reproducing the TypeError) and passes with the fix. The existing test only checked the mocked operation was called, so it never exercised serialization.
- Existing datastore unit tests pass.

The fix lives in azure-ai-ml; the az ml CLI extension only needs to bundle the fixed release.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
