### PR TITLE
Add preview API version warning for stable mgmt SDKs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,6 +140,7 @@ These rules apply to management-plane SDK packages located at `sdk/*/azure-mgmt-
 
 ### VERSION CONSISTENCY
 - The version string in `_version.py` **must** match the latest version listed in `CHANGELOG.md`.
+- Preview API versions must use preview SDK versions: when the package metadata file (`sdk/<service>/azure-mgmt-<package>/_metadata.json`) has an `apiVersion` containing `preview`, the generated package version file (`sdk/<service>/azure-mgmt-<package>/azure/mgmt/<package>/_version.py`) **must** define a beta version such as `1.0.0b1`, not a stable version such as `1.0.0`.
 
 ### CHANGELOG DATE
 - If the release date of the latest version in `CHANGELOG.md` is **more than 3 weeks in the future** from the current date, remind the author to verify and update the date.

--- a/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import os
+import json
 from packaging.version import Version
 import ast
 import shutil
@@ -22,6 +23,12 @@ from . import build_packaging
 from .change_log import main as change_log_main
 
 _LOGGER = logging.getLogger(__name__)
+
+PREVIEW_API_STABLE_VERSION_WARNING = (
+    "WARNING: Stable SDK version {sdk_version} is used with preview API version {api_version}. "
+    "If this is expected, delete this line; otherwise, check this PR."
+)
+PREVIEW_API_STABLE_VERSION_WARNING_PREFIX = "WARNING: Stable SDK version "
 
 
 # prefolder: "sdk/compute"; name: "azure-mgmt-compute"
@@ -354,12 +361,87 @@ class CheckFile:
 
         _LOGGER.info("Updated pyproject.toml with required azure-sdk-build configurations")
 
+    def check_preview_api_version(self):
+        metadata_path = self.package_path / "_metadata.json"
+        if not metadata_path.exists():
+            return
+
+        try:
+            with open(metadata_path, "r") as file:
+                metadata = json.load(file)
+        except Exception as e:
+            _LOGGER.info(f"Failed to parse {metadata_path}: {e}")
+            return
+
+        api_versions = []
+        api_version = metadata.get("apiVersion")
+        if isinstance(api_version, str):
+            api_versions.append(api_version)
+
+        api_versions_map = metadata.get("apiVersions")
+        if isinstance(api_versions_map, dict):
+            api_versions.extend(str(value) for value in api_versions_map.values())
+
+        preview_api_version = next((version for version in api_versions if "preview" in version.lower()), "")
+        if not preview_api_version:
+            return
+
+        version_files = list((self.package_path / "azure" / "mgmt").glob("**/_version.py"))
+        if not version_files:
+            _LOGGER.info(f"Can not find _version.py under {self.package_path / 'azure' / 'mgmt'}")
+            return
+
+        try:
+            with open(version_files[0], "r") as file:
+                tree = ast.parse(file.read())
+        except Exception as e:
+            _LOGGER.info(f"Failed to parse {version_files[0]}: {e}")
+            return
+
+        sdk_version = ""
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "VERSION" and isinstance(node.value, ast.Constant):
+                        sdk_version = str(node.value.value)
+                        break
+
+        if not sdk_version or "b" in sdk_version.lower():
+            return
+
+        warning = PREVIEW_API_STABLE_VERSION_WARNING.format(
+            sdk_version=sdk_version,
+            api_version=preview_api_version,
+        )
+
+        changelog_path = self.package_path / "CHANGELOG.md"
+        if not changelog_path.exists():
+            _LOGGER.info(f"{changelog_path} does not exist.")
+            return
+
+        def add_warning_to_changelog(content: List[str]):
+            if any(line.startswith(PREVIEW_API_STABLE_VERSION_WARNING_PREFIX) for line in content):
+                return
+            for i, line in enumerate(content):
+                if re.match(r"^## \d+\.\d+\.\d+(?:b\d+)?\s+\(", line):
+                    insert_at = i + 1
+                    if insert_at < len(content) and not content[insert_at].strip():
+                        insert_at += 1
+                    content.insert(insert_at, f"{warning}\n\n")
+                    _LOGGER.warning(
+                        f"Added preview API/stable SDK version warning to {changelog_path} for SDK version {sdk_version}"
+                    )
+                    break
+
+        modify_file(str(changelog_path), add_warning_to_changelog)
+
     def run(self):
         self.check_file_with_packaging_tool()
         self.check_pprint_name()
         self.check_sdk_readme()
         self.check_dev_requirement()
         self.check_pyproject_toml()
+        self.check_preview_api_version()
 
 
 def check_file(package_path: Path):

--- a/eng/tools/azure-sdk-tools/tests/test_package_utils.py
+++ b/eng/tools/azure-sdk-tools/tests/test_package_utils.py
@@ -100,11 +100,7 @@ def test_preview_api_with_stable_sdk_version_adds_changelog_warning(tmp_path):
         api_version="2026-01-01-preview",
     )
     assert changelog_content.count(expected_warning) == 1
-    assert (
-        "## 1.0.0 (2026-07-27)\n\n"
-        f"{expected_warning}\n\n"
-        "### Features Added"
-    ) in changelog_content
+    assert ("## 1.0.0 (2026-07-27)\n\n" f"{expected_warning}\n\n" "### Features Added") in changelog_content
 
 
 def test_stable_api_with_stable_sdk_version_does_not_add_changelog_warning(tmp_path):

--- a/eng/tools/azure-sdk-tools/tests/test_package_utils.py
+++ b/eng/tools/azure-sdk-tools/tests/test_package_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import json
 from unittest.mock import patch, MagicMock
 from packaging.version import Version
 
@@ -30,6 +31,12 @@ def _create_basic_package(tmp_path: Path, package_name: str, version_line: str):
     (package_dir / "README.md").write_text("This is MyService client library.\n")
 
     return package_dir
+
+
+def _write_mgmt_version_file(package_dir: Path, sdk_version: str):
+    version_file = package_dir / "azure" / "mgmt" / package_dir.name.replace("azure-mgmt-", "") / "_version.py"
+    version_file.parent.mkdir(parents=True, exist_ok=True)
+    version_file.write_text(f'VERSION = "{sdk_version}"\n')
 
 
 def test_check_file_populates_pyproject_stable(tmp_path, monkeypatch):
@@ -71,6 +78,48 @@ def test_check_file_sets_is_stable_false_for_beta(tmp_path, monkeypatch):
     assert data["packaging"]["is_stable"] is False
     # title still populated
     assert data["packaging"]["title"] == "FooClient"
+
+
+def test_preview_api_with_stable_sdk_version_adds_changelog_warning(tmp_path):
+    package_name = "azure-mgmt-foo"
+    package_dir = _create_basic_package(
+        tmp_path,
+        package_name,
+        "## 1.0.0 (2026-07-27)\n\n### Features Added\n\n  - Initial version",
+    )
+    (package_dir / "_metadata.json").write_text(json.dumps({"apiVersion": "2026-01-01-preview"}))
+    _write_mgmt_version_file(package_dir, "1.0.0")
+
+    checker = pu.CheckFile(package_dir)
+    checker.check_preview_api_version()
+    checker.check_preview_api_version()
+
+    changelog_content = (package_dir / "CHANGELOG.md").read_text()
+    expected_warning = pu.PREVIEW_API_STABLE_VERSION_WARNING.format(
+        sdk_version="1.0.0",
+        api_version="2026-01-01-preview",
+    )
+    assert changelog_content.count(expected_warning) == 1
+    assert (
+        "## 1.0.0 (2026-07-27)\n\n"
+        f"{expected_warning}\n\n"
+        "### Features Added"
+    ) in changelog_content
+
+
+def test_stable_api_with_stable_sdk_version_does_not_add_changelog_warning(tmp_path):
+    package_name = "azure-mgmt-foo"
+    package_dir = _create_basic_package(
+        tmp_path,
+        package_name,
+        "## 1.0.0 (2026-07-27)\n\n### Features Added\n\n  - Initial version",
+    )
+    (package_dir / "_metadata.json").write_text(json.dumps({"apiVersions": {"Foo": "2026-01-01"}}))
+    _write_mgmt_version_file(package_dir, "1.0.0")
+
+    pu.CheckFile(package_dir).check_preview_api_version()
+
+    assert pu.PREVIEW_API_STABLE_VERSION_WARNING_PREFIX not in (package_dir / "CHANGELOG.md").read_text()
 
 
 def test_get_version_info_treats_0_0_0_as_invalid():


### PR DESCRIPTION
For https://github.com/Azure/azure-sdk-tools/issues/16495

Adds a management SDK review rule and package generation check for preview API versions paired with stable SDK versions.

Summary:
- Document the MGMT SDK review expectation that preview API versions require beta SDK versions.
- Add a package utility check that reads _metadata.json and generated azure/mgmt/**/_version.py.
- Insert an idempotent CHANGELOG.md warning with the concrete SDK version and API version when a stable SDK version is used with a preview API version.
- Add focused unit tests for warning insertion, idempotency, and non-preview API behavior.

Validation:
- pytest eng/tools/azure-sdk-tools/tests/test_package_utils.py