### PR TITLE
[Core] Explicitly Support gzip & deflate for Encodings in Aiohttp

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `azure-deprecating` to the default allowed headers list in `HttpLoggingPolicy`, so deprecation notification headers are logged without redaction.
 
+### Bugs Fixed
+
+- `AioHttpTransport` now explicitly requests only `gzip` and `deflate` via the `Accept-Encoding` header (unless the caller sets it), preventing services from returning `br` (Brotli) or `zstd` responses that `azure-core` cannot decompress. #47186
+
 ## 1.41.0 (2026-05-07)
 
 ### Features Added

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- `AioHttpTransport` now explicitly requests only `gzip` and `deflate` via the `Accept-Encoding` header (unless the caller sets it), preventing services from returning `br` (Brotli) or `zstd` responses that `azure-core` cannot decompress. #47186
+- `AioHttpTransport` now explicitly requests only `gzip` and `deflate` as the supported encodings  via the `Accept-Encoding` header. #47186
 
 ## 1.41.0 (2026-05-07)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- `AioHttpTransport` now explicitly requests only `gzip` and `deflate` as the supported encodings  via the `Accept-Encoding` header. #47186
+- `AioHttpTransport` now explicitly requests only `gzip` and `deflate` as the supported encodings via the `Accept-Encoding` header. #47186
 
 ## 1.41.0 (2026-05-07)
 

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -62,10 +62,7 @@ from azure.core.pipeline import AsyncPipeline
 
 from ._base import HttpRequest
 from ._base_async import AsyncHttpTransport, AsyncHttpResponse, _ResponseStopIteration
-from ...utils._pipeline_transport_rest_shared import (
-    _aiohttp_body_helper,
-    get_file_items,
-)
+from ...utils._pipeline_transport_rest_shared import get_file_items
 from .._tools import is_rest as _is_rest
 from .._tools_async import (
     handle_no_stream_rest_response as _handle_no_stream_rest_response,
@@ -80,6 +77,7 @@ if TYPE_CHECKING:
 
 # Matching requests, because why not?
 CONTENT_CHUNK_SIZE = 10 * 1024
+_SUPPORTED_ACCEPT_ENCODING = "gzip, deflate"
 _LOGGER = logging.getLogger(__name__)
 
 try:
@@ -344,6 +342,7 @@ class AioHttpTransport(AsyncHttpTransport):
         # and that break services like storage signature
         if not request.data and not request.files:
             config["skip_auto_headers"] = ["Content-Type"]
+        request.headers.setdefault("Accept-Encoding", _SUPPORTED_ACCEPT_ENCODING)
         try:
             stream_response = stream
             timeout = config.pop("connection_timeout", self.connection_config.timeout)
@@ -398,6 +397,42 @@ class AioHttpTransport(AsyncHttpTransport):
         except aiohttp.client_exceptions.ClientError as err:
             raise ServiceRequestError(err, error=err) from err
         return response
+
+
+def _aiohttp_body_helper(
+    response: Union["AioHttpTransportResponse", "RestAioHttpTransportResponse"],
+) -> bytes:
+    # pylint: disable=protected-access
+    """Helper for body method of Aiohttp responses.
+
+    Since aiohttp body methods need decompression work synchronously,
+    need to share this code across old and new aiohttp transport responses
+    for backcompat.
+
+    :param response: The response to decode
+    :type response: ~azure.core.pipeline.transport.AioHttpTransportResponse
+    :rtype: bytes
+    :return: The response's bytes
+    """
+    if response._content is None:
+        raise ValueError("Body is not available. Call async method load_body, or do your call with stream=False.")
+    if not response._decompress:
+        return response._content
+    if response._decompressed_content:
+        return response._content
+    enc = response.headers.get("Content-Encoding")
+    if not enc:
+        return response._content
+    enc = enc.lower()
+    if enc in ("gzip", "deflate"):
+        import zlib
+
+        zlib_mode = (16 + zlib.MAX_WBITS) if enc == "gzip" else -zlib.MAX_WBITS
+        decompressor = zlib.decompressobj(wbits=zlib_mode)
+        response._content = decompressor.decompress(response._content)
+        response._decompressed_content = True
+        return response._content
+    return response._content
 
 
 class AioHttpStreamDownloadGenerator(AsyncIterator):

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -188,6 +188,7 @@ class AioHttpTransport(AsyncHttpTransport):
                     "trust_env": self._use_env_settings,
                     "cookie_jar": jar,
                     "auto_decompress": False,
+                    "headers": {"Accept-Encoding": _SUPPORTED_ACCEPT_ENCODING},
                 }
                 if self._loop is not None:
                     clientsession_kwargs["loop"] = self._loop
@@ -342,7 +343,6 @@ class AioHttpTransport(AsyncHttpTransport):
         # and that break services like storage signature
         if not request.data and not request.files:
             config["skip_auto_headers"] = ["Content-Type"]
-        request.headers.setdefault("Accept-Encoding", _SUPPORTED_ACCEPT_ENCODING)
         try:
             stream_response = stream
             timeout = config.pop("connection_timeout", self.connection_config.timeout)

