### PR TITLE
Use use-python-version.yml

### DIFF
--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -28,9 +28,8 @@ stages:
           os: linux
 
         steps:
-          - task: UsePythonVersion@0
-            displayName: 'Use Python 3.10'
-            inputs:
+          - template: /eng/pipelines/templates/steps/use-python-version.yml
+            parameters:
               versionSpec: '3.10'
 
           # Authenticate pip to the configured Azure DevOps feed before installs.
@@ -102,9 +101,8 @@ stages:
               GH_TOKEN: $(GH_TOKEN)
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-          - task: UsePythonVersion@0
-            displayName: 'Use Python 3.13 for docs generation'
-            inputs:
+          - template: /eng/pipelines/templates/steps/use-python-version.yml
+            parameters:
               versionSpec: '3.13'
 
           - script: |

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -28,15 +28,16 @@ stages:
           os: linux
 
         steps:
-          - template: /eng/pipelines/templates/steps/use-python-version.yml
+          - template: /eng/pipelines/templates/steps/use-python-version.yml 
             parameters:
               versionSpec: '3.10'
 
           # Authenticate pip to the configured Azure DevOps feed before installs.
-          - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+          - template: /eng/common/pipelines/templates/steps/python-auth-dev-feed.yml
             parameters:
               DevFeedName: ${{ parameters.DevFeedName }}
               EnableTwineAuth: false
+              DisableAdditionalIndexes : true
 
           - script: |
               python -m pip install -r eng/ci_tools.txt

--- a/eng/tools/azure-sdk-tools/ci_tools/variables.py
+++ b/eng/tools/azure-sdk-tools/ci_tools/variables.py
@@ -102,7 +102,6 @@ DEFAULT_ENVIRONMENT_VARIABLES = {
     "VIRTUALENV_WHEEL": "0.45.1",
     "VIRTUALENV_PIP": "24.0",
     "VIRTUALENV_SETUPTOOLS": "75.3.2",
-    "PIP_EXTRA_INDEX_URL": "https://pypi.python.org/simple",
     # I haven't spent much time looking to see if a variable exists when invoking uv run. there might be one already that we can depend
     # on for get_pip_command adjustment.
     "IN_UV": "1",

--- a/eng/tools/azure-sdk-tools/tests/test_variables.py
+++ b/eng/tools/azure-sdk-tools/tests/test_variables.py
@@ -1,0 +1,20 @@
+import os
+
+from ci_tools.variables import set_envvar_defaults
+
+
+def test_set_envvar_defaults_does_not_add_public_pypi_extra_index(monkeypatch):
+    monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+
+    set_envvar_defaults()
+
+    assert "PIP_EXTRA_INDEX_URL" not in os.environ
+
+
+def test_set_envvar_defaults_preserves_explicit_extra_index(monkeypatch):
+    extra_index = "https://contoso.example/simple"
+    monkeypatch.setenv("PIP_EXTRA_INDEX_URL", extra_index)
+
+    set_envvar_defaults()
+
+    assert os.environ["PIP_EXTRA_INDEX_URL"] == extra_index


### PR DESCRIPTION
This pull request updates the way Python versions are set in the `python-analyze-weekly.yml` pipeline by switching from using the `UsePythonVersion@0` task to a shared template. This change improves consistency and maintainability in the pipeline configuration.

**Pipeline configuration improvements:**

* Replaced the `UsePythonVersion@0` task for Python 3.10 with the `/eng/pipelines/templates/steps/use-python-version.yml` template, passing `versionSpec: '3.10'` as a parameter.
* Replaced the `UsePythonVersion@0` task for Python 3.13 (used for docs generation) with the shared template, passing `versionSpec: '3.13'` as a parameter.

[python - agrifood - tests-weekly](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6683421&view=results)