### PR TITLE
[EngSys] Reserve name pipeline: authenticate pip to CFS feed

### DIFF
--- a/eng/pipelines/templates/jobs/build-namereserve-package.yml
+++ b/eng/pipelines/templates/jobs/build-namereserve-package.yml
@@ -18,6 +18,10 @@ jobs:
         inputs:
           versionSpec: '3.13'
 
+      - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+        parameters:
+          EnableTwineAuth: false
+
       - pwsh: |
           python -m pip install -r eng/ci_tools.txt
         displayName: Install Dependencies


### PR DESCRIPTION
## Problem

The `python - reserve-package-name` pipeline (definition 8013) fails at the **Install Dependencies** step on the `main` branch. Example: build 6568665.

Installing `./eng/tools/azure-sdk-tools[ghtools]` (from `eng/ci_tools.txt`) triggers pip **build isolation**, which spins up a fresh env and downloads `setuptools>=42`/`wheel` from public **pypi.org**. The build agents have no egress to pypi.org, so it fails:

```
WinError 10013: An attempt was made to access a socket in a way forbidden by its access permissions
ERROR: No matching distribution found for setuptools>=42
ERROR: Failed to build .../eng/tools/azure-sdk-tools when installing build dependencies
```

## Fix

Add the `auth-dev-feed.yml` template after `UsePythonVersion@0`. It runs `PipAuthenticate@1` and sets `PIP_INDEX_URL` to the authenticated, CFS-backed `public/azure-sdk-for-python` feed (with pypi.org upstream). The build-isolation subprocess inherits `PIP_INDEX_URL`, so `setuptools>=42` resolves via the feed instead of blocked pypi.org. This matches the pattern already used in `build-package-artifacts.yml`.

`EnableTwineAuth: false` because publishing uses 1ES artifact upload, not twine.

## Validation

Verified green on branch build 6568809 (`azure-storage-extensions==0.0.0b1` published to PyPI).