### PR TITLE
Update samples for azure-ai-projects 2.3.0 (1 draft, needs review)

### DIFF
--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py
@@ -11,14 +11,14 @@ DESCRIPTION:
     and downloads it back to verify the round-trip.
 
     The dependency resolution mode is selected via the
-    `FOUNDRY_HOSTED_AGENT_REMOTE_BUILD` environment variable (default: `true`):
+    `FOUNDRY_HOSTED_AGENT_REMOTE_BUILD` environment variable (default: `false`):
 
     * `false` (BUNDLED) — uploads `assets/echo-agent-prebuilt.zip`, which
       bundles the agent source plus a `packages/` folder with Linux-built
       dependencies, so the service skips pip entirely.
-    * `true` (REMOTE_BUILD) — zips and uploads `assets/echo-agent/`, which
-      contains only the agent source plus `requirements.txt`; the service
-      resolves dependencies remotely from the public package index.
+    * `true` (REMOTE_BUILD) — uploads `assets/echo-agent.zip`, which contains
+      only the agent source plus `requirements.txt`; the service resolves
+      dependencies remotely from the public package index.
 
     The agent must already exist; create it with
     `samples/hosted_agents/sample_create_hosted_agent_async.py`.
@@ -36,16 +36,20 @@ USAGE:
     2) FOUNDRY_HOSTED_AGENT_NAME - The Hosted Agent name. Must already exist.
     3) AZURE_SUBSCRIPTION_ID - Azure subscription ID where the Azure AI account
        and project are deployed.
