### PR TITLE
Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview

### DIFF
--- a/sdk/authorization/azure-mgmt-authorization/CHANGELOG.md
+++ b/sdk/authorization/azure-mgmt-authorization/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 5.0.0b3 (2026-07-08)
+
+### Features Added
+
+  - Model `RoleAssignmentProperties` added property `expiration_time`
+
 ## 5.0.0b2 (2026-04-14)
 
 ### Features Added

--- a/sdk/authorization/azure-mgmt-authorization/azure/mgmt/authorization/_version.py
+++ b/sdk/authorization/azure-mgmt-authorization/azure/mgmt/authorization/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "5.0.0b2"
+VERSION = "5.0.0b3"

--- a/sdk/authorization/azure-mgmt-authorization/azure/mgmt/authorization/models/_models.py
+++ b/sdk/authorization/azure-mgmt-authorization/azure/mgmt/authorization/models/_models.py
@@ -4203,6 +4203,7 @@ class RoleAssignment(ExtensionResource):
         "created_by",
         "updated_by",
         "delegated_managed_identity_resource_id",
+        "expiration_time",
     ]
 
     @overload
@@ -4335,6 +4336,8 @@ class RoleAssignmentProperties(_Model):
     :vartype updated_by: str
     :ivar delegated_managed_identity_resource_id: Id of the delegated managed identity resource.
     :vartype delegated_managed_identity_resource_id: str
+    :ivar expiration_time: Time at which the role assignment expires.
+    :vartype expiration_time: str
     """
 
     scope: Optional[str] = rest_field(visibility=["read"])
@@ -4372,6 +4375,8 @@ class RoleAssignmentProperties(_Model):
         name="delegatedManagedIdentityResourceId", visibility=["read", "create", "update", "delete", "query"]
     )
     """Id of the delegated managed identity resource."""
+    expiration_time: Optional[str] = rest_field(name="expirationTime", visibility=["read"])
+    """Time at which the role assignment expires."""
 
     @overload
     def __init__(


### PR DESCRIPTION
Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview

# Description

Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview. Link to type-spec PR - https://github.com/Azure/azure-rest-api-specs/pull/44421.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
