### PR TITLE
Move exception detail logs to debug level in Event Hubs packages

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated type annotations in `BlobCheckpointStore`.
 - Bumped `aiohttp` min dependency version to 3.11.0.
+- Changed logs that contain exception details to the debug level. This follows the Azure SDK guidelines for sensitive data in logs (pylint rules C4766 and C4762). ([#39287](https://github.com/Azure/azure-sdk-for-python/issues/39287))
 
 ## 1.2.0 (2025-02-13)
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -179,15 +179,14 @@ class BlobCheckpointStore(CheckpointStore):
             logger.warning(
                 "An exception occurred when EventProcessor instance %r claim_ownership for "
                 "namespace %r eventhub %r consumer group %r partition %r. "
-                "The ownership is now lost. Exception "
-                "is %r",
+                "The ownership is now lost.",
                 updated_ownership["owner_id"],
                 updated_ownership["fully_qualified_namespace"],
                 updated_ownership["eventhub_name"],
                 updated_ownership["consumer_group"],
                 updated_ownership["partition_id"],
-                error,
             )
+            logger.debug("Claim ownership failed with exception: %r", error)
             return updated_ownership  # Keep the ownership if an unexpected error happens
 
     async def list_ownership(
@@ -232,15 +231,13 @@ class BlobCheckpointStore(CheckpointStore):
                 }
                 result.append(ownership)
             return result
-        except Exception as error:
+        except Exception:
             logger.warning(
                 "An exception occurred during list_ownership for "
-                "namespace %r eventhub %r consumer group %r. "
-                "Exception is %r",
+                "namespace %r eventhub %r consumer group %r.",
                 fully_qualified_namespace,
                 eventhub_name,
                 consumer_group,
-                error,
             )
             raise
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/mypy.ini
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+ignore_missing_imports = True
+
+# Per-module options:
+
+# The _vendor directory holds a copy of azure-storage-blob. This package
+# does not own that code, so mypy must not report errors in it.
+[mypy-azure.eventhub.extensions.checkpointstoreblobaio._vendor.*]
+ignore_errors = True

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 - Updated type annotations in `BlobCheckpointStore`.
+- Changed logs that contain exception details to the debug level. This follows the Azure SDK guidelines for sensitive data in logs (pylint rules C4766 and C4762). ([#40744](https://github.com/Azure/azure-sdk-for-python/issues/40744))
 
 ## 1.2.0 (2025-02-13)
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
@@ -199,15 +199,14 @@ class BlobCheckpointStore(CheckpointStore):
             logger.warning(
                 "An exception occurred when EventProcessor instance %r claim_ownership for "
                 "namespace %r eventhub %r consumer group %r partition %r. "
-                "The ownership is now lost. Exception "
-                "is %r",
+                "The ownership is now lost.",
                 updated_ownership["owner_id"],
                 updated_ownership["fully_qualified_namespace"],
                 updated_ownership["eventhub_name"],
                 updated_ownership["consumer_group"],
                 updated_ownership["partition_id"],
-                error,
             )
+            logger.debug("Claim ownership failed with exception: %r", error)
             return updated_ownership  # Keep the ownership if an unexpected error happens
 
     def list_ownership(
@@ -252,15 +251,13 @@ class BlobCheckpointStore(CheckpointStore):
                 }
                 result.append(ownership)
             return result
-        except Exception as error:
+        except Exception:
             logger.warning(
                 "An exception occurred during list_ownership for "
-                "namespace %r eventhub %r consumer group %r. "
-                "Exception is %r",
+                "namespace %r eventhub %r consumer group %r.",
                 fully_qualified_namespace,
                 eventhub_name,
                 consumer_group,
-                error,
             )
             raise
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/mypy.ini
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+ignore_missing_imports = True
+
+# Per-module options:
+
+# The _vendor directory holds a copy of azure-storage-blob. This package
+# does not own that code, so mypy must not report errors in it.
+[mypy-azure.eventhub.extensions.checkpointstoreblob._vendor.*]
+ignore_errors = True

--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 5.15.2 (Unreleased)
+
+### Other Changes
+
+- Changed logs that contain exception details to the debug level. This follows the Azure SDK guidelines for sensitive data in logs (pylint rules C4766 and C4762). ([#40743](https://github.com/Azure/azure-sdk-for-python/issues/40743))
+
 ## 5.15.1 (2025-11-11)
 
 ### Bugs Fixed

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -78,7 +78,7 @@ class BufferedProducer:
             try:
                 self._check_max_wait_time_future.result(remain_timeout)
             except Exception as exc:  # pylint: disable=broad-except
-                _LOGGER.warning("Partition %r stopped with error %r", self.partition_id, exc)
+                _LOGGER.debug("Partition %r stopped with error %r", self.partition_id, exc)
         self._producer.close()
 
     def put_events(self, events, timeout_time=None):
@@ -122,7 +122,7 @@ class BufferedProducer:
             try:
                 callback(*args, **kwargs)
             except Exception as exc:  # pylint: disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "On partition %r, callback %r encountered exception %r",
                     callback.__name__,
                     exc,
@@ -163,7 +163,7 @@ class BufferedProducer:
                         except AttributeError:
                             self._on_success(batch, self.partition_id)
                     except Exception as exc:  # pylint: disable=broad-except
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "Partition %r sending %r events failed due to exception: %r ",
                             self.partition_id,
                             len(batch),

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
@@ -137,7 +137,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
             try:
                 self._error_handler(partition_context, err)
             except Exception as err_again:  # pylint:disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                     "An error occurred while running on_error. The exception is %r.",
                     self._id,
@@ -168,7 +168,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
             try:
                 self._partition_initialize_handler(self._partition_contexts[partition_id])
             except Exception as err:  # pylint:disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                     "An error occurred while running on_partition_initialize. The exception is %r.",
                     self._id,
@@ -288,13 +288,13 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
                 _LOGGER.warning(
                     "EventProcessor instance %r of eventhub %r consumer group %r. "
                     "An error occurred while load-balancing and claiming ownership. "
-                    "The exception is %r. Retrying after %r seconds",
+                    "Retrying after %r seconds",
                     self._id,
                     self._eventhub_name,
                     self._consumer_group,
-                    err,
                     load_balancing_interval,
                 )
+                _LOGGER.debug("Load-balancing failed with exception: %r", err)
                 self._process_error(None, err)  # type: ignore
 
             time.sleep(load_balancing_interval)
@@ -318,7 +318,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
             try:
                 self._partition_close_handler(self._partition_contexts[partition_id], reason)
             except Exception as err:  # pylint:disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                     "An error occurred while running on_partition_close. The exception is %r.",
                     self._id,
@@ -340,7 +340,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
         try:
             consumer.receive(self._batch, self._max_batch_size, self._max_wait_time)
         except Exception as error:  # pylint:disable=broad-except
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                 "An error occurred while receiving. The exception is %r.",
                 self._id,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -880,7 +880,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             self._wait_for_response(wait, ConnectionState.END)
         except Exception as exc:  # pylint:disable=broad-except
             # If error happened during closing, ignore the error and set state to END
-            _LOGGER.info("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
+            _LOGGER.debug("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
             self._set_state(ConnectionState.END)
         finally:
             self._disconnect()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -203,8 +203,7 @@ class _AbstractTransport(object):  # pylint: disable=too-many-instance-attribute
             # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
             # has _not_ been sent
             self.connected = True
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Transport connection failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             # if not fully connected, close socket, and reraise error
             if self.sock and not self.connected:
                 self.sock.close()
@@ -695,8 +694,7 @@ class WebSocketTransport(_AbstractTransport):
         except (WebSocketTimeoutException, SSLError, WebSocketConnectionClosedException) as exc:  # type: ignore
             self.close()
             raise ConnectionError("Websocket failed to establish connection: %r" % exc) from exc
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Websocket connection failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             self.close()
             raise
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 # TODO: Check types of kwargs (issue exists for this)
-import asyncio # pylint:disable=do-not-import-asyncio
+import asyncio  # pylint:disable=do-not-import-asyncio
 import logging
 import time
 import queue
@@ -152,7 +152,7 @@ class AMQPClientAsync(AMQPClientSync):
                     start_time = current_time
                 await asyncio.sleep(1)
         except Exception as e:  # pylint: disable=broad-except
-            _logger.info(
+            _logger.debug(
                 "Connection keep-alive for %r failed: %r.", self.__class__.__name__, e, extra=self._network_trace_params
             )
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -873,7 +873,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             await self._wait_for_response(wait, ConnectionState.END)
         except Exception as exc:  # pylint:disable=broad-except
             # If error happened during closing, ignore the error and set state to END
-            _LOGGER.info("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
+            _LOGGER.debug("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
             await self._set_state(ConnectionState.END)
         finally:
             await self._disconnect()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_link_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_link_async.py
@@ -138,7 +138,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
             if self._on_link_state_change is not None:
                 await self._on_link_state_change(previous_state, new_state)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+            _LOGGER.debug("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
     async def _on_session_state_change(self) -> None:
         if self._session.state == SessionState.MAPPED:
@@ -195,7 +195,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                     frame[6] = Target(*frame[6])
                 await self._on_attach(AttachFrame(*frame))
             except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.warning("Callback for link attach raised error: %s", e, extra=self.network_trace_params)
+                _LOGGER.debug("Callback for link attach raised error: %s", e, extra=self.network_trace_params)
 
     async def _outgoing_flow(self, **kwargs: Any) -> None:
         flow_frame = {
@@ -271,7 +271,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                 await self._outgoing_detach(close=close, error=error)
                 await self._set_state(LinkState.DETACH_SENT)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
             await self._set_state(LinkState.DETACHED)
 
     async def flow(self, *, link_credit: Optional[int] = None, **kwargs) -> None:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -44,7 +44,7 @@ class ReceiverLink(Link):
         try:
             return await self._on_transfer(frame, message)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
+            _LOGGER.debug("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
         return None
 
     async def _incoming_attach(self, frame):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_sender_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_sender_async.py
@@ -34,7 +34,7 @@ class PendingDelivery(object):
             try:
                 await self.on_delivery_settled(reason, state)
             except Exception as e:  # pylint:disable=broad-except
-                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
+                _LOGGER.debug("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
         self.settled = True
 
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -407,7 +407,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             await self._set_state(new_state)
             await self._wait_for_response(wait, SessionState.UNMAPPED)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
             await self._set_state(SessionState.UNMAPPED)
 
     def create_receiver_link(self, source_address, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -264,8 +264,7 @@ class AsyncTransport(AsyncTransportMixin):  # pylint: disable=too-many-instance-
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 self._set_socket_options(sock, self.socket_settings)
 
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Transport connect failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             # if not fully connected, close socket, and reraise error
             if self.writer and not self.connected:
                 self.writer.close()
@@ -476,7 +475,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
                 heartbeat=DEFAULT_WEBSOCKET_HEARTBEAT_SECONDS,
             )
         except ClientConnectorError as exc:
-            _LOGGER.info("Websocket connect failed: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("Websocket connect failed: %r", exc, extra=self.network_trace_params)
             if self._custom_endpoint:
                 raise AuthenticationException(
                     ErrorCondition.ClientError,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
@@ -133,7 +133,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
             if self._on_link_state_change is not None:
                 self._on_link_state_change(previous_state, new_state)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+            _LOGGER.debug("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
     def _on_session_state_change(self) -> None:
         if self._session.state == SessionState.MAPPED:
@@ -190,7 +190,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                     frame[6] = Target(*frame[6])
                 self._on_attach(AttachFrame(*frame))
             except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.warning("Callback for link attach raised error: %r", e, extra=self.network_trace_params)
+                _LOGGER.debug("Callback for link attach raised error: %r", e, extra=self.network_trace_params)
 
     def _outgoing_flow(self, **kwargs: Any) -> None:
         flow_frame = {
@@ -268,7 +268,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                 self._outgoing_detach(close=close, error=error)
                 self._set_state(LinkState.DETACH_SENT)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
             self._set_state(LinkState.DETACHED)
 
     def flow(self, *, link_credit: Optional[int] = None, **kwargs: Any) -> None:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
@@ -41,7 +41,7 @@ class ReceiverLink(Link):
         try:
             return self._on_transfer(frame, message)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
+            _LOGGER.debug("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
         return None
 
     def _incoming_attach(self, frame):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
@@ -34,7 +34,7 @@ class PendingDelivery(object):
             try:
                 self.on_delivery_settled(reason, state)
             except Exception as e:  # pylint:disable=broad-except
-                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
+                _LOGGER.debug("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
         self.settled = True
 
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -405,7 +405,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._set_state(new_state)
             self._wait_for_response(wait, SessionState.UNMAPPED)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
             self._set_state(SessionState.UNMAPPED)
 
     def create_receiver_link(self, source_address, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_tracing.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_tracing.py
@@ -178,7 +178,7 @@ def trace_message(
                             message_span.add_attribute(key, value)
 
     except Exception as exp:  # pylint:disable=broad-except
-        _LOGGER.warning("trace_message had an exception %r", exp)
+        _LOGGER.debug("trace_message had an exception %r", exp)
 
     return message
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_version.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "5.15.1"
+VERSION = "5.15.2"

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -74,7 +74,7 @@ class BufferedProducer:
             try:
                 await self._check_max_wait_time_future
             except Exception as exc:  # pylint: disable=broad-except
-                _LOGGER.warning("Partition %r stopped with error %r", self.partition_id, exc)
+                _LOGGER.debug("Partition %r stopped with error %r", self.partition_id, exc)
         await self._producer.close()
 
     async def put_events(self, events, timeout_time=None):
@@ -118,7 +118,7 @@ class BufferedProducer:
             try:
                 await callback(*args, **kwargs)
             except Exception as exc:  # pylint: disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "On partition %r, callback %r encountered exception %r",
                     callback.__name__,
                     exc,
@@ -162,7 +162,7 @@ class BufferedProducer:
                     except AttributeError:
                         await self._on_success(batch, self.partition_id)
                 except Exception as exc:  # pylint: disable=broad-except
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Partition %r sending %r events failed due to exception: %r",
                         self.partition_id,
                         len(batch),

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
@@ -172,7 +172,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
             try:
                 await self._error_handler(partition_context, err)
             except Exception as err_again:  # pylint:disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                     "An error occurred while running on_error. The exception is %r.",
                     self._id,
@@ -196,7 +196,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
             try:
                 await self._partition_close_handler(partition_context, reason)
             except Exception as err:  # pylint:disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                     "An error occurred while running on_partition_close. The exception is %r.",
                     self._id,
@@ -282,7 +282,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
                 try:
                     await self._partition_initialize_handler(partition_context)
                 except Exception as err:  # pylint:disable=broad-except
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                         "An error occurred while running on_partition_initialize. The exception is %r.",
                         self._id,
@@ -306,7 +306,7 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
                     )
                     raise
                 except Exception as error:  # pylint:disable=broad-except
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "EventProcessor instance %r of eventhub %r partition %r consumer group %r. "
                         "An error occurred while receiving. The exception is %r.",
                         self._id,
@@ -367,13 +367,13 @@ class EventProcessor(EventProcessorMixin):  # pylint:disable=too-many-instance-a
                     _LOGGER.warning(
                         "EventProcessor instance %r of eventhub %r consumer group %r. "
                         "An error occurred while load-balancing and claiming ownership. "
-                        "The exception is %r. Retrying after %r seconds",
+                        "Retrying after %r seconds",
                         self._id,
                         self._eventhub_name,
                         self._consumer_group,
-                        err,
                         load_balancing_interval,
                     )
+                    _LOGGER.debug("Load-balancing failed with exception: %r", err)
                     await self._process_error(None, err)  # type: ignore
 
                 await asyncio.sleep(load_balancing_interval, **self._internal_kwargs)

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Other Changes
 
 - When using the async `AmqpOverWebsocket` transport on Python 3.10 or later, `aiohttp>=3.14.0` is now recommended. Earlier `aiohttp` versions have a WebSocket heartbeat bug ([aio-libs/aiohttp#12030](https://github.com/aio-libs/aiohttp/pull/12030)) that can cause the connection to be dropped during long message processing, surfacing as a `SocketError` ("Cannot write to closing transport"). Python 3.9 users must upgrade Python to install an `aiohttp` release containing this fix. ([#44028](https://github.com/Azure/azure-sdk-for-python/issues/44028))
+- Changed vendored `_pyamqp` logs that contain exception details to the debug level. This keeps the `_pyamqp` copy identical to the copy in `azure-eventhub` (pylint rules C4766 and C4762). Log levels are the only change.
 
 ## 7.14.3 (2025-11-11)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -880,7 +880,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             self._wait_for_response(wait, ConnectionState.END)
         except Exception as exc:  # pylint:disable=broad-except
             # If error happened during closing, ignore the error and set state to END
-            _LOGGER.info("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
+            _LOGGER.debug("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
             self._set_state(ConnectionState.END)
         finally:
             self._disconnect()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -203,8 +203,7 @@ class _AbstractTransport(object):  # pylint: disable=too-many-instance-attribute
             # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
             # has _not_ been sent
             self.connected = True
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Transport connection failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             # if not fully connected, close socket, and reraise error
             if self.sock and not self.connected:
                 self.sock.close()
@@ -695,8 +694,7 @@ class WebSocketTransport(_AbstractTransport):
         except (WebSocketTimeoutException, SSLError, WebSocketConnectionClosedException) as exc:  # type: ignore
             self.close()
             raise ConnectionError("Websocket failed to establish connection: %r" % exc) from exc
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Websocket connection failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             self.close()
             raise
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -152,7 +152,7 @@ class AMQPClientAsync(AMQPClientSync):
                     start_time = current_time
                 await asyncio.sleep(1)
         except Exception as e:  # pylint: disable=broad-except
-            _logger.info(
+            _logger.debug(
                 "Connection keep-alive for %r failed: %r.", self.__class__.__name__, e, extra=self._network_trace_params
             )
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -873,7 +873,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             await self._wait_for_response(wait, ConnectionState.END)
         except Exception as exc:  # pylint:disable=broad-except
             # If error happened during closing, ignore the error and set state to END
-            _LOGGER.info("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
+            _LOGGER.debug("An error occurred when closing the connection: %r", exc, extra=self._network_trace_params)
             await self._set_state(ConnectionState.END)
         finally:
             await self._disconnect()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
@@ -138,7 +138,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
             if self._on_link_state_change is not None:
                 await self._on_link_state_change(previous_state, new_state)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+            _LOGGER.debug("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
     async def _on_session_state_change(self) -> None:
         if self._session.state == SessionState.MAPPED:
@@ -195,7 +195,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                     frame[6] = Target(*frame[6])
                 await self._on_attach(AttachFrame(*frame))
             except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.warning("Callback for link attach raised error: %s", e, extra=self.network_trace_params)
+                _LOGGER.debug("Callback for link attach raised error: %s", e, extra=self.network_trace_params)
 
     async def _outgoing_flow(self, **kwargs: Any) -> None:
         flow_frame = {
@@ -271,7 +271,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                 await self._outgoing_detach(close=close, error=error)
                 await self._set_state(LinkState.DETACH_SENT)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
             await self._set_state(LinkState.DETACHED)
 
     async def flow(self, *, link_credit: Optional[int] = None, **kwargs) -> None:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -44,7 +44,7 @@ class ReceiverLink(Link):
         try:
             return await self._on_transfer(frame, message)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
+            _LOGGER.debug("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
         return None
 
     async def _incoming_attach(self, frame):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sender_async.py
@@ -34,7 +34,7 @@ class PendingDelivery(object):
             try:
                 await self.on_delivery_settled(reason, state)
             except Exception as e:  # pylint:disable=broad-except
-                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
+                _LOGGER.debug("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
         self.settled = True
 
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
@@ -407,7 +407,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             await self._set_state(new_state)
             await self._wait_for_response(wait, SessionState.UNMAPPED)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
             await self._set_state(SessionState.UNMAPPED)
 
     def create_receiver_link(self, source_address, **kwargs):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -264,8 +264,7 @@ class AsyncTransport(AsyncTransportMixin):  # pylint: disable=too-many-instance-
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 self._set_socket_options(sock, self.socket_settings)
 
-        except (OSError, IOError, SSLError) as e:
-            _LOGGER.info("Transport connect failed: %r", e, extra=self.network_trace_params)
+        except (OSError, IOError, SSLError):
             # if not fully connected, close socket, and reraise error
             if self.writer and not self.connected:
                 self.writer.close()
@@ -476,7 +475,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):  # pylint: disable=too-many-
                 heartbeat=DEFAULT_WEBSOCKET_HEARTBEAT_SECONDS,
             )
         except ClientConnectorError as exc:
-            _LOGGER.info("Websocket connect failed: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("Websocket connect failed: %r", exc, extra=self.network_trace_params)
             if self._custom_endpoint:
                 raise AuthenticationException(
                     ErrorCondition.ClientError,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
@@ -133,7 +133,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
             if self._on_link_state_change is not None:
                 self._on_link_state_change(previous_state, new_state)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+            _LOGGER.debug("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
     def _on_session_state_change(self) -> None:
         if self._session.state == SessionState.MAPPED:
@@ -190,7 +190,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                     frame[6] = Target(*frame[6])
                 self._on_attach(AttachFrame(*frame))
             except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.warning("Callback for link attach raised error: %r", e, extra=self.network_trace_params)
+                _LOGGER.debug("Callback for link attach raised error: %r", e, extra=self.network_trace_params)
 
     def _outgoing_flow(self, **kwargs: Any) -> None:
         flow_frame = {
@@ -268,7 +268,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                 self._outgoing_detach(close=close, error=error)
                 self._set_state(LinkState.DETACH_SENT)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when detaching the link: %r", exc, extra=self.network_trace_params)
             self._set_state(LinkState.DETACHED)
 
     def flow(self, *, link_credit: Optional[int] = None, **kwargs: Any) -> None:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -41,7 +41,7 @@ class ReceiverLink(Link):
         try:
             return self._on_transfer(frame, message)
         except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
+            _LOGGER.debug("Transfer callback function failed with error: %r", e, extra=self.network_trace_params)
         return None
 
     def _incoming_attach(self, frame):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sender.py
@@ -34,7 +34,7 @@ class PendingDelivery(object):
             try:
                 self.on_delivery_settled(reason, state)
             except Exception as e:  # pylint:disable=broad-except
-                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
+                _LOGGER.debug("Message 'on_send_complete' callback failed: %r", e, extra=self._network_trace_params)
         self.settled = True
 
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
@@ -405,7 +405,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._set_state(new_state)
             self._wait_for_response(wait, SessionState.UNMAPPED)
         except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.info("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
+            _LOGGER.debug("An error occurred when ending the session: %r", exc, extra=self.network_trace_params)
             self._set_state(SessionState.UNMAPPED)
 
     def create_receiver_link(self, source_address, **kwargs):


### PR DESCRIPTION
## Summary

The `azure-pylint-guidelines-checker` reports `do-not-log-exceptions-if-not-debug` (C4766) and `do-not-log-raised-errors` (C4762) in three Event Hubs packages. This change clears every one of those messages. Tracking issues: #40743 (azure-eventhub), #40744 (azure-eventhub-checkpointstoreblob), #39287 (azure-eventhub-checkpointstoreblob-aio).

Rules cleared per package:

- `azure-eventhub`: C4766 (35 sites), C4762 (3 sites).
- `azure-eventhub-checkpointstoreblob`: C4766 (2 sites), C4762 (1 site).
- `azure-eventhub-checkpointstoreblob-aio`: C4766 (2 sites), C4762 (1 site). The existing `do-not-import-asyncio` (C4763) disable on the `asyncio` import stays in place, because the module calls `asyncio.gather`.

## Motivation

A log call that passes an exception object above the debug level can leak sensitive data. See the [Azure SDK logging guidance](https://azure.github.io/azure-sdk/python_implementation.html#python-logging-sensitive-info). A log call that reports an exception and then re-raises it as-is is also redundant, because the caller sees the exception.

These three rules are disabled in the root `pylintrc`, so the PR-blocking Analyze step does not report them today. The weekly `next-pylint` check uses `eng/pylintrc`, which enables them, and that check is the source of the three tracking issues. This change therefore targets `next-pylint` while it keeps the regular gate green.

Two earlier draft PRs attempted this work and stalled: #41728 for azure-eventhub and #41228 for azure-eventhub-checkpointstoreblob. This PR supersedes both. The transport log deletions in #41728 leave an unused `except ... as e:` binding, which causes `W0612 unused-variable` under the root `pylintrc` and fails the PR-blocking pylint step. This PR drops each binding together with its log call.

## Changes

Most sites only change the log level to `debug`, and keep the message text and every argument.

Four sites keep a warning, because the warning carries operational value beyond the exception. At those sites the warning drops the exception argument and a new `debug` call carries the exception. The sites are the load-balancing retry loop in both event processors, and `_claim_one_partition` ("The ownership is now lost") in both blob checkpoint stores.

Three transport sites logged an exception and then re-raised it. Those log calls are deleted, and the unused exception binding is dropped from each handler.

`list_ownership` in both blob checkpoint stores keeps its warning call and drops the exception argument and the `as error` binding. The warning cannot be deleted, because an `except` block that holds only a `raise` statement causes `W0706 try-except-raise`.

The `_pyamqp` directory is vendored two times, in `azure-eventhub` and in `azure-servicebus`, and the two copies are byte identical. Every `_pyamqp` edit in this PR is applied to both copies, so the copies stay in sync. `azure-servicebus` has its own tracking issue for the same rules, and this mirror clears the `_pyamqp` part of it. No `azure-servicebus` file outside `_pyamqp` is touched, and the only `azure-servicebus` behavior change is the log level. The files `_pyamqp/aio/_transport_async.py` and `_pyamqp/utils.py` already differed between the two copies before this change, and this PR does not touch that difference. The comment spacing on the `asyncio` import in `_pyamqp/aio/_client_async.py` is normalized, which returns that file to byte identity.

The two checkpoint store packages also get a `mypy.ini` that turns off error reports for their `_vendor` package. Each `_vendor` directory holds a copy of `azure-storage-blob`, and mypy reports 4 errors in that copy. Those errors also occur on `main`, so the Analyze step fails for any pull request that touches these two packages. The sibling package `azure-eventhub` and the package `azure-monitor-opentelemetry` already use this pattern. This change adds no suppression to code that the packages own.

No new dependency is added, no rule is disabled, and no unrelated code is reformatted. `azure-eventhub` moves to version 5.15.2 to hold its changelog entry. All four changelogs record the change.

## Test plan

The pinned toolchain was used locally: Python 3.10, pylint 4.0.6, and `azure-pylint-guidelines-checker` 0.5.7.

- `azpysdk pylint .` gives exit code 0 and a 10.00/10 rating for `azure-eventhub`, `azure-eventhub-checkpointstoreblob`, `azure-eventhub-checkpointstoreblob-aio`, and `azure-servicebus`.
- `pylint --rcfile=eng/pylintrc azure` reports zero messages for the three Event Hubs packages. Before this change it reported 41, 3, and 3 messages.
- For `azure-servicebus`, the same command reports no `_pyamqp` message. The 11 messages outside `_pyamqp` existed before this change and belong to the servicebus tracking issue.
- `mypy --python-version 3.10 --show-error-codes --ignore-missing-imports azure` gives `Success: no issues found` for all four packages, and for the samples of both checkpoint store packages. Before the `mypy.ini` change, the two checkpoint store packages reported 4 errors in `_vendor`, and a pristine copy of `main` reported the same 4 errors.
- A byte comparison of the two `_pyamqp` trees reports only the two pre-existing differences.
- No test asserts on these log levels. The package test suites need live resources and skip without them.

The three tracking issues may need manual closure. The `next-pylint` check also lints `samples/` and `tests/`, which hold unrelated pre-existing messages in all three packages, so the automatic close may not fire.
