### PR TITLE
Bump TypeSpec Python emitter to 0.63.3

### DIFF
--- a/.github/skills/emitter-package-update/alignment-sources.json
+++ b/.github/skills/emitter-package-update/alignment-sources.json
@@ -3,9 +3,7 @@
     "packageJsonUrl": "https://github.com/Azure/azure-rest-api-specs/blob/main/package.json",
     "packages": [
       "@azure-tools/openai-typespec",
-      "@typespec/openapi3",
-      "@azure-tools/typespec-liftr-base",
-      "@azure-tools/typespec-azure-portal-core"
+      "@azure-tools/typespec-liftr-base"
     ]
   }
 }

--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -9,11 +9,14 @@
         "@azure-tools/typespec-python": "0.63.3"
       },
       "devDependencies": {
+        "@azure-tools/openai-typespec": "1.21.1",
         "@azure-tools/typespec-autorest": "~0.70.0",
         "@azure-tools/typespec-azure-core": "~0.70.0",
+        "@azure-tools/typespec-azure-portal-core": "~0.70.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
         "@azure-tools/typespec-azure-rulesets": "~0.70.0",
         "@azure-tools/typespec-client-generator-core": "~0.70.0",
+        "@azure-tools/typespec-liftr-base": "0.13.0",
         "@typespec/compiler": "^1.14.0",
         "@typespec/events": "~0.84.0",
         "@typespec/http": "^1.14.0",
@@ -25,6 +28,17 @@
         "@typespec/streams": "~0.84.0",
         "@typespec/versioning": "~0.84.0",
         "@typespec/xml": "~0.84.0"
+      }
+    },
+    "node_modules/@azure-tools/openai-typespec": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.21.1.tgz",
+      "integrity": "sha512-h9O0jAkcSLKzWzk4KzkOv8zLw3P8pYzxflBd3e0RHJ6v4mcI71T1BX4aYmmLUhWmALCqGtqkh17ClAWKuwYWsw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typespec/http": "^1.13.0",
+        "@typespec/openapi": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
@@ -69,6 +83,17 @@
         "@typespec/compiler": "^1.14.0",
         "@typespec/http": "^1.14.0",
         "@typespec/rest": "^0.84.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-portal-core": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.70.0.tgz",
+      "integrity": "sha512-HZSSht0qu8B0Ara6Ni4iu5mfr43wjaq+tWXKuv5eMOSixxMrkZetiYdZDeyKaQpqK08vNTKS6D7OFNDotWuauQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
@@ -135,6 +160,12 @@
         "@typespec/versioning": "^0.84.0",
         "@typespec/xml": "^0.84.0"
       }