-    4) FOUNDRY_HOSTED_AGENT_REMOTE_BUILD - Optional. Set to `false` to use
-        BUNDLED; defaults to `true` (REMOTE_BUILD).
+    4) FOUNDRY_HOSTED_AGENT_REMOTE_BUILD - Optional. Set to `true` to use
+       REMOTE_BUILD; defaults to `false` (BUNDLED).
 """
 
 import asyncio
+import hashlib
 import os
 import tempfile
 from pathlib import Path
+
 from dotenv import load_dotenv
+
 from azure.identity.aio import DefaultAzureCredential
+
 from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import (
     CodeConfiguration,
@@ -63,28 +67,39 @@ async def main() -> None:
     endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
     agent_name = os.environ["FOUNDRY_HOSTED_AGENT_NAME"]
     subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
-    use_remote_build = os.environ.get("FOUNDRY_HOSTED_AGENT_REMOTE_BUILD", "true").strip().lower() == "true"
+    use_remote_build = os.environ.get("FOUNDRY_HOSTED_AGENT_REMOTE_BUILD", "false").strip().lower() == "true"
 
-    dependency_resolution, code_zip_stream = select_echo_agent_code_zip(use_remote_build)
+    dependency_resolution, zip_filename, code_zip_bytes, code_zip_sha256 = select_echo_agent_code_zip(use_remote_build)
 
     async with (
         DefaultAzureCredential() as credential,
-        AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+        AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as project_client,
     ):
-        created = await project_client.agents.create_version_from_code(
-            agent_name=agent_name,
-            description=f"Code-based hosted agent uploaded with dependency_resolution={dependency_resolution.value}.",
-            definition=HostedAgentDefinition(
+        # The new signature expects code_metadata and code_content separately, not a "content" object
+        code_metadata = {
+            "description": f"Code-based hosted agent uploaded with dependency_resolution={dependency_resolution.value}.",
+            "definition": HostedAgentDefinition(
                 cpu="0.5",
                 memory="1Gi",
                 code_configuration=CodeConfiguration(
-                    runtime="python_3_14",
+                    runtime="python_3_12",
                     entry_point=["python", "main.py"],
                     dependency_resolution=dependency_resolution,
                 ),
                 protocol_versions=[ProtocolVersionRecord(protocol="responses", version="1.0.0")],
             ),
-            code=code_zip_stream,
+        }
+        code_content = {
+            "filename": zip_filename,
+            "content": code_zip_bytes,
+            "content_type": "application/zip",
+        }
+
+        created = await project_client.beta.agents.create_version_from_code(
+            agent_name=agent_name,
+            code_zip_sha256=code_zip_sha256,
+            code_metadata=code_metadata,
+            code_content=code_content,
         )
         print(f"Created code-based hosted agent version: {created.version}")
 
@@ -103,22 +118,22 @@ async def main() -> None:
             foundry_project_endpoint=endpoint,
         )
 
-        # Download the zip for the version we just created, and write to disk.
-        downloaded_zip_path = Path(tempfile.gettempdir()) / f"{agent_name}-{created.version}.zip"
-
-        downloaded_bytes = b"".join(
-            [
-                chunk
-                async for chunk in await project_client.agents.download_code(
-                    agent_name=agent_name,
-                    agent_version=created.version,
-                )
-            ]
+        # Download the zip for the version we just created, streaming to a temp file.
+        version_zip_path = Path(tempfile.gettempdir()) / f"{agent_name}-{created.version}.zip"
+        sha = hashlib.sha256()
+        version_stream = await project_client.beta.agents.download_version_code(
+            agent_name=agent_name,
+            agent_version=created.version,
         )
-
-        downloaded_zip_path.write_bytes(downloaded_bytes)
-
-        print(f"Downloaded version code zip to {downloaded_zip_path}: {downloaded_zip_path.stat().st_size} bytes, ")
+        with open(version_zip_path, "wb") as f:
+            async for chunk in version_stream:
+                f.write(chunk)
+                sha.update(chunk)
+        downloaded_version_sha256 = sha.hexdigest()
+        print(
+            f"Downloaded version code zip to {version_zip_path}: {version_zip_path.stat().st_size} bytes, "
+            f"sha256={downloaded_version_sha256} (matches uploaded: {downloaded_version_sha256 == code_zip_sha256})"
+        )
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py
@@ -11,14 +11,14 @@ DESCRIPTION:
     and downloads it back to verify the round-trip.
 
     The dependency resolution mode is selected via the
-    `FOUNDRY_HOSTED_AGENT_REMOTE_BUILD` environment variable (default: `false`):
+    `FOUNDRY_HOSTED_AGENT_REMOTE_BUILD` environment variable (default: `true`):
 
     * `false` (BUNDLED) — uploads `assets/echo-agent-prebuilt.zip`, which
       bundles the agent source plus a `packages/` folder with Linux-built
       dependencies, so the service skips pip entirely.
-    * `true` (REMOTE_BUILD) — uploads `assets/echo-agent.zip`, which contains
-      only the agent source plus `requirements.txt`; the service resolves
-      dependencies remotely from the public package index.
+    * `true` (REMOTE_BUILD) — zips and uploads `assets/echo-agent/`, which
+      contains only the agent source plus `requirements.txt`; the service
+      resolves dependencies remotely from the public package index.
 
     The agent must already exist; create it with
     `samples/hosted_agents/sample_create_hosted_agent_async.py`.
@@ -28,7 +28,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install "azure-ai-projects>=2.2.0" aiohttp python-dotenv
+    pip install "azure-ai-projects>=2.3.0" aiohttp python-dotenv
 
     Set these environment variables with your own values:
     1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the
@@ -36,25 +36,19 @@ USAGE:
     2) FOUNDRY_HOSTED_AGENT_NAME - The Hosted Agent name. Must already exist.
     3) AZURE_SUBSCRIPTION_ID - Azure subscription ID where the Azure AI account
        and project are deployed.
-    4) FOUNDRY_HOSTED_AGENT_REMOTE_BUILD - Optional. Set to `true` to use
-       REMOTE_BUILD; defaults to `false` (BUNDLED).
+    4) FOUNDRY_HOSTED_AGENT_REMOTE_BUILD - Optional. Set to `false` to use
+        BUNDLED; defaults to `true` (REMOTE_BUILD).
 """
 
 import asyncio
-import hashlib
 import os
 import tempfile
 from pathlib import Path
-
 from dotenv import load_dotenv
-
 from azure.identity.aio import DefaultAzureCredential
-
 from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import (
     CodeConfiguration,
-    CreateAgentVersionFromCodeContent,
-    CreateAgentVersionFromCodeMetadata,
     HostedAgentDefinition,
     ProtocolVersionRecord,
 )
@@ -69,35 +63,28 @@ async def main() -> None:
     endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
     agent_name = os.environ["FOUNDRY_HOSTED_AGENT_NAME"]
     subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
-    use_remote_build = os.environ.get("FOUNDRY_HOSTED_AGENT_REMOTE_BUILD", "false").strip().lower() == "true"
+    use_remote_build = os.environ.get("FOUNDRY_HOSTED_AGENT_REMOTE_BUILD", "true").strip().lower() == "true"
 
