### PR TITLE
fix(azure-ai-evaluation): retry output_items.list() on transient HTTP 408 timeout

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate_aoai.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluate/_evaluate_aoai.py
@@ -350,13 +350,40 @@ def _get_single_run_results(
     all_results: List[Any] = []
     next_cursor: Optional[str] = None
     limit = 100  # Max allowed by API
+    # Retry constants for transient 408 timeouts on the output-items list call.
+    # The eval run itself has already completed at this point; we are only fetching
+    # the results.  A 408 here is a transient service timeout, not a data error,
+    # so a short backoff and retry is safe and correct.
+    _LIST_MAX_RETRIES = 3
+    _LIST_RETRY_BASE_DELAY_SECONDS = 10
 
     while True:
         list_kwargs = {"eval_id": run_info["eval_group_id"], "run_id": run_info["eval_run_id"], "limit": limit}
         if next_cursor is not None:
             list_kwargs["after"] = next_cursor
 
-        raw_list_results = run_info["client"].evals.runs.output_items.list(**list_kwargs)
+        last_exc: Optional[Exception] = None
+        for attempt in range(_LIST_MAX_RETRIES):
+            try:
+                raw_list_results = run_info["client"].evals.runs.output_items.list(**list_kwargs)
+                last_exc = None
+                break
+            except Exception as exc:  # pylint: disable=broad-except
+                status_code = getattr(exc, "status_code", None)
+                if status_code == 408 and attempt < _LIST_MAX_RETRIES - 1:
+                    delay = _LIST_RETRY_BASE_DELAY_SECONDS * (2**attempt)
+                    LOGGER.warning(
+                        "AOAI: output_items.list() returned 408 on attempt %d/%d "
+                        "(run_id=%s, cursor=%s); retrying in %ds.",
+                        attempt + 1, _LIST_MAX_RETRIES,
+                        run_info["eval_run_id"], next_cursor, delay,
+                    )
+                    sleep(delay)
+                    last_exc = exc
+                else:
+                    raise
+        if last_exc is not None:
+            raise last_exc
 
         # Add current page results
         all_results.extend(raw_list_results.data)

--- a/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_aoai_evaluation_pagination.py
+++ b/sdk/evaluation/azure-ai-evaluation/tests/unittests/test_aoai_evaluation_pagination.py
@@ -250,3 +250,107 @@ class TestAOAIPagination:
         scores = df["outputs.test_grader.score"].tolist()
         expected_scores = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert scores == expected_scores
+
+
+class TestAOAIOutputItemsRetry:
+    """Test retry behaviour for transient 408 timeouts on output_items.list()."""
+
+    def _make_run_info(self, mock_client):
+        return OAIEvalRunCreationInfo(
+            client=mock_client,
+            eval_group_id="test-group",
+            eval_run_id="test-run",
+            grader_name_map={"grader-1": "test_grader"},
+            expected_rows=2,
+        )
+
+    def _make_run_results(self):
+        mock_run_results = Mock()
+        mock_run_results.status = "completed"
+        mock_run_results.per_testing_criteria_results = [Mock(testing_criteria="grader-1", passed=2, failed=0)]
+        return mock_run_results
+
+    def _make_output_items(self, n=2):
+        return MockOutputItemsList(
+            data=[
+                MockOutputItem(
+                    id=f"item-{i}",
+                    datasource_item_id=i,
+                    results=[{"name": "grader-1", "passed": True, "score": 1.0, "sample": f"s{i}"}],
+                )
+                for i in range(n)
+            ],
+            has_more=False,
+        )
+
+    def test_408_retried_then_succeeds(self):
+        """A single 408 on output_items.list() is retried and succeeds on the next attempt."""
+        from openai import APIStatusError
+        import httpx
+
+        mock_client = Mock()
+        run_info = self._make_run_info(mock_client)
+        mock_run_results = self._make_run_results()
+        ok_response = self._make_output_items(2)
+
+        # First call raises 408, second call succeeds.
+        err_408 = APIStatusError(
+            message="408 timeout",
+            response=httpx.Response(408, request=httpx.Request("GET", "https://example.com")),
+            body={"error": {"code": "Timeout", "message": "The operation was timeout."}},
+        )
+        mock_client.evals.runs.output_items.list.side_effect = [err_408, ok_response]
+
+        with patch("azure.ai.evaluation._evaluate._evaluate_aoai._wait_for_run_conclusion", return_value=mock_run_results), \
+             patch("azure.ai.evaluation._evaluate._evaluate_aoai.sleep"):
+            df, metrics = _get_single_run_results(run_info)
+
+        assert mock_client.evals.runs.output_items.list.call_count == 2
+        assert "test_grader.pass_rate" in metrics
+
+    def test_408_exhausts_retries_then_raises(self):
+        """If all 3 retry attempts return 408, the exception is re-raised."""
+        from openai import APIStatusError
+        import httpx
+
+        mock_client = Mock()
+        run_info = self._make_run_info(mock_client)
+        mock_run_results = self._make_run_results()
+
+        err_408 = APIStatusError(
+            message="408 timeout",
+            response=httpx.Response(408, request=httpx.Request("GET", "https://example.com")),
+            body={"error": {"code": "Timeout", "message": "The operation was timeout."}},
+        )
+        mock_client.evals.runs.output_items.list.side_effect = err_408
+
+        with patch("azure.ai.evaluation._evaluate._evaluate_aoai._wait_for_run_conclusion", return_value=mock_run_results), \
+             patch("azure.ai.evaluation._evaluate._evaluate_aoai.sleep"):
+            with pytest.raises(APIStatusError):
+                _get_single_run_results(run_info)
+
+        assert mock_client.evals.runs.output_items.list.call_count == 3  # _LIST_MAX_RETRIES
+
+    def test_non_408_error_not_retried(self):
+        """A non-408 error (e.g. 403 auth) propagates immediately without retry."""
+        from openai import APIStatusError
+        import httpx
+
+        mock_client = Mock()
+        run_info = self._make_run_info(mock_client)
+        mock_run_results = self._make_run_results()
+
+        err_403 = APIStatusError(
+            message="403 Forbidden",
+            response=httpx.Response(403, request=httpx.Request("GET", "https://example.com")),
+            body={"error": {"code": "Forbidden"}},
+        )
+        mock_client.evals.runs.output_items.list.side_effect = err_403
+
+        with patch("azure.ai.evaluation._evaluate._evaluate_aoai._wait_for_run_conclusion", return_value=mock_run_results), \
+             patch("azure.ai.evaluation._evaluate._evaluate_aoai.sleep"):
+            with pytest.raises(APIStatusError):
+                _get_single_run_results(run_info)
+
+        # Should not retry on 403 — only one call made
+        assert mock_client.evals.runs.output_items.list.call_count == 1


### PR DESCRIPTION
## Problem

When an AOAI evaluation run completes and results are fetched via paginated output_items.list(), a transient HTTP 408 from the AOAI service kills the entire evaluation with total=0, discarding all completed results.

This is the #1 system error in batch evaluations (31 occurrences/week). The exact production traceback:
  _evaluate_aoai.py _get_single_run_results()
    raw_list_results = run_info['client'].evals.runs.output_items.list(...)
  openai.APIStatusError: Error code: 408 - 'The operation was timeout.'

The eval run itself had already completed — only result retrieval timed out.

## Fix

Add retry with exponential backoff around output_items.list() in the pagination loop:
- 3 total attempts with 10s, 20s backoff
- Only retries on status_code == 408; all other exceptions propagate immediately

## Tests

3 new tests in TestAOAIOutputItemsRetry covering retry success, retry exhaustion, and non-408 passthrough.