+    },
+    "node_modules/@azure-tools/typespec-liftr-base": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.13.0.tgz",
+      "integrity": "sha512-MF40K/IHwyy3N606DTZSPhFSwA/84ekR9RqvmtJXsXD0SdYcQSoAHOJp4o5qw8OAPSC+aKZ5A+TXRx333V/3PQ==",
+      "dev": true
     },
     "node_modules/@azure-tools/typespec-python": {
       "version": "0.63.3",

--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,60 +6,49 @@
     "": {
       "name": "dist/src/index.js",
       "dependencies": {
-        "@azure-tools/typespec-python": "0.63.2"
+        "@azure-tools/typespec-python": "0.63.3"
       },
       "devDependencies": {
-        "@azure-tools/openai-typespec": "1.21.1",
-        "@azure-tools/typespec-autorest": "~0.69.1",
-        "@azure-tools/typespec-azure-core": "~0.69.0",
-        "@azure-tools/typespec-azure-portal-core": "0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.69.2",
-        "@azure-tools/typespec-azure-rulesets": "~0.69.2",
-        "@azure-tools/typespec-client-generator-core": "~0.69.2",
-        "@azure-tools/typespec-liftr-base": "0.13.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "~0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/http-client-python": "^0.34.1",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/openapi3": "1.13.0",
-        "@typespec/rest": "~0.83.0",
-        "@typespec/sse": "~0.83.0",
-        "@typespec/streams": "~0.83.0",
-        "@typespec/versioning": "~0.83.0",
-        "@typespec/xml": "~0.83.0"
-      }
-    },
-    "node_modules/@azure-tools/openai-typespec": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.21.1.tgz",
-      "integrity": "sha512-h9O0jAkcSLKzWzk4KzkOv8zLw3P8pYzxflBd3e0RHJ6v4mcI71T1BX4aYmmLUhWmALCqGtqkh17ClAWKuwYWsw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0"
+        "@azure-tools/typespec-autorest": "~0.70.0",
+        "@azure-tools/typespec-azure-core": "~0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.70.0",
+        "@azure-tools/typespec-client-generator-core": "~0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "~0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/http-client-python": "^0.34.2",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/openapi3": "^1.14.0",
+        "@typespec/rest": "~0.84.0",
+        "@typespec/sse": "~0.84.0",
+        "@typespec/streams": "~0.84.0",
+        "@typespec/versioning": "~0.84.0",
+        "@typespec/xml": "~0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.69.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.1.tgz",
-      "integrity": "sha512-nbAsTagr4pyBO0ajlRnE5TW4tAXrYKFYSoWD+8bevXpe23bkVIJkDUJCZPSgWE7CBf3kxfw53lAb70a50oJmRA==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.70.0.tgz",
+      "integrity": "sha512-OaxLkgMcuOXAbaqTNpezmFF24jtkiIH1+2PBwAeRo3ZG7C1r7Hf8xZwCK6KVtBEgMbqnrd5eCqxsPl1zy3y9/Q==",
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "yaml": "^2.8.3"
+      },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
-        "@azure-tools/typespec-client-generator-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/versioning": "^0.83.0",
-        "@typespec/xml": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -68,35 +57,24 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.69.0.tgz",
-      "integrity": "sha512-UNdPb/DgMvXqwWk9hb54QOAumCJ6u6GGy+bj3RIIT1Sht6FR9rIn8AQ/UQ7WtrhbJBoqvQo5dxtS565a9/VRZw==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.70.0.tgz",
+      "integrity": "sha512-8MojHWRtTLKycJJ98IMoXX/5b9tTo3F0d3Iu20OKoCsORnSDG2NfjOWHJVW63oxA2t8VTlqC6J8BDcnRihygQQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/rest": "^0.83.0"
-      }
-    },
-    "node_modules/@azure-tools/typespec-azure-portal-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.69.0.tgz",
-      "integrity": "sha512-f6S7wz2VdKessVkCIYTy9IFJpZakN2fvT9uQODD934Bq0tREUIeQQEbh53XWddUIJp0QFh7yJx8hTi4RWxAE9g==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/rest": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.2.tgz",
-      "integrity": "sha512-8Kcn68zKwRsAOc4LICYHOeGq9w5sCDLaXp2t0x0/DibVtYlKJI3ixQnUCW1P7et0nyKp92UZNKvjdUXC1kEINg==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.70.0.tgz",
+      "integrity": "sha512-hVrbbsOhU3EQ2yQTppCqsGQwY/HcVZPOINtFkoUo+PUVBmCFXyqLkTO4jvUbsp/LvJEwoQ8aEA8Y35f7VWT5uw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -107,34 +85,34 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/versioning": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/versioning": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.2.tgz",
-      "integrity": "sha512-7FI2Fv4weFGAjAgUnbBkh1FPCW3SxcEQElIo3SHtc4YDXYbDgvs1qCpz+eyGKEdELPnrIFJFrLa/Mu32GxSrZw==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.70.0.tgz",
+      "integrity": "sha512-Uxxl/18oryDwk2S+aYx6cIqiyjmoMeFDGmjuQ72a+aw6u8mZjgahMxNsY0ShvGLSchjsDqsVGaUlazXGXakVrw==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.2",
-        "@azure-tools/typespec-client-generator-core": "^0.69.2",
-        "@typespec/compiler": "^1.13.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.69.2.tgz",
-      "integrity": "sha512-Td+CUO9UNioD/k2aFnv7TcffGGSaxmodshonTwts3/ZBJLmFtZI06odXr0+7/QDM9K9koPDjCg0VwTbS2c6scA==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.70.0.tgz",
+      "integrity": "sha512-8yxOYJfID3wp3FLQYNIa3kbmR5YLWjYtpB+i4u66quHTTQWWANHV1/o9f8xymAf+8fO9jbLo5tw1JerumxISWg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -146,32 +124,26 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/sse": "^0.83.0",
-        "@typespec/streams": "^0.83.0",
-        "@typespec/versioning": "^0.83.0",
-        "@typespec/xml": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/sse": "^0.84.0",
+        "@typespec/streams": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       }
     },
