### PR TITLE
Enable OneSettings config manager in azure-monitor-opentelemetry distro

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -12,9 +12,9 @@
 
 ### Other Changes
 - Contribute distro profile information (`component="dst"` and distro version) to the OneSettings control plane during `configure_azure_monitor`
-  ([#TBD](https://github.com/Azure/azure-sdk-for-python/pull/TBD))
+  ([#48475](https://github.com/Azure/azure-sdk-for-python/pull/48475))
 - Update `azure-monitor-opentelemetry-exporter` minimum dependency to `1.0.0b56`
-  ([#TBD](https://github.com/Azure/azure-sdk-for-python/pull/TBD))
+  ([#48475](https://github.com/Azure/azure-sdk-for-python/pull/48475))
 
 ## 1.8.9 (2026-07-01)
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -11,6 +11,10 @@
 ### Bugs Fixed
 
 ### Other Changes
+- Contribute distro profile information (`component="dst"` and distro version) to the OneSettings control plane during `configure_azure_monitor`
+  ([#TBD](https://github.com/Azure/azure-sdk-for-python/pull/TBD))
+- Update `azure-monitor-opentelemetry-exporter` minimum dependency to `1.0.0b56`
+  ([#TBD](https://github.com/Azure/azure-sdk-for-python/pull/TBD))
 
 ## 1.8.9 (2026-07-01)
 

--- a/sdk/monitor/azure-monitor-opentelemetry/api.metadata.yml
+++ b/sdk/monitor/azure-monitor-opentelemetry/api.metadata.yml
@@ -1,3 +1,3 @@
 apiMdSha256: f733101c54405189c2d4489a68c838727d12cbddafebbca7469faae6871bb5bf
-parserVersion: 0.3.28
-pythonVersion: 3.13.14
+parserVersion: 0.3.31
+pythonVersion: 3.14.0

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -84,6 +84,9 @@ from azure.monitor.opentelemetry.exporter._utils import (  # pylint: disable=imp
     _is_attach_enabled,
     _is_on_functions,
 )
+from azure.monitor.opentelemetry.exporter._configuration._state import (  # pylint: disable=import-error,no-name-in-module
+    get_configuration_manager,
+)
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
     _DISTRO_DETECTS_ATTACH,
     AzureDiagnosticLogging,
@@ -144,6 +147,17 @@ def configure_azure_monitor(**kwargs) -> None:  # pylint: disable=C4758
     _send_attach_warning()
 
     configurations = _get_configurations(**kwargs)
+
+    # Contribute distro-level profile fields to the OneSettings control plane before any exporter is
+    # created. initialize() is idempotent and _ConfigurationProfile.fill() is first-wins per field, so
+    # setting component="dst" and the distro version here makes the profile reflect the distro; the
+    # exporters created below still supply ikey/region without overriding these already-set fields.
+    config_manager = get_configuration_manager()
+    if config_manager:
+        config_manager.initialize(
+            component="dst",
+            version=VERSION,
+        )
 
     disable_tracing = configurations[DISABLE_TRACING_ARG]
     disable_logging = configurations[DISABLE_LOGGING_ARG]

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -83,7 +83,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "azure-core-tracing-opentelemetry~=1.0.0b11",
-        "azure-monitor-opentelemetry-exporter~=1.0.0b54",
+        "azure-monitor-opentelemetry-exporter~=1.0.0b56",
         "opentelemetry-sdk~=1.43.0",
         "opentelemetry-instrumentation-django>=0.64b0,<0.65.0",
         "opentelemetry-instrumentation-fastapi>=0.64b0,<0.65.0",

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
@@ -28,7 +28,7 @@ from azure.monitor.opentelemetry._configure import (
     configure_azure_monitor,
 )
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import _DISTRO_DETECTS_ATTACH
-
+from azure.monitor.opentelemetry._version import VERSION
 
 TEST_RESOURCE = Resource({"foo": "bar"})
 
@@ -53,8 +53,12 @@ class TestConfigure(unittest.TestCase):
     @patch(
         "azure.monitor.opentelemetry._configure._setup_tracing",
     )
+    @patch(
+        "azure.monitor.opentelemetry._configure.get_configuration_manager",
+    )
     def test_configure_azure_monitor(
         self,
+        get_config_manager_mock,
         tracing_mock,
         logging_mock,
         metrics_mock,
@@ -72,6 +76,85 @@ class TestConfigure(unittest.TestCase):
         live_metrics_mock.assert_called_once()
         instrumentation_mock.assert_called_once()
         detect_attach_mock.assert_called_once()
+
+    @patch(
+        "azure.monitor.opentelemetry._configure._send_attach_warning",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_instrumentations",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_live_metrics",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_metrics",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_logging",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_tracing",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure.get_configuration_manager",
+    )
+    def test_configure_azure_monitor_initializes_config_manager(
+        self,
+        get_config_manager_mock,
+        tracing_mock,
+        logging_mock,
+        metrics_mock,
+        live_metrics_mock,
+        instrumentation_mock,
+        detect_attach_mock,
+    ):
+        config_manager_mock = Mock()
+        get_config_manager_mock.return_value = config_manager_mock
+        configure_azure_monitor(connection_string="test_cs")
+        # Distro contributes component="dst" and its version before any exporter is created.
+        config_manager_mock.initialize.assert_called_once_with(
+            component="dst",
+            version=VERSION,
+        )
+
+    @patch(
+        "azure.monitor.opentelemetry._configure._send_attach_warning",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_instrumentations",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_live_metrics",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_metrics",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_logging",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure._setup_tracing",
+    )
+    @patch(
+        "azure.monitor.opentelemetry._configure.get_configuration_manager",
+    )
+    def test_configure_azure_monitor_config_manager_disabled(
+        self,
+        get_config_manager_mock,
+        tracing_mock,
+        logging_mock,
+        metrics_mock,
+        live_metrics_mock,
+        instrumentation_mock,
+        detect_attach_mock,
+    ):
+        # When the control plane is disabled, get_configuration_manager returns None and the distro
+        # skips initialize() without raising.
+        get_config_manager_mock.return_value = None
+        configure_azure_monitor(connection_string="test_cs")
+        tracing_mock.assert_called_once()
+        logging_mock.assert_called_once()
+        metrics_mock.assert_called_once()
 
     @patch(
         "azure.monitor.opentelemetry._configure._setup_instrumentations",

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
@@ -35,6 +35,14 @@ TEST_RESOURCE = Resource({"foo": "bar"})
 
 # pylint: disable=too-many-public-methods
 class TestConfigure(unittest.TestCase):
+    def setUp(self):
+        # Patch get_configuration_manager for every test so configure_azure_monitor never starts the
+        # real OneSettings worker thread. Tests that care about the interaction use
+        # self._get_config_manager_mock to control the returned manager.
+        patcher = patch("azure.monitor.opentelemetry._configure.get_configuration_manager")
+        self._get_config_manager_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
     @patch(
         "azure.monitor.opentelemetry._configure._send_attach_warning",
     )
@@ -53,12 +61,8 @@ class TestConfigure(unittest.TestCase):
     @patch(
         "azure.monitor.opentelemetry._configure._setup_tracing",
     )
-    @patch(
-        "azure.monitor.opentelemetry._configure.get_configuration_manager",
-    )
     def test_configure_azure_monitor(
         self,
-        get_config_manager_mock,
         tracing_mock,
         logging_mock,
         metrics_mock,
@@ -95,12 +99,8 @@ class TestConfigure(unittest.TestCase):
     @patch(
         "azure.monitor.opentelemetry._configure._setup_tracing",
     )
-    @patch(
-        "azure.monitor.opentelemetry._configure.get_configuration_manager",
-    )
     def test_configure_azure_monitor_initializes_config_manager(
         self,
-        get_config_manager_mock,
         tracing_mock,
         logging_mock,
         metrics_mock,
@@ -108,8 +108,7 @@ class TestConfigure(unittest.TestCase):
         instrumentation_mock,
         detect_attach_mock,
     ):
-        config_manager_mock = Mock()
-        get_config_manager_mock.return_value = config_manager_mock
+        config_manager_mock = self._get_config_manager_mock.return_value
         configure_azure_monitor(connection_string="test_cs")
         # Distro contributes component="dst" and its version before any exporter is created.
         config_manager_mock.initialize.assert_called_once_with(
@@ -135,12 +134,8 @@ class TestConfigure(unittest.TestCase):
     @patch(
         "azure.monitor.opentelemetry._configure._setup_tracing",
     )
-    @patch(
-        "azure.monitor.opentelemetry._configure.get_configuration_manager",
-    )
     def test_configure_azure_monitor_config_manager_disabled(
         self,
-        get_config_manager_mock,
         tracing_mock,
         logging_mock,
         metrics_mock,
@@ -150,7 +145,7 @@ class TestConfigure(unittest.TestCase):
     ):
         # When the control plane is disabled, get_configuration_manager returns None and the distro
         # skips initialize() without raising.
-        get_config_manager_mock.return_value = None
+        self._get_config_manager_mock.return_value = None
         configure_azure_monitor(connection_string="test_cs")
         tracing_mock.assert_called_once()
         logging_mock.assert_called_once()

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/test_configure.py
@@ -109,12 +109,25 @@ class TestConfigure(unittest.TestCase):
         detect_attach_mock,
     ):
         config_manager_mock = self._get_config_manager_mock.return_value
+        # Record the order of manager initialization relative to exporter setup. initialize() must run
+        # before any exporter setup so the distro's component="dst" wins under first-wins fill(); if it
+        # ran afterward the profile would revert to the exporter's component="ext".
+        call_order = []
+        config_manager_mock.initialize.side_effect = lambda *a, **k: call_order.append("initialize")
+        metrics_mock.side_effect = lambda *a, **k: call_order.append("metrics")
+        tracing_mock.side_effect = lambda *a, **k: call_order.append("tracing")
+        logging_mock.side_effect = lambda *a, **k: call_order.append("logging")
         configure_azure_monitor(connection_string="test_cs")
         # Distro contributes component="dst" and its version before any exporter is created.
         config_manager_mock.initialize.assert_called_once_with(
             component="dst",
             version=VERSION,
         )
+        # initialize() is recorded first, ahead of every exporter setup step.
+        self.assertEqual(call_order[0], "initialize")
+        self.assertIn("metrics", call_order)
+        self.assertIn("tracing", call_order)
+        self.assertIn("logging", call_order)
 
     @patch(
         "azure.monitor.opentelemetry._configure._send_attach_warning",


### PR DESCRIPTION
## Description

Enables the OneSettings control plane (config manager) in the `azure-monitor-opentelemetry` distro, as a follow-up to enabling it in the exporter ([#48429](https://github.com/Azure/azure-sdk-for-python/pull/48429)).

### Changes
- **Bump exporter minimum dependency** to `1.0.0b56` (the version that enabled the config manager in the exporter).
- **Contribute distro profile fields to OneSettings** during `configure_azure_monitor`: the distro calls `config_manager.initialize(component="dst", version=<distro version>)` before any exporter is created. Because `_ConfigurationProfile.fill()` is first-wins per field, the distro sets `component="dst"` and the distro version, while the exporters created afterward still supply `ikey`/`region`/`os`/`rp`/`attach` without overriding these already-set fields.
- Guarded by the `get_configuration_manager()` None-check, so the call is skipped when the control plane is disabled via env var (consistent with the exporter).

### Tests
- Added `test_configure_azure_monitor_initializes_config_manager` (asserts `initialize(component="dst", version=VERSION)`) and `test_configure_azure_monitor_config_manager_disabled` (None path).
- Added a `setUp`-level patch of `get_configuration_manager` so no distro configure test starts the real OneSettings worker thread.

All 27 `test_configure.py` tests pass; black clean.