### PR TITLE
Enable API stub generation for agent server core

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -64,6 +64,9 @@ readme = { file = ["README.md"], content-type = "text/markdown" }
 [tool.setuptools.package-data]
 "azure.ai.agentserver.core" = ["py.typed"]
 
+[tool.azure-sdk-conda]
+in_bundle = false
+
 [tool.azure-sdk-build]
 breaking = false
 mypy = true

--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -72,7 +72,6 @@ verifytypes = false
 latestdependency = false
 pylint = true
 type_check_samples = false
-# apistub crashes on Generic[Input, Output] classes (Python 3.10 inspect.getsource bug)
-apistub = false
+apistub = true
 
 [tool.uv.sources]


### PR DESCRIPTION
## Description

Enables the API stub generation check for `azure-ai-agentserver-core` now that generic task classes are handled successfully on the Python 3.10 CI path.

## Validation

- API stub generation with Python 3.10 CI-equivalent options
- Pylint
- MyPy
- Pyright
- Wheel installation and package tests