### PR TITLE
Prepare azure-ai-agentserver-responses release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b0 (Unreleased)
+## 2.0.0b0 (2026-07-29)
 
 ### Features Added
 


### PR DESCRIPTION
## Description

Prepare azure-ai-agentserver-responses 2.0.0b0 for release by setting the changelog date to 2026-07-29.

## Changes

- Updated CHANGELOG.md release entry from Unreleased to 2026-07-29.