### PR TITLE
Live Metrics now honors the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable for AAD authentication as a fallback when no explicit credential is supplied and local authentication is disabled.

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -13,6 +13,7 @@
   ([#47950](https://github.com/Azure/azure-sdk-for-python/pull/47950))
 - Live Metrics now honors the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable for AAD
   authentication as a fallback when no explicit credential is supplied and local authentication is disabled.
+  ([#48284](https://github.com/Azure/azure-sdk-for-python/pull/48284))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Bugs Fixed
 - Propagate main agent attribute to child spans
   ([#47950](https://github.com/Azure/azure-sdk-for-python/pull/47950))
+- Live Metrics now honors the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable for AAD
+  authentication as a fallback when no explicit credential is supplied and local authentication is disabled.
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/api.metadata.yml
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/api.metadata.yml
@@ -1,3 +1,3 @@
 apiMdSha256: e927f060406b601099194e0e8346efaed5f68fee04cc95eb441de90f67b1b3d6
-parserVersion: 0.3.28
+parserVersion: 0.3.30
 pythonVersion: 3.13.14

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -61,6 +61,9 @@ from azure.monitor.opentelemetry.exporter._quickpulse._utils import (
 from azure.monitor.opentelemetry.exporter._connection_string_parser import (
     ConnectionStringParser,
 )
+from azure.monitor.opentelemetry.exporter.export._base import (
+    _get_authentication_credential,
+)
 from azure.monitor.opentelemetry.exporter._utils import (
     _get_auth_policy,
     _ticks_since_dot_net_epoch,
@@ -106,7 +109,7 @@ class _QuickpulseExporter(MetricExporter):
 
         self._live_endpoint = parsed_connection_string.live_endpoint
         self._instrumentation_key = parsed_connection_string.instrumentation_key
-        self._credential = kwargs.get("credential")
+        self._credential = _get_authentication_credential(**kwargs)
         self.aad_audience = parsed_connection_string.aad_audience
         # Do not pass credential to config; auth is handled explicitly via _get_auth_policy
         config = LiveMetricsClientConfiguration()

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -102,7 +102,9 @@ class _QuickpulseExporter(MetricExporter):
 
         :param str connection_string: The connection string used for your Application Insights resource.
         :keyword TokenCredential credential: Token credential, such as ManagedIdentityCredential or
-            ClientSecretCredential, used for Azure Active Directory (AAD) authentication. Defaults to None.
+            ClientSecretCredential, used for Azure Active Directory (AAD) authentication. If omitted, the
+            credential is resolved from the ``APPLICATIONINSIGHTS_AUTHENTICATION_STRING`` environment variable
+            (the App Service / Functions AAD convention); if that variable is also absent, it will default to None.
         :rtype: None
         """
         parsed_connection_string = ConnectionStringParser(kwargs.get("connection_string"))

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_exporter.py
@@ -156,6 +156,58 @@ class TestQuickpulse(unittest.TestCase):
             "Auth policy scope must use double-slash format",
         )
 
+    @mock.patch("azure.monitor.opentelemetry.exporter._quickpulse._exporter.LiveMetricsClient")
+    @mock.patch("azure.monitor.opentelemetry.exporter.export._base.ManagedIdentityCredential")
+    def test_init_credential_from_auth_string_env_var(self, cred_mock, client_mock):
+        """Live Metrics resolves AAD credential from APPLICATIONINSIGHTS_AUTHENTICATION_STRING."""
+        with mock.patch.dict(
+            "os.environ",
+            {"APPLICATIONINSIGHTS_AUTHENTICATION_STRING": "Authorization=AAD;ClientId=test-client-id"},
+        ):
+            exporter = _QuickpulseExporter(
+                connection_string=(
+                    "InstrumentationKey=4321abcd-5678-4efa-8abc-1234567890ab;"
+                    "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+                )
+            )
+        cred_mock.assert_called_once_with(client_id="test-client-id")
+        self.assertIs(exporter._credential, cred_mock.return_value)
+        self.assertIs(client_mock.call_args.kwargs["credential"], cred_mock.return_value)
+
+    @mock.patch("azure.monitor.opentelemetry.exporter._quickpulse._exporter.LiveMetricsClient")
+    def test_init_credential_kwarg_takes_precedence_over_env_var(self, client_mock):
+        """An explicit credential kwarg wins over the env-var convention."""
+
+        class _FakeCredential:
+            def get_token(self, *scopes, **kwargs):  # pylint: disable=unused-argument
+                return mock.MagicMock(token="fake", expires_on=9999999999)
+
+        credential = _FakeCredential()
+        with mock.patch.dict(
+            "os.environ",
+            {"APPLICATIONINSIGHTS_AUTHENTICATION_STRING": "Authorization=AAD;ClientId=test-client-id"},
+        ):
+            exporter = _QuickpulseExporter(
+                connection_string=(
+                    "InstrumentationKey=4321abcd-5678-4efa-8abc-1234567890ab;"
+                    "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+                ),
+                credential=credential,
+            )
+        self.assertIs(exporter._credential, credential)
+
+    @mock.patch("azure.monitor.opentelemetry.exporter._quickpulse._exporter.LiveMetricsClient")
+    def test_init_credential_none_without_kwarg_or_env_var(self, client_mock):
+        """Without a credential kwarg or the auth-string env var, credential stays None."""
+        with mock.patch.dict("os.environ", {}, clear=True):
+            exporter = _QuickpulseExporter(
+                connection_string=(
+                    "InstrumentationKey=4321abcd-5678-4efa-8abc-1234567890ab;"
+                    "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+                )
+            )
+        self.assertIsNone(exporter._credential)
+
     def test_export_missing_data_point(self):
         result = self._exporter.export(OTMetricsData(resource_metrics=[]))
         self.assertEqual(result, MetricExportResult.FAILURE)


### PR DESCRIPTION
# Description

Fixes - https://github.com/Azure/azure-sdk-for-python/issues/48251

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
