### PR TITLE
[azure-ai-ml] Fix deployment_templates.get(name) resolving latest version (Bug 5402671)

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `MLClient.jobs.create_or_update`, `archive`, and `restore` failing for previously-fetched jobs across all job types by routing metadata-only edits through the RunHistory PATCH endpoint.
 - Fixed `DeploymentTemplate.creation_context` always being `None` when retrieved via `get()` or `list()`. The created/modified timestamps and identity returned by the service (as `createdTime` / `modifiedTime` / `createdBy`) are now populated on `creation_context`, making `DeploymentTemplate` consistent with `Model` and `Environment`.
 - Fixed `deployment_templates.list(name=...)` raising `AttributeError: 'str' object has no attribute 'request_timeout'`. In the list response, `requestSettings` / `livenessProbe` / `readinessProbe` arrive as stringified dicts nested under `properties`; these are now parsed before conversion, giving `list()` parity with `models.list()` / `environments.list()`.
+- Fixed `deployment_templates.get(name)` failing with a 404 (`DeploymentTemplate {name}:latest not found`) when no version was supplied, because the literal string `"latest"` was sent as the version. The latest version is now resolved client-side (the service exposes no `latest` label and no server-side ordering), and `get()` accepts a `label` keyword (`label="latest"` resolves to the latest version) mirroring `models.get()`. `delete(name)` resolves the latest version the same way.
 
 ### Other Changes
 

--- a/sdk/ml/azure-ai-ml/api.md
+++ b/sdk/ml/azure-ai-ml/api.md
@@ -10419,6 +10419,7 @@ namespace azure.ai.ml.operations
                 self, 
                 name: str, 
                 version: Optional[str] = None, 
+                label: Optional[str] = None, 
                 **kwargs: Any
             ) -> DeploymentTemplate: ...
 

--- a/sdk/ml/azure-ai-ml/api.metadata.yml
+++ b/sdk/ml/azure-ai-ml/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: 7262033cadec8b494dfa9cca72d97a9dad84e1e465ce8c455782d9fab275a81f
+apiMdSha256: 81371e37ca26ea3c761bdb2104b7a0b89a0026216a97510bc16f533cf936e2d9
 parserVersion: 0.3.28
 pythonVersion: 3.12.10

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_deployment_template_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_deployment_template_operations.py
@@ -318,33 +318,81 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
             ),
         )
 
-    @distributed_trace
-    @monitor_with_telemetry_mixin(ops_logger, "DeploymentTemplate.Get", ActivityType.PUBLICAPI)
-    @experimental
-    def get(self, name: str, version: Optional[str] = None, **kwargs: Any) -> DeploymentTemplate:
-        """Get a deployment template by name and version.
+    def _resolve_latest_version(self, name: str) -> str:
+        """Resolve the latest version of a deployment template by name.
+
+        The deployment-template service does not expose a ``latest`` label and its list endpoint
+        has no server-side ordering, so the latest version is resolved client-side by enumerating
+        the available (active) versions and returning the highest one.
 
         :param name: Name of the deployment template.
         :type name: str
-        :param version: Version of the deployment template. If not provided, gets the latest version.
+        :return: The highest available version.
+        :rtype: str
+        :raises: ~azure.core.exceptions.ResourceNotFoundError if no versions exist for the name.
+        """
+        versions = [template.version for template in self.list(name=name) if template.version is not None]
+        if not versions:
+            raise ResourceNotFoundError(f"DeploymentTemplate {name} not found: no versions available.")
+
+        def _version_sort_key(version: str) -> tuple:
+            # Numeric versions sort above (and among) non-numeric ones so the highest number wins,
+            # while non-numeric versions still resolve deterministically via string comparison.
+            try:
+                return (1, int(version))
+            except (TypeError, ValueError):
+                return (0, str(version))
+
+        return max(versions, key=_version_sort_key)
+
+    @distributed_trace
+    @monitor_with_telemetry_mixin(ops_logger, "DeploymentTemplate.Get", ActivityType.PUBLICAPI)
+    @experimental
+    def get(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        label: Optional[str] = None,
+        **kwargs: Any,
+    ) -> DeploymentTemplate:
+        """Get a deployment template by name and version (or label).
+
+        :param name: Name of the deployment template.
+        :type name: str
+        :param version: Version of the deployment template. If neither ``version`` nor ``label`` is
+            provided, the latest version is returned.
         :type version: Optional[str]
