### PR TITLE
Ensure that build-test uses pypi

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -21,16 +21,11 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This variable is set from resolve-package-targeting.yml.
 steps:
-  - template: /eng/pipelines/templates/steps/use-python-version.yml
-    parameters:
-      versionSpec: '${{ parameters.PythonVersion }}'
-
-  # Authenticate to Azure Artifacts feed immediately after checkout to prevent 401 errors
-  # Public feeds have upstream sources enabled and require authentication for passthrough to pypi.org
-  - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
-    parameters:
-      DevFeedName: ${{ parameters.DevFeedName }}
-      EnableTwineAuth: false
+  - task: UsePythonVersion@0
+    displayName: "Use Python ${{ parameters.PythonVersion }}"
+    inputs:
+      versionSpec: ${{ parameters.PythonVersion }}
+      allowUnstable: true
 
   - template: /eng/pipelines/templates/steps/use-venv.yml
 
@@ -74,6 +69,8 @@ steps:
         ScriptType: InlineScript
         Inline: >-
           $env:AZPYSDK_PIP_IMPL="uv";
+          $env:PIP_INDEX_URL="https://pypi.org/simple/";
+          $env:UV_DEFAULT_INDEX="https://pypi.org/simple/";
           $account = (Get-AzContext).Account;
           $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
           $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
@@ -101,6 +98,8 @@ steps:
   - ${{ else }}:
     - pwsh: |
         $env:AZPYSDK_PIP_IMPL="uv"
+        $env:PIP_INDEX_URL="https://pypi.org/simple/"
+        $env:UV_DEFAULT_INDEX="https://pypi.org/simple/"
         Write-Host (Get-Command python).Source
 
         if ($env:TESTMARKARGUMENT) {


### PR DESCRIPTION
This pull request updates the `build-test.yml` pipeline template to streamline Python version selection and package source configuration. The most important changes are grouped below:

**Python environment setup:**

* Replaced the `use-python-version.yml` template with the `UsePythonVersion@0` pipeline task, allowing for direct specification of the Python version and enabling unstable versions via the `allowUnstable` input.

**Package source configuration:**

* Added a new PowerShell step to explicitly set `PIP_INDEX_URL` and `UV_DEFAULT_INDEX` environment variables, ensuring that test checks use the official PyPI repository for Python packages.
* Removed the `auth-dev-feed.yml` template step, which previously authenticated to the Azure Artifacts feed, since tests now pull packages directly from PyPI.