### PR TITLE
Temporarily take azure-ai-agents out of build, to unblock release of azure-ai-projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,10 +35,10 @@
 /sdk/agrifood/azure-agrifood-farming/    @bhargav-kansagara
 
 # PRLabel: %AI
-/sdk/ai/    @dargilco @luigiw @needuv @paulshealy1 @singankit @trrwilson
+/sdk/ai/    @dargilco @luigiw @needuv @singankit @trrwilson @howieleung
 
 # ServiceLabel: %AI
-# ServiceOwners: @luigiw @needuv @paulshealy1 @singankit
+# ServiceOwners: @luigiw @needuv @singankit
 
 # ServiceLabel: %AI Agents %Service Attention
 # PRLabel: %AI Agents

--- a/sdk/ai/ci.yml
+++ b/sdk/ai/ci.yml
@@ -35,8 +35,8 @@ extends:
     Artifacts:
     - name: azure-ai-projects
       safeName: azureaiprojects
-    - name: azure-ai-agents
-      safeName: azureaiagents
+    # - name: azure-ai-agents
+    #   safeName: azureaiagents
     # These packages are deprecated:
     # - name: azure-ai-inference
     #   safeName: azureaiinference


### PR DESCRIPTION
On Friday this bug in the build was reported: https://github.com/Azure/azure-sdk-for-python/issues/48254 . It seems to affect only azure-ai-agents builds, but prevents us from releasing azure-ai-projects. Engineering system team is on it, but I don't know when a fix will be available.

Temporarily remove azure-ai-agents from the build to unblock the release. I will bring it back after the release (since azure-ai-agents had a stable release, we want to keep it in the build for now).

Also update codeowners for the /ask/ai path -- remove Paul S and add Howie.