### PR TITLE
Add validated pipeline auto-fix workflow

### DIFF
--- a/.github/workflows/pipeline-analysis-auto-fix.lock.yml
+++ b/.github/workflows/pipeline-analysis-auto-fix.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"4a8d3c4671ec54e28ebf5973f81cddd5b288b80d7dea347fb111aa197667fe47","body_hash":"c644c3b1d6bb0e7a858170f8a2d0588f92e6e94106d8dc9cdd02ec5840907f4a","compiler_version":"v0.80.9","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.63"}}
-# gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"f318c5fc87ac219fefed9b09f52c97d360bb6adc99a2ac4bb5827e0172cd3002","body_hash":"71e68493eb8defd6d707ac4035490aa933f6ccff1f7f3b7bbde639feb9a273db","compiler_version":"v0.80.9","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.63"}}
+# gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.80.9). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -23,9 +23,10 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Analyze a pull request's failing Azure DevOps pipeline with the azsdk analyze tool and post a Copilot-authored 'Pipeline Analysis Next Steps' comment.
+# Attempt an automated fix for a pull request's failing Azure DevOps pipeline and publish it as a draft PR targeting the original PR's branch.
 #
 # Secrets used:
+#   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -35,11 +36,11 @@
 #   - actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
 #   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 (source v8)
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (source v7)
 #   - github/gh-aw-actions/setup@8c7d04ebf1ece56cd381446125da3e0f6896294a # v0.80.9
 #
 # Container images used:
@@ -50,7 +51,7 @@
 #   - ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b
 #   - ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036
 
-name: "Pipeline Analysis - Next Steps"
+name: "Pipeline Analysis - Auto Fix"
 on:
   workflow_dispatch:
     inputs:
@@ -59,24 +60,32 @@ on:
         description: "Agent caller context (used internally by Agentic Workflows)."
         required: false
         type: string
-      ci_conclusion:
-        description: Conclusion of the completed azure-pipelines PR-CI check run (e.g. failure) for CI-triggered runs
-        required: false
+      analysis_run_id:
+        description: Run ID of the successful next-steps workflow containing the analysis artifact
+        required: true
         type: string
       ci_head_sha:
-        description: Head SHA of the completed PR-CI check run, for stale-commit detection on CI-triggered runs
-        required: false
+        description: Head SHA of the completed PR-CI check run; identifies the validation baseline
+        required: true
+        type: string
+      pr_head_ref:
+        description: Head branch of that pull request; the validated fix PR is retargeted here
+        required: true
         type: string
       pr_number:
-        description: Pull request number whose failing pipeline should be analyzed
+        description: Pull request number whose failing pipeline should be fixed
+        required: true
+        type: string
+      validation_base_ref:
+        description: CI-enabled base branch the draft fix PR initially targets
         required: true
         type: string
 
 permissions: {}
 
-concurrency: pipeline-analysis-next-steps-${{ github.event.inputs.pr_number }}
+concurrency: pipeline-analysis-auto-fix-${{ github.event.inputs.pr_number }}
 
-run-name: "Pipeline Analysis - Next Steps / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
+run-name: "Pipeline Analysis - Auto Fix / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
 
 jobs:
   activation:
@@ -109,8 +118,8 @@ jobs:
           job-name: ${{ github.job }}
           safe-output-artifact-client: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-next-steps.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-auto-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AWF_VERSION: "v0.27.7"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -123,7 +132,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AGENT_VERSION: "1.0.63"
           GH_AW_INFO_CLI_VERSION: "v0.80.9"
-          GH_AW_INFO_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
+          GH_AW_INFO_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -146,8 +155,8 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          key: agentic-workflow-usage-pipelineanalysisnextsteps-${{ github.run_id }}
-          restore-keys: agentic-workflow-usage-pipelineanalysisnextsteps-
+          key: agentic-workflow-usage-pipelineanalysisautofix-${{ github.run_id }}
+          restore-keys: agentic-workflow-usage-pipelineanalysisautofix-
           path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
       - name: Restore daily AIC usage cache (artifact fallback)
         id: restore-daily-aic-cache-fallback
@@ -169,8 +178,8 @@ jobs:
         if: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_ID: "pipeline-analysis-next-steps"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_ID: "pipeline-analysis-auto-fix"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_WORKFLOW_DISPATCH_AW_CONTEXT: ${{ github.event.inputs.aw_context || '' }}
           GH_AW_HAS_SLASH_COMMAND: "false"
@@ -210,7 +219,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_WORKFLOW_FILE: "pipeline-analysis-next-steps.lock.yml"
+          GH_AW_WORKFLOW_FILE: "pipeline-analysis-auto-fix.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -237,8 +246,11 @@ jobs:
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
+          GH_AW_GITHUB_EVENT_INPUTS_ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
           GH_AW_GITHUB_EVENT_INPUTS_CI_HEAD_SHA: ${{ github.event.inputs.ci_head_sha }}
