### PR TITLE
chore: add @meetamitbhatia to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -252,10 +252,10 @@
 /sdk/eventgrid/    @shankarsama @Nishanth-MS
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/    @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+/sdk/eventhub/    @axisc @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners: @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+# ServiceOwners: @axisc @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Graph
 /sdk/graphrbac/    @xirzec
@@ -741,10 +741,10 @@
 # ServiceOwners: @antcp @AzureAppServiceCLI
 
 # PRLabel: %Service Bus
-/sdk/servicebus/    @EldertGrootenboer @skarri-microsoft @j7nw4r
+/sdk/servicebus/    @EldertGrootenboer @skarri-microsoft @j7nw4r @meetamitbhatia
 
 # ServiceLabel: %Service Bus
-# ServiceOwners: @EldertGrootenboer @skarri-microsoft @j7nw4r
+# ServiceOwners: @EldertGrootenboer @skarri-microsoft @j7nw4r @meetamitbhatia
 
 # PRLabel: %Service Fabric
 /sdk/servicefabric/    @QingChenmsft @samedder
@@ -851,7 +851,7 @@
 /sdk/**/ci.yml                                                       @msyyc @xirzec @danieljurek
 
 # Add Johnathan Walker as code owner for Event Hubs SDK
-/sdk/eventhub/azure-eventhub/* @j7nw4r @SwayGom @sagar0207
+/sdk/eventhub/azure-eventhub/* @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # Add Johnathan Walker as code owner for Service Bus SDK
-/sdk/servicebus/azure-servicebus/* @j7nw4r @SwayGom @sagar0207
+/sdk/servicebus/azure-servicebus/* @j7nw4r @meetamitbhatia @SwayGom @sagar0207


### PR DESCRIPTION
## Summary

@meetamitbhatia (Amit Bhatia) is not in the CODEOWNERS file. He works on the messaging libraries and must get review requests on the same paths as @j7nw4r.

## Motivation

@meetamitbhatia joined the messaging team. Without a CODEOWNERS entry, GitHub does not add him to pull requests that touch the messaging paths. The team then loses a reviewer, and review latency goes up.

## Changes

This change adds `@meetamitbhatia` next to `@j7nw4r` on every line that already lists `@j7nw4r`. It changes 4 owner paths and 2 `ServiceOwners` comments. It removes no owner and adds no new path.

Owner paths:

- `/sdk/eventhub/`
- `/sdk/servicebus/`
- `/sdk/eventhub/azure-eventhub/*`
- `/sdk/servicebus/azure-servicebus/*`

## Validation

@meetamitbhatia is a member of the `Azure` organization, so the CODEOWNERS linter can resolve the handle.
