### PR TITLE
Prepare azure-ai-agentserver-responses 2.0.0 GA release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0 (2026-08-05)
+
+### Features Added
+
+- First stable release of the Azure AI Agent Server Responses client library.
+
 ## 2.0.0b1 (2026-08-04)
 
 ### Other Changes

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.0.0b1"
+VERSION = "2.0.0"

--- a/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Microsoft Corporation" }]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Overview

Prepares `azure-ai-agentserver-responses` for its 2.0.0 GA release.

## Changes

- Set the package version to `2.0.0`.
- Mark the package as Production/Stable.
- Add the 2.0.0 release entry dated 2026-08-05.

## Validation

- 1,505 tests passed; 6 skipped.
- Pylint passed.
- MyPy passed.
- Sphinx passed in an isolated environment.

## Release readiness

GA publishing remains blocked pending API approval in APIView.