-    "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.13.0.tgz",
-      "integrity": "sha512-MF40K/IHwyy3N606DTZSPhFSwA/84ekR9RqvmtJXsXD0SdYcQSoAHOJp4o5qw8OAPSC+aKZ5A+TXRx333V/3PQ==",
-      "dev": true
-    },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.63.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.63.2.tgz",
-      "integrity": "sha512-eHplLUQF1Ds02HESdtd6/l25glCtdWNI+WhSpaTIEEVx8RfY8gKwylUxWvlz6VlnhY5/u5M6D78+D+2EGk+Djg==",
+      "version": "0.63.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.63.3.tgz",
+      "integrity": "sha512-Ba4yZ1WcMgPZT0xaW4v7M5eOaUNtyLue2mpQwKNZ72dxO1Zm5d8OIhonEWPHvjv11GESc7ItMf2E0o40+gUHWA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-python": ">=0.33.0 <1.0.0",
+        "@typespec/http-client-python": ">=0.34.2 <1.0.0",
         "semver": "^7.7.4",
         "tsx": "^4.21.0"
       },
@@ -179,20 +151,20 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": "^0.69.1",
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
-        "@azure-tools/typespec-azure-rulesets": "^0.69.1",
-        "@azure-tools/typespec-client-generator-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/sse": "^0.83.0",
-        "@typespec/streams": "^0.83.0",
-        "@typespec/versioning": "^0.83.0",
-        "@typespec/xml": "^0.83.0"
+        "@azure-tools/typespec-autorest": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/sse": "^0.84.0",
+        "@typespec/streams": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1058,9 +1030,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.13.0.tgz",
-      "integrity": "sha512-DonoHiyAMx0UjSmssqTrFtya+v97wny1aHcTLU5QF2wFzLATtcwUU9hbPC+eXhepuTunMOCHf8yk3pEsH6PZYA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.14.0.tgz",
+      "integrity": "sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1075,8 +1047,8 @@
         "prettier": "^3.8.1",
         "semver": "^7.7.4",
         "tar": "^7.5.13",
-        "temporal-polyfill": "^0.3.2",
-        "vscode-languageserver": "^9.0.1",
+        "temporal-polyfill": "^1.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "yaml": "^2.8.3",
         "yargs": "^18.0.0"
@@ -1090,30 +1062,30 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.83.0.tgz",
-      "integrity": "sha512-3EP1EIjdLgwStgd2rGWaF/QqY7YRAt+DIYnnYG2VsdPwa8s2t6K6eJ9YJDXveeHImAkHs+cpFuwxnjKMl4hOyw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.84.0.tgz",
+      "integrity": "sha512-UroDIu6t6Z+cOLyX8I+GJWhSFmYGrp1L93F7ZVt0Ypmj0ndmC9YYa4cpeEyS5PDDIC8u49WfCIwfGegxt4rPVQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.13.0.tgz",
-      "integrity": "sha512-tf8XFddU6g1MZSAVCLC/0Xa4fNfUO0CcHe6PWpmC3bvUojxMnpRcERI2DdoRJ+aycB9Q+Z8wN8bJO3up6u+sCw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.14.0.tgz",
+      "integrity": "sha512-W+heCzu8K63AVcoX8MachVWaRxSAMFWOI1yBTc2Kq8QHaJeDiLL5JbU8VfTZ4tL/6EoGSdKfIT5ZNRW7oVCzhg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/streams": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/streams": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1122,9 +1094,9 @@
       }
     },
     "node_modules/@typespec/http-client-python": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.34.1.tgz",
