### PR TITLE
Move patched evaluation TypedDicts to the azure.ai.projects.types namespace

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.py
@@ -11,6 +11,7 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 import os
 import re
 import logging
+import importlib
 from typing import List, Any, Optional
 import httpx  # pylint: disable=networking-import-outside-azure-core-transport
 from openai import OpenAI
@@ -409,3 +410,8 @@ def patch_sdk():
     you can't accomplish using the techniques described in
     https://aka.ms/azsdk/python/dpcodegen/python/customize
     """
+    types_module = importlib.import_module(f"{__package__}.types")
+    patch_types_module = importlib.import_module(f"{__package__}._patch_types")
+
+    for name in getattr(patch_types_module, "__all__", []):
+        setattr(types_module, name, getattr(patch_types_module, name))

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.pyi
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch.pyi
@@ -33,7 +33,7 @@ from openai.types.eval_create_response import EvalCreateResponse
 from openai.types.shared_params.metadata import Metadata
 from ._client import AIProjectClient as AIProjectClientGenerated
 from .operations import TelemetryOperations
-from .models import (
+from ._patch_types import (
     AzureAIBenchmarkPreviewEvalRunDataSource,
     AzureAIDataSourceConfig,
     AzureAIResponsesEvalRunDataSource,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_types.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_types.py
@@ -13,61 +13,6 @@ from openai.types.evals.create_eval_completions_run_data_source_param import (
     SourceFileID,
 )
 
-# *********************************************************************************************
-# BEGIN - These are duplicates of full classes implementation in _models.py.
-# *********************************************************************************************
-
-class ModelSamplingConfig(TypedDict, total=False):
-    """Represents a set of parameters used to control the sampling behavior of a language model
-    during text generation.
-    """
-
-    temperature: float
-    """The temperature parameter for sampling. Required."""
-    top_p: float
-    """The top-p parameter for nucleus sampling. Required."""
-    seed: int
-    """The random seed for reproducibility. Required."""
-    max_completion_tokens: int
-    """The maximum number of tokens allowed in the completion. Required."""
-
-
-class ToolDescription(TypedDict, total=False):
-    """Description of a tool that can be used by an agent."""
-
-    name: str
-    """The name of the tool."""
-    description: str
-    """A brief description of the tool's purpose."""
-
-
-class AzureAIAgentTarget(TypedDict, total=False):
-    """Represents a target specifying an Azure AI agent."""
-
-    type: Required[Literal["azure_ai_agent"]]
-    """The type of target, always ``azure_ai_agent``. Required. Default value is \"azure_ai_agent\"."""
-    name: Required[str]
-    """The unique identifier of the Azure AI agent. Required."""
-    version: str
-    """The version of the Azure AI agent."""
-    tool_descriptions: List[ToolDescription]
-    """The parameters used to control the sampling behavior of the agent during text generation."""
-
-
-class AzureAIModelTarget(TypedDict, total=False):
-    """Represents a target specifying an Azure AI model for operations requiring model selection."""
-
-    type: Required[Literal["azure_ai_model"]]
-    """The type of target, always ``azure_ai_model``. Required. Default value is \"azure_ai_model\"."""
-    model: str
-    """The unique identifier of the Azure AI model."""
-    sampling_params: ModelSamplingConfig
-    """The parameters used to control the sampling behavior of the model during text generation."""
-
-# *************************************************************************************************
-# END - Typed re-definitions
-# *************************************************************************************************
-
 class ResponseRetrievalItemGenerationParams(TypedDict, total=False):
     """Represents the parameters for response retrieval item generation."""
 
@@ -217,18 +162,14 @@ class TracesPreviewEvalRunDataSource(TypedDict, total=False):
 
 
 __all__ = [
-    "AzureAIAgentTarget",
     "AzureAIBenchmarkPreviewEvalRunDataSource",
     "AzureAIDataSourceConfig",
-    "AzureAIModelTarget",
     "AzureAIResponsesEvalRunDataSource",
     "EvalCsvFileIdSource",
     "EvalCsvRunDataSource",
     "TestingCriterionAzureAIEvaluator",
-    "ModelSamplingConfig",
     "RedTeamEvalRunDataSource",
     "ResponseRetrievalItemGenerationParams",
     "TargetCompletionEvalRunDataSource",
-    "ToolDescription",
     "TracesPreviewEvalRunDataSource",
 ]

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_types.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/_patch_types.py
@@ -5,7 +5,7 @@
 # ------------------------------------
 
 import datetime
