### PR TITLE
[Translation] Bump azure-core minimum to 1.37.0 to fix mindependency check

### DIFF
--- a/sdk/translation/azure-ai-translation-document/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-document/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Other Changes
 
 - This version and all future versions will require Python 3.9+. Python 3.8 is no longer supported.
+- Bumped the minimum required `azure-core` version from `1.30.0` to `1.37.0`.
 
 ## 1.1.0 (2024-11-15)
 

--- a/sdk/translation/azure-ai-translation-document/setup.py
+++ b/sdk/translation/azure-ai-translation-document/setup.py
@@ -65,7 +65,7 @@ setup(
     },
     install_requires=[
         "isodate>=0.6.1",
-        "azure-core>=1.30.0",
+        "azure-core>=1.37.0",
         "typing-extensions>=4.6.0",
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
Fixes the `mindependency` CI failure blocking the `azure-ai-translation-document` 2.0.0 GA release.

### Problem

The `mindependency` check pins `azure-core` to the declared floor (`>=1.30.0` → `azure-core==1.30.0`). That conflicts with the in-repo `azure-identity` dev requirement:

```
Dev req dependency azure-identity's requirement specifier of azure-core>=1.31.0
is not compatible with immutable requirement azure-core==1.30.0.
```

Dependency resolution then falls back to fetching an older `azure-identity` (1.25.3) from pypi.org, but CI agents install from an internal Azure Artifacts feed and block pypi.org egress:

```
Dependency resolution failed: HTTPSConnectionPool(host='pypi.org', port=443):
Max retries exceeded ... [Errno 1] Operation not permitted
```

So the check fails deterministically. Because the `Release: azure-ai-translation-document` stage is gated on `Build`, this blocks the release entirely.

Reproduced on two consecutive runs of `python - translation`:
- [6629723](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6629723)
- [6630053](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6630053)

Both show `Total checks: 12 | Failed: 1`, with `mindependency` the sole failure and **zero failing tests**. All other checks (`whl`, `sdist`, `import_all`, `latestdependency`, `whl_no_aio`) pass.

### Fix

Raise the `azure-core` floor to `>=1.37.0`, matching the sibling `azure-ai-translation-text` package in the same service directory — which has the same local `azure-identity` dev requirement and whose `mindependency` check passes in the same pipeline run.

### Notes

- Pre-existing issue; not introduced by #47837, which left the dependency untouched.
- `>=1.31.0` would be the minimal fix; `1.37.0` matches the sibling package for consistency, and 2.0.0 is a major version, so raising the floor is appropriate.
- CHANGELOG updated under 2.0.0 → Other Changes.