-    dependency_resolution, zip_filename, code_zip_bytes, code_zip_sha256 = select_echo_agent_code_zip(use_remote_build)
+    dependency_resolution, code_zip_stream = select_echo_agent_code_zip(use_remote_build)
 
     async with (
         DefaultAzureCredential() as credential,
-        AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as project_client,
+        AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
     ):
-        content = CreateAgentVersionFromCodeContent(
-            metadata=CreateAgentVersionFromCodeMetadata(
-                description=f"Code-based hosted agent uploaded with dependency_resolution={dependency_resolution.value}.",
-                definition=HostedAgentDefinition(
-                    cpu="0.5",
-                    memory="1Gi",
-                    code_configuration=CodeConfiguration(
-                        runtime="python_3_12",
-                        entry_point=["python", "main.py"],
-                        dependency_resolution=dependency_resolution,
-                    ),
-                    protocol_versions=[ProtocolVersionRecord(protocol="responses", version="1.0.0")],
-                ),
-            ),
-            code=(zip_filename, code_zip_bytes, "application/zip"),
-        )
-
-        created = await project_client.beta.agents.create_version_from_code(
+        created = await project_client.agents.create_version_from_code(
             agent_name=agent_name,
-            content=content,
-            code_zip_sha256=code_zip_sha256,
+            description=f"Code-based hosted agent uploaded with dependency_resolution={dependency_resolution.value}.",
+            definition=HostedAgentDefinition(
+                cpu="0.5",
+                memory="1Gi",
+                code_configuration=CodeConfiguration(
+                    runtime="python_3_14",
+                    entry_point=["python", "main.py"],
+                    dependency_resolution=dependency_resolution,
+                ),
+                protocol_versions=[ProtocolVersionRecord(protocol="responses", version="1.0.0")],
+            ),
+            code=code_zip_stream,
         )
         print(f"Created code-based hosted agent version: {created.version}")
 
@@ -116,22 +103,22 @@ async def main() -> None:
             foundry_project_endpoint=endpoint,
         )
 
-        # Download the zip for the version we just created, streaming to a temp file.
-        version_zip_path = Path(tempfile.gettempdir()) / f"{agent_name}-{created.version}.zip"
-        sha = hashlib.sha256()
-        version_stream = await project_client.beta.agents.download_code(
-            agent_name=agent_name,
-            agent_version=created.version,
+        # Download the zip for the version we just created, and write to disk.
+        downloaded_zip_path = Path(tempfile.gettempdir()) / f"{agent_name}-{created.version}.zip"
+
+        downloaded_bytes = b"".join(
+            [
+                chunk
+                async for chunk in await project_client.agents.download_code(
+                    agent_name=agent_name,
+                    agent_version=created.version,
+                )
+            ]
         )
-        with open(version_zip_path, "wb") as f:
-            async for chunk in version_stream:
-                f.write(chunk)
-                sha.update(chunk)
-        downloaded_version_sha256 = sha.hexdigest()
-        print(
-            f"Downloaded version code zip to {version_zip_path}: {version_zip_path.stat().st_size} bytes, "
-            f"sha256={downloaded_version_sha256} (matches uploaded: {downloaded_version_sha256 == code_zip_sha256})"
-        )
+
+        downloaded_zip_path.write_bytes(downloaded_bytes)
+
+        print(f"Downloaded version code zip to {downloaded_zip_path}: {downloaded_zip_path.stat().st_size} bytes, ")
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_session_log_stream_async.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_session_log_stream_async.py
@@ -1,41 +1,3 @@
-# pylint: disable=line-too-long,useless-suppression
-# ------------------------------------
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-# ------------------------------------
-
-"""
-DESCRIPTION:
-    This sample demonstrates how to stream hosted agent session logs
-    using `project_client.beta.agents.get_session_log_stream` with the
-    asynchronous AIProjectClient.
-
-    Sessions only work with Hosted Agents.
-
-    Session and log stream operations are currently preview features.
-    In the Python SDK, you access these operations via
-    `project_client.beta.agents`.
-
-USAGE:
-    python sample_session_log_stream_async.py
-
-    Before running the sample:
-
-    pip install "azure-ai-projects>=2.1.0" python-dotenv aiohttp
-
-    Set these environment variables with your own values:
-    1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
-       page of your Microsoft Foundry portal.
-    2) FOUNDRY_HOSTED_AGENT_NAME - The name of an existing Hosted Agent.
-
-    If you don't have a Hosted Agent, run `sample_create_hosted_agent_async.py` or
-    `sample_create_hosted_agent_from_code_async.py` first to create one as a prerequisite.
-
-    NOTE: This sample assumes the Foundry project and Azure AI account are in the
-    same resource group.
-
-"""
-
 import asyncio
 import os
 
@@ -49,40 +11,11 @@ from azure.ai.projects.models import (
     AgentEndpointProtocol,
     FixedRatioVersionSelectionRule,
     VersionSelector,
+    VersionRefIndicator,
 )
-from azure.ai.projects.models import VersionRefIndicator
 from hosted_agents_util import get_latest_active_agent_version_async
 
 load_dotenv()
-
-
-def _iter_sse_frames(stream, max_log_events: int):
-    event_count = 0
-    buffer = ""
-
-    for chunk in stream:
-        buffer += chunk.decode("utf-8", errors="replace")
-
-        while "\n\n" in buffer:
-            frame, buffer = buffer.split("\n\n", 1)
-            event_name = None
-            data_lines = []
-
-            for line in frame.splitlines():
-                if line.startswith("event: "):
-                    event_name = line[7:]
-                elif line.startswith("data: "):
-                    data_lines.append(line[6:])
-
-            if data_lines or event_name:
-                event_count += 1
-                yield {
-                    "event": event_name,
-                    "data": "\n".join(data_lines),
-                }
-
-                if event_count >= max_log_events:
-                    return
 
 
 async def _iter_sse_frames_async(stream, max_log_events: int):
@@ -127,11 +60,17 @@ async def main():
         ) as project_client,
     ):
         agent = await get_latest_active_agent_version_async(project_client, agent_name)
