### PR TITLE
[Cosmos] Fix TypeError when using an empty dict as a partition key value

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,8 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed `TypeError: Unexpected type for PK component: <class 'dict'>` when passing `partition_key={}` (the legacy way to target items that have no value for the partition key path) to `query_items()` and other partition-key scoped APIs on containers with a Hash V1 partition key definition. On Hash V2 containers, `{}` also resolved to the `Null` effective partition key instead of `Undefined`, which could return the wrong rows or an empty result set. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [Issue 48420](https://github.com/Azure/azure-sdk-for-python/issues/48420)
+* Fixed `IndexError: index out of range` when computing the effective partition key for an empty string partition key value on containers with a Hash V1 partition key definition.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 #### Bugs Fixed
 * Fixed regression with handling of v1 legacy containers when passing `{}` as a partition key. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
-* Fixed `IndexError: index out of range` when computing the effective partition key for an empty string partition key value on containers with a Hash V1 partition key definition.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed `TypeError: Unexpected type for PK component: <class 'dict'>` when passing `partition_key={}` (the legacy way to target items that have no value for the partition key path) to `query_items()` and other partition-key scoped APIs on containers with a Hash V1 partition key definition. On Hash V2 containers, `{}` also resolved to the `Null` effective partition key instead of `Undefined`, which could return the wrong rows or an empty result set. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [Issue 48420](https://github.com/Azure/azure-sdk-for-python/issues/48420)
+* Fixed regression with handling of v1 legacy containers when passing `{}` as a partition key. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
 * Fixed `IndexError: index out of range` when computing the effective partition key for an empty string partition key value on containers with a Hash V1 partition key definition.
 
 #### Other Changes

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Fixed regression with handling of v1 legacy containers when passing `{}` as a partition key. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
+* Fixed the same `TypeError` on system key (migrated) containers, where a missing partition key value resolves to `_Empty` instead of `Undefined`. It now maps to the minimum effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
@@ -33,6 +33,12 @@ from ._routing.routing_range import Range as _Range
 
 _MaximumExclusiveEffectivePartitionKey = 0xFF
 _MinimumInclusiveEffectivePartitionKey = 0x00
+# The minimum effective partition key is the empty hex string, and its immediate successor is "00":
+# effective partition keys are compared as hex strings, so nothing sorts between the two. Using the
+# successor as an exclusive upper bound keeps the range normalized, since an inclusive point range at
+# the minimum normalizes to an empty range.
+_MinimumInclusiveEffectivePartitionKeyString = ""
+_MinimumEffectivePartitionKeySuccessorString = "00"
 _MaxStringChars = 100
 _MaxStringBytesToAppend = 100
 _MaxPartitionKeyBinarySize = \
@@ -217,6 +223,15 @@ class PartitionKey(dict):
             self,
             pk_value: PartitionKeyType
     ) -> _Range:
+        # _Empty is the sentinel for a partition key value missing from an item in a system key
+        # (migrated) container. Unlike the other sentinels it does not stand for a partition key
+        # *component*, it stands for an empty list of components -- it is serialized on the wire as
+        # `[]` rather than `[{}]` -- so it has no binary encoding and cannot be hashed. It maps to
+        # the minimum effective partition key, which is what hashing an empty component list yields.
+        if isinstance(pk_value, _Empty):
+            return _Range(_MinimumInclusiveEffectivePartitionKeyString,
+                          _MinimumEffectivePartitionKeySuccessorString, True, False)
+
         if self._is_prefix_partition_key(pk_value):
             return self._get_epk_range_for_prefix_partition_key(
                 cast(_SequentialPartitionKeyType, pk_value))

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
@@ -23,7 +23,7 @@
 from io import BytesIO
 import binascii
 import struct
-from typing import Any, IO, Sequence, Type, Union, cast, overload
+from typing import Any, IO, Mapping, Sequence, Type, Union, cast, overload
 from typing_extensions import Literal
 
 from ._cosmos_integers import _UInt32, _UInt64, _UInt128
@@ -246,7 +246,8 @@ class PartitionKey(dict):
         if isinstance(pk_value, str):
             truncated_components.append(PartitionKey._truncate_for_v1_hashing(pk_value))
         else:
-            truncated_components = [PartitionKey._truncate_for_v1_hashing(v) for v in pk_value]
+            truncated_components = [PartitionKey._truncate_for_v1_hashing(_normalize_undefined_component(v))
+                                    for v in pk_value]
         with BytesIO() as ms:
             for component in truncated_components:
                 if isinstance(component, int) and not isinstance(component, bool):
@@ -335,7 +336,7 @@ class PartitionKey(dict):
     ) -> str:
         with BytesIO() as ms:
             for component in pk_value:
