### PR TITLE
Fix RegressTest, move pyyaml up

### DIFF
--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -20,7 +20,7 @@ readme-renderer[md]==25.0
 json-delta==2.0
 ConfigArgParse==1.7
 six==1.14.0
-pyyaml==5.4.1
+pyyaml==6.0.2
 packaging==23.1
 Jinja2==3.1.2
 

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -16,7 +16,7 @@ pytoml==0.1.21
 json-delta==2.0
 ConfigArgParse==1.7
 six==1.14.0
-pyyaml==5.4.1
+pyyaml==6.0.2
 pytest==7.3.1
 pytest-cov==4.0.0
 coverage==7.2.5


### PR DESCRIPTION
## Problem
RegressTest jobs failed in **Prep Environment** (before any test ran) across all services:

```
× Failed to build `pyyaml==5.4.1`
  AttributeError: 'build_ext' object has no attribute 'cython_sources'
```

`eng/regression_tools.txt` pinned `pyyaml==5.4.1`, which has no cp310 wheel, so it builds from source. That source build is incompatible with the current Cython 3.x / setuptools in the CI image.

## Fix
Bump `pyyaml` 5.4.1 → 6.0.2 in both regression tools files (6.0.2 ships a cp310 wheel — no source build). Matches the pin already used in `eng/test_tools.txt` and `eng/ci_tools.txt`; these two files were the only outliers.

## Validation
Manual `python - storage` run with `Run.Regression=true` — all RegressTest jobs green (storage, ml, evaluation, ai): build 6604417.
