### PR TITLE
Add targeted pylint import suppressions to snippet samples

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/pylint.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pylint.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+from pathlib import Path
 
 from typing import Optional, List
 from subprocess import CalledProcessError, check_call
@@ -17,6 +18,36 @@ PYLINT_VERSION = "4.0.4"
 PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.7"
 NEXT_PYLINT_VERSION = "4.0.6"
 NEXT_PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.9"
+SNIPPET_IMPORT_DISABLES = (
+    "reimported",
+    "wrong-import-position",
+    "wrong-import-order",
+    "ungrouped-imports",
+)
+
+
+def get_sample_pylint_commands(executable: str, rcfile: str, samples_dir: str) -> List[List[str]]:
+    """Build separate Pylint commands for regular and README snippet sample files."""
+    regular_samples: List[str] = []
+    snippet_samples: List[str] = []
+
+    for sample_file in sorted(Path(samples_dir).rglob("*.py")):
+        targets = snippet_samples if b"# [START" in sample_file.read_bytes() else regular_samples
+        targets.append(str(sample_file))
+
+    base_command = [
+        executable,
+        "-m",
+        "pylint",
+        f"--rcfile={rcfile}",
+        "--output-format=parseable",
+    ]
+    commands = []
+    if regular_samples:
+        commands.append(base_command + regular_samples)
+    if snippet_samples:
+        commands.append(base_command + [f"--disable={','.join(SNIPPET_IMPORT_DISABLES)}"] + snippet_samples)
+    return commands
 
 
 class pylint(Check):
@@ -202,38 +233,19 @@ class pylint(Check):
 
                 # Run samples with samples_pylintrc
                 if os.path.exists(samples_dir):
-                    try:
-                        samples_rcfile = os.path.join(REPO_ROOT, "eng/samples_pylintrc")
-                        logger.info(
-                            [
-                                executable,
-                                "-m",
-                                "pylint",
-                                "--rcfile={}".format(samples_rcfile),
-                                "--output-format=parseable",
-                                samples_dir,
-                            ]
-                        )
-                        results.append(
-                            check_call(
-                                [
-                                    executable,
-                                    "-m",
-                                    "pylint",
-                                    "--rcfile={}".format(samples_rcfile),
-                                    "--output-format=parseable",
-                                    samples_dir,
-                                ]
+                    samples_rcfile = os.path.join(REPO_ROOT, "eng/samples_pylintrc")
+                    for command in get_sample_pylint_commands(executable, samples_rcfile, samples_dir):
+                        try:
+                            logger.info(command)
+                            results.append(check_call(command))
+                        except CalledProcessError as e:
+                            logger.error(
+                                "{} samples exited with linting error {}. Please see this link for more information https://aka.ms/azsdk/python/pylint-guide".format(
+                                    package_name, e.returncode
+                                )
                             )
-                        )
-                    except CalledProcessError as e:
-                        logger.error(
-                            "{} samples exited with linting error {}. Please see this link for more information https://aka.ms/azsdk/python/pylint-guide".format(
-                                package_name, e.returncode
-                            )
-                        )
-                        results.append(e.returncode)
-                        package_failed = True
+                            results.append(e.returncode)
+                            package_failed = True
 
             if args.next and in_ci():
                 if package_failed:

--- a/eng/tools/azure-sdk-tools/azpysdk/pylint.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pylint.py
@@ -25,7 +25,7 @@ SNIPPET_SAMPLE_IMPORT_DISABLES = (
     "wrong-import-position",
     "wrong-import-order",
     "ungrouped-imports",
-    "redefined-outer-name"
+    "redefined-outer-name",
 )
 
 

--- a/eng/tools/azure-sdk-tools/azpysdk/pylint.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pylint.py
@@ -18,7 +18,7 @@ PYLINT_VERSION = "4.0.4"
 PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.7"
 NEXT_PYLINT_VERSION = "4.0.6"
 NEXT_PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.9"
-SNIPPET_IMPORT_DISABLES = (
+SNIPPET_SAMPLE_IMPORT_DISABLES = (
     "reimported",
     "wrong-import-position",
     "wrong-import-order",
@@ -26,8 +26,8 @@ SNIPPET_IMPORT_DISABLES = (
 )
 
 
-def get_sample_pylint_commands(executable: str, rcfile: str, samples_dir: str) -> List[List[str]]:
-    """Build separate Pylint commands for regular and README snippet sample files."""
+def get_snippet_aware_sample_pylint_commands(executable: str, rcfile: str, samples_dir: str) -> List[List[str]]:
+    """Build the normal sample command plus an exception for README snippet files."""
     regular_samples: List[str] = []
     snippet_samples: List[str] = []
 
@@ -46,7 +46,7 @@ def get_sample_pylint_commands(executable: str, rcfile: str, samples_dir: str) -
     if regular_samples:
         commands.append(base_command + regular_samples)
     if snippet_samples:
-        commands.append(base_command + [f"--disable={','.join(SNIPPET_IMPORT_DISABLES)}"] + snippet_samples)
+        commands.append(base_command + [f"--disable={','.join(SNIPPET_SAMPLE_IMPORT_DISABLES)}"] + snippet_samples)
     return commands
 
 
@@ -234,7 +234,7 @@ class pylint(Check):
                 # Run samples with samples_pylintrc
                 if os.path.exists(samples_dir):
                     samples_rcfile = os.path.join(REPO_ROOT, "eng/samples_pylintrc")
-                    for command in get_sample_pylint_commands(executable, samples_rcfile, samples_dir):
+                    for command in get_snippet_aware_sample_pylint_commands(executable, samples_rcfile, samples_dir):
                         try:
                             logger.info(command)
                             results.append(check_call(command))

--- a/eng/tools/azure-sdk-tools/azpysdk/pylint.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pylint.py
@@ -18,11 +18,14 @@ PYLINT_VERSION = "4.0.4"
 PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.7"
 NEXT_PYLINT_VERSION = "4.0.6"
 NEXT_PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.9"
+# README snippet files can contain independent code blocks, so imports may be
+# repeated or appear after executable statements when the blocks share a file.
 SNIPPET_SAMPLE_IMPORT_DISABLES = (
     "reimported",
     "wrong-import-position",
     "wrong-import-order",
     "ungrouped-imports",
+    "redefined-outer-name"
 )
 
 

--- a/eng/tools/azure-sdk-tools/tests/test_pylint.py
+++ b/eng/tools/azure-sdk-tools/tests/test_pylint.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from azpysdk.pylint import SNIPPET_IMPORT_DISABLES, get_sample_pylint_commands
+from azpysdk.pylint import SNIPPET_SAMPLE_IMPORT_DISABLES, get_snippet_aware_sample_pylint_commands
 
 
-def test_get_sample_pylint_commands_separates_snippet_files(tmp_path):
+def test_get_snippet_aware_sample_pylint_commands_separates_snippet_files(tmp_path):
     samples_dir = tmp_path / "samples"
     nested_dir = samples_dir / "nested"
     nested_dir.mkdir(parents=True)
@@ -17,7 +17,7 @@ def test_get_sample_pylint_commands_separates_snippet_files(tmp_path):
         encoding="utf-8",
     )
 
-    commands = get_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir))
+    commands = get_snippet_aware_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir))
 
     assert commands == [
         [
@@ -34,15 +34,15 @@ def test_get_sample_pylint_commands_separates_snippet_files(tmp_path):
             "pylint",
             "--rcfile=samples_pylintrc",
             "--output-format=parseable",
-            f"--disable={','.join(SNIPPET_IMPORT_DISABLES)}",
+            f"--disable={','.join(SNIPPET_SAMPLE_IMPORT_DISABLES)}",
             str(snippet_sample),
         ],
     ]
 
 
