### PR TITLE
[Evaluation] Prepare azure-ai-evaluation 1.18.1 release

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Release History
 
-## 1.18.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.18.0 (2026-07-06)
+## 1.18.1 (2026-07-09)
 
 ### Bugs Fixed
 
@@ -36,15 +26,30 @@
   `ToolInputAccuracyEvaluator` are unaffected — they do not render tool
   results into the judge prompt and already opt out of the unsupported-tool
   check.
+- Fixed OpenAPI tool-call validation in tool evaluators (e.g. `ToolCallAccuracyEvaluator`). OpenAPI
+  tool definitions are expanded into their nested functions when present, so tool calls referencing a
+  nested function name validate correctly, while OpenAPI tool definitions without nested functions are
+  kept as is so tool calls referencing the top-level tool name continue to validate.
+
+### Other Changes
+
+- Conversation/tool message preprocessing now normalizes `openapi_call` / `openapi_call_output` content
+  items to `tool_call` / `tool_result` (previously only `function_call` / `function_call_output` were
+  normalized), so evaluators correctly handle OpenAPI-tool agent transcripts.
+- Evaluators no longer log raw customer payloads in fallback/debug paths. `reformat_agent_response`,
+  `reformat_conversation_history`, `reformat_tool_definitions`, the tool-call-success reformat helpers,
+  and Groundedness context extraction now emit structural summaries only (via `_log_safe_summary`),
+  never raw query/response/tool payloads.
+
+## 1.18.0 (2026-07-06)
+
+### Bugs Fixed
+
 - Evaluators now raise `EvaluationException` (instead of bare `ValueError`/`TypeError`) for input and
   configuration validation failures, and consistently set `blame=ErrorBlame.USER_ERROR` with an
   appropriate `category` and `target`. Affected evaluators include `ContentSafetyEvaluator`,
   `QAEvaluator`, `RougeScoreEvaluator`, `DocumentRetrievalEvaluator`, the task navigation efficiency
   evaluator, and the shared evaluator base (conversation/tool-call input validation).
-- Fixed OpenAPI tool-call validation in tool evaluators (e.g. `ToolCallAccuracyEvaluator`). OpenAPI
-  tool definitions are expanded into their nested functions when present, so tool calls referencing a
-  nested function name validate correctly, while OpenAPI tool definitions without nested functions are
-  kept as is so tool calls referencing the top-level tool name continue to validate.
 - Fixed `RedTeam.scan()` storing decoded plaintext instead of the actual
   encoded payload for converter-based attack strategies (Base64, Flip,
   Morse, ROT13, etc.) in `evaluation_results.json` / `results.json`. The
@@ -56,16 +61,6 @@
   which continues to expose only `role`/`content`/`name`). Baseline
   (non-encoded) strategies are unaffected.
   Resolves [#47228](https://github.com/Azure/azure-sdk-for-python/issues/47228).
-
-### Other Changes
-
-- Conversation/tool message preprocessing now normalizes `openapi_call` / `openapi_call_output` content
-  items to `tool_call` / `tool_result` (previously only `function_call` / `function_call_output` were
-  normalized), so evaluators correctly handle OpenAPI-tool agent transcripts.
-- Evaluators no longer log raw customer payloads in fallback/debug paths. `reformat_agent_response`,
-  `reformat_conversation_history`, `reformat_tool_definitions`, the tool-call-success reformat helpers,
-  and Groundedness context extraction now emit structural summaries only (via `_log_safe_summary`),
-  never raw query/response/tool payloads.
 
 ## 1.17.0 (2026-06-03)
 


### PR DESCRIPTION
## Prepare `azure-ai-evaluation` 1.18.1 release (patch)

Cuts the next `azure-ai-evaluation` release as a **patch (1.18.1)**. The changes since 1.18.0 are bug fixes + internal changes only — no new public API, features, or breaking changes — so this is a patch, not a minor.

### CHANGELOG correction
The post-1.18.0 fixes had been merged **under the already-published `1.18.0` header** while `1.18.1 (Unreleased)` sat empty. This PR moves them into `1.18.1` and stamps the release date:

- **Bugs Fixed** → moved to 1.18.1:
  - Enable `azure_ai_search` / `azure_fabric` / `sharepoint_grounding` tool calls for TCS/TOU (#47748)
  - OpenAPI tool-call validation in tool evaluators (#47840)
- **Other Changes** → moved to 1.18.1:
  - `openapi_call` / `openapi_call_output` message normalization (#47840)
  - Log-redaction of raw customer payloads (#47840)
- `1.18.0` retains only its two genuinely-shipped entries (EvaluationException normalization, `RedTeam.scan()` plaintext fix).

`_version.py` is already `1.18.1`. CHANGELOG-only change — no source/tests touched.

> Draft until the release pipeline / APIView / approvals are ready. Merging begins the code-freeze / ASK MODE window.