### PR TITLE
Exporter release 1.0.0b56

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b56 (Unreleased)
+## 1.0.0b56 (2026-08-05)
 
 ### Features Added
 - Retry payloads for which request is sent successfully but no response is received, per [SPEC.](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/1018)
@@ -26,7 +26,7 @@
   ([#47949](https://github.com/Azure/azure-sdk-for-python/pull/47949))
 - Harden OneSettings configuration manager and worker: handle non-retryable HTTP errors by slow-polling instead of retrying, fix worker holding its lock across network I/O, make shutdown a soft reset that leaves the singleton reusable, and make callback registration thread-safe and initialization-independent
   ([#48027](https://github.com/Azure/azure-sdk-for-python/pull/48027))
-- Align OneSettings feature-flag evaluation with the control-plane schema: use full-name `os`/`rp`/`attach` values, add `ikey` and `region` conditions, require exact single-value matches (removing list and version-range support), and only honor a `ver` condition when a matching `component` is also present <!-- cspell:ignore ikey -->
+- Align OneSettings feature-flag evaluation with the control-plane schema: use full-name `os`/`rp`/`attach` values, add `ikey` and `region` conditions, require exact single-value matches (removing list and version-range support), and only honor a `ver` condition when a matching `component` is also present
   ([#48059](https://github.com/Azure/azure-sdk-for-python/pull/48059))
 - Support remote toggling of local (offline) storage via the OneSettings `FEATURE_LOCAL_STORAGE` feature flag: the control plane can disable or re-enable disk-backed retry storage at runtime, but never overrides an explicit `disable_offline_storage=True` user opt-out. Statsbeat storage is decoupled from the user setting (always off), while customer-sdkstats honors the user setting and follows the remote toggle.
   ([#48379](https://github.com/Azure/azure-sdk-for-python/pull/48379))

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,8 +6,6 @@
 - Retry payloads for which request is sent successfully but no response is received, per [SPEC.](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/1018)
   ([#47870](https://github.com/Azure/azure-sdk-for-python/pull/47870))
 
-### Breaking Changes
-
 ### Bugs Fixed
 - Propagate main agent attribute to child spans
   ([#47950](https://github.com/Azure/azure-sdk-for-python/pull/47950))
@@ -20,7 +18,6 @@
   ([#48379](https://github.com/Azure/azure-sdk-for-python/pull/48379))
 
 ### Other Changes
-
 - Simplify OneSettings change detection to use ETag-based mechanism instead of change version tracking to reflect spec update
 - Change OneSettings log messages from warning to debug level to reduce noise for users with firewalls
   ([#47949](https://github.com/Azure/azure-sdk-for-python/pull/47949))

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b56 (2026-08-05)
+## 1.0.0b56 (2026-08-06)
 
 ### Features Added
 - Retry payloads for which request is sent successfully but no response is received, per [SPEC.](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/1018)


### PR DESCRIPTION
## 1.0.0b56 (2026-08-05)

### Features Added
- Retry payloads for which request is sent successfully but no response is received, per [SPEC.](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/1018)
  ([#47870](https://github.com/Azure/azure-sdk-for-python/pull/47870))

### Bugs Fixed
- Propagate main agent attribute to child spans
  ([#47950](https://github.com/Azure/azure-sdk-for-python/pull/47950))
- Live Metrics now honors the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable for AAD
  authentication as a fallback when no explicit credential is supplied and local authentication is disabled.
  ([#48284](https://github.com/Azure/azure-sdk-for-python/pull/48284))
- Fix a memory leak where exporters registered as OneSettings configuration callbacks were retained for the
  process lifetime; bound-method callbacks are now held via weak references so discarded exporters can be
  garbage collected.
  ([#48379](https://github.com/Azure/azure-sdk-for-python/pull/48379))

### Other Changes

- Simplify OneSettings change detection to use ETag-based mechanism instead of change version tracking to reflect spec update
- Change OneSettings log messages from warning to debug level to reduce noise for users with firewalls
  ([#47949](https://github.com/Azure/azure-sdk-for-python/pull/47949))
- Harden OneSettings configuration manager and worker: handle non-retryable HTTP errors by slow-polling instead of retrying, fix worker holding its lock across network I/O, make shutdown a soft reset that leaves the singleton reusable, and make callback registration thread-safe and initialization-independent
  ([#48027](https://github.com/Azure/azure-sdk-for-python/pull/48027))
- Align OneSettings feature-flag evaluation with the control-plane schema: use full-name `os`/`rp`/`attach` values, add `ikey` and `region` conditions, require exact single-value matches (removing list and version-range support), and only honor a `ver` condition when a matching `component` is also present
  ([#48059](https://github.com/Azure/azure-sdk-for-python/pull/48059))
- Support remote toggling of local (offline) storage via the OneSettings `FEATURE_LOCAL_STORAGE` feature flag: the control plane can disable or re-enable disk-backed retry storage at runtime, but never overrides an explicit `disable_offline_storage=True` user opt-out. Statsbeat storage is decoupled from the user setting (always off), while customer-sdkstats honors the user setting and follows the remote toggle.
  ([#48379](https://github.com/Azure/azure-sdk-for-python/pull/48379))
- Enable the OneSettings control plane in the base exporter: it now starts the configuration worker and registers the process profile (os/rp/attach/component/version/region/ikey) so feature flags can be evaluated. `_ConfigurationManager.initialize` merges profile fields first-wins across calls, letting a dependent component (e.g. the Azure Monitor distro) set `component` before the exporter contributes ikey/region.
  ([#48429](https://github.com/Azure/azure-sdk-for-python/pull/48429))