### PR TITLE
Enable resilient tasks in LRA samples (invocations + responses) + responses 2.0.0b1 core floor bump

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_langgraph/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_langgraph/app.py
@@ -66,6 +66,7 @@ from azure.ai.agentserver.core.streaming import (
     EventStreamNotFoundError,
     streams,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -81,6 +82,12 @@ logger = logging.getLogger(__name__)
 streams.use_in_memory_replay(ttl_seconds=600)
 
 app = InvocationAgentServerHost()
+
+# Opt into resilient-task startup recovery. This sample declares a durable
+# task, so the framework would enable recovery automatically; we set the switch
+# explicitly to make the intent clear and to keep recovery working even if the
+# task is ever registered lazily (after startup).
+set_resilient_tasks_enabled(True)
 
 
 async def _sse_from_stream(

--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_multiturn/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_multiturn/app.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
-from azure.ai.agentserver.core.tasks import TaskConflictError
+from azure.ai.agentserver.core.tasks import TaskConflictError, set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -45,6 +45,12 @@ except ImportError:  # allows `python app.py` from inside this directory
     from agent import session_workflow
 
 app = InvocationAgentServerHost()
+
+# Opt into resilient-task startup recovery. This sample declares a durable
+# task, so the framework would enable recovery automatically; we set the switch
+# explicitly to make the intent clear and to keep recovery working even if the
+# task is ever registered lazily (after startup).
+set_resilient_tasks_enabled(True)
 
 
 @app.invoke_handler

--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_research/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_research/app.py
@@ -77,6 +77,7 @@ from azure.ai.agentserver.core.streaming import (
     EventStreamNotFoundError,
     streams,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -100,6 +101,12 @@ logger = logging.getLogger(__name__)
 streams.use_file_backed_replay(cursor_fn=lambda ev: ev["sequence_number"])
 
 app = InvocationAgentServerHost()
+
+# Opt into resilient-task startup recovery. This sample declares a durable
+# task, so the framework would enable recovery automatically; we set the switch
+# explicitly to make the intent clear and to keep recovery working even if the
+# task is ever registered lazily (after startup).
+set_resilient_tasks_enabled(True)
 
 
 # --- SSE rendering ---------------------------------------------------------

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0b1 (Unreleased)
+
+### Other Changes
+
+- Bumped the minimum `azure-ai-agentserver-core` dependency to `>=2.0.0b10`, which adds an opt-in gate for resilient-task startup recovery. The resilient Responses samples now call `set_resilient_tasks_enabled(True)` to explicitly opt in, mirroring the invocations resilient samples.
+
 ## 2.0.0b0 (2026-07-29)
 
 ### Features Added

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.0.0b0"
+VERSION = "2.0.0b1"

--- a/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "azure-ai-agentserver-core>=2.0.0b9",
+    "azure-ai-agentserver-core>=2.0.0b10",
     "azure-core>=1.30.0",
     "isodate>=0.6.1",
     "aiohttp>=3.10.0,<4.0.0a0",

--- a/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_19_resilient_streaming.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_19_resilient_streaming.py
@@ -62,9 +62,16 @@ from azure.ai.agentserver.responses import (
     ResponsesAgentServerHost,
     ResponsesServerOptions,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 
 options = ResponsesServerOptions(resilient_background=True)
 app = ResponsesAgentServerHost(options=options)
+
+# Explicitly opt into resilient-task startup recovery, for parity with the
+# invocations resilient samples. The Responses framework already registers its
+# internal durable tasks at host construction (so recovery runs regardless);
+# this call just makes the opt-in intent explicit.
+set_resilient_tasks_enabled(True)
 
 _SIMULATE_SHUTDOWN_MS = int(os.environ.get("SIMULATE_SHUTDOWN_MS", "0"))
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_20_resilient_steering.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_20_resilient_steering.py
@@ -66,12 +66,19 @@ from azure.ai.agentserver.responses import (
     ResponsesAgentServerHost,
     ResponsesServerOptions,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 
 options = ResponsesServerOptions(
     resilient_background=True,
     steerable_conversations=True,
 )
 app = ResponsesAgentServerHost(options=options)
+
+# Explicitly opt into resilient-task startup recovery, for parity with the
+# invocations resilient samples. The Responses framework already registers its
+# internal durable tasks at host construction (so recovery runs regardless);
+# this call just makes the opt-in intent explicit.
+set_resilient_tasks_enabled(True)
 
 _SIMULATE_SHUTDOWN_MS = int(os.environ.get("SIMULATE_SHUTDOWN_MS", "0"))
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_21_resilient_langgraph.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_21_resilient_langgraph.py
@@ -77,6 +77,7 @@ from azure.ai.agentserver.responses import (
     ResponsesAgentServerHost,
     ResponsesServerOptions,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 
 
 # ─── Graph state ────────────────────────────────────────────────────────────
@@ -197,6 +198,12 @@ options = ResponsesServerOptions(
     steerable_conversations=True,
 )
 app = ResponsesAgentServerHost(options=options)
+
+# Explicitly opt into resilient-task startup recovery, for parity with the
+# invocations resilient samples. The Responses framework already registers its
+# internal durable tasks at host construction (so recovery runs regardless);
+# this call just makes the opt-in intent explicit.
+set_resilient_tasks_enabled(True)
 
 # Metadata key: the LangGraph checkpoint id whose completed work matches the
 # response items persisted so far. Recorded in ``internal_metadata`` (persisted

--- a/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_22_resilient_multiturn.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/samples/sample_22_resilient_multiturn.py
@@ -44,12 +44,19 @@ from azure.ai.agentserver.responses import (
     ResponsesServerOptions,
     TextResponse,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 
 options = ResponsesServerOptions(
     resilient_background=True,
     steerable_conversations=False,
 )
 app = ResponsesAgentServerHost(options=options)
+
+# Explicitly opt into resilient-task startup recovery, for parity with the
+# invocations resilient samples. The Responses framework already registers its
+# internal durable tasks at host construction (so recovery runs regardless);
+# this call just makes the opt-in intent explicit.
+set_resilient_tasks_enabled(True)
 
 
 @app.response_handler


### PR DESCRIPTION
## Summary

Enable resilient-task startup recovery explicitly (`set_resilient_tasks_enabled(True)`) in the resilient (LRA) samples across the **invocations** and **responses** packages, with parity across both protocols. Because the responses samples now use a core `2.0.0b10` API, this PR also raises the responses package's core floor and cuts a `2.0.0b1` prep entry.

## Changes

**Invocations resilient samples** — add `set_resilient_tasks_enabled(True)`:
- `samples/resilient_multiturn/app.py`
- `samples/resilient_langgraph/app.py`
- `samples/resilient_research/app.py`

**Responses resilient samples** — add `set_resilient_tasks_enabled(True)`:
- `samples/sample_19_resilient_streaming.py`
- `samples/sample_20_resilient_steering.py`
- `samples/sample_21_resilient_langgraph.py`
- `samples/sample_22_resilient_multiturn.py`

**Responses package release-prep** (required by the sample change):
- `pyproject.toml`: core floor `>=2.0.0b9` → `>=2.0.0b10`
- `_version.py`: `2.0.0b0` → `2.0.0b1`
- `CHANGELOG.md`: new `## 2.0.0b1 (Unreleased)` entry documenting the dependency bump

## Why

`azure-ai-agentserver-core` `2.0.0b10` introduced an **opt-in gate** for the resilient `TaskManager` startup recovery scan: recovery runs only when a durable task is declared **or** `set_resilient_tasks_enabled(True)` was called (an OR gate). Calling the switch explicitly in every resilient sample demonstrates the public opt-in API consistently, and keeps recovery working even if a task is registered lazily (the flag starts the periodic recovery loop at boot).

Since the responses samples now import `set_resilient_tasks_enabled` (a b10 API) at module top level, the responses package's core floor must be `>=2.0.0b10` or the samples would fail at import under the package's minimum supported dependency — hence the floor bump + `2.0.0b1` version + CHANGELOG note (addresses the Copilot review feedback).

### Note on the two packages

- **Invocations** samples declare user-facing `@task` / `@multi_turn_task`, so recovery runs via the task-declared branch; the flag makes the opt-in explicit and covers the lazy-registration edge.
- **Responses** samples enable resilience via `ResponsesServerOptions(resilient_background=True)`. The framework already registers its internal durable tasks at `ResponsesAgentServerHost` construction (before `app.run()`), so recovery runs regardless — the flag is added for parity and to showcase the opt-in API (the added comment states this explicitly).

## Validation

- All 7 sample apps compile (`py_compile`).
- `from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled` resolves against the published `azure-ai-agentserver-core==2.0.0b10`.
- `pyproject.toml` parses; responses deps resolve to `azure-ai-agentserver-core>=2.0.0b10`.
- Public API surface unchanged, so `api.md` / `api.metadata.yml` require no regeneration.
- Invocations core floor bump to `>=2.0.0b10` already merged via #48398.
