### PR TITLE
Update agentserver responses release date

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b1 (Unreleased)
+## 2.0.0b1 (2026-08-04)
 
 ### Other Changes
 


### PR DESCRIPTION
## Description
- Set the azure-ai-agentserver-responses 2.0.0b1 changelog release date to 2026-08-04.

## Testing
- Not run; changelog-only change.