### PR TITLE
Update azure-mgmt-computefleet 2.0.0b2 release date

### DIFF
--- a/sdk/computefleet/azure-mgmt-computefleet/CHANGELOG.md
+++ b/sdk/computefleet/azure-mgmt-computefleet/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Model `VirtualMachine` added property `vm_size`
   - Model `VirtualMachine` added property `zone`
 
-## 2.0.0b2 (2026-05-28)
+## 2.0.0b2 (2026-07-29)
 
 ### Features Added
 


### PR DESCRIPTION
Updates the planned release date for zure-mgmt-computefleet version 2.0.0b2 from 2026-05-28 to 2026-07-29 in CHANGELOG.md, to unblock release readiness for release plan 35313.