### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -36,7 +36,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean
     ${{ if ne(variables['Build.DefinitionName'], 'python - core') }}:
       featureFlags:
         autoBaseline: false


### PR DESCRIPTION
This pull request updates the network isolation policy in the `eng/pipelines/templates/stages/1es-redirect.yml` pipeline configuration. The change strengthens the network isolation by adding an additional policy.

Pipeline configuration:

* Updated the `networkIsolationPolicy` setting from `Permissive` to `Permissive, CFSClean` to enhance network security and compliance.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6562837&view=resultshttps://dev.azure.com/azure-sdk/internal/_build/results?buildId=6562837&view=results