### PR TITLE
[agentserver-activity] Set 1.0.0b2 release date

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 1.0.0b2 (2026-07-27)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - Digital-worker (MAIB) outbound auth now uses the M365 Agents SDK's native `IdentityProxyManager` connection auth type instead of a custom MSAL monkeypatch (`_apply_msal_patches`), which previously overrode `MsalAuth.get_agentic_application_token` to perform the federated-identity (FMI) token exchange. The M365 SDK performs that exchange natively from `1.1.0`.

--- a/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b2 (Unreleased)
+## 1.0.0b2 (2026-07-27)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b2 (2026-07-27)
+## 1.0.0b2 (2026-07-28)
 
 ### Other Changes
 


### PR DESCRIPTION
## Summary
Sets the `azure-ai-agentserver-activity` `1.0.0b2` CHANGELOG release date to `2026-07-28` (was `Unreleased`). The `1.0.0b2` content itself is already on main.