--- a/sdk/core/azure-core/azure/core/rest/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/rest/_aiohttp.py
@@ -167,7 +167,7 @@ class _RestAioHttpTransportResponseBackcompatMixin(AsyncHttpResponseBackcompatMi
         :return: The response's bytes
         :rtype: bytes
         """
-        return _aiohttp_body_helper(self)
+        return _aiohttp_body_helper(cast("RestAioHttpTransportResponse", self))
 
     async def _load_body(self) -> None:
         """Load in memory the body, so it could be accessible from sync methods."""

--- a/sdk/core/azure-core/azure/core/rest/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/rest/_aiohttp.py
@@ -35,8 +35,8 @@ from ._http_response_impl_async import (
     AsyncHttpResponseImpl,
     AsyncHttpResponseBackcompatMixin,
 )
-from ..pipeline.transport._aiohttp import AioHttpStreamDownloadGenerator
-from ..utils._pipeline_transport_rest_shared import _pad_attr_name, _aiohttp_body_helper
+from ..pipeline.transport._aiohttp import AioHttpStreamDownloadGenerator, _aiohttp_body_helper
+from ..utils._pipeline_transport_rest_shared import _pad_attr_name
 from ..exceptions import (
     ResponseNotReadError,
     IncompleteReadError,

--- a/sdk/core/azure-core/azure/core/utils/_pipeline_transport_rest_shared.py
+++ b/sdk/core/azure-core/azure/core/utils/_pipeline_transport_rest_shared.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
     from ..pipeline.policies import SansIOHTTPPolicy
     from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
         HttpResponse as PipelineTransportHttpResponse,
-        AioHttpTransportResponse as PipelineTransportAioHttpTransportResponse,
     )
     from azure.core.pipeline.transport._base import (
         _HttpResponseBase as PipelineTransportHttpResponseBase,
@@ -376,42 +375,6 @@ def _format_data_helper(
     if content_type:
         return (filename, file_bytes, content_type)
     return (filename, cast(str, file_bytes))
-
-
-def _aiohttp_body_helper(
-    response: "PipelineTransportAioHttpTransportResponse",
-) -> bytes:
-    # pylint: disable=protected-access
-    """Helper for body method of Aiohttp responses.
-
-    Since aiohttp body methods need decompression work synchronously,
-    need to share this code across old and new aiohttp transport responses
-    for backcompat.
-
-    :param response: The response to decode
-    :type response: ~azure.core.pipeline.transport.AioHttpTransportResponse
-    :rtype: bytes
-    :return: The response's bytes
-    """
-    if response._content is None:
-        raise ValueError("Body is not available. Call async method load_body, or do your call with stream=False.")
-    if not response._decompress:
-        return response._content
-    if response._decompressed_content:
-        return response._content
-    enc = response.headers.get("Content-Encoding")
-    if not enc:
-        return response._content
-    enc = enc.lower()
-    if enc in ("gzip", "deflate"):
-        import zlib
-
-        zlib_mode = (16 + zlib.MAX_WBITS) if enc == "gzip" else -zlib.MAX_WBITS
-        decompressor = zlib.decompressobj(wbits=zlib_mode)
-        response._content = decompressor.decompress(response._content)
-        response._decompressed_content = True
-        return response._content
-    return response._content
 
 
 def get_file_items(files: "FilesType") -> Sequence[Tuple[str, "FileType"]]:

--- a/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
@@ -78,6 +78,21 @@ async def test_aiohttp_preserves_accept_encoding_header(port, http_request):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_aiohttp_preserves_injected_session_accept_encoding(port, http_request):
+    # A user-provided session may configure its own default Accept-Encoding (for example
+    # "identity", or an encoding handled by a custom decompressor). The transport must not
+    # override that default with its own supported-encodings value.
+    session = aiohttp.ClientSession(headers={"Accept-Encoding": "identity"}, auto_decompress=False)
+    request = http_request("GET", "http://localhost:{}/basic/string".format(port))
+    transport = AioHttpTransport(session=session, session_owner=False)
+    async with transport:
+        response = await transport.send(request)
+        assert response.internal_response.request_info.headers["Accept-Encoding"] == "identity"
+    await session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_basic_async_requests(port, http_request):
 
     request = http_request("GET", "http://localhost:{}/basic/string".format(port))

--- a/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
@@ -51,13 +51,29 @@ async def test_basic_aiohttp(port, http_request):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_aiohttp_auto_headers(port, http_request):
+async def test_aiohttp_auto_headers(port, http_request, monkeypatch):
 
+    monkeypatch.setitem(aiohttp.ClientRequest.DEFAULT_HEADERS, "Accept-Encoding", "gzip, deflate, br")
     request = http_request("POST", "http://localhost:{}/basic/string".format(port))
     async with AioHttpTransport() as sender:
         response = await sender.send(request)
         auto_headers = response.internal_response.request_info.headers
         assert "Content-Type" not in auto_headers
+        assert auto_headers["Accept-Encoding"] == "gzip, deflate"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_aiohttp_preserves_accept_encoding_header(port, http_request):
+
+    request = http_request(
+        "GET",
+        "http://localhost:{}/basic/string".format(port),
+        headers={"Accept-Encoding": "identity"},
+    )
+    async with AioHttpTransport() as sender:
+        response = await sender.send(request)
+        assert response.internal_response.request_info.headers["Accept-Encoding"] == "identity"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR addresses an issue with `aiohttp` and `core`. Today `aiohttp` automatically appends  `br`  (Brotli) and  `zstd`  to the `Accept-Encoding`  request header when it detects the corresponding optional library (e.g.  brotli / brotlicffi ) installed in the environment. 

When the service honors that and returns a Brotli-encoded response, `azure-core` can't decode it: the aiohttp transport runs with `auto_decompress=False`  and decompresses manually, supporting only  `gzip / deflate` , so the raw bytes reach `response.text()` and raise a `UnicodeDecodeError`

Request does similar, but lets `requests/urllib3` decompress the response itself, so it decodes whatever it advertised

We do the following:
* Explicitly pass in `gzip` and `deflate` for `aiohttp`
* Move the aiohttp body helper into the aiohttp section; its not generic and used only by aiohttp
* Update tests