### PR TITLE
Enforce CFSClean

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -36,7 +36,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean
     ${{ if ne(variables['Build.DefinitionName'], 'python - core') }}:
       featureFlags:
         autoBaseline: false

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -2,6 +2,9 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: ''
+  - name: DevFeedName
+    type: string
+    default: 'public/azure-sdk-for-python'
   - name: BuildTargetingString
     type: string
     default: 'azure-*'
@@ -29,6 +32,13 @@ stages:
             displayName: 'Use Python 3.10'
             inputs:
               versionSpec: '3.10'
+
+          # Authenticate pip to the configured Azure DevOps feed before installs.
+          - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+            parameters:
+              DevFeedName: ${{ parameters.DevFeedName }}
+              EnableTwineAuth: false
+
           - script: |
               python -m pip install -r eng/ci_tools.txt
             displayName: 'Prep Environment'


### PR DESCRIPTION
This pull request makes a small configuration update to the pipeline template. The change updates the `networkIsolationPolicy` setting to include an additional policy.

- Pipeline configuration:
  * In `eng/pipelines/templates/stages/1es-redirect.yml`, the `networkIsolationPolicy` setting is changed from `Permissive` to `Permissive, CFSClean` to enhance network isolation during pipeline execution.
  
[python - conda sync](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8044)
[python - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6569923&view=results)
[python - identity - tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6569940&view=results)
[python - core - tests-weekly](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6572821&view=results)
[python - core](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6573738&view=results)