### PR TITLE
ci: fork PRs in regen workflow

### DIFF
--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -71,7 +71,6 @@ jobs:
             HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
             HEAD_OWNER=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login')
             HEAD_REPO_NAME=$(echo "$PR_JSON" | jq -r '.headRepository.name')
-            # Security: refuse to run code from a fork of microsoft/typespec.
             # This job checks out and EXECUTES the PR head repo's code (npm
             # install/build/prepare/regenerate) with a write-scoped token, so a
             # fork head would run untrusted code in a privileged context.

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -71,6 +71,14 @@ jobs:
             HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
             HEAD_OWNER=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login')
             HEAD_REPO_NAME=$(echo "$PR_JSON" | jq -r '.headRepository.name')
+            # Security: refuse to run code from a fork of microsoft/typespec.
+            # This job checks out and EXECUTES the PR head repo's code (npm
+            # install/build/prepare/regenerate) with a write-scoped token, so a
+            # fork head would run untrusted code in a privileged context.
+            if [ "${HEAD_OWNER}/${HEAD_REPO_NAME}" != "microsoft/typespec" ]; then
+              echo "::error::Regeneration from fork-based pull requests is not allowed for security reasons. PR #${PR_NUMBER} has its head branch on '${HEAD_OWNER}/${HEAD_REPO_NAME}', not 'microsoft/typespec'. Push the PR branch to microsoft/typespec directly (a non-fork branch) and re-run this workflow."
+              exit 1
+            fi
             REPO="${HEAD_OWNER}/${HEAD_REPO_NAME}"
             REF="${HEAD_SHA}"
             DISPLAY_REF="PR #${PR_NUMBER} @ ${HEAD_SHA:0:7}"

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -75,7 +75,7 @@ jobs:
             # install/build/prepare/regenerate) with a write-scoped token, so a
             # fork head would run untrusted code in a privileged context.
             if [ "${HEAD_OWNER}/${HEAD_REPO_NAME}" != "microsoft/typespec" ]; then
-              echo "::error::Regeneration from fork-based pull requests is not allowed for security reasons. PR #${PR_NUMBER} has its head branch on '${HEAD_OWNER}/${HEAD_REPO_NAME}', not 'microsoft/typespec'. Push the PR branch to microsoft/typespec directly (a non-fork branch) and re-run this workflow."
+              echo "::error::Regeneration from fork-based pull requests is not allowed. PR #${PR_NUMBER} has its head branch on '${HEAD_OWNER}/${HEAD_REPO_NAME}', not 'microsoft/typespec'. Push the PR branch to microsoft/typespec directly (a non-fork branch) and re-run this workflow."
               exit 1
             fi
             REPO="${HEAD_OWNER}/${HEAD_REPO_NAME}"

--- a/.github/workflows/typespec-python-regenerate.yml
+++ b/.github/workflows/typespec-python-regenerate.yml
@@ -72,7 +72,7 @@ jobs:
             HEAD_OWNER=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login')
             HEAD_REPO_NAME=$(echo "$PR_JSON" | jq -r '.headRepository.name')
             # This job checks out and EXECUTES the PR head repo's code (npm
-            # install/build/prepare/regenerate) with a write-scoped token, so a
+            # install/build/prepare/regenerate), so a
             # fork head would run untrusted code in a privileged context.
             if [ "${HEAD_OWNER}/${HEAD_REPO_NAME}" != "microsoft/typespec" ]; then
               echo "::error::Regeneration from fork-based pull requests is not allowed. PR #${PR_NUMBER} has its head branch on '${HEAD_OWNER}/${HEAD_REPO_NAME}', not 'microsoft/typespec'. Push the PR branch to microsoft/typespec directly (a non-fork branch) and re-run this workflow."


### PR DESCRIPTION
## Problem

The `typespec-python-regenerate.yml` workflow accepts a `microsoft/typespec` pull request URL via `workflow_dispatch`. The 'Resolve TypeSpec repo/ref' step resolves that PR to its **head repository + SHA** (`headRepositoryOwner.login` / `headRepository.name`) 

## Change

After resolving the PR's head repo owner/name - if it is anything else (a fork), the step fails with an actionable `::error::` and exits non-zero.