-def test_get_sample_pylint_commands_ignores_non_python_files(tmp_path):
+def test_get_snippet_aware_sample_pylint_commands_ignores_non_python_files(tmp_path):
     samples_dir = tmp_path / "samples"
     samples_dir.mkdir()
     Path(samples_dir / "README.md").write_text("# [START example]\n", encoding="utf-8")
 
-    assert get_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir)) == []
+    assert get_snippet_aware_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir)) == []

--- a/eng/tools/azure-sdk-tools/tests/test_pylint.py
+++ b/eng/tools/azure-sdk-tools/tests/test_pylint.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from azpysdk.pylint import SNIPPET_IMPORT_DISABLES, get_sample_pylint_commands
+
+
+def test_get_sample_pylint_commands_separates_snippet_files(tmp_path):
+    samples_dir = tmp_path / "samples"
+    nested_dir = samples_dir / "nested"
+    nested_dir.mkdir(parents=True)
+
+    regular_sample = samples_dir / "regular.py"
+    regular_sample.write_text("print('regular')\n", encoding="utf-8")
+
+    snippet_sample = nested_dir / "snippet.py"
+    snippet_sample.write_text(
+        "# [START example]\nimport os\n# [END example]\n",
+        encoding="utf-8",
+    )
+
+    commands = get_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir))
+
+    assert commands == [
+        [
+            "python",
+            "-m",
+            "pylint",
+            "--rcfile=samples_pylintrc",
+            "--output-format=parseable",
+            str(regular_sample),
+        ],
+        [
+            "python",
+            "-m",
+            "pylint",
+            "--rcfile=samples_pylintrc",
+            "--output-format=parseable",
+            f"--disable={','.join(SNIPPET_IMPORT_DISABLES)}",
+            str(snippet_sample),
+        ],
+    ]
+
+
+def test_get_sample_pylint_commands_ignores_non_python_files(tmp_path):
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    Path(samples_dir / "README.md").write_text("# [START example]\n", encoding="utf-8")
+
+    assert get_sample_pylint_commands("python", "samples_pylintrc", str(samples_dir)) == []


### PR DESCRIPTION
## Description

Update `azpysdk pylint` to separate regular sample files from files used to populate README snippets. 

- Imports can be intentionally scattered across sample files intended for snippet usage, but this triggers pylint errors. 

- For example, `sdk/appconfiguration/azure-appconfiguration-provider/samples/entra_id_sample.py` repeats `load` and related imports inside multiple `# [START ...]` blocks so each README snippet is self-contained.

## Solution

snippet-bearing files receive targeted suppressions for `reimported`, `wrong-import-position`, `wrong-import-order`, and `ungrouped-imports`, while ordinary samples retain the full import checks.

This avoids disabling the four checks universally in `eng/samples_pylintrc` while accommodating independently runnable README snippets.

## Testing

- Added unit coverage for regular/snippet file classification and generated Pylint commands
- Confirmed App Configuration regular samples still report genuine import-order findings while snippet files suppress the expected repeated-import findings

Addresses the sample portion of #48308 and provides an alternative to the sample configuration changes in #48309.