### PR TITLE
Disable mindependency testing for cosmos

### DIFF
--- a/sdk/cosmos/cosmos-emulator-internal-matrix.json
+++ b/sdk/cosmos/cosmos-emulator-internal-matrix.json
@@ -75,31 +75,31 @@
             "PythonVersion": "3.10",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
-            "ChecksOverride": "latestdependency,mindependency"
+            "ChecksOverride": "latestdependency"
         },
         "Emulator Tests Python 3.11 Dependency Checks": {
             "PythonVersion": "3.11",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
-            "ChecksOverride": "latestdependency,mindependency"
+            "ChecksOverride": "latestdependency"
         },
         "Emulator Tests Python 3.12 Dependency Checks": {
             "PythonVersion": "3.12",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
-            "ChecksOverride": "latestdependency,mindependency"
+            "ChecksOverride": "latestdependency"
         },
         "Emulator Tests Python 3.13 Dependency Checks": {
             "PythonVersion": "3.13",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
-            "ChecksOverride": "latestdependency,mindependency"
+            "ChecksOverride": "latestdependency"
         },
         "Emulator Tests Python 3.14 Dependency Checks": {
             "PythonVersion": "3.14",
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
-            "ChecksOverride": "latestdependency,mindependency"
+            "ChecksOverride": "latestdependency"
         }
       }
     }

--- a/sdk/cosmos/cosmos-emulator-public-matrix.json
+++ b/sdk/cosmos/cosmos-emulator-public-matrix.json
@@ -44,31 +44,6 @@
             "CoverageArg": "--disablecov",
             "TestSamples": "false",
             "ChecksOverride": "whl,sdist"
-        },
-
-        "Emulator Tests Python 3.10 Dependency Checks": {
-            "PythonVersion": "3.10",
-            "CoverageArg": "--disablecov",
-            "TestSamples": "false",
-            "ChecksOverride": "mindependency"
-        },
-        "Emulator Tests Python 3.11 Dependency Checks": {
-            "PythonVersion": "3.11",
-            "CoverageArg": "--disablecov",
-            "TestSamples": "false",
-            "ChecksOverride": "mindependency"
-        },
-        "Emulator Tests Python 3.12 Dependency Checks": {
-            "PythonVersion": "3.12",
-            "CoverageArg": "--disablecov",
-            "TestSamples": "false",
-            "ChecksOverride": "mindependency"
-        },
-        "Emulator Tests Python 3.13 Dependency Checks": {
-            "PythonVersion": "3.13",
-            "CoverageArg": "--disablecov",
-            "TestSamples": "false",
-            "ChecksOverride": "mindependency"
         }
       }
     }


### PR DESCRIPTION
Issue to re-enable when fixed: https://github.com/Azure/azure-sdk-for-python/issues/48346