### PR TITLE
update emitter-package dependencies

### DIFF
--- a/.github/skills/emitter-package-update/SKILL.md
+++ b/.github/skills/emitter-package-update/SKILL.md
@@ -70,7 +70,12 @@ npx npm-check-updates --packageFile eng/emitter-package.json -u
 > (cross-checked against `packages/typespec-python/package.json` on `main`) — and edit
 > `eng/emitter-package.json` by hand to that version.
 
-Align the packages listed in `alignment-sources.json` with the versions pinned in each configured source repo package file to ensure consistency between the emitter and the spec repo. For the `azure-rest-api-specs` source, read the current values from [azure-rest-api-specs/package.json](https://github.com/Azure/azure-rest-api-specs/blob/main/package.json) and set those packages to match in `eng/emitter-package.json` (do not assume specific version numbers — use whatever the spec repo currently pins). To add more libraries for alignment later, add their package names to the relevant `packages` array in `alignment-sources.json`.
+Align the packages listed in `alignment-sources.json` with the versions pinned in each
+configured source repo package file to ensure consistency between the emitter and its
+upstream sources. For each source, read `packageJsonUrl`, set every package listed in
+that source's `packages` array to the version currently pinned there, and do not assume
+specific version numbers. To add more libraries for alignment later, add their package
+names to the relevant `packages` array in `alignment-sources.json`.
 
 If a specific version was requested, pin `@azure-tools/typespec-python` to that exact
 version in `eng/emitter-package.json` (overriding what npm-check-updates picked).

--- a/.github/skills/emitter-package-update/SKILL.md
+++ b/.github/skills/emitter-package-update/SKILL.md
@@ -70,7 +70,7 @@ npx npm-check-updates --packageFile eng/emitter-package.json -u
 > (cross-checked against `packages/typespec-python/package.json` on `main`) — and edit
 > `eng/emitter-package.json` by hand to that version.
 
-Align `@azure-tools/openai-typespec` and `@typespec/openapi3` with the versions pinned in [azure-rest-api-specs/package.json](https://github.com/Azure/azure-rest-api-specs/blob/main/package.json) to ensure consistency between the emitter and the spec repo. Read the spec repo's current values for those two packages and set them to match in `eng/emitter-package.json` (do not assume specific version numbers — use whatever the spec repo currently pins).
+Align the packages listed in `alignment-sources.json` with the versions pinned in each configured source repo package file to ensure consistency between the emitter and the spec repo. For the `azure-rest-api-specs` source, read the current values from [azure-rest-api-specs/package.json](https://github.com/Azure/azure-rest-api-specs/blob/main/package.json) and set those packages to match in `eng/emitter-package.json` (do not assume specific version numbers — use whatever the spec repo currently pins). To add more libraries for alignment later, add their package names to the relevant `packages` array in `alignment-sources.json`.
 
 If a specific version was requested, pin `@azure-tools/typespec-python` to that exact
 version in `eng/emitter-package.json` (overriding what npm-check-updates picked).

--- a/.github/skills/emitter-package-update/alignment-sources.json
+++ b/.github/skills/emitter-package-update/alignment-sources.json
@@ -1,0 +1,11 @@
+{
+  "azure-rest-api-specs": {
+    "packageJsonUrl": "https://github.com/Azure/azure-rest-api-specs/blob/main/package.json",
+    "packages": [
+      "@azure-tools/openai-typespec",
+      "@typespec/openapi3",
+      "@azure-tools/typespec-liftr-base",
+      "@azure-tools/typespec-azure-portal-core"
+    ]
+  }
+}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -301,6 +301,7 @@
     "ivars",
     "jwks",
     "kashifkhan",
+    "liftr",
     "keybak",
     "kube",
     "kubeconfig",

--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -9,13 +9,14 @@
         "@azure-tools/typespec-python": "0.63.2"
       },
       "devDependencies": {
-        "@azure-tools/openai-typespec": "1.21.0",
+        "@azure-tools/openai-typespec": "1.21.1",
         "@azure-tools/typespec-autorest": "~0.69.1",
         "@azure-tools/typespec-azure-core": "~0.69.0",
+        "@azure-tools/typespec-azure-portal-core": "0.69.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.69.2",
         "@azure-tools/typespec-azure-rulesets": "~0.69.2",
         "@azure-tools/typespec-client-generator-core": "~0.69.2",
-        "@azure-tools/typespec-liftr-base": "0.14.0",
+        "@azure-tools/typespec-liftr-base": "0.13.0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/events": "~0.83.0",
         "@typespec/http": "^1.13.0",
@@ -30,9 +31,9 @@
       }
     },
     "node_modules/@azure-tools/openai-typespec": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.21.0.tgz",
-      "integrity": "sha512-wKHNsyXii+/ZJn/mqKC/ey+/Y+RoW7XGBQD5yNRhGKA3VRibLNIhn/0PGLEIZhWWsFp3okTvifhPDs/b0DmOTA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.21.1.tgz",
+      "integrity": "sha512-h9O0jAkcSLKzWzk4KzkOv8zLw3P8pYzxflBd3e0RHJ6v4mcI71T1BX4aYmmLUhWmALCqGtqkh17ClAWKuwYWsw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -79,6 +80,17 @@
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
         "@typespec/rest": "^0.83.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-portal-core": {
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.69.0.tgz",
+      "integrity": "sha512-f6S7wz2VdKessVkCIYTy9IFJpZakN2fvT9uQODD934Bq0tREUIeQQEbh53XWddUIJp0QFh7yJx8hTi4RWxAE9g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
@@ -147,9 +159,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.14.0.tgz",
-      "integrity": "sha512-q9pEaOiIaE2VF+BsnaDG98zrj0sZ7/8AD8aBrwXtHbzH+id3sWprl8rRF0qagDSVchslfrHcGFhXs2bM6Hie0g==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.13.0.tgz",
+      "integrity": "sha512-MF40K/IHwyy3N606DTZSPhFSwA/84ekR9RqvmtJXsXD0SdYcQSoAHOJp4o5qw8OAPSC+aKZ5A+TXRx333V/3PQ==",
       "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -15,13 +15,13 @@
     "@typespec/xml": "~0.83.0",
     "@typespec/openapi3": "1.13.0",
     "@typespec/http-client-python": "^0.34.1",
-    "@azure-tools/openai-typespec": "1.21.0",
-    "@azure-tools/typespec-azure-portal-core": "~0.67.0",
+    "@azure-tools/openai-typespec": "1.21.1",
+    "@azure-tools/typespec-azure-portal-core": "0.69.0",
     "@azure-tools/typespec-autorest": "~0.69.1",
     "@azure-tools/typespec-azure-core": "~0.69.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.69.2",
     "@azure-tools/typespec-azure-rulesets": "~0.69.2",
     "@azure-tools/typespec-client-generator-core": "~0.69.2",
-    "@azure-tools/typespec-liftr-base": "0.14.0"
+    "@azure-tools/typespec-liftr-base": "0.13.0"
   }
 }

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -16,6 +16,7 @@
     "@typespec/openapi3": "1.13.0",
     "@typespec/http-client-python": "^0.34.1",
     "@azure-tools/openai-typespec": "1.21.0",
+    "@azure-tools/typespec-azure-portal-core": "~0.67.0",
     "@azure-tools/typespec-autorest": "~0.69.1",
     "@azure-tools/typespec-azure-core": "~0.69.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.69.2",


### PR DESCRIPTION
Fix python failure of https://github.com/Azure/azure-rest-api-specs-pr/pull/29346

Update emitter-package.json dependencies to their latest aligned versions.

This adds `@azure-tools/typespec-azure-portal-core` to `eng/emitter-package.json`, aligns configured packages with the current `azure-rest-api-specs` pins, and regenerates `eng/emitter-package-lock.json`.

The emitter package update skill now drives alignment from `alignment-sources.json` so additional aligned packages can be managed consistently.