### PR TITLE
Release Agent Server core 2.0.0

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.0.0 (2026-08-05)
 
+### Other Changes
+
+- Promoted `azure-ai-agentserver-core` to GA.
+
+## 2.0.0b11 (2026-08-05)
+
 ### Features Added
 
 - Added a shared `experimental` decorator for marking Agent Server preview feature surfaces with docstring notes and one-time runtime warnings. The resilient task primitive and Foundry storage public APIs are now marked experimental.

--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0b11 (2026-08-05)
+## 2.0.0 (2026-08-05)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-core/api.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/api.md
@@ -129,6 +129,7 @@ namespace azure.ai.agentserver.core
 
         def shutdown_handler(self, fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]: ...
 
+
     class azure.ai.agentserver.core.FoundryAgentRequestContext:
         call_id: str | None
         session_id: str | None

--- a/sdk/agentserver/azure-ai-agentserver-core/api.metadata.yml
+++ b/sdk/agentserver/azure-ai-agentserver-core/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: c59f884d22c608e6d7378fff27745622a58935876b369cacb7b4669dea0ee257
-parserVersion: 0.3.30
+apiMdSha256: af641b1656c5d7033120dc627043abae459030f20ad9fcec49ee0ec4d5725265
+parserVersion: 0.3.31
 pythonVersion: 3.12.13

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.0.0b11"
+VERSION = "2.0.0"

--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Description

Prepares `azure-ai-agentserver-core` for GA release.

- Promotes package version from `2.0.0b11` to `2.0.0`
- Updates the changelog heading to `2.0.0 (2026-08-05)`
- Updates the package classifier from Beta to Production/Stable

## Validation

- `python -m compileall -q azure` from `sdk/agentserver/azure-ai-agentserver-core`