+        :param label: Label of the deployment template. Only the ``latest`` label is supported, which
+            resolves to the latest version. Cannot be used together with ``version``.
+        :type label: Optional[str]
         :return: DeploymentTemplate object.
         :rtype: ~azure.ai.ml.entities.DeploymentTemplate
         :raises: ~azure.core.exceptions.ResourceNotFoundError if deployment template not found.
         """
-        version = version or "latest"
+        if version and label:
+            raise ValueError("Cannot specify both version and label.")
+
+        if label is not None and label != "latest":
+            raise ResourceNotFoundError(
+                f"DeploymentTemplate {name} with label '{label}' not found. Only the 'latest' label is supported."
+            )
+
+        # No explicit version (or label='latest') -> resolve the latest version client-side.
+        resolved_version = version or self._resolve_latest_version(name)
 
         try:
             result = self._service_client.deployment_templates.get(
                 registry_name=self._operation_scope.registry_name,
                 name=name,
-                version=version,
+                version=resolved_version,
                 **kwargs,
             )
             return DeploymentTemplate._from_rest_object(result)
+        except ResourceNotFoundError:
+            raise
         except Exception as e:
             module_logger.debug("DeploymentTemplate get operation failed: %s", e)
-            raise ResourceNotFoundError(f"DeploymentTemplate {name}:{version} not found") from e
+            raise ResourceNotFoundError(f"DeploymentTemplate {name}:{resolved_version} not found") from e
 
     @distributed_trace
     @monitor_with_telemetry_mixin(ops_logger, "DeploymentTemplate.CreateOrUpdate", ActivityType.PUBLICAPI)
@@ -389,7 +437,7 @@ class DeploymentTemplateOperations(_ScopeDependentOperations):
         :param version: Version of the deployment template to delete. If not provided, deletes the latest version.
         :type version: Optional[str]
         """
-        version = version or "latest"
+        version = version or self._resolve_latest_version(name)
 
         try:
             self._service_client.deployment_templates.delete(

--- a/sdk/ml/azure-ai-ml/tests/deployment_template/unittests/test_deployment_template_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/deployment_template/unittests/test_deployment_template_operations.py
@@ -243,7 +243,7 @@ class TestDeploymentTemplateOperations:
         )
 
         with pytest.raises(HttpResponseError):
-            deployment_template_ops.get("nonexistent-template")
+            deployment_template_ops.get("nonexistent-template", "1.0")
 
     def test_list_deployment_templates(self, deployment_template_ops, sample_rest_template):
         """Test list operation for deployment templates."""
@@ -331,7 +331,74 @@ class TestDeploymentTemplateOperations:
         deployment_template_ops._operation_scope.workspace_name = "test-workspace"
 
         with pytest.raises(HttpResponseError):
