### PR TITLE
[azure-ai-projects] Fix README context-manager snippets, a typo, and non-canonical env var names in samples

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -104,6 +104,8 @@ with (
         credential=credential
     ) as project_client,
 ):
+    # Use project_client here; the context manager closes it on exit.
+    ...
 ```
 
 To construct an asynchronous client, install the additional package [aiohttp](https://pypi.org/project/aiohttp/):
@@ -127,6 +129,8 @@ async with (
         credential=credential
     ) as project_client,
 ):
+    # Use project_client here; the context manager closes it on exit.
+    ...
 ```
 ### Performing Responses operations using OpenAI client
 
@@ -242,7 +246,7 @@ import sys
 import logging
 
 # Acquire the logger for this client library. Use 'azure' to affect both
-# `azure.core` and `azure.ai.projects' libraries.
+# `azure.core` and `azure.ai.projects` libraries.
 logger = logging.getLogger("azure")
 
 # Set the desired logging level. logging.INFO or logging.DEBUG are good options.

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_audio.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_audio.py
@@ -20,10 +20,10 @@ USAGE:
     pip install "azure-ai-projects>=2.0.0" azure-identity python-dotenv
 
     Set these environment variables with your own values:
-    1) AZURE_AI_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
+    1) FOUNDRY_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Microsoft Foundry project. It has the form: https://<account_name>.services.ai.azure.com/api/projects/<project_name>.
-    2) AZURE_AI_MODEL_DEPLOYMENT_NAME - Required. The name of the model deployment to use for evaluation.
-    3) AZURE_AI_MODEL_DEPLOYMENT_NAME_FOR_AUDIO - Required. The name of the model deployment for audio to use for evaluation, recommend to use "gpt-4o-audio-preview"
+    2) FOUNDRY_MODEL_NAME - Required. The name of the model deployment to use for evaluation.
+    3) FOUNDRY_MODEL_NAME_FOR_AUDIO - Required. The name of the model deployment for audio to use for evaluation, recommend to use "gpt-4o-audio-preview"
 """
 
 import base64
@@ -48,9 +48,9 @@ load_dotenv()
 file_path = os.path.abspath(__file__)
 folder_path = os.path.dirname(file_path)
 
-endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
-model_deployment_name = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
-model_deployment_name_for_audio = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME_FOR_AUDIO"]
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["FOUNDRY_MODEL_NAME"]
+model_deployment_name_for_audio = os.environ["FOUNDRY_MODEL_NAME_FOR_AUDIO"]
 
 
 def audio_to_base64(audio_path: str) -> str:

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_audio_model_target.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_audio_model_target.py
@@ -20,10 +20,10 @@ USAGE:
     pip install "azure-ai-projects>=2.0.0" azure-identity python-dotenv
 
     Set these environment variables with your own values:
-    1) AZURE_AI_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
+    1) FOUNDRY_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Microsoft Foundry project. It has the form: https://<account_name>.services.ai.azure.com/api/projects/<project_name>.
-    2) AZURE_AI_MODEL_DEPLOYMENT_NAME - Required. The name of the model deployment to use for evaluation.
-    3) AZURE_AI_MODEL_DEPLOYMENT_NAME_FOR_AUDIO - Required. The name of the model deployment for audio to use for evaluation, recommend to use "gpt-4o-audio-preview"
+    2) FOUNDRY_MODEL_NAME - Required. The name of the model deployment to use for evaluation.
+    3) FOUNDRY_MODEL_NAME_FOR_AUDIO - Required. The name of the model deployment for audio to use for evaluation, recommend to use "gpt-4o-audio-preview"
 """
 
 import base64
@@ -47,9 +47,9 @@ load_dotenv()
 file_path = os.path.abspath(__file__)
 folder_path = os.path.dirname(file_path)
 
-endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
-model_deployment_name = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
-model_deployment_name_for_audio = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME_FOR_AUDIO"]
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["FOUNDRY_MODEL_NAME"]
+model_deployment_name_for_audio = os.environ["FOUNDRY_MODEL_NAME_FOR_AUDIO"]
 
 
 def audio_to_base64(audio_path: str) -> str:

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_image_model_target.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_score_model_grader_with_image_model_target.py
@@ -18,9 +18,9 @@ USAGE:
     pip install "azure-ai-projects>=2.0.0" azure-identity python-dotenv Pillow
 
     Set these environment variables with your own values:
-    1) AZURE_AI_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
+    1) FOUNDRY_PROJECT_ENDPOINT - Required. The Azure AI Project endpoint, as found in the overview page of your
        Microsoft Foundry project. It has the form: https://<account_name>.services.ai.azure.com/api/projects/<project_name>.
-    2) AZURE_AI_MODEL_DEPLOYMENT_NAME - Required. The name of the model deployment to use for evaluation.
+    2) FOUNDRY_MODEL_NAME - Required. The name of the model deployment to use for evaluation.
 """
 
 import base64
@@ -47,8 +47,8 @@ load_dotenv()
 file_path = os.path.abspath(__file__)
 folder_path = os.path.dirname(file_path)
 
-endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
-model_deployment_name = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_deployment_name = os.environ["FOUNDRY_MODEL_NAME"]
 
 
 def image_to_data_uri(image_file_path: str) -> str:


### PR DESCRIPTION
Documentation-only fixes in the `azure-ai-projects` package. No library code changes.

**README.md**
- The synchronous and asynchronous context-manager snippets end at `):` with no body, which is a `SyntaxError` if copy-pasted. Add a placeholder body (`...`) so the snippets run.
- Fix a mismatched delimiter in a comment: `` `azure.ai.projects' `` -> `` `azure.ai.projects` ``.

**samples/evaluations/** (3 files)
- Standardize the environment variable names on the package convention used by every other sample in the folder: `AZURE_AI_PROJECT_ENDPOINT` -> `FOUNDRY_PROJECT_ENDPOINT` and `AZURE_AI_MODEL_DEPLOYMENT_NAME` -> `FOUNDRY_MODEL_NAME` (the audio variant becomes `FOUNDRY_MODEL_NAME_FOR_AUDIO`). Docstrings and code are updated together so each sample stays self-consistent.