### PR TITLE
[agentserver] Bump core to 2.0.0b8 (span attribute enrichment fix)

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0b8 (2026-07-22)
+
+### Bugs Fixed
+
+- Fixed span attribute enrichment under `opentelemetry-sdk` >= 1.43.0, where `span._attributes` became a `BoundedAttributes` (backed by `._dict`) that no longer supports item assignment. Enrichment now resolves the backing store so agent identity attributes are written on both older and newer OpenTelemetry SDKs.
+
 ## 2.0.0b7 (2026-06-28)
 
 ### Features Added

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.0.0b7"
+VERSION = "2.0.0b8"


### PR DESCRIPTION
Releases `azure-ai-agentserver-core` 2.0.0b8 on its own so the fix can be published before dependent packages raise their floors.

### Change
- Bumps `azure-ai-agentserver-core` to 2.0.0b8.
- Fixes span attribute enrichment under `opentelemetry-sdk` >= 1.43.0, where `span._attributes` became a `BoundedAttributes` (backed by `._dict`) that no longer supports item assignment. Enrichment now resolves the backing store so agent identity attributes are written on both older and newer OpenTelemetry SDKs.

### Why split out
 Split from #48193. The dependent packages (activity/invocations/responses) require `core>=2.0.0b8`; their apistub/consistency checks can only pass once b8 is published to the feed. This PR ships core first; the floor bumps follow in a separate PR after b8 is available.