-      "integrity": "sha512-ts5eI67WdDeMZEQ8SVNI1BOlU34gqTTBGZEicKqgZ99O1q61mDCbMIcC3Aphgdgvh/dmSCWU4XteQpy/gg1LAA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-python/-/http-client-python-0.34.2.tgz",
+      "integrity": "sha512-GngEovDgQlDD/+LIMsINT103t4MfxqDV6dJnJ5osRdg2sMWcNqYnCglAmIgMHsQHrvji3FIdcsD8LJ7Lqdiurg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1138,20 +1110,20 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.69.1 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.69.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.69.1 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.69.1 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.69.1 <1.0.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": ">=0.83.0 <1.0.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": ">=0.83.0 <1.0.0",
-        "@typespec/sse": ">=0.83.0 <1.0.0",
-        "@typespec/streams": ">=0.83.0 <1.0.0",
-        "@typespec/versioning": ">=0.83.0 <1.0.0",
-        "@typespec/xml": ">=0.83.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.70.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.70.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.70.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.70.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.70.0 <1.0.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": ">=0.84.0 <1.0.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": ">=0.84.0 <1.0.0",
+        "@typespec/sse": ">=0.84.0 <1.0.0",
+        "@typespec/streams": ">=0.84.0 <1.0.0",
+        "@typespec/versioning": ">=0.84.0 <1.0.0",
+        "@typespec/xml": ">=0.84.0 <1.0.0"
       }
     },
     "node_modules/@typespec/http-client-python/node_modules/semver": {
@@ -1167,23 +1139,23 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.13.0.tgz",
-      "integrity": "sha512-omPc9n+LM2WvjYwnIf31RCxmG17fFUOVLBRsWg4T1mbcsNCj4grnNP7Lwt+irIZCiKtmLKxq3ViE7jYixCkZ3g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.14.0.tgz",
+      "integrity": "sha512-KL7kImPhCXRmxpHVt1k7TWaa4bb3NbSeUx2rxyxeq7lYZFllI6/NYRCTOI/5JOrbElWmmSxrajU9K9IAKI6PkQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.13.0.tgz",
-      "integrity": "sha512-G6ayl30kXYVhJvL2/zFwtTdWnCt6N6jZWxs8rAwYiFlZfaG8R/dzjRgcap9Dr0v+6AyWmRwooxRKM3TLi5R/mg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.14.0.tgz",
+      "integrity": "sha512-14wjep65fvxWQHObYMaT2zISzwfdkArQ2SPkM7+t5pvAWMwKn4dnv7rSP4QRvxqjaiLsQAz7GT1SS8DaX9BhgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1200,14 +1172,14 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/json-schema": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/sse": "^0.83.0",
-        "@typespec/streams": "^0.83.0",
-        "@typespec/versioning": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/json-schema": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/sse": "^0.84.0",
+        "@typespec/streams": "^0.84.0",
+        "@typespec/versioning": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/events": {
@@ -1231,72 +1203,72 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.83.0.tgz",
-      "integrity": "sha512-WMEwEe1kdaOdZ0c+ct5BVmTSBXkrPniUYDWCz3K52T4in2dNc7J6YGP6tL8bXgQz5B0CsP0VNO12N+UysQDsLw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.84.0.tgz",
+      "integrity": "sha512-9s5dDfRoHRPdtbVvkBasUx/RnMvwWMTuXRieSQDEji4gWGgxVu4Zt4MiEEKSfQrkMr3Aw0QjRCSxBxjMCHIOmA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.83.0.tgz",
-      "integrity": "sha512-04WNaju2rwBbcF5pG+HrKQtdcrmSGuTVziLHNA9XOqj1qM7Uon3+wo2g+ZZ3Z6tngfqQoTCPyDcRHqZtGRdNuw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.84.0.tgz",
+      "integrity": "sha512-9joNgVisRCWDFfV1d79iTAuR1W/6r+AKJrKUfcjsaTrq5A8OWW3v5TTsfxbHAZArn7n2WxQkqhNGgNyc8LjEng==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/streams": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/streams": "^0.84.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.83.0.tgz",
-      "integrity": "sha512-wbO6sdH1Uf+UwjxxsWdHQkjJ3wwiYsAKI+L66qnDYVXAFe02sUdMKd0mxH5o9ipGXE52MZ+yvZ52vHAD+g3RFQ==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.84.0.tgz",
+      "integrity": "sha512-SDneR8+zY+ueOpzg9yJtttfDe/ikB99JgddZSXKPwiDPlAIEeEvI8auipcYfB58EEOB21h8Oq0tEm8HqiAAWdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.83.0.tgz",
-      "integrity": "sha512-nE66ta0ixpHB6FQpSzqnj8QnVfgFsxeK/4Xv+DxYx2nB/w18f6VjkF+hW+A/zs1tZIYvBZVbCNa/Rcr8zM6fhg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.84.0.tgz",
+      "integrity": "sha512-ZoDasTDj4z0mgFK+0cJL2+7DduCaTjvICHL2nQ/RBWc7nLgObaIYCjvXLno8WneDXnpxCAr7larN4/nlHEv9fg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.83.0.tgz",
-      "integrity": "sha512-2/dtAD8jGPkIdwpQ1G1P+5+qdMPeafQiIKCd8NdAnOo0w9OZ59Io52jINm9HdN8+FcbOrqK8+B2N9rlPRj7PqA==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.84.0.tgz",
+      "integrity": "sha512-3x0spgIrr4u3azkYaOxrlumtjoqPiUnJ/G5RwGBmUCAeE5F413MHf/AeIkmZ2ULT1gY3myabfZp8bOijTbMk7A==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/ajv": {
@@ -1746,9 +1718,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1844,9 +1816,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -1860,24 +1832,31 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -1893,34 +1872,34 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1930,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -1953,9 +1932,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -19,6 +19,9 @@
     "@azure-tools/typespec-azure-core": "~0.70.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
     "@azure-tools/typespec-azure-rulesets": "~0.70.0",
-    "@azure-tools/typespec-client-generator-core": "~0.70.0"
+    "@azure-tools/typespec-client-generator-core": "~0.70.0",
+    "@azure-tools/typespec-azure-portal-core": "~0.70.0",
+    "@azure-tools/typespec-liftr-base": "0.13.0",
+    "@azure-tools/openai-typespec": "1.21.1"
   }
 }

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,27 +1,24 @@
 {
   "name": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.63.2"
+    "@azure-tools/typespec-python": "0.63.3"
   },
   "devDependencies": {
-    "@typespec/compiler": "^1.13.0",
-    "@typespec/http": "^1.13.0",
-    "@typespec/rest": "~0.83.0",
-    "@typespec/versioning": "~0.83.0",
-    "@typespec/openapi": "^1.13.0",
-    "@typespec/events": "~0.83.0",
-    "@typespec/sse": "~0.83.0",
-    "@typespec/streams": "~0.83.0",
-    "@typespec/xml": "~0.83.0",
-    "@typespec/openapi3": "1.13.0",
-    "@typespec/http-client-python": "^0.34.1",
-    "@azure-tools/openai-typespec": "1.21.1",
-    "@azure-tools/typespec-azure-portal-core": "0.69.0",
-    "@azure-tools/typespec-autorest": "~0.69.1",
-    "@azure-tools/typespec-azure-core": "~0.69.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.69.2",
-    "@azure-tools/typespec-azure-rulesets": "~0.69.2",
-    "@azure-tools/typespec-client-generator-core": "~0.69.2",
-    "@azure-tools/typespec-liftr-base": "0.13.0"
+    "@typespec/compiler": "^1.14.0",
+    "@typespec/http": "^1.14.0",
+    "@typespec/rest": "~0.84.0",
+    "@typespec/versioning": "~0.84.0",
+    "@typespec/openapi": "^1.14.0",
+    "@typespec/events": "~0.84.0",
+    "@typespec/sse": "~0.84.0",
+    "@typespec/streams": "~0.84.0",
+    "@typespec/xml": "~0.84.0",
+    "@typespec/openapi3": "^1.14.0",
+    "@typespec/http-client-python": "^0.34.2",
+    "@azure-tools/typespec-autorest": "~0.70.0",
+    "@azure-tools/typespec-azure-core": "~0.70.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.70.0",
+    "@azure-tools/typespec-client-generator-core": "~0.70.0"
   }
 }


### PR DESCRIPTION
Bumps `@azure-tools/typespec-python` to `0.63.3` in `eng/emitter-package.json` and refreshes `eng/emitter-package-lock.json` accordingly.