### PR TITLE
Scan Python + cpp in compiled CodeQL; disable compiled CodeQL on macOS arm64

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -74,6 +74,14 @@ jobs:
       os: ${{ parameters.OSName }}
 
     templateContext:
+      # Compiled CodeQL is auto-injected by 1ES but is unsupported on macOS ARM64
+      # (and the test jobs do not compile the extension). Mirror the Build_MacOS carve-out.
+      ${{ if eq(parameters.OSName, 'macOS') }}:
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: "Compiled language support is not available on macOS ARM64. See: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#arm64-cpu-on-macos"
       # See eng/common/pipelines/templates/steps/upload-llm-artifacts.yml for corresponding file copy step
       outputs:
         - output: pipelineArtifact

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -116,6 +116,13 @@ jobs:
       vmImage: $(MACVMIMAGE)
       os: macOS
 
+    templateContext:
+      sdl:
+        codeql:
+          compiled:
+            enabled: false
+            justificationForDisabling: "Compiled language support is not available on macOS ARM64. See: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#arm64-cpu-on-macos"
+
     steps:
     - template: /eng/pipelines/templates/steps/build-package-artifacts.yml
       parameters:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -65,7 +65,7 @@ extends:
         ${{ if eq(parameters.EnableCompiledCodeql, true) }}:
           # "cpp" covers both C and C++ code. Language is specified because 
           # checkout happens after the injected "CodeQL Initialize" step
-          language: cpp
+          language: cpp,python
           compiled:
             enabled: true
         ${{ else }}:


### PR DESCRIPTION
## What

Two SDL/CodeQL pipeline changes surfaced while wiring the compiled `azure-storage-extensions` build:

1. **`1es-redirect.yml`** — when `EnableCompiledCodeql: true`, set the injected CodeQL `language` from `cpp` to `cpp,python`. The traced build job now scans both the native C extension and Python source, instead of `cpp` only. (Interpreted Python is still scanned centrally in the source-analysis stage; this makes the compiled build job cover it too when compiled CodeQL is on.)

2. **`jobs/ci.yml`** — disable compiled CodeQL on the `Build_MacOS` job. 1ES CodeQL's compiled-language tracer is unsupported on macOS arm64 ([1ES docs](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#arm64-cpu-on-macos)). Without this guard, enabling `EnableCompiledCodeql` on any pipeline that includes the mac job fails CodeQL onboarding. No-op when compiled CodeQL isn't enabled.

## Why

These are the general, main-worthy pieces of the storage-extensions compiled-build work. The mac guard prevents arm64 CodeQL onboarding failures; the `cpp,python` change broadens coverage on the traced build.

## Scope

Infra-only; no package/source changes. Both edits are inert unless a pipeline opts in via `EnableCompiledCodeql: true`.