-            deployment_template_ops.delete("nonexistent-template")
+            deployment_template_ops.delete("nonexistent-template", "1.0")
+
+    def test_get_no_version_resolves_latest(self, deployment_template_ops, sample_rest_template):
+        """get() without a version resolves the highest available version instead of sending 'latest'."""
+        deployment_template_ops._service_client.deployment_templates.get = Mock(return_value=sample_rest_template)
+        # list() returns versions out of order; the highest (5) must be selected.
+        deployment_template_ops.list = Mock(
+            return_value=[
+                DeploymentTemplate(name="test-template", version="2"),
+                DeploymentTemplate(name="test-template", version="5"),
+                DeploymentTemplate(name="test-template", version="3"),
+            ]
+        )
+
+        result = deployment_template_ops.get("test-template")
+
+        deployment_template_ops.list.assert_called_once_with(name="test-template")
+        call_args = deployment_template_ops._service_client.deployment_templates.get.call_args
+        assert call_args[1]["version"] == "5"
+        assert isinstance(result, DeploymentTemplate)
+
+    def test_get_label_latest_resolves_latest(self, deployment_template_ops, sample_rest_template):
+        """get(label='latest') resolves to the highest available version."""
+        deployment_template_ops._service_client.deployment_templates.get = Mock(return_value=sample_rest_template)
+        deployment_template_ops.list = Mock(
+            return_value=[
+                DeploymentTemplate(name="test-template", version="1"),
+                DeploymentTemplate(name="test-template", version="4"),
+            ]
+        )
+
+        result = deployment_template_ops.get("test-template", label="latest")
+
+        call_args = deployment_template_ops._service_client.deployment_templates.get.call_args
+        assert call_args[1]["version"] == "4"
+        assert isinstance(result, DeploymentTemplate)
+
+    def test_get_version_and_label_raises(self, deployment_template_ops):
+        """get() with both version and label is rejected."""
+        with pytest.raises(ValueError):
+            deployment_template_ops.get("test-template", version="1", label="latest")
+
+    def test_get_unsupported_label_raises(self, deployment_template_ops):
+        """Only the 'latest' label is supported; other labels raise ResourceNotFoundError."""
+        with pytest.raises(ResourceNotFoundError):
+            deployment_template_ops.get("test-template", label="production")
+
+    def test_get_no_versions_raises_not_found(self, deployment_template_ops):
+        """get() without a version raises when no versions exist to resolve."""
+        deployment_template_ops.list = Mock(return_value=[])
+
+        with pytest.raises(ResourceNotFoundError):
+            deployment_template_ops.get("test-template")
+
+    def test_delete_no_version_resolves_latest(self, deployment_template_ops):
+        """delete() without a version resolves the highest available version instead of sending 'latest'."""
+        deployment_template_ops._service_client.deployment_templates.delete = Mock(return_value=None)
+        deployment_template_ops.list = Mock(
+            return_value=[
+                DeploymentTemplate(name="test-template", version="2"),
+                DeploymentTemplate(name="test-template", version="5"),
+            ]
+        )
+
+        deployment_template_ops.delete("test-template")
+
+        call_args = deployment_template_ops._service_client.deployment_templates.delete.call_args
+        assert call_args[1]["version"] == "5"
 
     def test_create_or_update_with_none_input(self, deployment_template_ops):
         """Test create_or_update with None input."""
@@ -416,7 +483,7 @@ class TestDeploymentTemplateOperations:
         )
 
         with pytest.raises(HttpResponseError):
-            deployment_template_ops.get("")
+            deployment_template_ops.get("", "1.0")
 
     def test_delete_with_invalid_name(self, deployment_template_ops):
         """Test delete operation with invalid template name."""
@@ -434,7 +501,7 @@ class TestDeploymentTemplateOperations:
         deployment_template_ops._operation_scope.workspace_name = "test-workspace"
 
         with pytest.raises(HttpResponseError):
-            deployment_template_ops.delete("")
+            deployment_template_ops.delete("", "1.0")
 
     @patch("azure.ai.ml.entities._load_functions.load_deployment_template")
     def test_create_or_update_yaml_file_not_found(self, mock_load, deployment_template_ops):
@@ -813,27 +880,39 @@ class TestDeploymentTemplateOperations:
             deployment_template_ops.create_or_update({"name": "test"})
 
     def test_delete_default_version(self, deployment_template_ops):
-        """Test delete operation with default version."""
+        """Test delete resolves the latest version when no version is provided."""
         deployment_template_ops._service_client.deployment_templates.delete = Mock()
+        deployment_template_ops.list = Mock(
+            return_value=[
+                DeploymentTemplate(name="test-template", version="1"),
+                DeploymentTemplate(name="test-template", version="3"),
+            ]
+        )
         deployment_template_ops._operation_scope.subscription_id = "test-sub"
         deployment_template_ops._operation_scope.resource_group_name = "test-rg"
         deployment_template_ops._operation_scope.registry_name = "test-registry"
 
         deployment_template_ops.delete("test-template")
 
-        # Verify version defaults to "latest"
+        # Verify version defaults to the highest available version (not the literal string "latest")
         call_args = deployment_template_ops._service_client.deployment_templates.delete.call_args
-        assert call_args[1]["version"] == "latest"
+        assert call_args[1]["version"] == "3"
 
     def test_get_default_version(self, deployment_template_ops, sample_rest_template):
-        """Test get operation with default version."""
+        """Test get resolves the latest version when no version is provided."""
         deployment_template_ops._service_client.deployment_templates.get = Mock(return_value=sample_rest_template)
+        deployment_template_ops.list = Mock(
+            return_value=[
+                DeploymentTemplate(name="test-template", version="1"),
+                DeploymentTemplate(name="test-template", version="3"),
+            ]
+        )
         deployment_template_ops._operation_scope.subscription_id = "test-sub"
         deployment_template_ops._operation_scope.resource_group_name = "test-rg"
         deployment_template_ops._operation_scope.registry_name = "test-registry"
 
         deployment_template_ops.get("test-template")
 
