### PR TITLE
Increase Python 3 signoff job timeout to 300 minutes

### DIFF
--- a/sdk/cosmos/cosmos-staging.yml
+++ b/sdk/cosmos/cosmos-staging.yml
@@ -11,7 +11,7 @@ resources:
 jobs:
 - job: Job_1
   displayName: Python 3
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
   pool:
     name: Azure Pipelines
   steps:


### PR DESCRIPTION
## Summary

The `CosmosDB-SDK-SQL-MultiWrite-Python-Signoff` pipeline (definition 3824) has been timing out. The **Python 3** job (`Job_1`) exceeded the 240-minute maximum and was canceled (e.g. build 227538339).

This raises the job timeout in `sdk/cosmos/cosmos-staging.yml` from **240 -> 300 minutes**.

## Change

```diff
 - job: Job_1
   displayName: Python 3
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
```

## Notes

- Confirmed definition 3824 sources `sdk/cosmos/cosmos-staging.yml`, and the `Python 3` / `Job_1` display name + 240 timeout is unique to this file across `sdk/cosmos`.
- Other signoff definitions that share `cosmos-staging.yml` will also pick up the 300-minute timeout, since they share the same job definition.