### PR TITLE
[agentserver-core] Set 2.0.0b9 release date

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b9 (Unreleased)
+## 2.0.0b9 (2026-07-28)
 
 ### Features Added
 


### PR DESCRIPTION
## Summary
Sets the `azure-ai-agentserver-core` `2.0.0b9` CHANGELOG release date to `2026-07-28` (was `Unreleased`), so the package is release-ready. The `2.0.0b9` content itself is already on main; the version is unchanged.

Generated via the repo's `Prepare-Release.ps1` / `sdk_set_version` flow. Follows the pattern of #48277.