+          GH_AW_GITHUB_EVENT_INPUTS_PR_HEAD_REF: ${{ github.event.inputs.pr_head_ref }}
           GH_AW_GITHUB_EVENT_INPUTS_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          GH_AW_GITHUB_EVENT_INPUTS_VALIDATION_BASE_REF: ${{ github.event.inputs.validation_base_ref }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -246,20 +258,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_689f912f6e6cc667_EOF'
+          cat << 'GH_AW_PROMPT_20c471fad19b9783_EOF'
           <system>
-          GH_AW_PROMPT_689f912f6e6cc667_EOF
+          GH_AW_PROMPT_20c471fad19b9783_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_689f912f6e6cc667_EOF'
+          cat << 'GH_AW_PROMPT_20c471fad19b9783_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: create_pull_request, missing_tool, missing_data, noop
+          GH_AW_PROMPT_20c471fad19b9783_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
+          cat << 'GH_AW_PROMPT_20c471fad19b9783_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_689f912f6e6cc667_EOF
+          GH_AW_PROMPT_20c471fad19b9783_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_689f912f6e6cc667_EOF'
+          cat << 'GH_AW_PROMPT_20c471fad19b9783_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -287,7 +302,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           - **checkouts**: The following repositories have been checked out and are available in the workspace:
-            - repo `__GH_AW_GITHUB_REPOSITORY__` → `$GITHUB_WORKSPACE` (cwd) [shallow clone, fetch-depth=1 (default)] [sparse checkout enabled]
+            - repo `__GH_AW_GITHUB_REPOSITORY__` → `$GITHUB_WORKSPACE` (cwd) [full history, all branches available as remote-tracking refs]
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
             - **Warning: No git credentials are available to the agent.** Credentials are
               intentionally removed after the checkout step for security. This means any git
@@ -301,20 +316,23 @@ jobs:
               stop immediately and report the limitation rather than spending turns trying to work around it.
           </github-context>
           
-          GH_AW_PROMPT_689f912f6e6cc667_EOF
+          GH_AW_PROMPT_20c471fad19b9783_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_689f912f6e6cc667_EOF'
+          cat << 'GH_AW_PROMPT_20c471fad19b9783_EOF'
           </system>
-          {{#runtime-import .github/workflows/pipeline-analysis-next-steps.md}}
-          GH_AW_PROMPT_689f912f6e6cc667_EOF
+          {{#runtime-import .github/workflows/pipeline-analysis-auto-fix.md}}
+          GH_AW_PROMPT_20c471fad19b9783_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
+          GH_AW_GITHUB_EVENT_INPUTS_ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
           GH_AW_GITHUB_EVENT_INPUTS_CI_HEAD_SHA: ${{ github.event.inputs.ci_head_sha }}
+          GH_AW_GITHUB_EVENT_INPUTS_PR_HEAD_REF: ${{ github.event.inputs.pr_head_ref }}
           GH_AW_GITHUB_EVENT_INPUTS_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          GH_AW_GITHUB_EVENT_INPUTS_VALIDATION_BASE_REF: ${{ github.event.inputs.validation_base_ref }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
@@ -331,8 +349,11 @@ jobs:
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
+          GH_AW_GITHUB_EVENT_INPUTS_ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
           GH_AW_GITHUB_EVENT_INPUTS_CI_HEAD_SHA: ${{ github.event.inputs.ci_head_sha }}
+          GH_AW_GITHUB_EVENT_INPUTS_PR_HEAD_REF: ${{ github.event.inputs.pr_head_ref }}
           GH_AW_GITHUB_EVENT_INPUTS_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          GH_AW_GITHUB_EVENT_INPUTS_VALIDATION_BASE_REF: ${{ github.event.inputs.validation_base_ref }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -353,8 +374,11 @@ jobs:
                 GH_AW_EXPR_802A9F6A: process.env.GH_AW_EXPR_802A9F6A,
                 GH_AW_EXPR_FF1D34CE: process.env.GH_AW_EXPR_FF1D34CE,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
+                GH_AW_GITHUB_EVENT_INPUTS_ANALYSIS_RUN_ID: process.env.GH_AW_GITHUB_EVENT_INPUTS_ANALYSIS_RUN_ID,
                 GH_AW_GITHUB_EVENT_INPUTS_CI_HEAD_SHA: process.env.GH_AW_GITHUB_EVENT_INPUTS_CI_HEAD_SHA,
+                GH_AW_GITHUB_EVENT_INPUTS_PR_HEAD_REF: process.env.GH_AW_GITHUB_EVENT_INPUTS_PR_HEAD_REF,
                 GH_AW_GITHUB_EVENT_INPUTS_PR_NUMBER: process.env.GH_AW_GITHUB_EVENT_INPUTS_PR_NUMBER,
+                GH_AW_GITHUB_EVENT_INPUTS_VALIDATION_BASE_REF: process.env.GH_AW_GITHUB_EVENT_INPUTS_VALIDATION_BASE_REF,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
@@ -406,7 +430,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: pipelineanalysisnextsteps
+      GH_AW_WORKFLOW_ID_SANITIZED: pipelineanalysisautofix
     outputs:
       agentic_engine_timeout: ${{ steps.detect-agent-errors.outputs.agentic_engine_timeout || 'false' }}
       ai_credits_rate_limit_error: ${{ steps.parse-mcp-gateway.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -435,8 +459,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-next-steps.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-auto-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AWF_VERSION: "v0.27.7"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -452,31 +476,54 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          filter: 'blob:limit=1073741824'
-          sparse-checkout: |
-            eng
-            .github/skills
-            .github/hooks
-            documentation/ci-fix.md
-      - name: Clear partial clone markers after sparse checkout
-        continue-on-error: true
-        run: |
-          git config --local --unset-all remote.origin.promisor || true
-          git config --local --unset-all remote.origin.partialclonefilter || true
+          ref: ${{ github.event.inputs.ci_head_sha }}
+          fetch-depth: 0
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - env:
+          AUTO_FIX_MODE: ${{ vars.PIPELINE_ANALYSIS_AUTO_FIX_MODE }}
+          EXPECTED_BASE_REF: ${{ github.event.inputs.validation_base_ref }}
+          EXPECTED_HEAD_REF: ${{ github.event.inputs.pr_head_ref }}
+          EXPECTED_HEAD_SHA: ${{ github.event.inputs.ci_head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        name: Validate dispatch eligibility
+        run: "set -euo pipefail\npr_json=\"$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" \\\n  --json baseRefName,headRefName,headRefOid,isCrossRepository,isDraft,labels,state)\"\n\ncase \"${AUTO_FIX_MODE:-disabled}\" in\n  enabled) ;;\n  pilot)\n    if ! jq -e '[.labels[].name] | index(\"pipeline-auto-fix\") != null' \\\n         <<<\"$pr_json\" >/dev/null; then\n      echo \"::error::Pilot mode requires the pipeline-auto-fix label.\"\n      exit 1\n    fi\n    ;;\n  disabled|\"\")\n    echo \"::error::Pipeline auto-fix is disabled.\"\n    exit 1\n    ;;\n  *)\n    echo \"::error::Unknown PIPELINE_ANALYSIS_AUTO_FIX_MODE '$AUTO_FIX_MODE'.\"\n    exit 1\n    ;;\nesac\n\nif [ \"$(jq -r '.state' <<<\"$pr_json\")\" != \"OPEN\" ] ||\n   [ \"$(jq -r '.isDraft' <<<\"$pr_json\")\" = \"true\" ] ||\n   [ \"$(jq -r '.isCrossRepository' <<<\"$pr_json\")\" = \"true\" ] ||\n   [ \"$(jq -r '.headRefName' <<<\"$pr_json\")\" != \"$EXPECTED_HEAD_REF\" ] ||\n   [ \"$(jq -r '.headRefOid' <<<\"$pr_json\")\" != \"$EXPECTED_HEAD_SHA\" ] ||\n   [ \"$(jq -r '.baseRefName' <<<\"$pr_json\")\" != \"$EXPECTED_BASE_REF\" ]; then\n  echo \"::error::Dispatch inputs do not match an open, non-draft, same-repository PR.\"\n  exit 1\nfi\ncase \"$EXPECTED_HEAD_REF\" in\n  copilot-pipeline-fix/*)\n    echo \"::error::Automated fix PRs cannot recursively trigger auto-fix.\"\n    exit 1\n    ;;\nesac\n"
+        shell: bash
       - name: Install azsdk CLI
-        run: "# Install to the azsdk common install directory ($HOME/bin) rather than a custom path so the\n# Copilot telemetry hook (eng/common/scripts/azsdk_tool_telemetry.ps1), which locates the\n# binary via Get-CommonInstallDirectory, can run `azsdk ingest-telemetry` on skill\n# invocations. Still add it to PATH so the analyze step below resolves `azsdk`.\n$dir = Join-Path $HOME 'bin'\n./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir\nAdd-Content -Path $env:GITHUB_PATH -Value $dir\n"
+        run: |
+          $dir = Join-Path $HOME 'bin'
+          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir
+          Add-Content -Path $env:GITHUB_PATH -Value $dir
         shell: pwsh
       - env:
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_URL: https://github.com/${{ github.repository }}/pull/${{ github.event.inputs.pr_number }}
-        name: Analyze failing pipeline
-        run: "set -uo pipefail\n# `azsdk ci analyze` exits non-zero both when it finds no failing builds (it sets a\n# \"No failed Azure Pipeline builds found ...\" response error) and on real auth/network/CLI\n# errors. Only the former is an acceptable no-op; every other non-zero exit must fail this\n# step so the run surfaces the problem instead of the agent silently treating an error as\n# \"nothing to report\" and finishing green.\nexit_code=0\nazsdk ci analyze \"$PR_URL\" > \"$GITHUB_WORKSPACE/pipeline-analysis.txt\" 2>&1 || exit_code=$?\necho \"azsdk ci analyze exit code: $exit_code\"\necho \"----- pipeline-analysis.txt -----\"\n# The file holds PR-controlled build output. Prefix any line that looks like a GitHub\n# Actions workflow command (starts with `::`) with a space so it is logged as plain text\n# instead of being interpreted.\nsed 's/^::/ ::/' \"$GITHUB_WORKSPACE/pipeline-analysis.txt\"\nif [ \"$exit_code\" -ne 0 ]; then\n  if grep -qF \"No failed Azure Pipeline builds found\" \"$GITHUB_WORKSPACE/pipeline-analysis.txt\"; then\n    echo \"No failing Azure Pipeline builds resolved for this PR; the agent will no-op.\"\n  else\n    echo \"::error::azsdk ci analyze failed (exit $exit_code) with an unexpected error; failing the step.\"\n    exit \"$exit_code\"\n  fi\nfi\n"
+          ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
+          EXPECTED_RUN_TITLE: "Pipeline Analysis - Next Steps / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
+          GH_TOKEN: ${{ github.token }}
+        name: Verify analysis run
+        run: "set -euo pipefail\nrun_json=\"$(gh run view \"$ANALYSIS_RUN_ID\" --repo \"$GITHUB_REPOSITORY\" \\\n  --json conclusion,displayTitle,event)\"\nif [ \"$(jq -r '.event' <<<\"$run_json\")\" != \"workflow_dispatch\" ] ||\n   [ \"$(jq -r '.displayTitle' <<<\"$run_json\")\" != \"$EXPECTED_RUN_TITLE\" ] ||\n   [ \"$(jq -r '.conclusion' <<<\"$run_json\")\" != \"success\" ]; then\n  echo \"::error::Analysis run $ANALYSIS_RUN_ID is not the successful run for this PR and SHA.\"\n  exit 1\nfi\n"
+        shell: bash
+      - name: Download pipeline analysis
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 (source v8)
+        with:
+          github-token: ${{ github.token }}
+          name: pipeline-analysis
+          path: ${{ github.workspace }}
+          run-id: ${{ github.event.inputs.analysis_run_id }}
+      - env:
+          ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
+        name: Verify pipeline analysis
+        run: |
+          set -euo pipefail
+          if [ ! -s "$GITHUB_WORKSPACE/pipeline-analysis.txt" ]; then
+            echo "::error::Analysis run $ANALYSIS_RUN_ID did not provide a non-empty pipeline-analysis.txt artifact."
+            exit 1
+          fi
+          sed 's/^::/ ::/' "$GITHUB_WORKSPACE/pipeline-analysis.txt"
         shell: bash
 
       - name: Configure Git credentials
@@ -542,40 +589,59 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_22f39b5822ecc845_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"${{ github.event.inputs.pr_number }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_22f39b5822ecc845_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_dbce54da0b97d81e_EOF'
+          {"create_pull_request":{"allowed_branches":["copilot-pipeline-fix/*"],"base_branch":"${{ github.event.inputs.validation_base_ref }}","branch_prefix":"copilot-pipeline-fix/pr-${{ github.event.inputs.pr_number }}-${{ github.event.inputs.ci_head_sha }}/","draft":true,"expires":168,"fallback_as_issue":false,"if_no_changes":"ignore","labels":["automated"],"max":1,"max_patch_files":100,"max_patch_size":4096,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"request_review","signed_commits":false,"title_prefix":"[pipeline-fix] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_dbce54da0b97d81e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: ${{ github.event.inputs.pr_number }}. Supports reply_to_id for discussion threading."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Branch name will be prefixed with \"copilot-pipeline-fix/pr-${{ github.event.inputs.pr_number }}-${{ github.event.inputs.ci_head_sha }}/\". Title will be prefixed with \"[pipeline-fix] \". Labels [\"automated\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "add_comment": {
+              "create_pull_request": {
                 "defaultMax": 1,
                 "fields": {
+                  "base": {
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 128
+                  },
                   "body": {
                     "required": true,
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 65000
                   },
-                  "item_number": {
-                    "issueOrPRNumber": true
-                  },
-                  "reply_to_id": {
+                  "branch": {
+                    "required": true,
                     "type": "string",
+                    "sanitize": true,
                     "maxLength": 256
+                  },
+                  "draft": {
+                    "type": "boolean"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
                   },
                   "repo": {
                     "type": "string",
                     "maxLength": 256
+                  },
+                  "title": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 128
                   }
                 }
               },
@@ -783,11 +849,22 @@ jobs:
         # Copilot CLI tool arguments (sorted):
         # --allow-tool github
         # --allow-tool safeoutputs
+        # --allow-tool shell(azpysdk:*)
         # --allow-tool shell(azsdk ci test-results:*)
         # --allow-tool shell(cat)
         # --allow-tool shell(date)
         # --allow-tool shell(echo)
         # --allow-tool shell(find)
+        # --allow-tool shell(git add:*)
+        # --allow-tool shell(git branch:*)
+        # --allow-tool shell(git checkout:*)
+        # --allow-tool shell(git commit:*)
+        # --allow-tool shell(git diff:*)
+        # --allow-tool shell(git merge:*)
+        # --allow-tool shell(git rm:*)
+        # --allow-tool shell(git status)
+        # --allow-tool shell(git status:*)
+        # --allow-tool shell(git switch:*)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
         # --allow-tool shell(ls)
@@ -800,7 +877,7 @@ jobs:
         # --allow-tool shell(wc)
         # --allow-tool shell(yq)
         # --allow-tool write
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           set -o pipefail
           printf '%s' "$(date +%s%3N)" > /tmp/gh-aw/agent_cli_start_ms.txt
@@ -848,7 +925,7 @@ jobs:
           fi
           # shellcheck disable=SC1003,SC2086
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" ${GH_AW_TOOL_CACHE_MOUNT:+--mount "$GH_AW_TOOL_CACHE_MOUNT"} ${GH_AW_DOCKER_HOST:+--docker-host "$GH_AW_DOCKER_HOST"} ${GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS} --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(azsdk ci test-results:*)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(azpysdk:*)'\'' --allow-tool '\''shell(azsdk ci test-results:*)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git diff:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git status:*)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -860,7 +937,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_TIMEOUT_MINUTES: 20
+          GH_AW_TIMEOUT_MINUTES: 30
           GH_AW_VERSION: v0.80.9
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
@@ -1003,14 +1080,6 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
-      - name: Upload pipeline analysis
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (source v7)
-        with:
-          if-no-files-found: error
-          name: pipeline-analysis
-          path: pipeline-analysis.txt
-          retention-days: 7
-
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
@@ -1048,11 +1117,10 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
-      issues: write
+      contents: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-pipeline-analysis-next-steps"
+      group: "gh-aw-conclusion-pipeline-analysis-auto-fix"
       cancel-in-progress: false
       queue: max
     outputs:
@@ -1070,8 +1138,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-next-steps.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-auto-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AWF_VERSION: "v0.27.7"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1136,8 +1204,8 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          key: agentic-workflow-usage-pipelineanalysisnextsteps-${{ github.run_id }}
-          restore-keys: agentic-workflow-usage-pipelineanalysisnextsteps-
+          key: agentic-workflow-usage-pipelineanalysisautofix-${{ github.run_id }}
+          restore-keys: agentic-workflow-usage-pipelineanalysisautofix-
           path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
       - name: Write daily AIC usage cache entry
         id: write-daily-aic-cache
@@ -1157,7 +1225,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          key: agentic-workflow-usage-pipelineanalysisnextsteps-${{ github.run_id }}
+          key: agentic-workflow-usage-pipelineanalysisautofix-${{ github.run_id }}
           path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
       - name: Upload daily AIC usage cache artifact
         id: upload-daily-aic-cache
@@ -1175,15 +1243,15 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "false"
           GH_AW_AIC: ${{ needs.agent.outputs.aic }}
           GH_AW_THREAT_DETECTION_AIC: ${{ needs.detection.outputs.aic }}
           GH_AW_AMBIENT_CONTEXT: ${{ needs.agent.outputs.ambient_context }}
-          GH_AW_WORKFLOW_ID: "pipeline-analysis-next-steps"
+          GH_AW_WORKFLOW_ID: "pipeline-analysis-auto-fix"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1196,8 +1264,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -1215,8 +1283,8 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "false"
           GH_AW_MISSING_TOOL_TITLE_PREFIX: "[missing tool]"
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1231,8 +1299,8 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "false"
           GH_AW_REPORT_INCOMPLETE_TITLE_PREFIX: "[incomplete]"
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1246,11 +1314,11 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+          GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "pipeline-analysis-next-steps"
+          GH_AW_WORKFLOW_ID: "pipeline-analysis-auto-fix"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
@@ -1265,6 +1333,8 @@ jobs:
           GH_AW_AGENTIC_ENGINE_TIMEOUT: ${{ needs.agent.outputs.agentic_engine_timeout }}
           GH_AW_MODEL_NOT_SUPPORTED_ERROR: ${{ needs.agent.outputs.model_not_supported_error }}
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
+          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
+          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_DAILY_AI_CREDITS_EXCEEDED: ${{ needs.activation.outputs.daily_ai_credits_exceeded }}
@@ -1274,7 +1344,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "20"
+          GH_AW_TIMEOUT_MINUTES: "30"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1308,8 +1378,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-next-steps.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-auto-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AWF_VERSION: "v0.27.7"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1381,8 +1451,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          WORKFLOW_DESCRIPTION: "Analyze a pull request's failing Azure DevOps pipeline with the azsdk analyze tool and post a Copilot-authored 'Pipeline Analysis Next Steps' comment."
+          WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          WORKFLOW_DESCRIPTION: "Attempt an automated fix for a pull request's failing Azure DevOps pipeline and publish it as a draft PR targeting the original PR's branch."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1537,15 +1607,14 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: read
-      issues: write
+      contents: write
       pull-requests: write
     timeout-minutes: 45
     env:
       GH_AW_AGENT_AIC: ${{ needs.agent.outputs.aic }}
       GH_AW_AIC: ${{ needs.agent.outputs.aic }}
       GH_AW_AMBIENT_CONTEXT: ${{ needs.agent.outputs.ambient_context }}
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/pipeline-analysis-next-steps"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/pipeline-analysis-auto-fix"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
@@ -1553,16 +1622,16 @@ jobs:
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_ENGINE_VERSION: "1.0.63"
       GH_AW_THREAT_DETECTION_AIC: ${{ needs.detection.outputs.aic }}
-      GH_AW_WORKFLOW_ID: "pipeline-analysis-next-steps"
-      GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-      GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-next-steps.md"
+      GH_AW_WORKFLOW_ID: "pipeline-analysis-auto-fix"
+      GH_AW_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+      GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/pipeline-analysis-auto-fix.md"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
-      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
-      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
+      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
+      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1575,8 +1644,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Next Steps"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-next-steps.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Pipeline Analysis - Auto Fix"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/pipeline-analysis-auto-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.63"
           GH_AW_INFO_AWF_VERSION: "v0.27.7"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1594,6 +1663,27 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          ref: ${{ github.event.inputs.ci_head_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Configure Git credentials
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_git_credentials.sh"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1612,7 +1702,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.in.applicationinsights.azure.com,aka.ms,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dev.azure.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"${{ github.event.inputs.pr_number }}\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"allowed_branches\":[\"copilot-pipeline-fix/*\"],\"base_branch\":\"${{ github.event.inputs.validation_base_ref }}\",\"branch_prefix\":\"copilot-pipeline-fix/pr-${{ github.event.inputs.pr_number }}-${{ github.event.inputs.ci_head_sha }}/\",\"draft\":true,\"expires\":168,\"fallback_as_issue\":false,\"if_no_changes\":\"ignore\",\"labels\":[\"automated\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":4096,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"request_review\",\"signed_commits\":false,\"title_prefix\":\"[pipeline-fix] \"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pipeline-analysis-auto-fix.md
+++ b/.github/workflows/pipeline-analysis-auto-fix.md
@@ -1,0 +1,302 @@
+---
+# Pipeline Analysis - Auto Fix (agentic workflow)
+#
+# Companion to `pipeline-analysis-next-steps.md`. Where that workflow only *explains* a failing
+# Azure DevOps CI run, this one attempts to *fix* it.
+#
+# Delivery model: the fix is NOT pushed onto the contributor's branch. The agent's changes are
+# published to a separate `copilot-pipeline-fix/*` branch and offered as a draft pull request.
+# The PR initially targets the original PR's CI-enabled base branch so the repository's normal
+# Azure DevOps PR pipeline runs. After that CI proves the fix,
+# `pipeline-analysis-fix-validation.yml` retargets the same PR to the original PR's head branch.
+# Nothing lands without a human merge.
+#
+# Fork PRs are skipped by the dispatcher: the head branch lives in the fork, so a base-repo
+# workflow cannot push a branch there or open a PR against it.
+#
+# Branches created here are cleaned up after 7 days by
+# `pipeline-analysis-fix-branch-cleanup.yml`, and the draft PR auto-closes via `expires: 7`.
+#
+# After editing this file, run 'gh aw compile pipeline-analysis-auto-fix' to regenerate the
+# lock file.
+description: "Attempt an automated fix for a pull request's failing Azure DevOps pipeline and publish it as a draft PR targeting the original PR's branch."
+run-name: "Pipeline Analysis - Auto Fix / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number whose failing pipeline should be fixed"
+        required: true
+        type: string
+      pr_head_ref:
+        description: "Head branch of that pull request; the validated fix PR is retargeted here"
+        required: true
+        type: string
+      ci_head_sha:
+        description: "Head SHA of the completed PR-CI check run; identifies the validation baseline"
+        required: true
+        type: string
+      analysis_run_id:
+        description: "Run ID of the successful next-steps workflow containing the analysis artifact"
+        required: true
+        type: string
+      validation_base_ref:
+        description: "CI-enabled base branch the draft fix PR initially targets"
+        required: true
+        type: string
+
+if: ${{ github.event_name == 'workflow_dispatch' }}
+
+engine: copilot
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+  checks: read
+  copilot-requests: write
+
+network:
+  allowed:
+    - defaults
+    - github
+    - dev.azure.com
+    - aka.ms
+    - "*.in.applicationinsights.azure.com"
+
+# Check out the exact failing commit, not the mutable branch. The stale guard below separately
+# verifies that this commit is still the PR head before the agent publishes anything.
+checkout:
+  ref: ${{ github.event.inputs.ci_head_sha }}
+  # The create-pull-request handler compares the fix with the validation base.
+  fetch-depth: 0
+
+steps:
+  - name: Validate dispatch eligibility
+    shell: bash
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AUTO_FIX_MODE: ${{ vars.PIPELINE_ANALYSIS_AUTO_FIX_MODE }}
+      PR_NUMBER: ${{ github.event.inputs.pr_number }}
+      EXPECTED_HEAD_REF: ${{ github.event.inputs.pr_head_ref }}
+      EXPECTED_HEAD_SHA: ${{ github.event.inputs.ci_head_sha }}
+      EXPECTED_BASE_REF: ${{ github.event.inputs.validation_base_ref }}
+    run: |
+      set -euo pipefail
+      pr_json="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+        --json baseRefName,headRefName,headRefOid,isCrossRepository,isDraft,labels,state)"
+
+      case "${AUTO_FIX_MODE:-disabled}" in
+        enabled) ;;
+        pilot)
+          if ! jq -e '[.labels[].name] | index("pipeline-auto-fix") != null' \
+               <<<"$pr_json" >/dev/null; then
+            echo "::error::Pilot mode requires the pipeline-auto-fix label."
+            exit 1
+          fi
+          ;;
+        disabled|"")
+          echo "::error::Pipeline auto-fix is disabled."
+          exit 1
+          ;;
+        *)
+          echo "::error::Unknown PIPELINE_ANALYSIS_AUTO_FIX_MODE '$AUTO_FIX_MODE'."
+          exit 1
+          ;;
+      esac
+
+      if [ "$(jq -r '.state' <<<"$pr_json")" != "OPEN" ] ||
+         [ "$(jq -r '.isDraft' <<<"$pr_json")" = "true" ] ||
+         [ "$(jq -r '.isCrossRepository' <<<"$pr_json")" = "true" ] ||
+         [ "$(jq -r '.headRefName' <<<"$pr_json")" != "$EXPECTED_HEAD_REF" ] ||
+         [ "$(jq -r '.headRefOid' <<<"$pr_json")" != "$EXPECTED_HEAD_SHA" ] ||
+         [ "$(jq -r '.baseRefName' <<<"$pr_json")" != "$EXPECTED_BASE_REF" ]; then
+        echo "::error::Dispatch inputs do not match an open, non-draft, same-repository PR."
+        exit 1
+      fi
+      case "$EXPECTED_HEAD_REF" in
+        copilot-pipeline-fix/*)
+          echo "::error::Automated fix PRs cannot recursively trigger auto-fix."
+          exit 1
+          ;;
+      esac
+  - name: Install azsdk CLI
+    shell: pwsh
+    run: |
+      $dir = Join-Path $HOME 'bin'
+      ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir
+      Add-Content -Path $env:GITHUB_PATH -Value $dir
+  - name: Verify analysis run
+    shell: bash
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
+      EXPECTED_RUN_TITLE: "Pipeline Analysis - Next Steps / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
+    run: |
+      set -euo pipefail
+      run_json="$(gh run view "$ANALYSIS_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+        --json conclusion,displayTitle,event)"
+      if [ "$(jq -r '.event' <<<"$run_json")" != "workflow_dispatch" ] ||
+         [ "$(jq -r '.displayTitle' <<<"$run_json")" != "$EXPECTED_RUN_TITLE" ] ||
+         [ "$(jq -r '.conclusion' <<<"$run_json")" != "success" ]; then
+        echo "::error::Analysis run $ANALYSIS_RUN_ID is not the successful run for this PR and SHA."
+        exit 1
+      fi
+  - name: Download pipeline analysis
+    uses: actions/download-artifact@v8
+    with:
+      name: pipeline-analysis
+      path: ${{ github.workspace }}
+      run-id: ${{ github.event.inputs.analysis_run_id }}
+      github-token: ${{ github.token }}
+  - name: Verify pipeline analysis
+    shell: bash
+    env:
+      ANALYSIS_RUN_ID: ${{ github.event.inputs.analysis_run_id }}
+    run: |
+      set -euo pipefail
+      if [ ! -s "$GITHUB_WORKSPACE/pipeline-analysis.txt" ]; then
+        echo "::error::Analysis run $ANALYSIS_RUN_ID did not provide a non-empty pipeline-analysis.txt artifact."
+        exit 1
+      fi
+      sed 's/^::/ ::/' "$GITHUB_WORKSPACE/pipeline-analysis.txt"
+
+tools:
+  github:
+    toolsets: [context, repos, pull_requests, actions]
+  edit:
+  # Read commands plus the artifact download and the repo's own check runner, so the agent can
+  # both diagnose and verify a formatting/lint fix before proposing it.
+  bash:
+    - "cat"
+    - "ls"
+    - "head"
+    - "tail"
+    - "wc"
+    - "find"
+    - "grep"
+    - "git diff:*"
+    - "git status:*"
+    - "azsdk ci test-results:*"
+    - "azpysdk:*"
+
+safe-outputs:
+  create-pull-request:
+    title-prefix: "[pipeline-fix] "
+    labels: [automated]
+    draft: true
+    max: 1
+    # Signed replay cannot preserve the original PR commits when the temporary validation base
+    # differs from the checked-out head. Push the complete branch directly instead.
+    signed-commits: false
+    # Carry routing metadata in a compiler-controlled prefix instead of relying on the agent to
+    # reproduce it in the branch field.
+    branch-prefix: "copilot-pipeline-fix/pr-${{ github.event.inputs.pr_number }}-${{ github.event.inputs.ci_head_sha }}/"
+    # Validate against the original PR's base branch first. The validation workflow retargets to the
+    # contributor's branch only after Azure DevOps CI proves the fix.
+    base-branch: ${{ github.event.inputs.validation_base_ref }}
+    # Keep generated branches under one prefix so the 7-day cleanup workflow can find them.
+    allowed-branches:
+      - "copilot-pipeline-fix/*"
+    expires: 7
+    if-no-changes: "ignore"
+    fallback-as-issue: false
+  noop:
+    report-as-issue: false
+  missing-tool:
+    create-issue: false
+  missing-data:
+    create-issue: false
+  report-incomplete:
+    create-issue: false
+  report-failure-as-issue: false
+
+timeout-minutes: 30
+concurrency: pipeline-analysis-auto-fix-${{ github.event.inputs.pr_number }}
+---
+
+# Pipeline Analysis - Auto Fix
+
+You are the Azure SDK Tools **pipeline auto-fix** agent for `${{ github.repository }}`.
+
+A CI pipeline failed on pull request **#${{ github.event.inputs.pr_number }}**. That PR's head
+branch (`${{ github.event.inputs.pr_head_ref }}`) is checked out in your workspace, and the exact
+analysis produced by next-steps run `${{ github.event.inputs.analysis_run_id }}` is available at
+**`pipeline-analysis.txt`**.
+
+Your job is to attempt a **narrow, high-confidence fix** and publish it as a draft pull request.
+The PR initially targets `${{ github.event.inputs.validation_base_ref }}` so the full upstream PR
+pipeline runs. A separate workflow retargets it to `${{ github.event.inputs.pr_head_ref }}` only
+after CI validates the fix. You are not merging anything - the PR author decides.
+
+## Step 0 - Read the analysis and decide whether to act
+
+1. Read `pipeline-analysis.txt`.
+2. If it is empty, contains `No failed Azure Pipeline builds found`, or shows no real failure, use
+   the `noop` safe output and stop.
+3. Stale-commit guard: if `${{ github.event.inputs.ci_head_sha }}` is non-empty, compare it with
+   the PR's current head SHA. If they differ, the run is for a superseded commit - `noop` and stop.
+4. **Only proceed if the failure is deterministically fixable from the repository itself** -
+   formatting, linting, a changelog or README validation error, a spelling failure, a missing
+   import, a stale snippet. If the failure is a flaky test, an infrastructure/auth error, a live
+   test, or anything whose root cause you cannot see in the code, use `noop` and stop. A wrong fix
+   is worse than none.
+
+## Step 1 - Understand the failure
+
+Consult the repository's skills before changing anything. **Read every `SKILL.md` with the `view`
+tool, not with `cat`** - the Copilot `PostToolUse` telemetry hook only recognizes skill invocations
+from the `view`/`read_file` tools, so a shell read is not counted.
+
+- Read `.github/skills/azsdk-common-pipeline-analysis/SKILL.md` and its
+  `references/failure-patterns.md` for the failure categories and pattern-to-fix mappings.
+- If a skill under `.github/skills/` describes how to fix this specific failure, read its
+  `SKILL.md` with `view` and follow it.
+- If `pipeline-analysis.txt` only names artifacts and you need their contents, run:
+  `azsdk ci test-results "https://github.com/${{ github.repository }}/pull/${{ github.event.inputs.pr_number }}"`
+- If `${{ github.repository }}` is `Azure/azure-rest-api-specs`, also read
+  `documentation/ci-fix.md` and prefer its documented local commands. It does not exist in other
+  repositories - skip it there.
+
+## Step 2 - Make the smallest fix that addresses the reported failure
+
+- Change only what the failure requires. Do not reformat unrelated files, bump versions, or
+  refactor.
+- Never modify CI configuration, pipeline YAML, or `eng/` tooling to make a check pass.
+- Where the repo offers a deterministic fixer, prefer it over hand-editing (for example
+  `azpysdk black <target>` for Python formatting).
+- Verify your change where you cheaply can (re-run the same lint/format command) and say in the PR
+  body exactly what you ran and what it reported. If you could not verify locally, say that
+  plainly instead of implying it is proven.
+
+## Step 3 - Publish the fix
+
+Emit exactly one `create-pull-request` safe output.
+
+- Use `fix` as the source branch name. The safe-output handler prepends the immutable
+  `copilot-pipeline-fix/pr-${{ github.event.inputs.pr_number }}-${{ github.event.inputs.ci_head_sha }}/`
+  routing prefix and may append a uniqueness suffix.
+- Title: a one-line summary of the fix.
+- Body must contain:
+  - which pipeline check failed, with the Azure DevOps build link from the analysis;
+  - the root cause in one or two sentences;
+  - what you changed and why it addresses that specific failure;
+  - what you ran to verify, or an explicit statement that it is unverified;
+  - a closing note that the PR temporarily targets `${{ github.event.inputs.validation_base_ref }}`
+    for CI validation, must not be merged there, and will be retargeted automatically to
+    `${{ github.event.inputs.pr_head_ref }}` if validation passes.
+
+## Constraints (non-negotiable)
+
+1. **One draft PR, initially targeting the validation branch.** Never push directly to
+   `${{ github.event.inputs.pr_head_ref }}`. The validation workflow, not the agent, retargets the
+   PR after CI passes.
+2. **No speculative fixes.** If you are not confident the change addresses the reported failure,
+   `noop`. Silence is an acceptable outcome; a plausible-looking wrong patch is not.
+3. **Ground every claim in `pipeline-analysis.txt` or in output you actually produced.** Do not
+   assert that a check now passes unless you ran it and saw it pass.
+4. **Do not touch** CI/pipeline definitions, `eng/`, secrets, or dependency lock files to force a
+   check green.
+5. Do not use `gh` or GitHub write APIs directly - publishing happens only through the
+   `create-pull-request` safe output.

--- a/.github/workflows/pipeline-analysis-fix-branch-cleanup.yml
+++ b/.github/workflows/pipeline-analysis-fix-branch-cleanup.yml
@@ -1,0 +1,73 @@
+# Pipeline Analysis - Fix Branch Cleanup
+#
+# `pipeline-analysis-auto-fix.md` publishes automated fixes to `copilot-pipeline-fix/*` branches
+# and offers them as draft PRs against the contributor's branch. Those branches are disposable:
+# once the author has merged or ignored the suggestion, the branch is dead weight.
+#
+# This workflow deletes any `copilot-pipeline-fix/*` branch whose last commit is older than 7 days.
+# A branch with an open PR is kept, so a suggestion still under review is never pulled out from
+# under the author. (The draft PRs themselves also auto-close after 7 days via `expires: 7`.)
+name: Pipeline Analysis - Fix Branch Cleanup
+
+on:
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write # delete stale fix branches
+
+concurrency:
+  group: pipeline-analysis-fix-branch-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale copilot-pipeline-fix branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          MAX_AGE_DAYS: "7"
+        run: |
+          set -euo pipefail
+
+          cutoff=$(( $(date -u +%s) - (MAX_AGE_DAYS * 86400) ))
+          echo "Deleting copilot-pipeline-fix/* branches with no commit after $(date -u -d "@$cutoff" '+%Y-%m-%dT%H:%M:%SZ')."
+
+          # Branches that still have an open PR are exempt.
+          open_pr_branches="$(gh pr list --repo "$REPOSITORY" --state open --limit 1000 --json headRefName --jq '.[].headRefName' || true)"
+
+          # matching-refs returns each branch with its last commit date, newest first.
+          gh api --paginate \
+            "repos/$REPOSITORY/git/matching-refs/heads/copilot-pipeline-fix/" \
+            --jq '.[].ref' | sed 's#^refs/heads/##' | while read -r branch; do
+            [ -z "$branch" ] && continue
+
+            if printf '%s\n' "$open_pr_branches" | grep -qxF "$branch"; then
+              echo "keep   $branch (open pull request)"
+              continue
+            fi
+
+            commit_date="$(gh api "repos/$REPOSITORY/commits/$branch" --jq '.commit.committer.date' 2>/dev/null || true)"
+            if [ -z "$commit_date" ]; then
+              echo "skip   $branch (could not resolve last commit date)"
+              continue
+            fi
+
+            commit_epoch="$(date -u -d "$commit_date" +%s)"
+            if [ "$commit_epoch" -ge "$cutoff" ]; then
+              echo "keep   $branch (last commit $commit_date)"
+              continue
+            fi
+
+            if gh api -X DELETE "repos/$REPOSITORY/git/refs/heads/$branch" >/dev/null 2>&1; then
+              echo "delete $branch (last commit $commit_date)"
+            else
+              echo "::warning::Failed to delete branch $branch"
+            fi
+          done
+
+          echo "Cleanup complete."

--- a/.github/workflows/pipeline-analysis-fix-validation.yml
+++ b/.github/workflows/pipeline-analysis-fix-validation.yml
@@ -1,0 +1,410 @@
+# Pipeline Analysis - Fix Validation
+#
+# Closes the loop opened by `pipeline-analysis-auto-fix.md`. That workflow publishes an automated
+# fix to a `copilot-pipeline-fix/pr-<N>-<SHA>` branch and initially offers it as a draft PR against
+# the original PR's CI-enabled base branch. After the fix is proven, this workflow retargets the
+# same draft PR to the original PR's head branch, where merging it applies the fix. No Azure DevOps
+# credentials enter this repo's Actions trust boundary.
+#
+# This workflow watches the fix PR's CI. When it finishes, it compares the fix PR's per-leg results
+# against the original PR's, and only if the fix demonstrably worked does it append a suggestion to
+# the "[Pilot] PR Pipeline Failure Analysis" comment on the original PR.
+#
+# Why leg-level and not "is the build green":
+#   Azure Pipelines publishes each stage/job as its own check run (`python - pullrequest (Build
+#   Analyze)`) alongside a rollup (`python - pullrequest`). Judging by the rollup is wrong in both
+#   directions: it can go green because a flaky leg happened to pass, and it can stay red on an
+#   unrelated leg even though the fix worked. So the assertion is:
+#
+#       every leg that FAILED on the original PR now PASSES on the fix PR,
+#       no leg that PASSED on the original PR now FAILS,
+#       no newly introduced leg FAILS, and the candidate rollup is green.
+#
+# Why the "leg missing" guard:
+#   The matrix is generated per-PR (`generate_job_matrix`) from the changed file set, so the fix PR
+#   can legitimately produce a different set of legs than the original. If a baseline-failing leg is
+#   absent from the fix run, the fix is UNPROVEN, not proven - that case is treated as inconclusive
+#   and stays silent.
+#
+# On anything other than a clean pass - inconclusive, regressed, still failing - this workflow does
+# nothing at all. No comment, no issue. Success-rate telemetry is deliberately out of scope here
+# and is handled separately.
+#
+# Note this workflow must NOT skip draft PRs: the fix PR is always a draft. It only ever acts on
+# head branches matching `copilot-pipeline-fix/pr-<N>-<SHA>`, which are created solely by the
+# auto-fix workflow, so it cannot be triggered by ordinary contributor branches.
+name: Pipeline Analysis - Fix Validation
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: write # append the validated-fix suggestion to the analysis comment
+
+concurrency:
+  # Serialize per fix branch so two completing check runs cannot double-post.
+  group: pipeline-analysis-fix-validation-${{ github.event.check_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  validate-fix:
+    # React to every Azure DevOps pipeline rollup, including service-specific pipelines such as
+    # `python - cosmos - ci`. Parenthesized checks are per-stage legs. Both conclusions are
+    # evaluated; the regression checks below decide whether the fix is proven.
+    if: >
+      github.event.check_run.check_suite.app.slug == 'azure-pipelines' &&
+      !contains(github.event.check_run.name, ' (') &&
+      (github.event.check_run.conclusion == 'success' || github.event.check_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate automated fix and suggest it on the original PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CI_HEAD_SHA: ${{ github.event.check_run.head_sha }}
+          PIPELINE: ${{ github.event.check_run.name }}
+          FIX_PR_NUMBER: ${{ github.event.check_run.pull_requests[0].number }}
+        run: |
+          # shellcheck disable=SC2016
+          # SC2016 (expressions don't expand in single quotes) is intentional throughout: every
+          # single-quoted `$` below is either a jq program variable bound with `--arg`, or an awk
+          # field reference - never a shell expansion.
+          set -euo pipefail
+
+          # The marker the analysis comment is built around (see pipeline-analysis-next-steps.md).
+          ANALYSIS_MARKER='[Pilot] PR Pipeline Failure Analysis'
+
+          # A repo can have several Azure DevOps pipelines reporting on the same commit. Azure
+          # DevOps names each per-stage check run `<pipeline name> (<stage> <job>)`, so legs are
+          # identified by that exact prefix rather than by "anything that is not a rollup" -
+          # otherwise a *different* pipeline's rollup would be mistaken for a leg of this one and
+          # its unrelated failure would block validation forever.
+          #
+          # Everything below is therefore scoped to PIPELINE, the pipeline whose completion woke
+          # this run. Other pipelines are validated by their own invocations of this workflow.
+
+          # Emit "<name>\t<conclusion>" for each completed check run of one azure-pipelines
+          # pipeline on a commit. `mode=legs` yields only per-stage legs, `mode=rollup` only the
+          # pipeline's own rollup.
+          fetch_checks() {
+            local sha="$1" pipeline="$2" mode="$3" raw=""
+            # `|| true`: a transient API failure must leave this workflow silent, not red.
+            raw="$(gh api --paginate "repos/$REPOSITORY/commits/$sha/check-runs?per_page=100" \
+              --jq '.check_runs[]
+                    | select(.app.slug == "azure-pipelines")
+                    | select(.status == "completed")
+                    | [.name, .conclusion]
+                    | @tsv' 2>/dev/null || true)"
+            [ -z "$raw" ] && return 0
+            while IFS=$'\t' read -r name conclusion; do
+              [ -z "$name" ] && continue
+              case "$mode" in
+                legs)   case "$name" in "$pipeline ("*")") ;; *) continue ;; esac ;;
+                rollup) [ "$name" = "$pipeline" ] || continue ;;
+              esac
+              printf '%s\t%s\n' "$name" "$conclusion"
+            done <<< "$raw"
+          }
+
+          fetch_legs()   { fetch_checks "$1" "$PIPELINE" legs;   }
+          fetch_rollup() { fetch_checks "$1" "$PIPELINE" rollup; }
+
+          fetch_all_rollups() {
+            local sha="$1"
+            gh api --paginate "repos/$REPOSITORY/commits/$sha/check-runs?per_page=100" \
+              --jq '.check_runs[]
+                    | select(.app.slug == "azure-pipelines")
+                    | select(.name | contains(" (") | not)
+                    | [.name, .status, .conclusion]
+                    | @tsv'
+          }
+
+          conclusion_of() { # conclusion_of <legs-file> <leg-name>
+            awk -F'\t' -v n="$2" '$1 == n { print $2; exit }' "$1"
+          }
+
+          rollup_field() { # rollup_field <rollups-file> <pipeline-name> <field-number>
+            awk -F'\t' -v n="$2" -v field="$3" '$1 == n { print $field; exit }' "$1"
+          }
+
+          # --- Resolve the fix PR ------------------------------------------------------------
+          if [ -z "${FIX_PR_NUMBER:-}" ]; then
+            FIX_PR_NUMBER="$(gh api --paginate "repos/$REPOSITORY/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"$CI_HEAD_SHA\") | [.updated_at, .number] | @tsv" |
+              sort -r | sed -n '1s/^[^\t]*\t//p')"
+          fi
+
+          if [ -z "${FIX_PR_NUMBER:-}" ]; then
+            echo "No pull request associated with this check run; nothing to do."
+            exit 0
+          fi
+
+          fix_pr_json="$(gh pr view "$FIX_PR_NUMBER" --repo "$REPOSITORY" \
+            --json baseRefName,headRefName,headRefOid,state,url 2>/dev/null || true)"
+          if [ -z "$fix_pr_json" ]; then
+            echo "Could not read PR #$FIX_PR_NUMBER; nothing to do."
+            exit 0
+          fi
+
+          fix_base_ref="$(jq -r '.baseRefName' <<<"$fix_pr_json")"
+          fix_head_ref="$(jq -r '.headRefName' <<<"$fix_pr_json")"
+          fix_head_oid="$(jq -r '.headRefOid'  <<<"$fix_pr_json")"
+          fix_state="$(   jq -r '.state'       <<<"$fix_pr_json")"
+          fix_pr_url="$(  jq -r '.url'         <<<"$fix_pr_json")"
+
+          # Only ever act on branches produced by the auto-fix workflow.
+          case "$fix_head_ref" in
+            copilot-pipeline-fix/pr-*) ;;
+            *) echo "PR #$FIX_PR_NUMBER (branch '$fix_head_ref') is not an automated fix branch; nothing to do."; exit 0 ;;
+          esac
+
+          if [ "$fix_state" != "OPEN" ]; then
+            echo "Fix PR #$FIX_PR_NUMBER is $fix_state; nothing to do."
+            exit 0
+          fi
+
+          # Do not judge a superseded commit.
+          if [ "$CI_HEAD_SHA" != "$fix_head_oid" ]; then
+            echo "Check run SHA $CI_HEAD_SHA no longer matches fix PR head $fix_head_oid; nothing to do."
+            exit 0
+          fi
+
+          # The requested branch prefix carries both the original PR and immutable baseline SHA.
+          # gh-aw appends a uniqueness suffix, so parse the prefix instead of the entire branch.
+          if ! [[ "$fix_head_ref" =~ ^copilot-pipeline-fix/pr-([0-9]+)-([0-9a-f]{40})/ ]]; then
+            echo "Could not parse an original PR and baseline SHA from branch '$fix_head_ref'; nothing to do."
+            exit 0
+          fi
+          original_pr="${BASH_REMATCH[1]}"
+          original_sha="${BASH_REMATCH[2]}"
+
+          original_json="$(gh pr view "$original_pr" --repo "$REPOSITORY" \
+            --json headRefName,headRefOid,state 2>/dev/null || true)"
+          if [ -z "$original_json" ]; then
+            echo "Could not read original PR #$original_pr; nothing to do."
+            exit 0
+          fi
+
+          original_state="$(jq -r '.state'      <<<"$original_json")"
+          original_head_ref="$(jq -r '.headRefName' <<<"$original_json")"
+          current_original_sha="$(jq -r '.headRefOid' <<<"$original_json")"
+          if [ "$original_state" != "OPEN" ]; then
+            echo "Original PR #$original_pr is $original_state; nothing to do."
+            exit 0
+          fi
+          if [ "$current_original_sha" != "$original_sha" ]; then
+            echo "Original PR #$original_pr advanced from $original_sha to $current_original_sha; fix validation is stale."
+            exit 0
+          fi
+
+          echo "Validating fix PR #$FIX_PR_NUMBER (branch $fix_head_ref) against original PR #$original_pr."
+
+          # --- Compare results ---------------------------------------------------------------
+          # Do not let one successful pipeline approve while another is pending or failing.
+          fetch_all_rollups "$CI_HEAD_SHA" > candidate-rollups.tsv
+          if [ ! -s candidate-rollups.tsv ]; then
+            echo "Candidate has no Azure Pipelines rollups; staying silent."
+            exit 0
+          fi
+          while IFS=$'\t' read -r pipeline status conclusion; do
+            if [ "$status" != "completed" ]; then
+              echo "Candidate pipeline '$pipeline' is still '$status'; waiting for another completion event."
+              exit 0
+            fi
+            if [ "$conclusion" != "success" ]; then
+              echo "Candidate pipeline '$pipeline' concluded '${conclusion:-without a result}'; staying silent."
+              exit 0
+            fi
+          done < candidate-rollups.tsv
+
+          fetch_all_rollups "$original_sha" > baseline-rollups.tsv
+          if [ ! -s baseline-rollups.tsv ]; then
+            echo "Original PR #$original_pr has no Azure Pipelines rollups at $original_sha; nothing to prove."
+            exit 0
+          fi
+          while IFS=$'\t' read -r pipeline status conclusion; do
+            case "$conclusion" in success|failure) ;; *) continue ;; esac
+            candidate_status="$(rollup_field candidate-rollups.tsv "$pipeline" 2)"
+            candidate_conclusion="$(rollup_field candidate-rollups.tsv "$pipeline" 3)"
+            if [ "$candidate_status" != "completed" ] || [ "$candidate_conclusion" != "success" ]; then
+              echo "Baseline pipeline '$pipeline' is '${candidate_conclusion:-missing}' on the fix run; staying silent."
+              exit 0
+            fi
+          done < baseline-rollups.tsv
+
+          baseline_failed_pipelines="$(awk -F'\t' \
+            '$2 == "completed" && $3 == "failure" { print $1 }' baseline-rollups.tsv)"
+          if [ -z "$baseline_failed_pipelines" ]; then
+            echo "Original PR #$original_pr has no failed pipeline rollups at $original_sha; nothing to prove."
+            exit 0
+          fi
+
+          fixed_legs=""
+          COMPARISON="per-stage legs, with pipeline-rollup fallback"
+
+          validate_pipeline() {
+            local pipeline="$1"
+            local baseline_failures candidate_conclusion baseline_conclusion
+            PIPELINE="$pipeline"
+
+            fetch_legs "$original_sha" > baseline.tsv
+            fetch_legs "$CI_HEAD_SHA"  > candidate.tsv
+            echo "Pipeline '$PIPELINE': baseline legs $(wc -l < baseline.tsv), candidate legs $(wc -l < candidate.tsv)."
+
+            if [ ! -s baseline.tsv ] || [ ! -s candidate.tsv ]; then
+              fetch_rollup "$original_sha" > baseline.tsv
+              fetch_rollup "$CI_HEAD_SHA"  > candidate.tsv
+              echo "Pipeline '$PIPELINE' lacks comparable legs; falling back to its rollup."
+            fi
+
+            baseline_failures="$(awk -F'\t' '$2 == "failure" { print $1 }' baseline.tsv)"
+            if [ -z "$baseline_failures" ]; then
+              fetch_rollup "$original_sha" > baseline.tsv
+              fetch_rollup "$CI_HEAD_SHA"  > candidate.tsv
+              baseline_failures="$(awk -F'\t' '$2 == "failure" { print $1 }' baseline.tsv)"
+            fi
+            if [ -z "$baseline_failures" ] || [ ! -s candidate.tsv ]; then
+              echo "Pipeline '$PIPELINE' has no comparable failure results; inconclusive."
+              exit 0
+            fi
+
+            while IFS= read -r leg; do
+              [ -z "$leg" ] && continue
+              candidate_conclusion="$(conclusion_of candidate.tsv "$leg")"
+              if [ "$candidate_conclusion" != "success" ]; then
+                echo "Baseline failure '$leg' is '${candidate_conclusion:-missing}' on the fix run; staying silent."
+                exit 0
+              fi
+              fixed_legs="${fixed_legs}${leg}"$'\n'
+            done <<< "$baseline_failures"
+
+            while IFS=$'\t' read -r leg conclusion; do
+              [ "$conclusion" = "success" ] || continue
+              candidate_conclusion="$(conclusion_of candidate.tsv "$leg")"
+              if [ "$candidate_conclusion" != "success" ]; then
+                echo "Baseline-successful leg '$leg' is '${candidate_conclusion:-missing}' on the fix run; staying silent."
+                exit 0
+              fi
+            done < baseline.tsv
+
+            while IFS=$'\t' read -r leg conclusion; do
+              baseline_conclusion="$(conclusion_of baseline.tsv "$leg")"
+              if [ -z "$baseline_conclusion" ] && [ "$conclusion" != "success" ]; then
+                echo "New leg '$leg' is '$conclusion' on the fix run; staying silent."
+                exit 0
+              fi
+            done < candidate.tsv
+          }
+
+          while IFS= read -r failed_pipeline; do
+            [ -z "$failed_pipeline" ] && continue
+            validate_pipeline "$failed_pipeline"
+          done <<< "$baseline_failed_pipelines"
+
+          echo "Fix validated across every originally failing pipeline; all candidate rollups are green."
+
+          # --- Suggest the fix on the original PR --------------------------------------------
+          # Idempotency marker: never suggest the same fix PR twice.
+          suggestion_marker="<!-- pipeline-fix-validated:${FIX_PR_NUMBER} -->"
+
+          # `--paginate` emits one JSON array per page, so stream the elements and re-slurp them
+          # into a single array that jq can query as a whole.
+          comments_json="$(gh api --paginate "repos/$REPOSITORY/issues/$original_pr/comments?per_page=100" \
+            --jq '.[]' | jq -s '.')"
+
+          if jq -e --arg m "$suggestion_marker" 'any(.[]; .body != null and (.body | contains($m)))' \
+               <<<"$comments_json" >/dev/null; then
+            echo "Fix PR #$FIX_PR_NUMBER has already been suggested on PR #$original_pr; nothing to do."
+            exit 0
+          fi
+
+          # Close the race between the initial stale checks and publishing the suggestion.
+          latest_original_json="$(gh pr view "$original_pr" --repo "$REPOSITORY" \
+            --json headRefName,headRefOid,state 2>/dev/null || true)"
+          latest_fix_json="$(gh pr view "$FIX_PR_NUMBER" --repo "$REPOSITORY" \
+            --json headRefOid,state 2>/dev/null || true)"
+          if [ -z "$latest_original_json" ] || [ -z "$latest_fix_json" ] ||
+             [ "$(jq -r '.state' <<<"$latest_original_json")" != "OPEN" ] ||
+             [ "$(jq -r '.headRefName' <<<"$latest_original_json")" != "$original_head_ref" ] ||
+             [ "$(jq -r '.headRefOid' <<<"$latest_original_json")" != "$original_sha" ] ||
+             [ "$(jq -r '.state' <<<"$latest_fix_json")" != "OPEN" ] ||
+             [ "$(jq -r '.headRefOid' <<<"$latest_fix_json")" != "$CI_HEAD_SHA" ]; then
+            echo "Original or fix PR advanced during validation; staying silent."
+            exit 0
+          fi
+
+          # The fix PR initially targets the original PR's base so Azure DevOps PR CI runs.
+          # Once proven, retarget it to the contributor branch so merging applies only to the
+          # original PR and can never land directly on its base branch.
+          retargeted=false
+          if [ "$fix_base_ref" != "$original_head_ref" ]; then
+            gh api -X PATCH "repos/$REPOSITORY/pulls/$FIX_PR_NUMBER" \
+              -f base="$original_head_ref" >/dev/null
+            retargeted=true
+            echo "Retargeted fix PR #$FIX_PR_NUMBER from $fix_base_ref to $original_head_ref."
+          fi
+
+          post_retarget_original_json="$(gh pr view "$original_pr" --repo "$REPOSITORY" \
+            --json headRefName,headRefOid,state 2>/dev/null || true)"
+          post_retarget_fix_json="$(gh pr view "$FIX_PR_NUMBER" --repo "$REPOSITORY" \
+            --json baseRefName,headRefOid,state 2>/dev/null || true)"
+          if [ -z "$post_retarget_original_json" ] || [ -z "$post_retarget_fix_json" ] ||
+             [ "$(jq -r '.state' <<<"$post_retarget_original_json")" != "OPEN" ] ||
+             [ "$(jq -r '.headRefName' <<<"$post_retarget_original_json")" != "$original_head_ref" ] ||
+             [ "$(jq -r '.headRefOid' <<<"$post_retarget_original_json")" != "$original_sha" ] ||
+             [ "$(jq -r '.state' <<<"$post_retarget_fix_json")" != "OPEN" ] ||
+             [ "$(jq -r '.headRefOid' <<<"$post_retarget_fix_json")" != "$CI_HEAD_SHA" ] ||
+             [ "$(jq -r '.baseRefName' <<<"$post_retarget_fix_json")" != "$original_head_ref" ]; then
+            if [ "$retargeted" = "true" ]; then
+              gh api -X PATCH "repos/$REPOSITORY/pulls/$FIX_PR_NUMBER" \
+                -f base="$fix_base_ref" >/dev/null
+              echo "Rolled fix PR #$FIX_PR_NUMBER back to $fix_base_ref after a concurrent update."
+            fi
+            echo "Original or fix PR advanced while retargeting; staying silent."
+            exit 0
+          fi
+
+          # Render as a markdown list without a sed end-of-line anchor, which shellcheck
+          # misreads as an unexpanded shell variable.
+          fixed_leg_list=""
+          while IFS= read -r leg; do
+            [ -z "$leg" ] && continue
+            fixed_leg_list="${fixed_leg_list}- \`${leg}\`"$'\n'
+          done <<< "$fixed_legs"
+
+          {
+            printf '%s\n\n' "$suggestion_marker"
+            printf '### ✅ An automated fix for this failure passed CI\n\n'
+            printf '%s proposes a fix for the failure analyzed above, and its pipeline run has\n' "$fix_pr_url"
+            printf 'confirmed it:\n\n'
+            printf '%s\n\n' "$fixed_leg_list"
+            printf 'These failed on this PR and now pass on the fix branch, with nothing else\n'
+            printf 'regressing (compared by %s).\n\n' "$COMPARISON"
+            printf 'Merging that pull request applies the fix to this one. Review it as you would any\n'
+            printf 'other change - it is a suggestion, not an approval.\n'
+          } > suggestion.md
+
+          # Prefer appending to the existing analysis comment so the suggestion lives with the
+          # failure it addresses, and is collapsed along with it when a newer analysis supersedes
+          # both. Fall back to a standalone comment if that comment is not present.
+          analysis_comment_id="$(jq -r --arg m "$ANALYSIS_MARKER" \
+            '[.[] | select(.body != null and (.body | contains($m)))] | last | .id // empty' \
+            <<<"$comments_json")"
+
+          if [ -n "$analysis_comment_id" ]; then
+            jq -r --arg m "$ANALYSIS_MARKER" \
+              '[.[] | select(.body != null and (.body | contains($m)))] | last | .body' \
+              <<<"$comments_json" > existing-body.md
+            printf '\n\n---\n\n' >> existing-body.md
+            cat suggestion.md >> existing-body.md
+
+            gh api -X PATCH "repos/$REPOSITORY/issues/comments/$analysis_comment_id" \
+              -F body=@existing-body.md >/dev/null
+            echo "Appended the validated fix suggestion to analysis comment $analysis_comment_id on PR #$original_pr."
+          else
+            gh pr comment "$original_pr" --repo "$REPOSITORY" --body-file suggestion.md
+            echo "Analysis comment not found; posted a standalone suggestion on PR #$original_pr."
+          fi

--- a/.github/workflows/pipeline-analysis-next-steps-trigger.yml
+++ b/.github/workflows/pipeline-analysis-next-steps-trigger.yml
@@ -12,11 +12,15 @@
 #   * Keeps the privileged Copilot run (copilot-requests) isolated in the agentic workflow;
 #     this dispatcher only needs `actions: write` to start it.
 #
-# CI note: azure-sdk-for-python's PR builds roll up into a single Azure Pipelines check run
-# named `python - pullrequest` per commit (its per-stage jobs are `python - pullrequest (...)`,
-# which do NOT end in `- pullrequest`). We trigger on `check_run` and gate on the name ending
-# in `- pullrequest` plus a failing conclusion, so the analysis fires once per failing PR CI
-# run and ignores unrelated checks. This mirrors azure-sdk-for-net's `net - pullrequest` gate.
+# CI note: Azure Pipelines publishes one rollup check plus parenthesized per-stage checks for each
+# pipeline. The repository has both the general `python - pullrequest` pipeline and service
+# pipelines such as `python - cosmos - ci`, so the trigger accepts any failed, non-parenthesized
+# Azure Pipelines check. Run-name deduplication ensures multiple failed pipelines on the same
+# commit produce only one analysis and one auto-fix attempt.
+#
+# Auto-fix rollout is controlled by the `PIPELINE_ANALYSIS_AUTO_FIX_MODE` repository variable:
+# unset/`disabled` analyzes only, `pilot` fixes PRs labeled `pipeline-auto-fix`, and `enabled`
+# fixes every eligible same-repository PR. Unknown values fail closed.
 name: Pipeline Analysis - Next Steps Trigger
 
 on:
@@ -25,18 +29,22 @@ on:
 
 permissions:
   actions: write # dispatch the agentic (lock) workflow
+  checks: read
   contents: read
   pull-requests: read
 
+concurrency:
+  group: pipeline-analysis-trigger-${{ github.event.check_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   dispatch-next-steps:
-    # Only react to a failing Azure DevOps PR-CI check run whose name ends in `- pullrequest`;
-    # ignore every other check run (github-actions, policy service, SDL sub-jobs, and this
-    # workflow's own runs).
+    # Parenthesized checks are per-stage legs; non-parenthesized checks are pipeline rollups.
     if: >
       github.event.check_run.check_suite.app.slug == 'azure-pipelines' &&
-      endsWith(github.event.check_run.name, '- pullrequest') &&
-      github.event.check_run.conclusion == 'failure'
+      !contains(github.event.check_run.name, ' (') &&
+      (github.event.check_run.conclusion == 'success' ||
+       github.event.check_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch pipeline next-steps analysis
@@ -44,8 +52,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          AUTO_FIX_MODE: ${{ vars.PIPELINE_ANALYSIS_AUTO_FIX_MODE }}
           PR_NUMBER: ${{ github.event.check_run.pull_requests[0].number }}
-          CI_CONCLUSION: ${{ github.event.check_run.conclusion }}
           CI_HEAD_SHA: ${{ github.event.check_run.head_sha }}
         run: |
           set -euo pipefail
@@ -61,44 +69,207 @@ jobs:
               sed -n '1s/^[^\t]*\t//p'
           }
 
+          workflow_runs() {
+            local workflow="$1"
+            gh run list \
+              --repo "$REPOSITORY" \
+              --workflow "$workflow" \
+              --event workflow_dispatch \
+              --limit 1000 \
+              --json databaseId,displayTitle,status,conclusion
+          }
+
+          find_workflow_run_id() {
+            local workflow="$1"
+            local run_title="$2"
+            workflow_runs "$workflow" |
+              jq -r --arg title "$run_title" \
+                '[.[] | select(.displayTitle == $title)] | first | .databaseId // empty'
+          }
+
+          wait_for_workflow_run_id() {
+            local workflow="$1"
+            local run_title="$2"
+            local run_id
+            for _ in {1..10}; do
+              run_id="$(find_workflow_run_id "$workflow" "$run_title")"
+              if [ -n "$run_id" ]; then
+                printf '%s\n' "$run_id"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "::error::Dispatched run '$run_title' did not become visible."
+            return 1
+          }
+
+          wait_for_successful_workflow_run() {
+            local run_id="$1"
+            local run_json status conclusion
+            for _ in {1..180}; do
+              run_json="$(gh run view "$run_id" --repo "$REPOSITORY" --json status,conclusion)"
+              status="$(jq -r '.status' <<<"$run_json")"
+              conclusion="$(jq -r '.conclusion // ""' <<<"$run_json")"
+              if [ "$status" = "completed" ]; then
+                if [ "$conclusion" = "success" ]; then
+                  return 0
+                fi
+                echo "::error::Analysis run $run_id concluded '$conclusion'; auto-fix will not run."
+                return 1
+              fi
+              sleep 10
+            done
+            echo "::error::Analysis run $run_id did not complete within the dispatcher timeout."
+            return 1
+          }
+
           dispatch_next_steps() {
             local pr_number="$1"
             local conclusion="$2"
             local head_sha="$3"
+            local pr_json current_head_sha head_ref base_ref is_fork labels_json
 
             if [ -z "$pr_number" ]; then
               echo "No pull request associated with this check run; nothing to do."
               return 0
             fi
 
-            if [ "$(gh pr view "$pr_number" --repo "$REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
+            pr_json="$(gh pr view "$pr_number" --repo "$REPOSITORY" \
+              --json baseRefName,headRefName,headRefOid,isCrossRepository,isDraft,labels)"
+            if [ "$(jq -r '.isDraft' <<<"$pr_json")" = "true" ]; then
               echo "Skipping draft PR #$pr_number."
               return 0
             fi
 
             # Do not analyze a superseded commit: if the completed check run's SHA no longer
             # matches the PR head, the author has already pushed newer code.
-            local current_head_sha
-            current_head_sha="$(gh pr view "$pr_number" --repo "$REPOSITORY" --json headRefOid --jq '.headRefOid')"
+            current_head_sha="$(jq -r '.headRefOid' <<<"$pr_json")"
             if [ -n "$head_sha" ] && [ "$head_sha" != "$current_head_sha" ]; then
               echo "Skipping PR #$pr_number; check run SHA $head_sha no longer matches head $current_head_sha."
               return 0
             fi
 
+            head_ref="$(jq -r '.headRefName' <<<"$pr_json")"
+            case "$head_ref" in
+              copilot-pipeline-fix/*)
+                echo "Skipping automated fix PR #$pr_number."
+                return 0
+                ;;
+            esac
+            base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+            is_fork="$(jq -r '.isCrossRepository' <<<"$pr_json")"
+            labels_json="$(jq -c '[.labels[].name]' <<<"$pr_json")"
+
             local aw_context
             aw_context="$(printf '{"item_type":"pull_request","item_number":%s}' "$pr_number")"
 
-            gh workflow run pipeline-analysis-next-steps.lock.yml \
+            local analysis_run_title analysis_run_id
+            analysis_run_title="Pipeline Analysis - Next Steps / PR #$pr_number / $head_sha"
+            analysis_run_id="$(find_workflow_run_id pipeline-analysis-next-steps.lock.yml "$analysis_run_title")"
+            if [ -n "$analysis_run_id" ]; then
+              echo "Pipeline analysis already dispatched for PR #$pr_number at $head_sha."
+            else
+              gh workflow run pipeline-analysis-next-steps.lock.yml \
+                --repo "$REPOSITORY" \
+                --ref "$DEFAULT_BRANCH" \
+                -f aw_context="$aw_context" \
+                -f pr_number="$pr_number" \
+                -f ci_conclusion="$conclusion" \
+                -f ci_head_sha="$head_sha"
+              echo "Dispatched pipeline next-steps analysis for PR #$pr_number."
+              analysis_run_id="$(wait_for_workflow_run_id \
+                pipeline-analysis-next-steps.lock.yml "$analysis_run_title")"
+            fi
+
+            dispatch_auto_fix "$pr_number" "$head_sha" "$is_fork" "$head_ref" "$base_ref" \
+              "$analysis_run_id" "$labels_json"
+          }
+
+          # Attempt an automated fix. Its draft PR initially targets the default branch for CI,
+          # then the validation workflow retargets it to the contributor branch after a clean run.
+          # Fork PRs are skipped because this repo cannot publish a branch into the contributor's
+          # fork or open the final PR against a branch there.
+          dispatch_auto_fix() {
+            local pr_number="$1"
+            local head_sha="$2"
+            local is_fork="$3"
+            local head_ref="$4"
+            local validation_base_ref="$5"
+            local analysis_run_id="$6"
+            local labels_json="$7"
+            local auto_fix_run_title existing_run_titles
+
+            case "${AUTO_FIX_MODE:-disabled}" in
+              enabled) ;;
+              pilot)
+                if ! jq -e 'index("pipeline-auto-fix") != null' <<<"$labels_json" >/dev/null; then
+                  echo "Skipping auto-fix for PR #$pr_number; pilot mode requires the pipeline-auto-fix label."
+                  return 0
+                fi
+                ;;
+              disabled|"")
+                echo "Skipping auto-fix for PR #$pr_number; PIPELINE_ANALYSIS_AUTO_FIX_MODE is disabled."
+                return 0
+                ;;
+              *)
+                echo "::warning::Unknown PIPELINE_ANALYSIS_AUTO_FIX_MODE '$AUTO_FIX_MODE'; skipping auto-fix."
+                return 0
+                ;;
+            esac
+
+            if [ "$is_fork" = "true" ]; then
+              echo "Skipping auto-fix for PR #$pr_number; fork PRs cannot receive a fix branch."
+              return 0
+            fi
+
+            if [ -z "$head_ref" ]; then
+              echo "Could not resolve head branch for PR #$pr_number; skipping auto-fix."
+              return 0
+            fi
+
+            auto_fix_run_title="Pipeline Analysis - Auto Fix / PR #$pr_number / $head_sha"
+            existing_run_titles="$(workflow_runs pipeline-analysis-auto-fix.lock.yml |
+              jq -r '.[].displayTitle')"
+            if grep -qxF "$auto_fix_run_title" <<<"$existing_run_titles"; then
+              echo "Pipeline auto-fix already dispatched for PR #$pr_number at $head_sha."
+              return 0
+            fi
+
+            echo "Waiting for analysis run $analysis_run_id before dispatching auto-fix."
+            wait_for_successful_workflow_run "$analysis_run_id"
+
+            gh workflow run pipeline-analysis-auto-fix.lock.yml \
               --repo "$REPOSITORY" \
               --ref "$DEFAULT_BRANCH" \
-              -f aw_context="$aw_context" \
               -f pr_number="$pr_number" \
-              -f ci_conclusion="$conclusion" \
-              -f ci_head_sha="$head_sha"
-            echo "Dispatched pipeline next-steps analysis for PR #$pr_number."
+              -f pr_head_ref="$head_ref" \
+              -f ci_head_sha="$head_sha" \
+              -f analysis_run_id="$analysis_run_id" \
+              -f validation_base_ref="$validation_base_ref"
+            echo "Dispatched pipeline auto-fix for PR #$pr_number (validation base $validation_base_ref)."
+            wait_for_workflow_run_id pipeline-analysis-auto-fix.lock.yml "$auto_fix_run_title" >/dev/null
           }
 
           if [ -z "$PR_NUMBER" ]; then
             PR_NUMBER="$(find_open_pr_for_head_sha "$CI_HEAD_SHA")"
           fi
-          dispatch_next_steps "$PR_NUMBER" "$CI_CONCLUSION" "$CI_HEAD_SHA"
+
+          # Wait for every Azure Pipelines rollup currently registered on this commit. The last
+          # rollup to complete performs the single dispatch, so analysis and auto-fix see the full
+          # failure set instead of racing service pipelines that finish at different times.
+          rollups_json="$(gh api --paginate \
+            "repos/$REPOSITORY/commits/$CI_HEAD_SHA/check-runs?per_page=100" \
+            --jq '.check_runs[]
+                  | select(.app.slug == "azure-pipelines")
+                  | select(.name | contains(" (") | not)
+                  | {name, status, conclusion}' | jq -s '.')"
+          if jq -e 'any(.[]; .status != "completed")' <<<"$rollups_json" >/dev/null; then
+            echo "Azure Pipelines rollups are still running for $CI_HEAD_SHA; waiting for the next completion event."
+            exit 0
+          fi
+          if ! jq -e 'any(.[]; .conclusion == "failure")' <<<"$rollups_json" >/dev/null; then
+            echo "All Azure Pipelines rollups passed for $CI_HEAD_SHA; nothing to analyze."
+            exit 0
+          fi
+
+          dispatch_next_steps "$PR_NUMBER" "failure" "$CI_HEAD_SHA"

--- a/.github/workflows/pipeline-analysis-next-steps.md
+++ b/.github/workflows/pipeline-analysis-next-steps.md
@@ -8,9 +8,22 @@
 # Copilot runs on the built-in token via `copilot-requests: write` (billed to the org) # The agent job is read-only; the comment is posted by a separate
 # gh-aw safe-outputs job.
 #
+# The agent has read-only access to the repository's skills under `.github/skills/` (checked
+# out from the default branch, NOT the PR branch). It consults the azsdk pipeline-analysis skill
+# to categorize failures; drop in additional pipeline skills and the agent will pick them up.
+#
+# Skill invocations emit usage telemetry to the azsdk producer (Application Insights) via the
+# Copilot PostToolUse hook in `.github/hooks/hooks.json`. That hook only recognizes a skill
+# invocation from the `skill`, `view`, or `read_file` tools (matching `/skills/<name>/SKILL.md`),
+# so the prompt requires skills to be read with `view` - reading them via shell `cat` would make
+# the invocations invisible to telemetry. Ingestion uses the InstrumentationKey baked into the
+# azsdk connection string, so it only needs egress to the ingestion endpoint (see network.allowed)
+# - not an Azure login.
+#
 # After editing this file, run 'gh aw compile pipeline-analysis-next-steps' to regenerate the
 # lock file.
 description: "Analyze a pull request's failing Azure DevOps pipeline with the azsdk analyze tool and post a Copilot-authored 'Pipeline Analysis Next Steps' comment."
+run-name: "Pipeline Analysis - Next Steps / PR #${{ github.event.inputs.pr_number }} / ${{ github.event.inputs.ci_head_sha }}"
 
 on:
   workflow_dispatch:
@@ -45,16 +58,29 @@ permissions:
 
 # network.allowed also governs content sanitization: dev.azure.com and aka.ms must be allowed
 # so the Azure DevOps build links and the CI-fix link in the analysis survive in the comment.
+# *.in.applicationinsights.azure.com lets the azsdk telemetry producer (the Copilot PostToolUse
+# hook -> `azsdk ingest-telemetry`) upload skill-invocation telemetry from inside the sandbox;
+# ingestion authenticates with the InstrumentationKey in the azsdk connection string, so no Azure
+# login is required - only egress to the ingestion endpoint. Mirrors issue-triage.
 network:
   allowed:
     - defaults
     - github
     - dev.azure.com
     - aka.ms
+    - "*.in.applicationinsights.azure.com"
 
+# Sparse-checkout keeps the agent's tree minimal: eng (azsdk CLI installer + telemetry hook
+# script), .github/skills (read-only skills the agent consults), and .github/hooks (so Copilot
+# loads the PostToolUse hook that emits skill-invocation telemetry to the azsdk producer).
+# `documentation` is only present in azure-rest-api-specs; sparse-checkout silently ignores it in
+# repos that do not have it, so the same workflow file stays syncable across all language repos.
 checkout:
   sparse-checkout: |
     eng
+    .github/skills
+    .github/hooks
+    documentation/ci-fix.md
 
 # Deterministic pre-agent steps: install the azsdk CLI (the analyze tool is a plain stdio MCP
 # server that gh-aw's MCP Gateway cannot host, so we drive its CLI surface) and run the
@@ -63,7 +89,11 @@ steps:
   - name: Install azsdk CLI
     shell: pwsh
     run: |
-      $dir = Join-Path $env:RUNNER_TEMP 'azsdk-cli'
+      # Install to the azsdk common install directory ($HOME/bin) rather than a custom path so the
+      # Copilot telemetry hook (eng/common/scripts/azsdk_tool_telemetry.ps1), which locates the
+      # binary via Get-CommonInstallDirectory, can run `azsdk ingest-telemetry` on skill
+      # invocations. Still add it to PATH so the analyze step below resolves `azsdk`.
+      $dir = Join-Path $HOME 'bin'
       ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir
       Add-Content -Path $env:GITHUB_PATH -Value $dir
   - name: Analyze failing pipeline
@@ -95,11 +125,23 @@ steps:
         fi
       fi
 
+post-steps:
+  - name: Upload pipeline analysis
+    uses: actions/upload-artifact@v7
+    with:
+      name: pipeline-analysis
+      path: pipeline-analysis.txt
+      if-no-files-found: error
+      retention-days: 7
+
 tools:
   github:
     toolsets: [context, repos, pull_requests, actions]
-  # Read-only: the agent only needs to read the analysis file produced above.
-  bash: ["cat", "ls", "head", "tail", "wc"]
+  # Read-only: the agent reads the analysis file plus the checked-out skills under
+  # `.github/skills/` (find/ls to discover them, cat/head/tail to read). No write tools.
+  # `azsdk ci test-results` is allowed because `azsdk ci analyze` reports artifact *names* only;
+  # fetching their contents is a read-only download and is often required to explain a failure.
+  bash: ["cat", "ls", "head", "tail", "wc", "find", "azsdk ci test-results:*"]
 
 safe-outputs:
   # A single, self-updating "Pipeline Analysis Next Steps" comment on the PR. hide-older-comments
@@ -148,19 +190,53 @@ workspace root. Your job is to turn that raw tool output into one concise, actio
 
 ## Step 1 - Analyze the failures
 
-From the tool output, determine what failed and the most likely cause(s):
+**Consult the repository's skills first.** The skills directory is checked out read-only at
+`.github/skills/` (from the default branch — this is *not* the PR's code):
 
-- Group the failures (by pipeline/stage/job, failed build task, and/or failed tests).
-- Categorize each failure as one of: **test** (assertion/test-case failure), **build**
-  (compilation error), **validation** (lint/format/analyzer/spec violation), or
-  **infrastructure** (network timeout, agent crash/disconnect, throttling, image/tooling
-  outage). Note when several failures share one root cause.
-- Identify concrete signals (compiler/build errors, failed test names, timeouts, missing
-  files, lint/format violations, etc.). Rely **only** on what the tool output actually shows -
-  do not invent failures or speculate beyond the evidence. If the cause is unclear, say so.
-- For **infrastructure** failures, recommend re-running the pipeline rather than changing code;
-  only recommend code changes for test/build/validation failures.
-- Preserve any Azure DevOps build URLs from the output so reviewers can jump to the logs.
+> **Read every `SKILL.md` with the `view` tool, not with `cat`/`head`/`tail`.** Skill-usage
+> telemetry is emitted by the Copilot `PostToolUse` hook, which only recognizes a skill invocation
+> from the `view`/`read_file` tools (or an explicit `skill` call). A skill read through a shell
+> command is invisible to telemetry and will not be counted.
+
+- Read `.github/skills/azsdk-common-pipeline-analysis/SKILL.md` and its
+  `references/failure-patterns.md` - they define the failure categories and the pattern-to-fix
+  mappings you apply below.
+- The pipeline analysis has **already been run for you** (its output is in
+  `pipeline-analysis.txt`), so ignore any skill instructions about invoking `azsdk` /
+  `azsdk_analyze_pipeline` MCP tools - you do not have them and do not need them.
+- Keep the comment in the exact format defined in Step 2; do **not** adopt the skill's own
+  output format from `references/output-format.md`.
+- If another skill under `.github/skills/` is directly relevant to the specific failure you are
+  analyzing (for example, a skill describing how to fix a particular pipeline failure), read its
+  `SKILL.md` with the `view` tool and apply it too. Ignore skills unrelated to the failures at hand.
+
+Apply those categories and pattern-to-fix mappings to the `pipeline-analysis.txt` output to
+determine what failed and the most likely root cause(s), and preserve any Azure DevOps build URLs
+from the output so reviewers can jump to the logs.
+
+### Step 1a - Fetch artifact contents if the analysis only names them
+
+`azsdk ci analyze` reports the *names* of published artifacts, not their contents. If
+`pipeline-analysis.txt` references artifacts (for example test-results or log artifacts) and their
+names alone are not enough to explain the failure, download them:
+
+```bash
+azsdk ci test-results "https://github.com/${{ github.repository }}/pull/${{ github.event.inputs.pr_number }}"
+```
+
+Only do this when the analysis is insufficient on its own - it is an extra network call. If the
+command fails or returns nothing, continue with what `pipeline-analysis.txt` already gave you and
+do not treat the failure as fatal.
+
+### Step 1b - azure-rest-api-specs only: consult the CI fix guide
+
+If `${{ github.repository }}` is `Azure/azure-rest-api-specs`, also read `documentation/ci-fix.md`
+from the checked-out tree. It documents how to reproduce and fix that repo's specific checks
+(Swagger BreakingChange, ModelValidation, SemanticValidation, PrettierCheck, TypeSpec Validation,
+Avocado, and the SDK Validation suites), including the exact local commands. Prefer its guidance
+over generic advice, and cite the relevant commands in your recommended next steps.
+
+For every other repository this file does not exist - skip this step entirely and do not mention it.
 
 ## Step 2 - Compose the "Pipeline Analysis Next Steps" comment
 
@@ -201,9 +277,11 @@ root cause, with Azure DevOps build links where available>
 
 ## Constraints (non-negotiable)
 
-1. **Read-only.** Do not check out, build, run, or modify PR code. Your only external action is
-   posting the single comment via the `add-comment` safe output. Do not use `gh`, the GitHub
-   MCP write tools, or direct API calls to comment.
+1. **Read-only.** Do not check out, build, run, or modify PR code. (Reading the repository's own
+   checked-out `.github/skills/` guidance is fine - that is not PR code, and `azsdk ci test-results`
+   only downloads published artifacts.) Your only mutating action is posting the single comment via
+   the `add-comment` safe output. Do not use `gh`, the GitHub MCP write tools, or direct API calls
+   to comment.
 2. **One comment.** Emit at most one `add-comment`. Keep it concise and skimmable; put the raw
    tool output inside the collapsible `<details>` block, trimming it if it is very long.
 3. **The `@copilot` line is an example only.** Write it in backticks exactly as shown so it does


### PR DESCRIPTION
## Summary

- reuse the exact pipeline-analysis.txt artifact from the successful analysis run instead of invoking zsdk ci analyze twice
- create isolated draft fix PRs for eligible same-repository branches and validate every relevant Azure Pipelines rollup and leg before suggesting them
- reject stale baselines, missing checks, regressions, new failures, recursive fix runs, and concurrent PR updates
- clean up expired generated branches

## Rollout safety

Auto-fix is off by default. PIPELINE_ANALYSIS_AUTO_FIX_MODE must be configured after merge:

- unset or disabled: analysis only
- pilot: only non-draft, same-repository PRs labeled pipeline-auto-fix
- nabled: all eligible same-repository PRs

The auto-fix workflow independently enforces the same mode and PR eligibility checks, so manual dispatch cannot bypass the rollout gate. Fork PRs remain analysis-only.

Generated fixes initially target the original PR base to receive normal CI, remain draft, and are retargeted to the contributor branch only after validation. A post-retarget stale check rolls the PR back to its validation base if either branch moves concurrently.

## Validation

- compiled both gh-aw workflows with compiler v0.80.9
- parsed all five executable workflow YAML files
- parsed all embedded Bash scripts with ash -n
- exercised the red-to-green fix, draft PR creation, CI validation, retargeting, and suggestion flow in the fork demo

After merge, enable pilot mode for a controlled same-repository canary before broader rollout.
