### PR TITLE
Upgrade BinSkim from deprecated v1.9.5 to v4.3.1 in 1ES SDL config

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -51,6 +51,11 @@ extends:
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false
+      # Upgrade BinSkim from the deprecated v1.9.5 to v4.3.1. The automatic
+      # upgrade only applies to pipelines with auto-baselining enabled, which is
+      # disabled here for everything except 'python - core', so set it manually.
+      binskim:
+        preReleaseVersion: '4.3.1'
       eslint:
         enabled: false
         justificationForDisabling: "ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azur     19 e-sdk/internal/_build/results?buildId=3556850"


### PR DESCRIPTION
## Summary
1ES Pipeline Templates inject BinSkim as part of SDL Binary Analysis. 1ES PT auto-upgraded BinSkim from v1.9.5 to v4.3.1 **only** for pipelines with auto-baselining enabled. Our `sdl` config in `eng/pipelines/templates/stages/1es-redirect.yml` sets `featureFlags.autoBaseline: false` for every pipeline except `python - core`, so the automatic upgrade never applied and those pipelines still surface the non-blocking S360 warning:

> 1ES PT Non-Blocking Error: This pipeline is using the deprecated BinSkim v1.9.5 which will be retired and upgraded to the latest version.

## Why v4.3.1
Per the 1ES guidance (https://aka.ms/1espt/binskim195): v1.9.5 bundles a vulnerable `msdia140.dll` (malicious PDBs could attack BinSkim users). v4.3.1 fixes this and adds features such as scanning DLLs with embedded PDBs.

## Change
Adds the recommended manual override to the shared `sdl:` block:

```yaml
sdl:
  binskim:
    preReleaseVersion: '4.3.1'
```

This works for both Official and Unofficial 1ES templates and applies repo-wide.

## Notes
- If BinSkim v4.3.1 surfaces new findings, manual rebaselining will be required (download new baselines and check in). Unlikely for this repo since it ships no compiled binaries of its own.
- Flagging for eng-sys / 1ES owners to review — this is a repo-wide pipeline config change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>