### PR TITLE
Pin apistub to released apiview-stub-generator==0.3.29

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -15,5 +15,5 @@ tomli==2.2.1
 tomlkit==0.13.2
 typing_extensions==4.15.0
 wrapt==1.17.2
-apiview-stub-generator @ git+https://github.com/Azure/azure-sdk-tools.git@518af99f75272f8644e2b357d214f9d61706df60#subdirectory=packages/python-packages/apiview-stub-generator
+apiview-stub-generator==0.3.29
 pip==24.0


### PR DESCRIPTION
Draft to observe how `azure-ai-agentserver-core` builds against the **released** apistub instead of the git-commit prototype pin.

## Change
`eng/apiview_reqs.txt`: swap
`apiview-stub-generator @ git+...@518af99f` → `apiview-stub-generator==0.3.29`

0.3.29 is the shipped release (2026-07-17) built from that same prototype commit; it includes the 120s→300s package-install timeout raise for large dep trees (e.g. the OpenTelemetry distro pulled by agentserver-core).

## Why
Base branch currently installs apistub from a git commit. This pins to the released package so the CI build reflects the shipped version. Draft — for build observation only.

Related: Azure/azure-sdk-tools#16426