### PR TITLE
Exclude python - pullrequest from CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,6 +40,9 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+    ${{ if eq(variables['Build.DefinitionName'], 'python - pullrequest') }}:
+      networkIsolationPolicy: Permissive
+    ${{ else }}:
       networkIsolationPolicy: Permissive, CFSClean
     ${{ if ne(variables['Build.DefinitionName'], 'python - core') }}:
       featureFlags:


### PR DESCRIPTION
This pull request updates the network isolation policy configuration in the `1es-redirect.yml` pipeline template. The main change is to apply a more permissive network isolation policy for pull request builds in the `python - pullrequest` pipeline, while keeping stricter policies for other pipelines.

Pipeline configuration changes:

* Updated the `networkIsolationPolicy` setting to be `Permissive` specifically for the `python - pullrequest` pipeline, and `Permissive, CFSClean` for all other pipelines. This allows more flexible network access during pull request builds for the `python - pullrequest` pipeline.