### PR TITLE
[sdk generation pipeline] Use apistub for changelog generation

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -33,7 +33,7 @@ def create_package(prefolder, name):
 @return_origin_path
 def change_log_new(package_folder: str, lastest_pypi_version: bool) -> str:
     os.chdir(package_folder)
-    cmd = "azpysdk breaking . --changelog"
+    cmd = "azpysdk breaking . --changelog --use-apistub "
     if lastest_pypi_version:
         cmd += " --latest-pypi-version"
     try:


### PR DESCRIPTION
Updates changelog generation to pass `--use-apistub` to `azpysdk breaking . --changelog`.

This uses the apistub path for changelog generation so the packaging utility benefits from the faster breaking-change detector option added in #47743.


## Effect

changelog generation cost time of `azure-mgmt-network` could be reduced from `2800+` s to `160` s:

- Old:
<img width="864" height="131" alt="image" src="https://github.com/user-attachments/assets/57b9b011-5256-460a-bed6-841d8939a0c3" />

- New:
<img width="705" height="61" alt="image" src="https://github.com/user-attachments/assets/3b35c7bf-1a10-4164-baad-fa8e37af0a6b" />
