### PR TITLE
[Storage] [STG 103/104] Changelog updates + date for release

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -18,6 +18,11 @@ properties are now populated on the downloaded blob's `properties`.
 `upload_blob_from_url`) in addition to `content_md5` when a content MD5 is
 provided with the request.
 
+### Other Changes
+- Partitioned upload via `upload_blob` with Block Blobs will now generate random,
+unique block ids for each block rather than using a sequential count.
+The length of the new block ids will be the same as previous versions to ensure backwards compatibility.
+
 ## 12.30.0 (2026-06-08)
 
 ### Features Added

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.31.0b1 (Unreleased)
+## 12.31.0b1 (2026-07-21)
 
 ### Features Added
 - Added support for service version 2026-10-06.

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.26.0b1 (Unreleased)
+## 12.26.0b1 (2026-07-21)
 
 ### Features Added
 

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.26.0b1 (2026-07-21)
 
 ### Features Added
+- Added support for service version 2026-10-06.
 
 ## 12.25.0 (2026-06-08)
 

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Release History
 
-## 12.27.0b1 (Unreleased)
+## 12.27.0b1 (2026-07-21)
 
 ### Features Added
 - Added `list_ranges` and `list_ranges_diff` APIs to `ShareFileClient` which return an auto-paging iterable of
 `FileRange` and support continuation tokens and `results_per_page` for enumerating file ranges across multiple
 service responses.
-- Added a new `FileRange` model with `start`, `end`, and `cleared` properties.
 
 ### Other Changes
 - Deprecated `ShareFileClient`'s `get_ranges` and `get_ranges_diff` APIs in favor of `list_ranges` and

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -11,7 +11,7 @@ service responses.
 ### Other Changes
 - Deprecated `ShareFileClient`'s `get_ranges` and `get_ranges_diff` APIs in favor of `list_ranges` and
 `list_ranges_diff`.
-- Migrated generated code to use new TypeSpec generator.
+- Migrated generated code to use the new TypeSpec generator.
 
 ## 12.26.0 (2026-06-08)
 

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.27.0b1 (2026-07-21)
 
 ### Features Added
+- Added support for service version 2026-10-06.
 - Added `list_ranges` and `list_ranges_diff` APIs to `ShareFileClient` which return an auto-paging iterable of
 `FileRange` and support continuation tokens and `results_per_page` for enumerating file ranges across multiple
 service responses.
@@ -10,6 +11,7 @@ service responses.
 ### Other Changes
 - Deprecated `ShareFileClient`'s `get_ranges` and `get_ranges_diff` APIs in favor of `list_ranges` and
 `list_ranges_diff`.
+- Migrated generated code to use new TypeSpec generator.
 
 ## 12.26.0 (2026-06-08)
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added support for service version 2026-10-06.
 
 ### Other Changes
-- Migrated generated code to use new TypeSpec generator.
+- Migrated generated code to use the new TypeSpec generator.
 
 ## 12.17.0 (2026-06-08)
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 12.18.0b1 (2026-07-21)
 
 ### Features Added
+- Added support for service version 2026-10-06.
+
+### Other Changes
+- Migrated generated code to use new TypeSpec generator.
 
 ## 12.17.0 (2026-06-08)
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.18.0b1 (Unreleased)
+## 12.18.0b1 (2026-07-21)
 
 ### Features Added
 


### PR DESCRIPTION
Updated the release date (for now) to 2026-07-21.

Two questions:
1. In Datalake, there are no changes other than `_shared` folder changes from the Unique Put Block IDs feature. Is it fine to leave blank? We've had releases where `Features Added` were left blank.
2. In Queue, there's the TypeSpec changes. Because it's largely generated code, `Features Added`, `Bugs Fixed` are both weird. We could potentially consider specifying this in `Other Changes`, but again none that directly affect the users because they're generated code.