### PR TITLE
Bump apiview-stub-generator pin to 0.3.30

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -15,5 +15,5 @@ tomli==2.2.1
 tomlkit==0.13.2
 typing_extensions==4.15.0
 wrapt==1.17.2
-apiview-stub-generator==0.3.28
+apiview-stub-generator==0.3.30
 pip==24.0


### PR DESCRIPTION
Update the APIView stub-generator pin in `eng/apiview_reqs.txt`: `0.3.28` → `0.3.30`.

0.3.30 is the latest released version. 0.3.29 raised the apistub package-install timeout 120s→300s for large dependency trees (OpenTelemetry distro); 0.3.30 follows on.

Single-file change.