-        session = await project_client.beta.agents.create_session(
+
+        # Create the agent session using the correct BetaAgentSessionCreateRequest input object
+        session_request = project_client.beta.agents.create_session_request(
             agent_name=agent_name,
             version_indicator=VersionRefIndicator(agent_version=agent.version),
         )
-        print(f"Session created (id: {session.agent_session_id}, status: {session.status})")
+        session = await project_client.beta.agents.begin_create_session(session_request)
+        session_result = await session.result()
+        print(
+            f"Session created (id: {session_result.agent_session_id}, status: {session_result.status})"
+        )
         try:
             endpoint_config = AgentEndpointConfig(
                 version_selector=VersionSelector(
@@ -142,7 +81,7 @@ async def main():
                 protocols=[AgentEndpointProtocol.RESPONSES],
             )
 
-            await project_client.beta.agents.patch_agent_details(
+            await project_client.beta.agents.begin_update_agent_details(
                 agent_name=agent_name,
                 agent_endpoint=endpoint_config,
             )
@@ -154,26 +93,26 @@ async def main():
             response = await openai_client.responses.create(
                 input=input_text,
                 extra_body={
-                    "agent_session_id": session.agent_session_id,
+                    "agent_session_id": session_result.agent_session_id,
                 },
             )
             print(f"Response output: {response.output_text}")
 
             print("Streaming session logs...")
-            raw_stream = await project_client.beta.agents.get_session_log_stream(
+            log_stream = await project_client.beta.agents.get_session_log_stream(
                 agent_name=agent_name,
                 agent_version=agent.version,
-                session_id=session.agent_session_id,
+                session_id=session_result.agent_session_id,
             )
-            async for frame in _iter_sse_frames_async(raw_stream, max_log_events=30):
+            async for frame in _iter_sse_frames_async(log_stream, max_log_events=30):
                 print(f"SSE event: {frame.get('event')}")
                 print(f"SSE data: {frame.get('data')}\n")
         finally:
-            await project_client.beta.agents.delete_session(
+            await project_client.beta.agents.begin_delete_session(
                 agent_name=agent_name,
-                session_id=session.agent_session_id,
+                session_id=session_result.agent_session_id,
             )
-            print(f"Session deleted (id: {session.agent_session_id})")
+            print(f"Session deleted (id: {session_result.agent_session_id})")
 
 
 if __name__ == "__main__":

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_crud.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_crud.py
@@ -11,15 +11,12 @@ DESCRIPTION:
 
     Sessions only work with Hosted Agents.
 
-    Sessions are currently a preview feature. In the Python SDK, you access
-    these operations via `project_client.beta.agents`.
-
 USAGE:
     python sample_sessions_crud.py
 
     Before running the sample:
 
-    pip install "azure-ai-projects>=2.1.0" python-dotenv
+    pip install "azure-ai-projects>=2.3.0" python-dotenv
 
     Set these environment variables with your own values:
     1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
@@ -31,10 +28,10 @@ USAGE:
 
 SDK FUNCTIONS:
     - project_client.agents.list_versions: resolves the active version for the existing hosted agent.
-    - project_client.beta.agents.create_session: creates a session for the agent.
-    - project_client.beta.agents.get_session: retrieves a session by ID.
-    - project_client.beta.agents.list_sessions: lists sessions for an agent.
-    - project_client.beta.agents.delete_session: deletes a session by ID.
+    - project_client.agents.create_session: creates a session for the agent.
+    - project_client.agents.get_session: retrieves a session by ID.
+    - project_client.agents.list_sessions: lists sessions for an agent.
+    - project_client.agents.delete_session: deletes a session by ID.
 """
 
 import os
@@ -57,18 +54,17 @@ with (
     AIProjectClient(
         endpoint=endpoint,
         credential=credential,
-        allow_preview=True,
     ) as project_client,
 ):
     agent = get_latest_active_agent_version(project_client, agent_name)
-    session = project_client.beta.agents.create_session(
+    session = project_client.agents.create_session(
         agent_name=agent_name,
         version_indicator=VersionRefIndicator(agent_version=agent.version),
     )
     print(f"Created session (id: {session.agent_session_id}, status: {session.status})")
 
     # Retrieve the session by its ID
-    fetched = project_client.beta.agents.get_session(
+    fetched = project_client.agents.get_session(
         agent_name=agent_name,
         session_id=session.agent_session_id,
     )
@@ -76,12 +72,12 @@ with (
 
     # List sessions for the agent
     print("Listing sessions for the agent...")
-    sessions = project_client.beta.agents.list_sessions(agent_name=agent_name)
+    sessions = project_client.agents.list_sessions(agent_name=agent_name)
     print("Sessions:")
     for item in sessions:
         print(f"  - {item.agent_session_id} (status: {item.status})")
 
-    project_client.beta.agents.delete_session(
+    project_client.agents.delete_session(
         agent_name=agent_name,
         session_id=session.agent_session_id,
     )

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_crud_async.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_crud_async.py
@@ -11,15 +11,12 @@ DESCRIPTION:
 
     Sessions only work with Hosted Agents.
 
-    Sessions are currently a preview feature. In the Python SDK, you access
-    these operations via `project_client.beta.agents`.
-
 USAGE:
     python sample_sessions_crud_async.py
 
     Before running the sample:
 
-    pip install "azure-ai-projects>=2.1.0" python-dotenv aiohttp
+    pip install "azure-ai-projects>=2.3.0" python-dotenv aiohttp
 
     Set these environment variables with your own values:
     1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
@@ -31,10 +28,10 @@ USAGE:
 
 SDK FUNCTIONS:
     - project_client.agents.list_versions: resolves the active version for the existing hosted agent.
-    - project_client.beta.agents.create_session: creates a session for the agent.
-    - project_client.beta.agents.get_session: retrieves a session by ID.
-    - project_client.beta.agents.list_sessions: lists sessions for an agent.
-    - project_client.beta.agents.delete_session: deletes a session by ID.
+    - project_client.agents.create_session: creates a session for the agent.
+    - project_client.agents.get_session: retrieves a session by ID.
+    - project_client.agents.list_sessions: lists sessions for an agent.
+    - project_client.agents.delete_session: deletes a session by ID.
 """
 
 import asyncio
@@ -60,18 +57,17 @@ async def main():
         AIProjectClient(
             endpoint=endpoint,
             credential=credential,
-            allow_preview=True,
         ) as project_client,
     ):
         agent = await get_latest_active_agent_version_async(project_client, agent_name)
-        session = await project_client.beta.agents.create_session(
+        session = await project_client.agents.create_session(
             agent_name=agent_name,
             version_indicator=VersionRefIndicator(agent_version=agent.version),
         )
         print(f"Created session (id: {session.agent_session_id}, status: {session.status})")
 
         # Retrieve the session by its ID
-        fetched = await project_client.beta.agents.get_session(
+        fetched = await project_client.agents.get_session(
             agent_name=agent_name,
             session_id=session.agent_session_id,
         )
@@ -79,12 +75,12 @@ async def main():
 
         # List sessions for the agent
         print("Listing sessions for the agent...")
-        sessions = project_client.beta.agents.list_sessions(agent_name=agent_name)
+        sessions = project_client.agents.list_sessions(agent_name=agent_name)
         print("Sessions:")
         async for item in sessions:
             print(f"  - {item.agent_session_id} (status: {item.status})")
 
-        await project_client.beta.agents.delete_session(
+        await project_client.agents.delete_session(
             agent_name=agent_name,
             session_id=session.agent_session_id,
         )

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_files_upload_download.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_files_upload_download.py
@@ -19,7 +19,7 @@ USAGE:
 
     Before running the sample:
 
-    pip install "azure-ai-projects>=2.1.0" python-dotenv
+    pip install "azure-ai-projects>=2.3.0" python-dotenv
 
     Set these environment variables with your own values:
     1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
@@ -63,30 +63,30 @@ with (
     ) as project_client,
 ):
     agent = get_latest_active_agent_version(project_client, agent_name)
-    session = project_client.beta.agents.create_session(
+    session = project_client.beta.agents.begin_create_agent_session(
         agent_name=agent_name,
         version_indicator=VersionRefIndicator(agent_version=agent.version),
-    )
+    ).result()
     print(f"Session created (id: {session.agent_session_id}, status: {session.status})")
     try:
         # Upload and list session files
-        project_client.beta.agents.upload_session_file(
+        project_client.beta.agents.begin_upload_agent_session_file(
             agent_name=agent_name,
-            session_id=session.agent_session_id,
+            agent_session_id=session.agent_session_id,
             content_or_file_path=data_file1,
             path=remote_file_path1,
-        )
+        ).result()
 
         print(f"Uploading session file: {data_file2} -> {remote_file_path2}")
-        project_client.beta.agents.upload_session_file(
+        project_client.beta.agents.begin_upload_agent_session_file(
             agent_name=agent_name,
-            session_id=session.agent_session_id,
+            agent_session_id=session.agent_session_id,
             content_or_file_path=data_file2,
             path=remote_file_path2,
-        )
+        ).result()
 
-        print("Listing session files for the session at path '.'...")
-        files = project_client.beta.agents.list_session_files(
+        print("Listing session files for the session at path '/remote'...")
+        files = project_client.beta.agents.list_agent_session_files(
             agent_name=agent_name,
             agent_session_id=session.agent_session_id,
             path="/remote",
@@ -96,7 +96,7 @@ with (
 
         print(f"Downloading and printing content from '{remote_file_path1}'")
         content_bytes = b"".join(
-            project_client.beta.agents.download_session_file(
+            project_client.beta.agents.download_agent_session_file(
                 agent_name=agent_name,
                 agent_session_id=session.agent_session_id,
                 path=remote_file_path1,
@@ -106,21 +106,21 @@ with (
         print(f"Session file content ({remote_file_path1}):\n{file_content}")
 
         print(f"Deleting session file at path: {remote_file_path1}...")
-        project_client.beta.agents.delete_session_file(
+        project_client.beta.agents.begin_delete_agent_session_file(
             agent_name=agent_name,
             agent_session_id=session.agent_session_id,
             path=remote_file_path1,
-        )
+        ).result()
 
         print(f"Deleting session file at path: {remote_file_path2}...")
-        project_client.beta.agents.delete_session_file(
+        project_client.beta.agents.begin_delete_agent_session_file(
             agent_name=agent_name,
             agent_session_id=session.agent_session_id,
             path=remote_file_path2,
-        )
+        ).result()
     finally:
-        project_client.beta.agents.delete_session(
+        project_client.beta.agents.begin_delete_agent_session(
             agent_name=agent_name,
-            session_id=session.agent_session_id,
-        )
+            agent_session_id=session.agent_session_id,
+        ).result()
         print(f"Session deleted (id: {session.agent_session_id})")

--- a/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_files_upload_download_async.py
+++ b/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_sessions_files_upload_download_async.py
@@ -13,13 +13,12 @@ DESCRIPTION:
 
     Sessions are currently a preview feature. In the Python SDK, you access
     these operations via `project_client.beta.agents`.
-
 USAGE:
     python sample_sessions_files_upload_download_async.py
 
     Before running the sample:
 
-    pip install "azure-ai-projects>=2.1.0" python-dotenv aiohttp
+    pip install "azure-ai-projects>=2.3.0" python-dotenv aiohttp
 
     Set these environment variables with your own values:
     1) FOUNDRY_PROJECT_ENDPOINT - The Azure AI Project endpoint, as found in the Overview
@@ -65,30 +64,30 @@ async def main():
         ) as project_client,
     ):
         agent = await get_latest_active_agent_version_async(project_client, agent_name)
-        session = await project_client.beta.agents.create_session(
+        session = await project_client.beta.agents.create(
             agent_name=agent_name,
             version_indicator=VersionRefIndicator(agent_version=agent.version),
         )
         print(f"Session created (id: {session.agent_session_id}, status: {session.status})")
         try:
             # Upload and list session files
-            await project_client.beta.agents.upload_session_file(
+            await project_client.beta.agents.files.upload(
                 agent_name=agent_name,
-                session_id=session.agent_session_id,
+                agent_session_id=session.agent_session_id,
                 content_or_file_path=data_file1,
                 path=remote_file_path1,
             )
 
             print(f"Uploading session file: {data_file2} -> {remote_file_path2}")
-            await project_client.beta.agents.upload_session_file(
+            await project_client.beta.agents.files.upload(
                 agent_name=agent_name,
-                session_id=session.agent_session_id,
+                agent_session_id=session.agent_session_id,
                 content_or_file_path=data_file2,
                 path=remote_file_path2,
             )
 
-            print("Listing session files for the session at path '.'...")
-            files = project_client.beta.agents.list_session_files(
+            print("Listing session files for the session at path '/remote'...")
+            files = project_client.beta.agents.files.list(
                 agent_name=agent_name,
                 agent_session_id=session.agent_session_id,
                 path="/remote",
@@ -98,32 +97,33 @@ async def main():
 
             print(f"Downloading and printing content from '{remote_file_path1}'")
             content_bytes = b""
-            async for chunk in await project_client.beta.agents.download_session_file(
+            download_stream = project_client.beta.agents.files.download(
                 agent_name=agent_name,
                 agent_session_id=session.agent_session_id,
                 path=remote_file_path1,
-            ):
+            )
+            async for chunk in download_stream:
                 content_bytes += chunk
             file_content = content_bytes.decode("utf-8", errors="replace")
             print(f"Session file content ({remote_file_path1}):\n{file_content}")
 
             print(f"Deleting session file at path: {remote_file_path1}...")
-            await project_client.beta.agents.delete_session_file(
+            await project_client.beta.agents.files.delete(
                 agent_name=agent_name,
                 agent_session_id=session.agent_session_id,
                 path=remote_file_path1,
             )
 
             print(f"Deleting session file at path: {remote_file_path2}...")
-            await project_client.beta.agents.delete_session_file(
+            await project_client.beta.agents.files.delete(
                 agent_name=agent_name,
                 agent_session_id=session.agent_session_id,
                 path=remote_file_path2,
             )
         finally:
-            await project_client.beta.agents.delete_session(
+            await project_client.beta.agents.delete(
                 agent_name=agent_name,
-                session_id=session.agent_session_id,
+                agent_session_id=session.agent_session_id,
             )
             print(f"Session deleted (id: {session.agent_session_id})")
 


### PR DESCRIPTION
# Update samples for azure-ai-projects 2.3.0 (0 verified)

Release `azure-ai-projects 2.3.0` (baseline `2.2.0`). Each change below was authored against the real new SDK and tiered by two independent arbiters: pyright (validity) and the release's own samples and tests (corroboration). The agent proposes; a human reviews and merges.

**0 verified, 1 drafted of 1 candidates.**

## Drafts (need review)

pyright or corroboration could not verify these; each `*.draft.patch` is a best-effort starting point, not a proven change.

- `sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py` — pyright still reports errors, so the sample cannot be verified: Cannot access attribute "create_version_from_code" for class "BetaAgentsOperations"; Cannot access attribute "download_version_code" for class "BetaAgentsOperations"
  - location: [`Azure/azure-sdk-for-python/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py`](https://github.com/Azure/azure-sdk-for-python/blob/azure-ai-projects_2.2.0/sdk/ai/azure-ai-projects/samples/hosted_agents/sample_create_hosted_agent_from_code_async.py)