-from typing import Dict, Any, List, Union
+from typing import Any, Dict, List, Union
 from typing_extensions import Literal, Required, TypedDict
 from openai.types.evals.create_eval_completions_run_data_source_param import (
     InputMessagesItemReference,
@@ -13,14 +13,11 @@ from openai.types.evals.create_eval_completions_run_data_source_param import (
     SourceFileID,
 )
 
-# **************************************************************************************************
-# BEGIN - These are duplicates of full classes implementation in _models.py. Redefined here as TypedDicts
-# with "Param" suffix, so they can be used in type annotations for "openai_client.evals" operations
-# **************************************************************************************************
+# *********************************************************************************************
+# BEGIN - These are duplicates of full classes implementation in _models.py.
+# *********************************************************************************************
 
-
-# Note all properties on this class where required. Sample code suggest they are all optional. Update it here.
-class ModelSamplingConfigParam(TypedDict, total=False):
+class ModelSamplingConfig(TypedDict, total=False):
     """Represents a set of parameters used to control the sampling behavior of a language model
     during text generation.
     """
@@ -35,7 +32,7 @@ class ModelSamplingConfigParam(TypedDict, total=False):
     """The maximum number of tokens allowed in the completion. Required."""
 
 
-class ToolDescriptionParam(TypedDict, total=False):
+class ToolDescription(TypedDict, total=False):
     """Description of a tool that can be used by an agent."""
 
     name: str
@@ -44,7 +41,7 @@ class ToolDescriptionParam(TypedDict, total=False):
     """A brief description of the tool's purpose."""
 
 
-class AzureAIAgentTargetParam(TypedDict, total=False):
+class AzureAIAgentTarget(TypedDict, total=False):
     """Represents a target specifying an Azure AI agent."""
 
     type: Required[Literal["azure_ai_agent"]]
@@ -53,25 +50,23 @@ class AzureAIAgentTargetParam(TypedDict, total=False):
     """The unique identifier of the Azure AI agent. Required."""
     version: str
     """The version of the Azure AI agent."""
-    tool_descriptions: List[ToolDescriptionParam]
+    tool_descriptions: List[ToolDescription]
     """The parameters used to control the sampling behavior of the agent during text generation."""
 
 
-class AzureAIModelTargetParam(TypedDict, total=False):
+class AzureAIModelTarget(TypedDict, total=False):
     """Represents a target specifying an Azure AI model for operations requiring model selection."""
 
     type: Required[Literal["azure_ai_model"]]
     """The type of target, always ``azure_ai_model``. Required. Default value is \"azure_ai_model\"."""
     model: str
     """The unique identifier of the Azure AI model."""
-    sampling_params: ModelSamplingConfigParam
+    sampling_params: ModelSamplingConfig
     """The parameters used to control the sampling behavior of the model during text generation."""
-
 
 # *************************************************************************************************
 # END - Typed re-definitions
 # *************************************************************************************************
-
 
 class ResponseRetrievalItemGenerationParams(TypedDict, total=False):
     """Represents the parameters for response retrieval item generation."""
@@ -79,7 +74,7 @@ class ResponseRetrievalItemGenerationParams(TypedDict, total=False):
     type: Required[Literal["response_retrieval"]]
     """The type of item generation parameters, always ``response_retrieval``. Required. The
      ResponseRetrieval item generation parameters."""
-    max_num_turns: int  # Required[int] # TODO: In TypeSpec this is required, but sample code does not set it
+    max_num_turns: int
     """The maximum number of turns of chat history to evaluate. Required."""
     data_mapping: Required[Dict[str, str]]
     """Mapping from source fields to response_id field, required for retrieving chat history.
@@ -99,9 +94,9 @@ class AzureAIResponsesEvalRunDataSource(TypedDict, total=False):
      \"azure_ai_responses\"."""
     item_generation_params: Required[ResponseRetrievalItemGenerationParams]
     """The parameters for item generation. Required."""
-    max_runs_hourly: int  # Required[int]  # TODO: In TypeSpec this is required, but sample code does not set it
+    max_runs_hourly: int
     """Maximum number of evaluation runs allowed per hour. Required."""
-    event_configuration_id: str  # Required[str] # TODO: In TypeSpec this is required, but sample code does not set it
+    event_configuration_id: str
     """The event configuration name associated with this evaluation run. Required."""
 
 
@@ -111,7 +106,7 @@ class AzureAIDataSourceConfig(TypedDict, total=False):
     type: Required[Literal["azure_ai_source"]]
     """The object type, which is always ``azure_ai_source``. Required. Default value is
      \"azure_ai_source\"."""
-    scenario: Required[str]  # TODO: Update typespec to define the below strings as enum
+    scenario: Required[str]
     """Data schema scenario. Required. Is one of the following types: Literal[\"red_team\"],
      Literal[\"responses\"], Literal[\"traces_preview\"], Literal[\"synthetic_data_gen_preview\"],
      Literal[\"benchmark_preview\"]"""
@@ -126,7 +121,7 @@ class TargetCompletionEvalRunDataSource(TypedDict, total=False):
     source: Required[Union[SourceFileContent, SourceFileID]]
     """The source configuration for inline or file data. Required. Is either a
      SourceFileContent type or a SourceFileID type."""
-    target: Required[Union[AzureAIAgentTargetParam, AzureAIModelTargetParam, dict[str, Any]]]
+    target: Required[Union[AzureAIAgentTarget, AzureAIModelTarget, dict[str, Any]]]
     """The target configuration for the evaluation. Required."""
     input_messages: Required[InputMessagesItemReference]
     """Input messages configuration."""
@@ -156,11 +151,11 @@ class AzureAIBenchmarkPreviewEvalRunDataSource(TypedDict, total=False):
     type: Required[Literal["azure_ai_benchmark_preview"]]
     """The type of data source, always ``azure_ai_benchmark_preview``. Required. Default value is
      \"azure_ai_benchmark_preview\"."""
-    target: Required[Union[AzureAIModelTargetParam, AzureAIAgentTargetParam, dict[str, Any]]]
+    target: Required[Union[AzureAIModelTarget, AzureAIAgentTarget, dict[str, Any]]]
     """The target model or agent to evaluate against the benchmark. When using ``azure_ai_model``
      target, ``sampling_params`` must not be provided; inference parameters are auto-filled from the
      benchmark specification stored in eval group properties. Required. Is either a
-     AzureAIModelTargetParam type or a AzureAIAgentTargetParam type."""
+     AzureAIModelTarget type or a AzureAIAgentTarget type."""
     input_messages: InputMessagesItemReference
     """Input messages configuration."""
 
@@ -179,7 +174,7 @@ class EvalCsvRunDataSource(TypedDict, total=False):
 
     type: Required[Literal["csv"]]
     """The type of data source, always ``csv``. Required. Default value is \"csv\"."""
-    source: Required[EvalCsvFileIdSource]  # EvalCsvFileIdSource
+    source: Required[EvalCsvFileIdSource]
     """The source of the CSV data, either inline content or a file reference. Required."""
 
 
@@ -189,9 +184,9 @@ class RedTeamEvalRunDataSource(TypedDict, total=False):
     type: Required[Literal["azure_ai_red_team"]]
     """The type of data source. Always ``azure_ai_red_team``. Required. Default value is
      \"azure_ai_red_team\"."""
-    item_generation_params: Required[Any]  # ItemGenerationParams
+    item_generation_params: Required[Any]
     """The parameters for item generation. Required."""
-    target: Required[Union[AzureAIModelTargetParam, AzureAIAgentTargetParam, dict[str, Any]]]
+    target: Required[Union[AzureAIModelTarget, AzureAIAgentTarget, dict[str, Any]]]
     """The target configuration for the evaluation. Required."""
 
 
@@ -219,3 +214,21 @@ class TracesPreviewEvalRunDataSource(TypedDict, total=False):
     """Sampling limit applied to traces retrieved for evaluation."""
     ingestion_delay_seconds: int
     """The delay to apply for ingestion when querying traces."""
+
+
+__all__ = [
+    "AzureAIAgentTarget",
+    "AzureAIBenchmarkPreviewEvalRunDataSource",
+    "AzureAIDataSourceConfig",
+    "AzureAIModelTarget",
+    "AzureAIResponsesEvalRunDataSource",
+    "EvalCsvFileIdSource",
+    "EvalCsvRunDataSource",
+    "TestingCriterionAzureAIEvaluator",
+    "ModelSamplingConfig",
+    "RedTeamEvalRunDataSource",
+    "ResponseRetrievalItemGenerationParams",
+    "TargetCompletionEvalRunDataSource",
+    "ToolDescription",
+    "TracesPreviewEvalRunDataSource",
+]

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.pyi
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/_patch.pyi
@@ -32,7 +32,7 @@ from openai.types.eval_create_response import EvalCreateResponse
 from openai.types.shared_params.metadata import Metadata
 from ._client import AIProjectClient as AIProjectClientGenerated
 from .operations import TelemetryOperations
-from ..models import (
+from .._patch_types import (
     AzureAIBenchmarkPreviewEvalRunDataSource,
     AzureAIDataSourceConfig,
     AzureAIResponsesEvalRunDataSource,

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/models/_patch.py
@@ -16,22 +16,6 @@ from azure.core.polling.base_polling import (
     _raise_if_bad_http_status_and_method,
 )
 from azure.core.polling.async_base_polling import AsyncLROBasePolling
-from ._patch_evaluation_typeddicts import (
-    AzureAIAgentTargetParam,
-    AzureAIBenchmarkPreviewEvalRunDataSource,
-    AzureAIDataSourceConfig,
-    AzureAIModelTargetParam,
-    AzureAIResponsesEvalRunDataSource,
-    EvalCsvFileIdSource,
-    EvalCsvRunDataSource,
-    TestingCriterionAzureAIEvaluator,
-    ModelSamplingConfigParam,
-    RedTeamEvalRunDataSource,
-    ResponseRetrievalItemGenerationParams,
-    TargetCompletionEvalRunDataSource,
-    ToolDescriptionParam,
-    TracesPreviewEvalRunDataSource,
-)
 from ._models import CustomCredential as CustomCredentialGenerated
 from ..models import MemoryStoreUpdateCompletedResult, MemoryStoreUpdateResult
 from ._enums import _FoundryFeaturesOptInKeys, _AgentDefinitionOptInKeys
@@ -382,21 +366,7 @@ class AsyncUpdateMemoriesLROPoller(AsyncLROPoller[MemoryStoreUpdateCompletedResu
 
 __all__: List[str] = [
     "AsyncUpdateMemoriesLROPoller",
-    "AzureAIAgentTargetParam",
-    "AzureAIBenchmarkPreviewEvalRunDataSource",
-    "AzureAIDataSourceConfig",
-    "AzureAIModelTargetParam",
-    "AzureAIResponsesEvalRunDataSource",
     "CustomCredential",
-    "EvalCsvFileIdSource",
-    "EvalCsvRunDataSource",
-    "TestingCriterionAzureAIEvaluator",
-    "ModelSamplingConfigParam",
-    "RedTeamEvalRunDataSource",
-    "ResponseRetrievalItemGenerationParams",
-    "TargetCompletionEvalRunDataSource",
-    "ToolDescriptionParam",
-    "TracesPreviewEvalRunDataSource",
     "UpdateMemoriesLROPoller",
 ]  # Add all objects you want publicly available to users at this package level
 

--- a/sdk/ai/azure-ai-projects/samples/datasets/sample_dataset_generation_job_simpleqna_with_prompt_source.py
+++ b/sdk/ai/azure-ai-projects/samples/datasets/sample_dataset_generation_job_simpleqna_with_prompt_source.py
@@ -69,8 +69,8 @@ from azure.ai.projects.models import (
     JobStatus,
     PromptDataGenerationJobSource,
     SimpleQnADataGenerationJobOptions,
-    TestingCriterionAzureAIEvaluator,
 )
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_coherence.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_coherence.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_fluency.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_fluency.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_generic_agentic_evaluator/agent_utils.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_generic_agentic_evaluator/agent_utils.py
@@ -17,7 +17,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_groundedness.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_groundedness.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_intent_resolution.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_intent_resolution.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_quality_grader.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_quality_grader.py
@@ -39,7 +39,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_relevance.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_relevance.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_response_completeness.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_response_completeness.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_adherence.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_adherence.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_completion.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_completion.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_navigation_efficiency.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_task_navigation_efficiency.py
@@ -36,7 +36,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_call_accuracy.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_call_accuracy.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_call_success.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_call_success.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 )
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_input_accuracy.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_input_accuracy.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_output_utilization.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_output_utilization.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_selection.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/agentic_evaluators/sample_tool_selection.py
@@ -37,7 +37,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_evaluation.py
@@ -37,11 +37,11 @@ from openai.types.evals.run_create_response import RunCreateResponse
 from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
+from azure.ai.projects.models import PromptAgentDefinition
+from azure.ai.projects.types import (
     TestingCriterionAzureAIEvaluator,
-    PromptAgentDefinition,
     TargetCompletionEvalRunDataSource,
-    AzureAIAgentTargetParam,
+    AzureAIAgentTarget,
 )
 
 load_dotenv()
@@ -114,7 +114,7 @@ with (
                 {"type": "message", "role": "user", "content": {"type": "input_text", "text": "{{item.query}}"}}
             ],
         },
-        target=AzureAIAgentTargetParam(
+        target=AzureAIAgentTarget(
             type="azure_ai_agent",
             name=agent.name,
             version=agent.version,  # Version is optional. Defaults to latest version if not specified

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_response_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_response_evaluation.py
@@ -36,11 +36,11 @@ from openai.types.evals.run_create_response import RunCreateResponse
 from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
+from azure.ai.projects.models import PromptAgentDefinition
+from azure.ai.projects.types import (
     AzureAIDataSourceConfig,
     AzureAIResponsesEvalRunDataSource,
     TestingCriterionAzureAIEvaluator,
-    PromptAgentDefinition,
     ResponseRetrievalItemGenerationParams,
 )
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_response_evaluation_with_function_tool.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_response_evaluation_with_function_tool.py
@@ -40,13 +40,15 @@ from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import (
+    PromptAgentDefinition,
+    Tool,
+    FunctionTool,
+)
+from azure.ai.projects.types import (
     AzureAIDataSourceConfig,
     AzureAIResponsesEvalRunDataSource,
     TestingCriterionAzureAIEvaluator,
-    PromptAgentDefinition,
     ResponseRetrievalItemGenerationParams,
-    Tool,
-    FunctionTool,
 )
 
 load_dotenv()

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_trace_evaluation_smart_filter.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_agent_trace_evaluation_smart_filter.py
@@ -38,7 +38,7 @@ from pprint import pprint
 from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_continuous_evaluation_rule.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_continuous_evaluation_rule.py
@@ -41,13 +41,15 @@ from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import (
-    AzureAIDataSourceConfig,
-    TestingCriterionAzureAIEvaluator,
     PromptAgentDefinition,
     EvaluationRule,
     ContinuousEvaluationRuleAction,
     EvaluationRuleFilter,
     EvaluationRuleEventType,
+)
+from azure.ai.projects.types import (
+    AzureAIDataSourceConfig,
+    TestingCriterionAzureAIEvaluator,
 )
 
 load_dotenv()

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_code_based_evaluators.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_code_based_evaluators.py
@@ -36,7 +36,11 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator, EvaluatorCategory, EvaluatorDefinitionType
+from azure.ai.projects.models import (
+    EvaluatorCategory,
+    EvaluatorDefinitionType,
+)
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_prompt_based_evaluators.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_eval_catalog_prompt_based_evaluators.py
@@ -69,7 +69,11 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator, EvaluatorCategory, EvaluatorDefinitionType
+from azure.ai.projects.models import (
+    EvaluatorCategory,
+    EvaluatorDefinitionType,
+)
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_ai_assisted.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_ai_assisted.py
@@ -35,7 +35,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_csv.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_csv.py
@@ -39,8 +39,8 @@ from openai.types.eval_create_params import DataSourceConfigCustom
 
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
-    DatasetVersion,
+from azure.ai.projects.models import DatasetVersion
+from azure.ai.projects.types import (
     EvalCsvFileIdSource,
     EvalCsvRunDataSource,
     TestingCriterionAzureAIEvaluator,

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_dataset_id.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_dataset_id.py
@@ -35,10 +35,8 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import CreateEva
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
-    DatasetVersion,
-    TestingCriterionAzureAIEvaluator,
-)
+from azure.ai.projects.models import DatasetVersion
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_inline_data.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_inline_data.py
@@ -35,7 +35,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_traces.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_evaluations_builtin_with_traces.py
@@ -49,9 +49,7 @@ from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
-    TestingCriterionAzureAIEvaluator,
-)
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation.py
@@ -40,7 +40,7 @@ from azure.ai.projects import AIProjectClient
 from azure.ai.projects.types import (
     AzureAIModelTarget,
     TestingCriterionAzureAIEvaluator,
-    ModelSamplingConfig,
+    ModelSamplingParams,
     TargetCompletionEvalRunDataSource,
 )
 
@@ -94,7 +94,7 @@ with (
         target=AzureAIModelTarget(
             type="azure_ai_model",
             model=model,
-            sampling_params=ModelSamplingConfig(  # Note: model sampling parameters are optional and can differ per model
+            sampling_params=ModelSamplingParams(  # Note: model sampling parameters are optional and can differ per model
                 top_p=1.0,
                 max_completion_tokens=2048,
             ),

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation.py
@@ -37,10 +37,10 @@ from openai.types.evals.run_create_response import RunCreateResponse
 from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
-    AzureAIModelTargetParam,
+from azure.ai.projects.types import (
+    AzureAIModelTarget,
     TestingCriterionAzureAIEvaluator,
-    ModelSamplingConfigParam,
+    ModelSamplingConfig,
     TargetCompletionEvalRunDataSource,
 )
 
@@ -91,10 +91,10 @@ with (
                 {"type": "message", "role": "user", "content": {"type": "input_text", "text": "{{item.query}}"}}
             ],
         },
-        target=AzureAIModelTargetParam(
+        target=AzureAIModelTarget(
             type="azure_ai_model",
             model=model,
-            sampling_params=ModelSamplingConfigParam(  # Note: model sampling parameters are optional and can differ per model
+            sampling_params=ModelSamplingConfig(  # Note: model sampling parameters are optional and can differ per model
                 top_p=1.0,
                 max_completion_tokens=2048,
             ),

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation_instant_model.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation_instant_model.py
@@ -40,7 +40,7 @@ from azure.ai.projects import AIProjectClient
 from azure.ai.projects.types import (
     AzureAIModelTarget,
     TestingCriterionAzureAIEvaluator,
-    ModelSamplingConfig,
+    ModelSamplingParams,
     TargetCompletionEvalRunDataSource,
 )
 
@@ -94,7 +94,7 @@ with (
         target=AzureAIModelTarget(
             type="azure_ai_model",
             model=model,
-            sampling_params=ModelSamplingConfig(  # Note: model sampling parameters are optional and can differ per model
+            sampling_params=ModelSamplingParams(  # Note: model sampling parameters are optional and can differ per model
                 top_p=1.0,
                 max_completion_tokens=2048,
             ),

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation_instant_model.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_model_evaluation_instant_model.py
@@ -37,10 +37,10 @@ from openai.types.evals.run_create_response import RunCreateResponse
 from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import (
-    AzureAIModelTargetParam,
+from azure.ai.projects.types import (
+    AzureAIModelTarget,
     TestingCriterionAzureAIEvaluator,
-    ModelSamplingConfigParam,
+    ModelSamplingConfig,
     TargetCompletionEvalRunDataSource,
 )
 
@@ -91,10 +91,10 @@ with (
                 {"type": "message", "role": "user", "content": {"type": "input_text", "text": "{{item.query}}"}}
             ],
         },
-        target=AzureAIModelTargetParam(
+        target=AzureAIModelTarget(
             type="azure_ai_model",
             model=model,
-            sampling_params=ModelSamplingConfigParam(  # Note: model sampling parameters are optional and can differ per model
+            sampling_params=ModelSamplingConfig(  # Note: model sampling parameters are optional and can differ per model
                 top_p=1.0,
                 max_completion_tokens=2048,
             ),

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_conversation_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_conversation_evaluation.py
@@ -43,7 +43,7 @@ from openai.types.evals.create_eval_jsonl_run_data_source_param import (
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_conversation_simulation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_conversation_simulation.py
@@ -45,7 +45,8 @@ from dotenv import load_dotenv
 from openai.types.eval_create_params import DataSourceConfigCustom
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator, PromptAgentDefinition
+from azure.ai.projects.models import PromptAgentDefinition
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_trace_evaluation_agent_filter.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_trace_evaluation_agent_filter.py
@@ -44,7 +44,7 @@ from pprint import pprint
 from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_trace_evaluation_by_id.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_multiturn_trace_evaluation_by_id.py
@@ -41,7 +41,7 @@ from pprint import pprint
 from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_redteam_evaluations.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_redteam_evaluations.py
@@ -31,13 +31,15 @@ from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import (
     AgentVersionDetails,
-    AzureAIDataSourceConfig,
     EvaluationTaxonomy,
-    AzureAIAgentTarget,
     AgentTaxonomyInput,
+    RiskCategory,
+)
+from azure.ai.projects.types import (
+    AzureAIDataSourceConfig,
+    AzureAIAgentTarget,
     TestingCriterionAzureAIEvaluator,
     RedTeamEvalRunDataSource,
-    RiskCategory,
 )
 import json
 import time

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_basic.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_generation_basic.py
@@ -66,8 +66,8 @@ from azure.ai.projects.models import (
     JobStatus,
     PromptEvaluatorGenerationJobSource,
     RubricBasedEvaluatorDefinition,
-    TestingCriterionAzureAIEvaluator,
 )
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_manual.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_rubric_evaluator_manual.py
@@ -64,8 +64,8 @@ from azure.ai.projects.models import (
     EvaluatorCategory,
     EvaluatorDefinitionType,
     RubricBasedEvaluatorDefinition,
-    TestingCriterionAzureAIEvaluator,
 )
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_scheduled_agent_traces_evaluation_smart_filter.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_scheduled_agent_traces_evaluation_smart_filter.py
@@ -39,12 +39,12 @@ from azure.mgmt.authorization import AuthorizationManagementClient
 from azure.mgmt.resource.resources import ResourceManagementClient
 import uuid
 from azure.ai.projects.models import (
-    TestingCriterionAzureAIEvaluator,
     Schedule,
     RecurrenceTrigger,
     DailyRecurrenceSchedule,
     EvaluationScheduleTask,
 )
+from azure.ai.projects.types import TestingCriterionAzureAIEvaluator
 import time
 
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_scheduled_evaluations.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_scheduled_evaluations.py
@@ -41,23 +41,23 @@ from azure.mgmt.resource.resources import ResourceManagementClient
 import uuid
 from azure.ai.projects.models import (
     AgentVersionDetails,
-    AzureAIDataSourceConfig,
     EvaluationTaxonomy,
-    AzureAIAgentTarget,
     AgentTaxonomyInput,
-    TestingCriterionAzureAIEvaluator,
-    RedTeamEvalRunDataSource,
     Schedule,
     RecurrenceTrigger,
     DailyRecurrenceSchedule,
     EvaluationScheduleTask,
     RiskCategory,
 )
+from azure.ai.projects.types import (
+    AzureAIDataSourceConfig,
+    AzureAIAgentTarget,
+    TestingCriterionAzureAIEvaluator,
+    RedTeamEvalRunDataSource,
+)
 from openai.types.evals.create_eval_jsonl_run_data_source_param import CreateEvalJSONLRunDataSourceParam, SourceFileID
 from openai.types.eval_create_params import DataSourceConfigCustom
-from azure.ai.projects.models import (
-    DatasetVersion,
-)
+from azure.ai.projects.models import DatasetVersion
 import json
 import time
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_synthetic_data_agent_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_synthetic_data_agent_evaluation.py
@@ -45,7 +45,11 @@ from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import AzureAIDataSourceConfig, TestingCriterionAzureAIEvaluator, PromptAgentDefinition
+from azure.ai.projects.models import PromptAgentDefinition
+from azure.ai.projects.types import (
+    AzureAIDataSourceConfig,
+    TestingCriterionAzureAIEvaluator,
+)
 
 load_dotenv()
 

--- a/sdk/ai/azure-ai-projects/samples/evaluations/sample_synthetic_data_model_evaluation.py
+++ b/sdk/ai/azure-ai-projects/samples/evaluations/sample_synthetic_data_model_evaluation.py
@@ -44,7 +44,10 @@ from openai.types.evals.run_retrieve_response import RunRetrieveResponse
 
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-from azure.ai.projects.models import AzureAIDataSourceConfig, TestingCriterionAzureAIEvaluator
+from azure.ai.projects.types import (
+    AzureAIDataSourceConfig,
+    TestingCriterionAzureAIEvaluator,
+)
 
 load_dotenv()
 


### PR DESCRIPTION
CoPilot notes:
- This guarantees runtime availability for normal imports.
- Static analysis/discovery (like pyright docs/intellisense) may still not show monkey-patched names unless stubs/generated sources include them.