### PR TITLE
Revert CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,10 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      ${{ if eq(variables['Build.DefinitionName'], 'python - pullrequest') }}:
-        networkIsolationPolicy: Permissive
-      ${{ else }}:
-        networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive
     ${{ if ne(variables['Build.DefinitionName'], 'python - core') }}:
       featureFlags:
         autoBaseline: false


### PR DESCRIPTION
This pull request simplifies the network isolation policy configuration in the `1es-redirect.yml` pipeline template by standardizing the policy settings. The main change is to always use the `Permissive` network isolation policy, regardless of the build definition.

Pipeline configuration simplification:

* [`eng/pipelines/templates/stages/1es-redirect.yml`](diffhunk://#diff-8800a9effcbb25b180d9532721d7d17e592bed1b8777e5336c0de6b5716212f4L43-L46): Updated to always set `networkIsolationPolicy` to `Permissive`, removing conditional logic that previously set it to `Permissive, CFSClean` for some build definitions.