### PR TITLE
Update ContentSafety CODEOWNERS to service team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,7 +78,7 @@
 
 # ServiceLabel: %Cognitive - Content Safety
 # PRLabel: %Cognitive - Content Safety
-/sdk/contentsafety/    @mengaims
+/sdk/contentsafety/    @Azure/azure-sdk-write-contentsafety
 
 # PRLabel: %Cognitive - Content Understanding
 /sdk/contentunderstanding/    @bojunehsu @yungshinlintw


### PR DESCRIPTION
Updates the ContentSafety source owner from an individual to the Content Safety service team.

```diff
- /sdk/contentsafety/    @mengaims
+ /sdk/contentsafety/    @Azure/azure-sdk-write-contentsafety
```

`@mengaims` has moved to another team and is no longer able to review ContentSafety pull requests, which currently leaves the package without an active reviewer. `@Azure/azure-sdk-write-contentsafety` ("Azure Content Safety devs and PMs with write access to the Azure SDK repos") is the service team for this package and is a child of `azure-sdk-write` with write access to this repository, so it satisfies the CODEOWNERS requirements.

Using the team rather than individual aliases matches the pattern already used elsewhere in the repo and means future membership changes will not require a CODEOWNERS pull request.

The equivalent change was recently made for the specs repo in Azure/azure-rest-api-specs#45187.
