### PR TITLE
[Cosmos] Preserve circuit breaker test environment

### DIFF
--- a/sdk/cosmos/azure-cosmos/tests/test_availability_strategy.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_availability_strategy.py
@@ -9,6 +9,7 @@ import unittest
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Any, Union
+from unittest.mock import patch
 
 import pytest
 from azure.core.exceptions import ServiceResponseError
@@ -716,9 +717,12 @@ class TestAvailabilityStrategy:
     @pytest.mark.parametrize("operation", [READ, QUERY_PK, CHANGE_FEED, CREATE, UPSERT, REPLACE, DELETE, PATCH, BATCH])
     def test_per_partition_circular_breaker_with_cancelled_first_future(self, operation):
         # QUERY, READ_ALL are not included because currently they are not targeting to a specific pkRange
-        os.environ["AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER"] = "True"
-        os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE"] = "5"
-        os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ"] = "5"
+        env_patch = patch.dict(os.environ, {
+            "AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER": "True",
+            "AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE": "5",
+            "AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ": "5",
+        })
+        env_patch.start()
 
         try:
             """Test that when per partition circular breaker is enabled and after hitting the threshold, subsequent requests go directly to second region.
@@ -799,9 +803,7 @@ class TestAvailabilityStrategy:
                     availability_strategy=strategy)
 
         finally:
-            del os.environ["AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER"]
-            del os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE"]
-            del os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ"]
+            env_patch.stop()
 
         self._clean_up_container(setup_with_fault_injection['db'].id, setup_with_fault_injection['col'].id)
 

--- a/sdk/cosmos/azure-cosmos/tests/test_availability_strategy_async.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_availability_strategy_async.py
@@ -7,6 +7,7 @@ import re
 import unittest
 import uuid
 from typing import Optional, Any, Union
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -847,9 +848,12 @@ class TestAsyncAvailabilityStrategy:
     @pytest.mark.parametrize("operation", [READ, QUERY_PK, CHANGE_FEED, CREATE, UPSERT, REPLACE, DELETE, PATCH, BATCH])
     async def test_per_partition_circular_breaker_with_cancelled_first_future_async(self, operation, setup):
         # QUERY, READ_ALL are not included because currently they are not targeting to a specific pkRange
-        os.environ["AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER"] = "True"
-        os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE"] = "5"
-        os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ"] = "5"
+        env_patch = patch.dict(os.environ, {
+            "AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER": "True",
+            "AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE": "5",
+            "AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ": "5",
+        })
+        env_patch.start()
 
         try:
             """Test that when per partition circular breaker is enabled and after hitting the threshold, subsequent requests go directly to second region.
@@ -938,9 +942,7 @@ class TestAsyncAvailabilityStrategy:
             await setup_with_fault_injection['client'].close()
             await setup_without_fault['client'].close()
         finally:
-            del os.environ["AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER"]
-            del os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_WRITE"]
-            del os.environ["AZURE_COSMOS_CONSECUTIVE_ERROR_COUNT_TOLERATED_FOR_READ"]
+            env_patch.stop()
         await self._clean_up_container(setup['client_without_fault'], setup_with_fault_injection['db'].id, setup_with_fault_injection['col'].id)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

- Preserve pipeline-provided circuit-breaker environment settings after the sync availability-strategy test.
- Apply the same restoration to the async availability-strategy test.
- Prevent order-dependent failures in the later multi-write circuit-breaker test matrix.

The availability-strategy tests previously set three circuit-breaker environment variables and then unconditionally deleted them. This removed the sign-off pipeline's `AZURE_COSMOS_ENABLE_CIRCUIT_BREAKER=True` setting for every test collected afterward.

## Validation

- Reproduced the order dependency locally: the availability-strategy test passed, then the following circuit-breaker test failed after the feature flag was deleted.
- Source mypy and CSpell checks passed for the changed code.
- Package-wide local tooling remains blocked by unrelated environment issues (private-feed authentication and pre-existing sample/tooling failures).

## Timeout note

The 900-second per-test timeout introduced in #47091 is already present. This PR does not change the separate 240-minute classic Azure DevOps job limit.
