### PR TITLE
[compute] Update azure-mgmt-compute-bulkaction 1.0.0b2 release date for release plan 35410

### DIFF
--- a/sdk/compute/azure-mgmt-compute-bulkaction/CHANGELOG.md
+++ b/sdk/compute/azure-mgmt-compute-bulkaction/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b2 (2026-07-22)
+## 1.0.0b2 (2026-07-30)
 
 ### Features Added
 


### PR DESCRIPTION
Updates the `azure-mgmt-compute-bulkaction` **1.0.0b2** CHANGELOG release date to `2026-07-30` so the release pipeline recognizes a valid planned release date.

Unblocks the first publish of the package (Public Preview) for release plan **35410**. The generation PR (#48179) is already merged; only the changelog release date needs to reflect the planned release day. No code changes -- changelog date only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>