### PR TITLE
Propagate directory upload errors without progress

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
+- Fixed directory uploads not propagating errors when progress reporting is disabled.
 - Fixed `MLClient.jobs.create_or_update`, `archive`, and `restore` failing for previously-fetched jobs across all job types by routing metadata-only edits through the RunHistory PATCH endpoint.
 - Fixed `DeploymentTemplate.creation_context` always being `None` when retrieved via `get()` or `list()`. The created/modified timestamps and identity returned by the service (as `createdTime` / `modifiedTime` / `createdBy`) are now populated on `creation_context`, making `DeploymentTemplate` consistent with `Model` and `Environment`.
 - Fixed `deployment_templates.list(name=...)` raising `AttributeError: 'str' object has no attribute 'request_timeout'`. In the list response, `requestSettings` / `livenessProbe` / `readinessProbe` arrive as stringified dicts nested under `properties`; these are now parsed before conversion, giving `list()` parity with `models.list()` / `environments.list()`.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -720,6 +720,9 @@ def upload_directory(
                     future.result()  # access result to propagate any exceptions
                     file_path_name = futures_dict[future][0]
                     pbar.update(size_dict.get(file_path_name) or 0)
+        else:
+            for future in as_completed(futures_dict):
+                future.result()
 
 
 @retry(

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_asset_utils.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Callable, List, Tuple
+from unittest.mock import patch
 
 import pytest
 
@@ -19,6 +20,7 @@ from azure.ai.ml._utils._asset_utils import (
     get_ignore_file,
     get_object_hash,
     get_upload_files_from_folder,
+    upload_directory,
 )
 from azure.ai.ml._utils.utils import convert_windows_path_to_unix
 from azure.ai.ml.constants._common import AutoDeleteCondition
@@ -174,6 +176,19 @@ class SymbolLinkTestCase:
 @pytest.mark.unittest
 @pytest.mark.core_sdk_test
 class TestAssetUtils:
+    def test_upload_directory_propagates_errors_without_progress(self, tmp_path: Path) -> None:
+        class BlobStorageClient:
+            def check_blob_exists(self):
+                pass
+
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "file.txt").write_text("content")
+
+        with patch("azure.ai.ml._utils._asset_utils.upload_file", side_effect=RuntimeError("upload failed")):
+            with pytest.raises(RuntimeError, match="upload failed"):
+                upload_directory(BlobStorageClient(), source, "destination", "Uploading", False, IgnoreFile(None))
+
     def test_amlignore_precedence(
         self, storage_test_directory: str, gitignore_file_directory: str, no_ignore_file_directory: str
     ) -> None:


### PR DESCRIPTION
Directory upload futures are only observed when progress is enabled. Always observe them so worker failures propagate with `show_progress=False`.

Fixes #48269