### PR TITLE
Deduplicate changelog entries from generated `types` module

### DIFF
--- a/scripts/breaking_changes_checker/README.md
+++ b/scripts/breaking_changes_checker/README.md
@@ -7,20 +7,6 @@ The breaking changes tool compares the last stable/GA version of the library (if
 
 Add your package name to the `RUN_BREAKING_CHANGES_PACKAGES` found [here](https://github.com/Azure/azure-sdk-for-python/tree/main/scripts/breaking_changes_checker/breaking_changes_allowlist.py).
 
-## Run tests
-
-The default test command runs the full suite, including slow integration tests that generate full code reports for large packages:
-
-```bash
-python -m pytest tests/
-```
-
-Skip those slow tests for a faster local signal:
-
-```bash
-python -m pytest tests/ --fast
-```
-
 ## Run locally with `azpysdk`
 
 **1) Install azpysdk:**
@@ -213,4 +199,18 @@ C:\azure-sdk-for-python\sdk\storage\azure-storage-blob> azpysdk breaking . --cha
 ```
 
 > **Note:** The apistub-based report is *functionally equivalent* to the import-based report (same namespaces, classes, enums, methods/overloads, properties and module functions) but not byte-identical — enum values reflect member names and the inherited `str`/`Mapping` boilerplate is omitted. Since both sides of a comparison use the same converter, those differences cancel out in the diff.
+
+## Run tests
+
+The default test command runs the full suite, including slow integration tests that generate full code reports for large packages:
+
+```bash
+python -m pytest tests/
+```
+
+Skip those slow tests for a faster local signal:
+
+```bash
+python -m pytest tests/ --fast
+```
 

--- a/scripts/breaking_changes_checker/README.md
+++ b/scripts/breaking_changes_checker/README.md
@@ -7,6 +7,20 @@ The breaking changes tool compares the last stable/GA version of the library (if
 
 Add your package name to the `RUN_BREAKING_CHANGES_PACKAGES` found [here](https://github.com/Azure/azure-sdk-for-python/tree/main/scripts/breaking_changes_checker/breaking_changes_allowlist.py).
 
+## Run tests
+
+The default test command runs the full suite, including slow integration tests that generate full code reports for large packages:
+
+```bash
+python -m pytest tests/
+```
+
+Skip those slow tests for a faster local signal:
+
+```bash
+python -m pytest tests/ --fast
+```
+
 ## Run locally with `azpysdk`
 
 **1) Install azpysdk:**

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -15,9 +15,10 @@
 # A `types` entry is only dropped when the sibling `models` module reports the *same* change
 # (same change type and arguments, with the module substituted). This ensures we never silently
 # drop a change that only exists on the `types` side (which would otherwise disappear from the
-# breaking-change / changelog output). Member names are normalized to snake_case before
-# comparison because the `types` TypedDicts expose wire names (e.g. `serviceTreeId`) while the
-# `models` classes expose the Python attribute names (e.g. `service_tree_id`).
+# breaking-change / changelog output). Class names and semantic values (type strings, defaults)
+# are compared exactly; only the member-name position is normalized to snake_case, because the
+# `types` TypedDicts expose wire names (e.g. `serviceTreeId`) while the `models` classes expose
+# the Python attribute names (e.g. `service_tree_id`).
 # --------------------------------------------------------------------------------------------
 
 import re
@@ -40,10 +41,16 @@ class ShadowTypesModuleChecker:
                 return None
             return module_name[: -len("types")] + "models"
 
-        def _normalized_payload(change, module):
-            # (change_type, module, *args) with member/class names normalized to snake_case so
-            # that `types` wire names match the corresponding `models` attribute names.
-            return (change[1], module) + tuple(_to_snake_case(arg) for arg in change[3:])
+        def _match_key(change, module):
+            # Key is (change_type, module, class_name, [member_name], *rest). The class name
+            # (args[0]) and any trailing semantic values are compared exactly; only the member
+            # name (args[1]) is normalized so that `types` wire names match `models` attribute
+            # names.
+            args = change[3:]
+            normalized_args = tuple(
+                _to_snake_case(arg) if index == 1 else arg for index, arg in enumerate(args)
+            )
+            return (change[1], module) + normalized_args
 
         def _is_shadow_duplicate(change, changes_list) -> bool:
             # The module name is the third element of every reported change tuple and the
@@ -54,11 +61,11 @@ class ShadowTypesModuleChecker:
             if len(change) <= 3:
                 # Module-level change with no class to match against; keep it to be safe.
                 return False
-            target = _normalized_payload(change, sibling_models)
+            target = _match_key(change, sibling_models)
             for candidate in changes_list:
                 if candidate is change or candidate[2] != sibling_models:
                     continue
-                if _normalized_payload(candidate, candidate[2]) == target:
+                if _match_key(candidate, candidate[2]) == target:
                     return True
             return False
 

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -32,6 +32,14 @@ def _to_snake_case(name):
     return name.lower()
 
 
+def _hashable(value):
+    # Change tuples may carry list arguments (e.g. parameter-ordering changes); convert them to
+    # tuples so the resulting match key can live in a set.
+    if isinstance(value, list):
+        return tuple(_hashable(item) for item in value)
+    return value
+
+
 class ShadowTypesModuleChecker:
     def run_check(self, breaking_changes: list, features_added: list, *, diff: dict, stable_nodes: dict, current_nodes: dict, **kwargs) -> tuple[list, list]:
         def _sibling_models_module(module_name):
@@ -48,31 +56,26 @@ class ShadowTypesModuleChecker:
             # names.
             args = change[3:]
             normalized_args = tuple(
-                _to_snake_case(arg) if index == 1 else arg for index, arg in enumerate(args)
+                _hashable(_to_snake_case(arg) if index == 1 else arg) for index, arg in enumerate(args)
             )
             return (change[1], module) + normalized_args
 
-        def _is_shadow_duplicate(change, changes_list) -> bool:
-            # The module name is the third element of every reported change tuple and the
-            # class name (when present) is the fourth.
-            sibling_models = _sibling_models_module(change[2])
-            if sibling_models is None:
-                return False
-            if len(change) <= 3:
-                # Module-level change with no class to match against; keep it to be safe.
-                return False
-            target = _match_key(change, sibling_models)
-            for candidate in changes_list:
-                if candidate is change or candidate[2] != sibling_models:
+        def _filter(changes_list):
+            # Pre-index the match key of every change once so each `types` entry can be checked
+            # with a single O(1) set lookup instead of rescanning the whole list (avoids O(n^2)).
+            candidate_keys = {_match_key(change, change[2]) for change in changes_list if len(change) > 3}
+            result = []
+            for change in changes_list:
+                sibling_models = _sibling_models_module(change[2])
+                # Drop a `types` entry only when the sibling `models` module reports the same
+                # change. A module-level change (len <= 3) has no class to match, so keep it.
+                if (
+                    sibling_models is not None
+                    and len(change) > 3
+                    and _match_key(change, sibling_models) in candidate_keys
+                ):
                     continue
-                if _match_key(candidate, candidate[2]) == target:
-                    return True
-            return False
+                result.append(change)
+            return result
 
-        breaking_changes_copy = [
-            change for change in breaking_changes if not _is_shadow_duplicate(change, breaking_changes)
-        ]
-        features_added_copy = [
-            change for change in features_added if not _is_shadow_duplicate(change, features_added)
-        ]
-        return breaking_changes_copy, features_added_copy
+        return _filter(breaking_changes), _filter(features_added)

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -12,11 +12,23 @@
 # name exists in both modules, changes such as adding a new model are reported twice, e.g.
 # "Added model `Foo`" appears once for `...models` and once for `...types`.
 #
-# A `types` entry is only treated as a shadow duplicate when the sibling `models` module
-# actually contains a class with the same name. This class-existence guard ensures we do not
-# silently drop a change that only exists on the `types` side (a class with no `models`
-# counterpart), which would otherwise disappear from the breaking-change / changelog output.
+# A `types` entry is only dropped when the sibling `models` module reports the *same* change
+# (same change type and arguments, with the module substituted). This ensures we never silently
+# drop a change that only exists on the `types` side (which would otherwise disappear from the
+# breaking-change / changelog output). Member names are normalized to snake_case before
+# comparison because the `types` TypedDicts expose wire names (e.g. `serviceTreeId`) while the
+# `models` classes expose the Python attribute names (e.g. `service_tree_id`).
 # --------------------------------------------------------------------------------------------
+
+import re
+
+
+def _to_snake_case(name):
+    if not isinstance(name, str):
+        return name
+    name = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    return name.lower()
 
 
 class ShadowTypesModuleChecker:
@@ -28,16 +40,12 @@ class ShadowTypesModuleChecker:
                 return None
             return module_name[: -len("types")] + "models"
 
-        def _models_has_class(models_module, class_name) -> bool:
-            if not isinstance(class_name, str):
-                return False
-            for nodes in (current_nodes, stable_nodes):
-                module = nodes.get(models_module)
-                if module and class_name in module.get("class_nodes", {}):
-                    return True
-            return False
+        def _normalized_payload(change, module):
+            # (change_type, module, *args) with member/class names normalized to snake_case so
+            # that `types` wire names match the corresponding `models` attribute names.
+            return (change[1], module) + tuple(_to_snake_case(arg) for arg in change[3:])
 
-        def _is_shadow_duplicate(change) -> bool:
+        def _is_shadow_duplicate(change, changes_list) -> bool:
             # The module name is the third element of every reported change tuple and the
             # class name (when present) is the fourth.
             sibling_models = _sibling_models_module(change[2])
@@ -46,12 +54,18 @@ class ShadowTypesModuleChecker:
             if len(change) <= 3:
                 # Module-level change with no class to match against; keep it to be safe.
                 return False
-            return _models_has_class(sibling_models, change[3])
+            target = _normalized_payload(change, sibling_models)
+            for candidate in changes_list:
+                if candidate is change or candidate[2] != sibling_models:
+                    continue
+                if _normalized_payload(candidate, candidate[2]) == target:
+                    return True
+            return False
 
         breaking_changes_copy = [
-            change for change in breaking_changes if not _is_shadow_duplicate(change)
+            change for change in breaking_changes if not _is_shadow_duplicate(change, breaking_changes)
         ]
         features_added_copy = [
-            change for change in features_added if not _is_shadow_duplicate(change)
+            change for change in features_added if not _is_shadow_duplicate(change, features_added)
         ]
         return breaking_changes_copy, features_added_copy

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -18,10 +18,6 @@
 # counterpart), which would otherwise disappear from the breaking-change / changelog output.
 # --------------------------------------------------------------------------------------------
 
-import sys
-import os
-sys.path.append(os.path.abspath("../../scripts/breaking_changes_checker"))
-
 
 class ShadowTypesModuleChecker:
     def run_check(self, breaking_changes: list, features_added: list, *, diff: dict, stable_nodes: dict, current_nodes: dict, **kwargs) -> tuple[list, list]:

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -12,9 +12,10 @@
 # name exists in both modules, changes such as adding a new model are reported twice, e.g.
 # "Added model `Foo`" appears once for `...models` and once for `...types`.
 #
-# Since the `types` module is always a shadow of the `models` module, any change reported for
-# the `types` module is a duplicate of the corresponding `models` change. This checker removes
-# entries originating from a `types` module when the sibling `models` module exists.
+# A `types` entry is only treated as a shadow duplicate when the sibling `models` module
+# actually contains a class with the same name. This class-existence guard ensures we do not
+# silently drop a change that only exists on the `types` side (a class with no `models`
+# counterpart), which would otherwise disappear from the breaking-change / changelog output.
 # --------------------------------------------------------------------------------------------
 
 import sys
@@ -24,20 +25,37 @@ sys.path.append(os.path.abspath("../../scripts/breaking_changes_checker"))
 
 class ShadowTypesModuleChecker:
     def run_check(self, breaking_changes: list, features_added: list, *, diff: dict, stable_nodes: dict, current_nodes: dict, **kwargs) -> tuple[list, list]:
-        def _is_shadow_types_module(module_name) -> bool:
-            # The module name is the third element of every reported change tuple.
+        def _sibling_models_module(module_name):
             if not isinstance(module_name, str):
-                return False
+                return None
             if module_name != "types" and not module_name.endswith(".types"):
+                return None
+            return module_name[: -len("types")] + "models"
+
+        def _models_has_class(models_module, class_name) -> bool:
+            if not isinstance(class_name, str):
                 return False
-            # Only treat it as a shadow module when a sibling `models` module exists.
-            sibling_models = module_name[: -len("types")] + "models"
-            return sibling_models in current_nodes or sibling_models in stable_nodes
+            for nodes in (current_nodes, stable_nodes):
+                module = nodes.get(models_module)
+                if module and class_name in module.get("class_nodes", {}):
+                    return True
+            return False
+
+        def _is_shadow_duplicate(change) -> bool:
+            # The module name is the third element of every reported change tuple and the
+            # class name (when present) is the fourth.
+            sibling_models = _sibling_models_module(change[2])
+            if sibling_models is None:
+                return False
+            if len(change) <= 3:
+                # Module-level change with no class to match against; keep it to be safe.
+                return False
+            return _models_has_class(sibling_models, change[3])
 
         breaking_changes_copy = [
-            change for change in breaking_changes if not _is_shadow_types_module(change[2])
+            change for change in breaking_changes if not _is_shadow_duplicate(change)
         ]
         features_added_copy = [
-            change for change in features_added if not _is_shadow_types_module(change[2])
+            change for change in features_added if not _is_shadow_duplicate(change)
         ]
         return breaking_changes_copy, features_added_copy

--- a/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
+++ b/scripts/breaking_changes_checker/checkers/shadow_types_module_checker.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------
+# This checker cleans up duplicate reporting caused by the generated `types` module.
+# TypeSpec generated libraries emit a `types` module containing `TypedDict` input aliases
+# that shadow the real models defined in the sibling `models` module. Because the same class
+# name exists in both modules, changes such as adding a new model are reported twice, e.g.
+# "Added model `Foo`" appears once for `...models` and once for `...types`.
+#
+# Since the `types` module is always a shadow of the `models` module, any change reported for
+# the `types` module is a duplicate of the corresponding `models` change. This checker removes
+# entries originating from a `types` module when the sibling `models` module exists.
+# --------------------------------------------------------------------------------------------
+
+import sys
+import os
+sys.path.append(os.path.abspath("../../scripts/breaking_changes_checker"))
+
+
+class ShadowTypesModuleChecker:
+    def run_check(self, breaking_changes: list, features_added: list, *, diff: dict, stable_nodes: dict, current_nodes: dict, **kwargs) -> tuple[list, list]:
+        def _is_shadow_types_module(module_name) -> bool:
+            # The module name is the third element of every reported change tuple.
+            if not isinstance(module_name, str):
+                return False
+            if module_name != "types" and not module_name.endswith(".types"):
+                return False
+            # Only treat it as a shadow module when a sibling `models` module exists.
+            sibling_models = module_name[: -len("types")] + "models"
+            return sibling_models in current_nodes or sibling_models in stable_nodes
+
+        breaking_changes_copy = [
+            change for change in breaking_changes if not _is_shadow_types_module(change[2])
+        ]
+        features_added_copy = [
+            change for change in features_added if not _is_shadow_types_module(change[2])
+        ]
+        return breaking_changes_copy, features_added_copy

--- a/scripts/breaking_changes_checker/supported_checkers.py
+++ b/scripts/breaking_changes_checker/supported_checkers.py
@@ -8,6 +8,7 @@
 from checkers.removed_method_overloads_checker import RemovedMethodOverloadChecker
 from checkers.added_method_overloads_checker import AddedMethodOverloadChecker
 from checkers.changed_function_return_type_checker import ChangedFunctionReturnTypeChecker
+from checkers.shadow_types_module_checker import ShadowTypesModuleChecker
 
 CHECKERS = [
     RemovedMethodOverloadChecker(),
@@ -16,5 +17,5 @@ CHECKERS = [
 ]
 
 POST_PROCESSING_CHECKERS = [
-    # Add any post-processing checkers here
+    ShadowTypesModuleChecker(),
 ]

--- a/scripts/breaking_changes_checker/tests/conftest.py
+++ b/scripts/breaking_changes_checker/tests/conftest.py
@@ -1,2 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--fast", action="store_true", default=False, help="skip slow integration tests")
+
+
 def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: tests that may take up to 10 minutes")
+    config.addinivalue_line("markers", "slow: tests that may take several minutes")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--fast"):
+        return
+
+    skip_slow = pytest.mark.skip(reason="skipped by --fast")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -232,6 +232,78 @@ def test_shadow_types_module_kept_without_models_sibling():
     assert class_name == "TrustedHostSubscription"
 
 
+def test_shadow_types_module_kept_when_class_missing_in_models():
+    # If the sibling `models` module exists but does NOT contain the class, the `types`
+    # class has no `models` counterpart and its change must be preserved.
+    stable = {
+        "azure.mgmt.computelimit.models": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    current = {
+        "azure.mgmt.computelimit.models": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+                # Only present in the `types` module, no counterpart in `models`.
+                "OrphanInput": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    bc = ChangelogTracker(
+        stable, current, "azure-mgmt-computelimit", post_processing_checkers=[ShadowTypesModuleChecker()]
+    )
+    bc.run_checks()
+
+    added_models = [fa for fa in bc.features_added if fa[0] == ChangelogTracker.ADDED_CLASS_MSG]
+    assert len(added_models) == 1
+    _, _, module_name, class_name = added_models[0]
+    assert module_name == "azure.mgmt.computelimit.types"
+    assert class_name == "OrphanInput"
+
+
+def test_shadow_types_module_breaking_change_preserved_for_unmatched_member():
+    # A breaking change on a `types` class that has NO counterpart in the sibling `models`
+    # module must be preserved, while a duplicate whose class does exist in `models` is dropped.
+    checker = ShadowTypesModuleChecker()
+    current_nodes = {
+        "azure.mgmt.computelimit.models": {"class_nodes": {"RealModel": {}}},
+        "azure.mgmt.computelimit.types": {"class_nodes": {"RealModel": {}}},
+    }
+    stable_nodes = {
+        "azure.mgmt.computelimit.models": {"class_nodes": {"RealModel": {}}},
+        "azure.mgmt.computelimit.types": {"class_nodes": {"RealModel": {}, "OrphanInput": {}}},
+    }
+    breaking_changes = [
+        # `OrphanInput` only ever existed in `types`, so its removal is a real breaking change.
+        ("Deleted model `{}`", "RemovedOrRenamedClass", "azure.mgmt.computelimit.types", "OrphanInput"),
+    ]
+    features_added = [
+        # `RealModel` exists in `models`, so the `types` copy is a shadow duplicate.
+        ("Added model `{}`", "AddedClass", "azure.mgmt.computelimit.types", "RealModel"),
+    ]
+
+    bc_out, fa_out = checker.run_check(
+        breaking_changes, features_added, diff={}, stable_nodes=stable_nodes, current_nodes=current_nodes
+    )
+
+    assert bc_out == breaking_changes  # unmatched `types` breaking change preserved
+    assert fa_out == []  # shadow duplicate removed
+
+
 def test_new_class_property_added_init():
     # Testing if a property is added both in the init and at the class level that we only get 1 report for it
     current = {

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -18,6 +18,7 @@ for path in (SCRIPTS_DIR, PACKAGE_DIR):
         sys.path.insert(0, path)
 
 from breaking_changes_checker.checkers.added_method_overloads_checker import AddedMethodOverloadChecker
+from breaking_changes_checker.checkers.shadow_types_module_checker import ShadowTypesModuleChecker
 from breaking_changes_checker.changelog_tracker import ChangelogTracker, BreakingChangesTracker
 from breaking_changes_checker.detect_breaking_changes import main
 from breaking_changes_checker.detect_breaking_changes import test_compare_reports as compare_reports
@@ -149,6 +150,86 @@ def test_async_cleanup_check():
     assert len(bc.features_added) == 1
     msg, _, *args = bc.features_added[0]
     assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
+
+
+def test_shadow_types_module_cleanup():
+    # A TypeSpec generated `types` module holds TypedDict input aliases that shadow the
+    # real models in the sibling `models` module. A newly added model therefore shows up in
+    # both modules and would be reported twice (e.g. "Added model `TrustedHostSubscription`").
+    # The ShadowTypesModuleChecker post-processing step should drop the `types` duplicate.
+    stable = {
+        "azure.mgmt.computelimit.models": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    current = {
+        "azure.mgmt.computelimit.models": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+                "TrustedHostSubscription": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+                "TrustedHostSubscription": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    bc = ChangelogTracker(
+        stable, current, "azure-mgmt-computelimit", post_processing_checkers=[ShadowTypesModuleChecker()]
+    )
+    bc.run_checks()
+
+    added_models = [fa for fa in bc.features_added if fa[0] == ChangelogTracker.ADDED_CLASS_MSG]
+    # Should only have 1 "Added model" reported instead of 2 (the `types` duplicate is removed).
+    assert len(added_models) == 1
+    _, _, module_name, class_name = added_models[0]
+    assert module_name == "azure.mgmt.computelimit.models"
+    assert class_name == "TrustedHostSubscription"
+    # No change originating from the shadow `types` module should remain.
+    assert not any(fa[2] == "azure.mgmt.computelimit.types" for fa in bc.features_added)
+
+
+def test_shadow_types_module_kept_without_models_sibling():
+    # If there is no sibling `models` module, a `types` module is a real public module and
+    # its changes should NOT be dropped.
+    stable = {
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    current = {
+        "azure.mgmt.computelimit.types": {
+            "class_nodes": {
+                "ExistingModel": {"type": None, "methods": {}, "properties": {}},
+                "TrustedHostSubscription": {"type": None, "methods": {}, "properties": {}},
+            }
+        },
+    }
+
+    bc = ChangelogTracker(
+        stable, current, "azure-mgmt-computelimit", post_processing_checkers=[ShadowTypesModuleChecker()]
+    )
+    bc.run_checks()
+
+    added_models = [fa for fa in bc.features_added if fa[0] == ChangelogTracker.ADDED_CLASS_MSG]
+    assert len(added_models) == 1
+    _, _, module_name, class_name = added_models[0]
+    assert module_name == "azure.mgmt.computelimit.types"
+    assert class_name == "TrustedHostSubscription"
 
 
 def test_new_class_property_added_init():

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -350,6 +350,25 @@ def test_shadow_types_module_member_change_deduped_across_naming():
     assert bc_out[0][2] == "azure.mgmt.computelimit.models"
 
 
+def test_shadow_types_module_class_name_matched_exactly():
+    # Class names are compared exactly (not snake_case normalized), so a `types` class whose
+    # name only collides with a differently-named `models` class after normalization is kept.
+    checker = ShadowTypesModuleChecker()
+    features_added = [
+        # Different class names that would collide if class names were snake_cased
+        # (`FooBar` -> `foo_bar`, `Foo_Bar` -> `foo_bar`).
+        ("Added model `{}`", "AddedClass", "azure.mgmt.computelimit.models", "Foo_Bar"),
+        ("Added model `{}`", "AddedClass", "azure.mgmt.computelimit.types", "FooBar"),
+    ]
+
+    _, fa_out = checker.run_check(
+        [], features_added, diff={}, stable_nodes={}, current_nodes={}
+    )
+
+    # No exact class-name match in `models`, so the `types` entry is preserved.
+    assert len(fa_out) == 2
+
+
 def test_new_class_property_added_init():
     # Testing if a property is added both in the init and at the class level that we only get 1 report for it
     current = {

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -276,32 +276,78 @@ def test_shadow_types_module_kept_when_class_missing_in_models():
 
 
 def test_shadow_types_module_breaking_change_preserved_for_unmatched_member():
-    # A breaking change on a `types` class that has NO counterpart in the sibling `models`
-    # module must be preserved, while a duplicate whose class does exist in `models` is dropped.
+    # A `types` change is dropped only when the sibling `models` module reports the *same*
+    # change. Here `OrphanInput` is removed only from `types` (no matching `models` entry), so it
+    # must be preserved, while the `RealModel` addition is mirrored in `models` and thus deduped.
     checker = ShadowTypesModuleChecker()
-    current_nodes = {
-        "azure.mgmt.computelimit.models": {"class_nodes": {"RealModel": {}}},
-        "azure.mgmt.computelimit.types": {"class_nodes": {"RealModel": {}}},
-    }
-    stable_nodes = {
-        "azure.mgmt.computelimit.models": {"class_nodes": {"RealModel": {}}},
-        "azure.mgmt.computelimit.types": {"class_nodes": {"RealModel": {}, "OrphanInput": {}}},
-    }
     breaking_changes = [
         # `OrphanInput` only ever existed in `types`, so its removal is a real breaking change.
         ("Deleted model `{}`", "RemovedOrRenamedClass", "azure.mgmt.computelimit.types", "OrphanInput"),
     ]
     features_added = [
-        # `RealModel` exists in `models`, so the `types` copy is a shadow duplicate.
+        # `RealModel` is added in both modules, so the `types` copy is a shadow duplicate.
+        ("Added model `{}`", "AddedClass", "azure.mgmt.computelimit.models", "RealModel"),
         ("Added model `{}`", "AddedClass", "azure.mgmt.computelimit.types", "RealModel"),
     ]
 
     bc_out, fa_out = checker.run_check(
-        breaking_changes, features_added, diff={}, stable_nodes=stable_nodes, current_nodes=current_nodes
+        breaking_changes, features_added, diff={}, stable_nodes={}, current_nodes={}
     )
 
     assert bc_out == breaking_changes  # unmatched `types` breaking change preserved
-    assert fa_out == []  # shadow duplicate removed
+    assert len(fa_out) == 1  # shadow duplicate removed, `models` entry kept
+    assert fa_out[0][2] == "azure.mgmt.computelimit.models"
+
+
+def test_shadow_types_module_member_change_preserved_when_not_mirrored():
+    # An unmatched *member* change on a class that exists in both modules must be preserved:
+    # `RealModel` loses `orphanProp` only on the `types` side, `models` reports nothing.
+    checker = ShadowTypesModuleChecker()
+    breaking_changes = [
+        (
+            "Model `{}` removed property `{}`",
+            "RemovedOrRenamedInstanceAttribute",
+            "azure.mgmt.computelimit.types",
+            "RealModel",
+            "orphanProp",
+        ),
+    ]
+
+    bc_out, fa_out = checker.run_check(
+        breaking_changes, [], diff={}, stable_nodes={}, current_nodes={}
+    )
+
+    assert bc_out == breaking_changes  # no matching `models` change -> preserved
+    assert fa_out == []
+
+
+def test_shadow_types_module_member_change_deduped_across_naming():
+    # A member change reported in both modules is deduped even though `types` uses the wire name
+    # (`serviceTreeId`) and `models` uses the Python attribute name (`service_tree_id`).
+    checker = ShadowTypesModuleChecker()
+    breaking_changes = [
+        (
+            "Model `{}` removed property `{}`",
+            "RemovedOrRenamedInstanceAttribute",
+            "azure.mgmt.computelimit.models",
+            "FeatureEnableRequest",
+            "service_tree_id",
+        ),
+        (
+            "Model `{}` removed property `{}`",
+            "RemovedOrRenamedInstanceAttribute",
+            "azure.mgmt.computelimit.types",
+            "FeatureEnableRequest",
+            "serviceTreeId",
+        ),
+    ]
+
+    bc_out, _ = checker.run_check(
+        breaking_changes, [], diff={}, stable_nodes={}, current_nodes={}
+    )
+
+    assert len(bc_out) == 1  # `types` duplicate removed despite the camelCase/snake_case names
+    assert bc_out[0][2] == "azure.mgmt.computelimit.models"
 
 
 def test_new_class_property_added_init():

--- a/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
@@ -278,6 +278,7 @@ def _compare_code_reports_to_changelog(
             )
 
 
+@pytest.mark.slow(reason="external package code report generation creates venvs and may take several minutes")
 def test_generate_old_code_report_for_azure_mgmt_peering():
     """Generate azure-mgmt-peering 2.0.0b1 code report."""
     _generate_and_compare_code_report(
@@ -288,6 +289,7 @@ def test_generate_old_code_report_for_azure_mgmt_peering():
     )
 
 
+@pytest.mark.slow(reason="external package code report generation creates venvs and may take several minutes")
 def test_generate_new_code_report_for_azure_mgmt_peering():
     """Generate azure-mgmt-peering 2.0.0b2 code report."""
     _generate_and_compare_code_report(
@@ -340,6 +342,7 @@ def test_compare_code_reports_for_azure_mgmt_apimanagement():
     )
 
 
+@pytest.mark.slow(reason="external package apistub code report generation creates venvs and may take several minutes")
 def test_generate_old_code_report_for_azure_mgmt_peering_apistub():
     """Generate azure-mgmt-peering 2.0.0b1 code report using --use-apistub."""
     _generate_and_compare_code_report(
@@ -351,6 +354,7 @@ def test_generate_old_code_report_for_azure_mgmt_peering_apistub():
     )
 
 
+@pytest.mark.slow(reason="external package apistub code report generation creates venvs and may take several minutes")
 def test_generate_new_code_report_for_azure_mgmt_peering_apistub():
     """Generate azure-mgmt-peering 2.0.0b2 code report using --use-apistub."""
     _generate_and_compare_code_report(
@@ -373,6 +377,7 @@ def test_compare_code_reports_for_azure_mgmt_peering_apistub():
     )
 
 
+@pytest.mark.slow(reason="azure-mgmt-apimanagement apistub code report generation may take several minutes")
 def test_generate_old_code_report_for_azure_mgmt_apimanagement_apistub():
     """Generate azure-mgmt-apimanagement 5.0.0 code report using --use-apistub."""
     _generate_and_compare_code_report(
@@ -385,6 +390,7 @@ def test_generate_old_code_report_for_azure_mgmt_apimanagement_apistub():
     )
 
 
+@pytest.mark.slow(reason="azure-mgmt-apimanagement apistub code report generation may take several minutes")
 def test_generate_new_code_report_for_azure_mgmt_apimanagement_apistub():
     """Generate azure-mgmt-apimanagement 6.0.0b1 code report using --use-apistub."""
     _generate_and_compare_code_report(

--- a/scripts/breaking_changes_checker/tests/test_performance.py
+++ b/scripts/breaking_changes_checker/tests/test_performance.py
@@ -160,6 +160,41 @@ class TestAsyncCleanupPerformance:
         assert "aio" not in changes[0][2]
 
 
+class TestShadowTypesModuleCheckerPerformance:
+    """Test performance of the ShadowTypesModuleChecker post-processing step."""
+
+    def test_shadow_types_cleanup_performance_large(self):
+        """Benchmark shadow-types cleanup with a large number of changes.
+
+        A naive O(n^2) implementation that rescans the whole change list for every `types`
+        entry would be very slow for large diffs. The set-based O(n) approach should handle
+        this in well under a second.
+        """
+        from breaking_changes_checker.checkers.shadow_types_module_checker import ShadowTypesModuleChecker
+
+        n = 10000  # 5,000 models entries + 5,000 shadow types duplicates
+        features_added = []
+        for i in range(n // 2):
+            features_added.append(
+                ("Added model `{}`", "AddedClass", "azure.mgmt.network.models", f"Model{i}")
+            )
+            features_added.append(
+                ("Added model `{}`", "AddedClass", "azure.mgmt.network.types", f"Model{i}")
+            )
+
+        checker = ShadowTypesModuleChecker()
+        start = time.perf_counter()
+        _, fa_out = checker.run_check(
+            [], features_added, diff={}, stable_nodes={}, current_nodes={}
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0, f"shadow types cleanup took {elapsed:.3f}s for {n} changes (expected < 1s)"
+        # All `types` duplicates removed, only the `models` entries remain.
+        assert len(fa_out) == n // 2
+        assert all(fa[2] == "azure.mgmt.network.models" for fa in fa_out)
+
+
 class TestReportableChangesPerformance:
     """Test performance of the optimized get_reportable_changes method."""
 


### PR DESCRIPTION
## Problem

When running `azpysdk breaking . --changelog --use-apistub`, newly added models can appear twice in the changelog, e.g.:

```
### Features Added
  - Client `ComputeLimitMgmtClient` added operation group `trusted_host_subscriptions`
  - Added model `TrustedHostSubscription`
  - Added model `TrustedHostSubscriptionsOperations`
  - Added model `TrustedHostSubscription`   <-- duplicate
```

### Root cause

TypeSpec generated libraries emit a `types` module (e.g. `azure.mgmt.computelimit.types`) containing `TypedDict` input aliases that shadow the real models defined in the sibling `models` module (`azure.mgmt.computelimit.models`). A newly added model is therefore defined in both modules, so the changelog checker reports an `AddedClass` feature for each. Because the `Added model \`{}\`` message only uses the class name (not the module), the two entries render identically and show up as a visible duplicate.

## Fix

Add a `ShadowTypesModuleChecker` post-processing step (registered in `POST_PROCESSING_CHECKERS`).

A `types`-module entry is dropped **only when the sibling `models` module reports the same change** — i.e. the same change type and arguments, with the module substituted. This targeted match avoids silently dropping a change that exists only on the `types` side (which would otherwise disappear from the breaking-change / changelog output).

When building the match key, **class names and semantic values (type strings, defaults) are compared exactly**; only the **member-name position** is normalized to `snake_case`, because the `types` TypedDicts expose wire names (e.g. `serviceTreeId`) while the `models` classes expose the Python attribute names (e.g. `service_tree_id`). This lets a genuine member-level duplicate match across the two naming styles while preserving unmatched, `types`-only changes and avoiding false collisions on class names.

The sibling `models` match keys are indexed once so each `types` entry is checked with an O(1) lookup (no per-entry rescans).

## Tests

Added tests in `tests/test_changelog.py`:

- `test_shadow_types_module_cleanup` — a model added to both `models` and `types` is reported once (from `models`).
- `test_shadow_types_module_kept_without_models_sibling` — a standalone `types` module (no sibling `models`) is not stripped.
- `test_shadow_types_module_kept_when_class_missing_in_models` — a `types` class with no `models` counterpart is preserved.
- `test_shadow_types_module_breaking_change_preserved_for_unmatched_member` — an unmatched `types` breaking change is preserved while a mirrored addition is deduped.
- `test_shadow_types_module_member_change_preserved_when_not_mirrored` — an unmatched member change on a class present in both modules is preserved.
- `test_shadow_types_module_member_change_deduped_across_naming` — a member change reported in both modules is deduped despite the `serviceTreeId` vs `service_tree_id` naming difference.
- `test_shadow_types_module_class_name_matched_exactly` — class names are matched exactly (no snake_case normalization), so differently-named classes that would collide under normalization are not deduped.

And a scalability test in `tests/test_performance.py`:

- `TestShadowTypesModuleCheckerPerformance::test_shadow_types_cleanup_performance_large` — 10,000 entries are processed in well under a second (verifies the O(n) set-based lookup).

Relevant suites (`test_changelog.py`, `test_apiview_converter.py`, shadow-types perf test) pass locally: 34 passed, 1 skipped.
