### PR TITLE
[Storage] append data streaming large live test fix

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -450,7 +450,7 @@ def _validate_content_response(
                 response=response.http_response,
             )
 
-    elif is_crc64_validation(validate_content):
+    elif is_crc64_validation(validate_content) and response.http_response.status_code < 300:
         # For upload and download verify structured message header present in response if provided in request.
         sm_request = request.http_request.headers.get(SM_HEADER)
         sm_response = response.http_response.headers.get(SM_HEADER)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -450,7 +450,7 @@ def _validate_content_response(
                 response=response.http_response,
             )
 
-    elif is_crc64_validation(validate_content):
+    elif is_crc64_validation(validate_content) and response.http_response.status_code < 300:
         # For upload and download verify structured message header present in response if provided in request.
         sm_request = request.http_request.headers.get(SM_HEADER)
         sm_response = response.http_response.headers.get(SM_HEADER)

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
@@ -183,7 +183,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
 
         data1 = b"abcde" * 1024 * 1024  # 5 MiB
         data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
-        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        data3 = b"12345678" * 4 * 1024 * 1024  # 32 MiB
         assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -183,7 +183,7 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
 
         data1 = b"abcde" * 1024 * 1024  # 5 MiB
         data2 = b"12345" * 2 * 1024 * 1024 + b"abcdefg"  # 10 MiB + 7
-        data3 = b"12345678" * 8 * 1024 * 1024  # 64 MiB
+        data3 = b"12345678" * 4 * 1024 * 1024  # 32 MiB
         assert_method = assert_structured_message if a == "crc64" else assert_content_md5
 
         # Act

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -459,7 +459,7 @@ def _validate_content_response(
                 response=response.http_response,
             )
 
-    elif is_crc64_validation(validate_content):
+    elif is_crc64_validation(validate_content) and response.http_response.status_code < 300:
         # For upload and download verify structured message header present in response if provided in request.
         sm_request = request.http_request.headers.get(SM_HEADER)
         sm_response = response.http_response.headers.get(SM_HEADER)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -459,7 +459,7 @@ def _validate_content_response(
                 response=response.http_response,
             )
 
-    elif is_crc64_validation(validate_content):
+    elif is_crc64_validation(validate_content) and response.http_response.status_code < 300:
         # For upload and download verify structured message header present in response if provided in request.
         sm_request = request.http_request.headers.get(SM_HEADER)
         sm_response = response.http_response.headers.get(SM_HEADER)


### PR DESCRIPTION
# Description

Currently `TestStorageContentValidation.test_append_data_streaming_large` is failing only on the Windows CI tests. The root cause is a service-side `OperationTimedOut` on the large append. The test runs three parametrizations (`True`, `md5`, and `crc64`) all of which hit the same underlying timeout. However, the error surfaced differently:

- `True` / `md5`: correctly propagate the real `HttpResponseError` (`OperationTimedOut`).
- `crc64`: masks the underlying error with: `azure.core.exceptions.AzureError: Expected structured message header in response does not match request.
Request: XSM/1.0; properties=crc64, Response: None`

This stems from `_validate_content_response` in `_shared/policies.py`, where the validation for the structured message header happened for every response. To address this, only responses that have been successful will now be validated.

As a first step, this PR only addresses the misleading error so we can confirm via CI that the `crc64` case now surfaces the real `OperationTimedOut`. A follow-up change will then reduce the test payload from 64 MiB to 32 MiB so the append completes in time and the tests pass.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

