### PR TITLE
Prepare azure-ai-agentserver-invocations 1.0.0b8 release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b8 (Unreleased)
+## 1.0.0b8 (2026-08-03)
 
 ### Samples
 
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Bumped the minimum `azure-ai-agentserver-core` dependency to `>=2.0.0b9`.
+- Bumped the minimum `azure-ai-agentserver-core` dependency to `>=2.0.0b10`, which adds an opt-in gate for resilient-task startup recovery so invocations-only agents no longer make a blocking task-store call during startup.
 
 ## 1.0.0b7 (2026-07-22)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ["azure", "azure sdk", "agent", "agentserver", "invocations"]
 
 dependencies = [
-    "azure-ai-agentserver-core>=2.0.0b9",
+    "azure-ai-agentserver-core>=2.0.0b10",
     # Constraint on the transitive aiohttp: the `--pre` CI install otherwise
     # resolves the unbuildable aiohttp 4.0.0a1 alpha. Cap must be <4.0.0a0
     # (<4.0.0 still admits 4.0.0a1 under PEP 440).


### PR DESCRIPTION
## Summary

Release preparation for **azure-ai-agentserver-invocations 1.0.0b8**.

## Changes

- **Dated the `1.0.0b8` CHANGELOG entry** — `## 1.0.0b8 (Unreleased)` → `## 1.0.0b8 (2026-08-03)`.
- **Bumped the minimum `azure-ai-agentserver-core` dependency** from `>=2.0.0b9` to `>=2.0.0b10` in `pyproject.toml`.
- **Updated the CHANGELOG "Other Changes" note** to explain the bump: core `2.0.0b10` adds an opt-in gate for resilient-task startup recovery, so invocations-only agents no longer make a blocking task-store (`GET /tasks`) call during startup.

## Why

`azure-ai-agentserver-core==2.0.0b10` (published to PyPI) ships the opt-in `TaskManager` startup gate that fixes a startup-latency regression: previously *every* hosted agent — including invocations-only agents that never declare a durable task — made a blocking task-store call at container startup. Raising the floor to `>=2.0.0b10` guarantees invocations users pick up that fix even if they pin `azure-ai-agentserver-core`.

## Validation

- `pyproject.toml` parses; resolved dependencies: `['azure-ai-agentserver-core>=2.0.0b10', 'aiohttp>=3.10.0,<4.0.0a0']`.
- `_version.py` = `1.0.0b8` (matches the dated CHANGELOG entry).
- No stray `>=2.0.0b9` floor references remain in the package.
- The core `2.0.0b10` behavior (recovery deferred when no task is declared and the flag is off; recovery runs when a task is declared or the flag is set) was validated end-to-end against the published package on a live West US 2 deployment.

> **Note:** the `1.0.0b8` date is set to `2026-08-03` (preparation date). Update it if the actual release lands on a different day.
