### PR TITLE
Revert "Enforce CFSClean" (#48082)

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,7 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive
     ${{ if ne(variables['Build.DefinitionName'], 'python - core') }}:
       featureFlags:
         autoBaseline: false

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -2,9 +2,6 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: ''
-  - name: DevFeedName
-    type: string
-    default: 'public/azure-sdk-for-python'
   - name: BuildTargetingString
     type: string
     default: 'azure-*'
@@ -32,13 +29,6 @@ stages:
             displayName: 'Use Python 3.10'
             inputs:
               versionSpec: '3.10'
-
-          # Authenticate pip to the configured Azure DevOps feed before installs.
-          - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
-            parameters:
-              DevFeedName: ${{ parameters.DevFeedName }}
-              EnableTwineAuth: false
-
           - script: |
               python -m pip install -r eng/ci_tools.txt
             displayName: 'Prep Environment'


### PR DESCRIPTION
Reverts #48082.

### Why
PR #48082 set `networkIsolationPolicy: Permissive, CFSClean` in `1es-redirect.yml`. This broke the `mindependency` CI check for packages whose minimum-dependency environment installs transitive/cross-package dependencies from the DevOps feed (e.g. `azure-eventhub`, where the check pulls in `azure-eventhub-checkpointstoreblob-aio` extensions). Under CFSClean the `mindependency` install step no longer resolves those packages, failing the build even though the package's own declared floors are fine.

### Evidence
Validated on a scratch PR (now closed): branching from an affected PR, reverting CFSClean, and re-enabling the `mindependency` check produced a fully green `python - pullrequest` build (all Build Test jobs across Linux/Windows/macOS). This isolates CFSClean as the cause rather than a genuine minimum-dependency incompatibility.

Observed failures on #45418 (eventhub `mindependency` exit 1) trace directly to this policy change.

### Scope
Reverts both files changed by #48082:
- `eng/pipelines/templates/stages/1es-redirect.yml` (`Permissive, CFSClean` -> `Permissive`)
- `eng/pipelines/templates/stages/python-analyze-weekly.yml` (removes the added `DevFeedName` param + weekly `auth-dev-feed` step)

cc @chidozieononiwu - if CFSClean is desired, the `mindependency` install path needs feed auth equivalent to the weekly-pipeline fix so it can resolve DevOps-feed packages before re-enabling.