### PR TITLE
Update FoundryStorage read validation expectation

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/tests/test_foundry_storage.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/tests/test_foundry_storage.py
@@ -290,7 +290,7 @@ async def test_validates_like_m365_storage(monkeypatch: pytest.MonkeyPatch) -> N
 
     with pytest.raises(ValueError, match="Keys are required"):
         await storage.read([], target_cls=_TestStoreItem)
-    with pytest.raises(ValueError, match="target_cls cannot be None"):
+    with pytest.raises(TypeError, match="target_cls"):
         await storage.read(["k"])
     with pytest.raises(ValueError, match="Changes are required"):
         await storage.write({})


### PR DESCRIPTION
## Description

Updates the FoundryStorage validation test for microsoft-agents-hosting-core==1.3.0. AsyncStorageBase.read now requires target_cls as a keyword-only argument, so omitting it raises TypeError at the base API boundary instead of the previous ValueError validation path.

This keeps FoundryStorage using the upstream AsyncStorageBase read/write/delete implementations. Valid runtime callers already pass target_cls.

## Validation

- PYTHONPATH=sdk/agentserver/azure-ai-agentserver-core:sdk/agentserver/azure-ai-agentserver-activity uv run --with pytest --with pytest-asyncio --with isodate --with azure-core --with azure-identity --with aiohttp --with starlette --with hypercorn --with opentelemetry-api --with opentelemetry-sdk --with microsoft-opentelemetry --with microsoft-agents-hosting-core==1.3.0 --with microsoft-agents-activity==1.3.0 --with microsoft-agents-authentication-msal==1.3.0 --with httpx python -m pytest sdk/agentserver/azure-ai-agentserver-activity/tests/test_foundry_storage.py -q