-        # Verify version defaults to "latest"
+        # Verify version defaults to the highest available version (not the literal string "latest")
         call_args = deployment_template_ops._service_client.deployment_templates.get.call_args
-        assert call_args[1]["version"] == "latest"
+        assert call_args[1]["version"] == "3"


### PR DESCRIPTION
### Notes
- Fixes internal bug #5402671: `deployment_templates.get(name)` with no version failed with `DeploymentTemplate {name}:latest not found` (404), and there was no way to resolve a `labels/latest` reference.
- Root cause: `get()` did `version = version or "latest"` and sent the literal string `"latest"` in the version slot. The service treats that as a **label** (a nickname), not "highest version". These templates have numeric versions (e.g. 1..5) with no `"latest"` label, so the lookup 404'd. There is also no `label=` parameter, so a Model's `allowedDeploymentTemplates` reference (`.../deploymenttemplates//labels/latest`) could not be resolved.
- Fix: the latest version is now resolved **client-side** by listing the available (active) versions and selecting the highest. This is required because the deployment-template REST surface exposes **no `latest` label** and its list endpoint has **no server-side ordering** (unlike Index/Prompt, which have a dedicated `get_latest` endpoint).
- `get()` now also accepts a `label` keyword, mirroring `models.get()`: `label="latest"` resolves to the latest version, `version` and `label` are mutually exclusive, and any other (unsupported) label raises a clear error instead of a bare `:latest not found`.
- `delete(name)` had the same latent `version or "latest"` bug and now resolves the latest version the same way. `archive(name)` / `restore(name)` are fixed transitively because they call `get()`.

### Testing
- Added `test_get_no_version_resolves_latest` and `test_delete_no_version_resolves_latest` — assert the highest version is selected (not the literal `"latest"`).
- Added `test_get_label_latest_resolves_latest` — `label="latest"` resolves to the latest version.
- Added `test_get_version_and_label_raises` (both supplied → `ValueError`) and `test_get_unsupported_label_raises` (non-`latest` label → `ResourceNotFoundError` naming the label).
- Added `test_get_no_versions_raises_not_found` — no versions available → clear `ResourceNotFoundError`.
- Updated `test_get_default_version` / `test_delete_default_version`, which previously asserted the buggy `version == "latest"`, to assert the resolved highest version.
- Verified live against the `azure-huggingface` registry: `get(name)` and `get(name, label="latest")` both return the latest version (v5), `get(name, version, label)` raises `ValueError`, and `get(name, <unsupported label>)` raises `ResourceNotFoundError`.
- Full `deployment_template` unit suite passes (111 tests); `black` and `isort` clean.

# Description

Fixes internal bug #5402671. `deployment_templates.get(name)` no longer fails with `DeploymentTemplate {name}:latest not found` when called without a version. Previously the literal string `"latest"` was sent as the version, which the service interprets as a label rather than "highest version". The latest version is now resolved client-side (list versions, pick the highest), since the deployment-template service exposes no `latest` label and no server-side ordering. `get()` additionally accepts a `label` keyword (`label="latest"` resolves to the latest version) mirroring `models.get()`, so `labels/latest` references carried on a Model's `allowedDeploymentTemplates` can be resolved; `version` and `label` are mutually exclusive and unsupported labels raise a clear error. `delete(name)` resolves the latest version the same way, and `archive()` / `restore()` inherit the fix via `get()`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

## Verification

All checks below were run against the live `azure-huggingface` registry (and the in-repo unit tests), on the branch with this fix.

### 1. Repro - the crash is gone
<img width="1245" height="682" alt="Screenshot 2026-07-09 195543" src="https://github.com/user-attachments/assets/93510a63-cb96-40f3-b794-d11e09f76383" />


### 2. Reporter's suggested acceptance test - passing
<img width="1241" height="923" alt="Screenshot 2026-07-09 200306" src="https://github.com/user-attachments/assets/bd6666e9-b6ac-49de-b2b7-446da82cd04e" />


### 3. In-repo unit tests - passing
<img width="1240" height="566" alt="Screenshot 2026-07-09 195944" src="https://github.com/user-attachments/assets/c83c86be-0052-4b76-a72a-0ffd063683fb" />


### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