-                PartitionKey._write_for_hashing_v2(component, ms)
+                PartitionKey._write_for_hashing_v2(_normalize_undefined_component(component), ms)
 
             ms_bytes = ms.getvalue()
             hash128 = _murmurhash3_128(bytearray(ms_bytes), _UInt128(0, 0))
@@ -358,7 +359,7 @@ class PartitionKey(dict):
             binary_writer = ms  # In Python, you can write bytes directly to a BytesIO object
 
             # Assuming paths[i] is the correct object to call write_for_hashing_v2 on
-            PartitionKey._write_for_hashing_v2(value, binary_writer)
+            PartitionKey._write_for_hashing_v2(_normalize_undefined_component(value), binary_writer)
 
             ms_bytes = ms.getvalue()
             hash128 = _murmurhash3_128(bytearray(ms_bytes), _UInt128(0, 0))
@@ -386,6 +387,23 @@ def _return_undefined_or_empty_partition_key(is_system_key: bool) -> Union[_Empt
     if is_system_key:
         return _Empty()
     return _Undefined()
+
+
+def _normalize_undefined_component(value: Any) -> Any:
+    """Normalize the sentinels that mean "the item has no value for this partition key path".
+
+    ``{}`` is the legacy spelling of an absent partition key value, and ``NonePartitionKeyValue``
+    is the modern one. Both are serialized on the wire as ``[{}]`` and must therefore hash to
+    ``Undefined``, not ``Null``. Without this normalization ``{}`` raises ``TypeError`` on Hash V1
+    partition keys and hashes to the ``Null`` effective partition key on Hash V2 ones.
+
+    :param any value: A single partition key component.
+    :return: ``_Undefined()`` when the component means "no value", otherwise the component itself.
+    :rtype: any
+    """
+    if value is NonePartitionKeyValue or (isinstance(value, Mapping) and not value):
+        return _Undefined()
+    return value
 
 
 def _to_hex(bytes_object: bytearray, start: int, length: int) -> str:
@@ -459,7 +477,9 @@ def _write_for_binary_encoding_v1(
         utf8_value = value.encode('utf-8')
         short_string = len(utf8_value) <= _MaxStringBytesToAppend
 
-        for index in range(short_string and len(utf8_value) or _MaxStringBytesToAppend + 1):
+        # `short_string and len(...) or ...` mis-evaluates to the long-string branch for the
+        # empty string, which then indexes past the end of `utf8_value`.
+        for index in range(len(utf8_value) if short_string else _MaxStringBytesToAppend + 1):
             char_byte = utf8_value[index]
             char_byte += 1
             binary_writer.write(bytes([char_byte]))

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_key_undefined_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_key_undefined_unit.py
@@ -1,0 +1,81 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+"""Unit tests for how "no partition key value" sentinels are hashed.
+
+``{}`` is the legacy spelling of "this item has no value for the partition key path".
+It is serialized on the wire as ``[{}]``, exactly like ``NonePartitionKeyValue``, so both
+must produce the ``Undefined`` effective partition key.
+
+Regression coverage for https://github.com/Azure/azure-sdk-for-python/issues/48420 where
+``query_items(query, partition_key={})`` raised
+``TypeError: Unexpected type for PK component: <class 'dict'>`` on Hash V1 containers, and
+silently resolved to the ``Null`` effective partition key on Hash V2 containers.
+"""
+
+import unittest
+
+import pytest
+
+from azure.cosmos.partition_key import (
+    NonePartitionKeyValue,
+    PartitionKey,
+    _Undefined,
+)
+
+UNDEFINED_EQUIVALENTS = ({}, NonePartitionKeyValue)
+
+
+@pytest.mark.cosmosEmulator
+@pytest.mark.unittest
+class TestUndefinedPartitionKeyHashingUnitTest(unittest.TestCase):
+
+    def test_undefined_equivalents_match_undefined_epk(self):
+        for version in (1, 2):
+            expected = PartitionKey(
+                path="/pk", kind="Hash", version=version
+            )._get_epk_range_for_partition_key(_Undefined())
+            for pk_value in UNDEFINED_EQUIVALENTS:
+                with self.subTest(version=version, pk_value=pk_value):
+                    actual = PartitionKey(
+                        path="/pk", kind="Hash", version=version
+                    )._get_epk_range_for_partition_key(pk_value)
+                    self.assertEqual(actual.min, expected.min)
+                    self.assertEqual(actual.max, expected.max)
+
+    def test_undefined_equivalents_differ_from_null_epk(self):
+        for version in (1, 2):
+            null_epk = PartitionKey(
+                path="/pk", kind="Hash", version=version
+            )._get_epk_range_for_partition_key(None)
+            for pk_value in UNDEFINED_EQUIVALENTS:
+                with self.subTest(version=version, pk_value=pk_value):
+                    actual = PartitionKey(
+                        path="/pk", kind="Hash", version=version
+                    )._get_epk_range_for_partition_key(pk_value)
+                    self.assertNotEqual(
+                        actual.min, null_epk.min,
+                        "An absent partition key value must not hash to the Null EPK.",
+                    )
+
+    def test_undefined_equivalents_match_undefined_epk_for_multi_hash(self):
+        pk_definition = PartitionKey(path=["/a", "/b"], kind="MultiHash", version=2)
+        expected = pk_definition._get_epk_range_for_partition_key([_Undefined(), "z"])
+        for pk_value in UNDEFINED_EQUIVALENTS:
+            with self.subTest(pk_value=pk_value):
+                actual = pk_definition._get_epk_range_for_partition_key([pk_value, "z"])
+                self.assertEqual(actual.min, expected.min)
+                self.assertEqual(actual.max, expected.max)
+
+    def test_defined_values_are_unaffected(self):
+        """Normalization must not alter any value that does have a partition key value."""
+        for version in (1, 2):
+            pk_definition = PartitionKey(path="/pk", kind="Hash", version=version)
+            for pk_value in (None, True, False, 0, 1, -1, 3.5, "", "a", "x" * 150):
+                with self.subTest(version=version, pk_value=pk_value):
+                    epk = pk_definition._get_epk_range_for_partition_key(pk_value)
+                    self.assertIsNotNone(epk.min)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/cosmos/azure-cosmos/tests/test_partition_key_undefined_unit.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_partition_key_undefined_unit.py
@@ -11,6 +11,10 @@ Regression coverage for https://github.com/Azure/azure-sdk-for-python/issues/484
 ``query_items(query, partition_key={})`` raised
 ``TypeError: Unexpected type for PK component: <class 'dict'>`` on Hash V1 containers, and
 silently resolved to the ``Null`` effective partition key on Hash V2 containers.
+
+``_Empty`` is the equivalent sentinel for system key (migrated) containers. It is serialized
+as ``[]`` rather than ``[{}]`` -- an empty list of partition key components rather than a single
+undefined one -- so it resolves to the minimum effective partition key instead.
 """
 
 import unittest
@@ -20,6 +24,7 @@ import pytest
 from azure.cosmos.partition_key import (
     NonePartitionKeyValue,
     PartitionKey,
+    _Empty,
     _Undefined,
 )
 
@@ -75,6 +80,45 @@ class TestUndefinedPartitionKeyHashingUnitTest(unittest.TestCase):
                 with self.subTest(version=version, pk_value=pk_value):
                     epk = pk_definition._get_epk_range_for_partition_key(pk_value)
                     self.assertIsNotNone(epk.min)
+
+    def test_empty_resolves_to_minimum_epk(self):
+        """``_Empty`` is an empty component list, so it maps to the minimum effective partition key."""
+        for pk_definition in (
+            PartitionKey(path="/pk", kind="Hash", version=1),
+            PartitionKey(path="/pk", kind="Hash", version=2),
+            PartitionKey(path=["/a", "/b"], kind="MultiHash", version=2),
+        ):
+            with self.subTest(kind=pk_definition.kind, version=pk_definition.version):
+                epk = pk_definition._get_epk_range_for_partition_key(_Empty())
+                self.assertEqual(epk.min, "")
+                self.assertEqual(epk.max, "00")
+                self.assertTrue(epk.isMinInclusive)
+                self.assertFalse(epk.isMaxInclusive)
+
+    def test_empty_range_survives_normalization(self):
+        """The range must stay non-empty once normalized, otherwise it matches no feed range.
+
+        An inclusive point range at the minimum effective partition key normalizes to an empty
+        range, which would silently resolve to no partitions at all.
+        """
+        for version in (1, 2):
+            with self.subTest(version=version):
+                epk = PartitionKey(
+                    path="/pk", kind="Hash", version=version
+                )._get_epk_range_for_partition_key(_Empty())
+                normalized = epk.to_normalized_range()
+                self.assertFalse(normalized.isEmpty())
+                self.assertEqual(normalized, epk)
+
+    def test_empty_differs_from_undefined(self):
+        """``_Empty`` and ``_Undefined`` are distinct sentinels with distinct wire forms."""
+        for version in (1, 2):
+            with self.subTest(version=version):
+                pk_definition = PartitionKey(path="/pk", kind="Hash", version=version)
+                self.assertNotEqual(
+                    pk_definition._get_epk_range_for_partition_key(_Empty()).min,
+                    pk_definition._get_epk_range_for_partition_key(_Undefined()).min,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #48420 and regressions introduced in 4.16.0 using undefined keys for legacy containers.

We now normalize `{}` (empty mapping) and `NonePartitionKeyValue` to `_Undefined()` in the three partition key hashing entry points (`_get_effective_partition_key_for_hash_partitioning`, `..._v2`, and `..._for_multi_hash_partitioning_v2`). One place, covering sync + async, Hash V1 + V2 + MultiHash, and both call paths above.

Also fixes an adjacent pre-existing `IndexError: index out of range` when computing the effective partition key for an **empty string** partition key value on Hash V1. `range(short_string and len(utf8_value) or _MaxStringBytesToAppend + 1)` mis-evaluates to the long-string branch when the string is empty (`True and 0` → `0` → falsy → `101`), then indexes past the end of the buffer.

## `_Empty()` on system key containers

`_Empty()` is what system-key (migrated) containers get from `_return_undefined_or_empty_partition_key` in place of `_Undefined()`. It reaches `_get_epk_range_for_partition_key` through the same session token path and hit the same `TypeError` on Hash V1 — which is exactly the bucket migrated containers land in, since their partition key definition carries no `version` and `.get('version', 1)` defaults to V1.

Unlike the other sentinels, `_Empty()` does not stand for a partition key *component*. It stands for an empty *list* of components, serialized on the wire as `[]` rather than `[{}]` (`_container_recreate_retry_policy.py`, `feed_range_internal.py`), so it has no binary encoding and must not be hashed. It now resolves to the minimum effective partition key, which is what `_get_hashed_partition_key_string([])` already denotes, what Hash V2 already resolved it to (`000…0` — the first partition), and what .NET uses (`MinimumInclusiveEffectivePartitionKey`).

The range is `["", "00")` rather than the inclusive point range `["", ""]`: `add_to_effective_partition_key("", 1)` returns `""` for an empty byte array, so the point range normalizes to an *empty* range and would silently match no partitions at all. Nothing sorts between `""` and `"00"`, so the two are equivalent as EPK sets, but only the latter survives normalization.

New offline unit test `tests/test_partition_key_undefined_unit.py` (7 tests / 37 subtests) asserts that `_Empty()` resolves to a non-empty, already-normalized minimum-EPK range on Hash V1, Hash V2 and MultiHash and stays distinct from `_Undefined()`, that `{}` and `NonePartitionKeyValue` produce the same EPK as `_Undefined()`, that neither collides with the `None`/`Null` EPK, that the same holds for MultiHash, and that values which *do* have a partition key value are unaffected.

## Effective partition keys

| value | V1 before | V1 after | V2 before | V2 after |
|---|---|---|---|---|
| `{}` | `TypeError` | `05C1D529E345DC00` | `378867E4…` (= Null) | `11622DAA…` (= Undefined) |
| `NonePartitionKeyValue` | `05C1ED45D74756` (= Null) | `05C1D529E345DC00` | `378867E4…` (= Null) | `11622DAA…` (= Undefined) |
| `""` | `IndexError` | `05C1CF33970FF80800` | unchanged | unchanged |
| `_Empty()` | `TypeError` | `["", "00")` | `["000…0", "000…0"]` | `["", "00")` |
| `_Undefined()` | `05C1D529E345DC00` | unchanged | `11622DAA…` | unchanged |
| `None` | `05C1ED45D74756` | unchanged | `378867E4…` | unchanged |

A differential dump over 16 values × Hash V1 / Hash V2 / MultiHash confirms `{}`, `NonePartitionKeyValue`, `""` and `_Empty()` are the only values whose effective partition key changes.

## Where the regressions came from

There is no single culprit PR. Both underlying defects in `partition_key.py` have always existed and were harmless, because nothing on a normal request path fed a *raw* user partition key value into the hashing code. The regressions are the PRs that started routing raw values into the latent bug.

| PR | Shipped | Role |
|---|---|---|
| #41678 | 4.14.0 | **Caused it.** Added `_get_epk_range_for_partition_key(pk_value=pk_value)` to `_session.get_session_token` (sync + async). Fires from the 2nd call onward, once a session token is cached. This is the path users hit today. |
| #47105 | 4.16.0 | **Caused it.** A second, independent call in `__QueryFeed`. Fired on the 1st call, and on Hash V2 silently returned empty results rather than raising. |
| #47798 | 4.16.2 | **Unmasked #41678.** Changed `collection_pk_definition['version']` to `.get('version', 1)`. The old `KeyError` was swallowed by `except (KeyError, AttributeError)`, accidentally hiding the crash for legacy `version`-less partition key definitions. |
| #48237 | 4.16.3 | **Reverted #47105's call**, leaving #41678's. |

Verified live against a real account with three containers — `c_v1` (`version: 1`), `c_v2` (`version: 2`), and `c_noversion` (created through the raw client connection with no `version` key, matching genuinely old containers):

| version | c_noversion | c_v1 | c_v2 |
|---|---|---|---|
| 4.9.0 | OK | OK | OK |
| 4.14.0 | OK | `TypeError` 2nd call | OK |
| 4.15.0 | OK | `TypeError` 2nd call | OK |
| 4.16.0 | `TypeError` 1st call | `TypeError` 1st call | silently `[]` |
| 4.16.2 | `TypeError` 1st call | `TypeError` 1st call | silently `[]` |
| 4.16.3 | `TypeError` 2nd call | `TypeError` 2nd call | OK |
| main (4.16.4) | `TypeError` 2nd call | `TypeError` 2nd call | OK |
| this PR | OK | OK | OK |

Worth noting for the issue: anyone on a container with an explicit `version: 1` was already broken in **4.14.0**, not 4.16.0. The reporter's container omits `version` entirely, which is why 4.15.0 appeared to work for them.

## Async note

`get_session_token_async` catches bare `except Exception` where the sync version catches `except (KeyError, AttributeError)`. On the async client the `TypeError` was therefore never surfaced — it silently dropped the session token, degrading session consistency invisibly. Confirmed: the token goes from `''` to `'0:-1#15'` with this fix. Narrowing that except clause to match the sync version is worth a follow-up so future bugs there don't hide the same way.

## Validation

Beyond comparing effective partition keys, correctness was checked end-to-end against a live account by seeding one item per partition key value (absent pk, `""`, `"a"`, `null`, `42`) and querying with `feed_range=container.feed_range_from_partition_key(pk)`, which sends `StartEpkString`/`EndEpkString` so the *service* does the filtering. Unpatched Hash V2 returned the **null-pk** item for `{}`; patched returns the **no-pk** item, as expected.