### PR TITLE
[Storage] added list support to BlobSasPermissions

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.32.0b1 (Unreleased)
 
 ### Features Added
+- Added `list` support to `BlobSasPermissions` for use with directory-scoped SAS tokens.
 
 ## 12.31.0b1 (2026-08-10)
 

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -1389,6 +1389,7 @@ namespace azure.storage.blob
         delete: bool = False
         delete_previous_version: bool = False
         execute: Optional[bool]
+        list: Optional[bool]
         move: Optional[bool]
         permanent_delete: Optional[bool]
         read: bool = False
@@ -1407,6 +1408,7 @@ namespace azure.storage.blob
                 tag: bool = False, 
                 *, 
                 execute: Optional[bool] = ..., 
+                list: Optional[bool] = ..., 
                 move: Optional[bool] = ..., 
                 permanent_delete: Optional[bool] = ..., 
                 set_immutability_policy: Optional[bool] = ..., 

--- a/sdk/storage/azure-storage-blob/api.metadata.yml
+++ b/sdk/storage/azure-storage-blob/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: 4fbccc27e1eda77dbcf6dc07ca8f9bf5d79265e8b58e44032363c779a6ac3702
-parserVersion: 0.3.30
+apiMdSha256: b2b4c934d58318c4437a0cd9016b9871bb257605ddf977383b09d8ef68c57a26
+parserVersion: 0.3.31
 pythonVersion: 3.13.14

--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_c32c7fcda0"
+  "Tag": "python/storage/azure-storage-blob_5442c15799"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -1111,6 +1111,8 @@ class BlobSasPermissions(object):
     :keyword bool set_immutability_policy:
         To enable operations related to set/delete immutability policy.
         To get immutability policy, you just need read permission.
+    :keyword bool list:
+        List blobs in a directory or the specified prefix.
     """
 
     read: bool = False
@@ -1137,6 +1139,8 @@ class BlobSasPermissions(object):
         get the POSIX ACL of a blob."""
     set_immutability_policy: Optional[bool]
     """To get immutability policy, you just need read permission."""
+    list: Optional[bool]
+    """List blobs in a directory or the specified prefix."""
 
     def __init__(
         self,
@@ -1160,6 +1164,7 @@ class BlobSasPermissions(object):
         self.move = kwargs.pop("move", False)
         self.execute = kwargs.pop("execute", False)
         self.set_immutability_policy = kwargs.pop("set_immutability_policy", False)
+        self.list = kwargs.pop("list", False)
         self._str = (
             ("r" if self.read else "")
             + ("a" if self.add else "")
@@ -1168,6 +1173,7 @@ class BlobSasPermissions(object):
             + ("d" if self.delete else "")
             + ("x" if self.delete_previous_version else "")
             + ("y" if self.permanent_delete else "")
+            + ("l" if self.list else "")
             + ("t" if self.tag else "")
             + ("m" if self.move else "")
             + ("e" if self.execute else "")
@@ -1197,6 +1203,7 @@ class BlobSasPermissions(object):
         p_delete = "d" in permission
         p_delete_previous_version = "x" in permission
         p_permanent_delete = "y" in permission
+        p_list = "l" in permission
         p_tag = "t" in permission
         p_move = "m" in permission
         p_execute = "e" in permission
@@ -1211,6 +1218,7 @@ class BlobSasPermissions(object):
             delete_previous_version=p_delete_previous_version,
             tag=p_tag,
             permanent_delete=p_permanent_delete,
+            list=p_list,
             move=p_move,
             execute=p_execute,
             set_immutability_policy=p_set_immutability_policy,

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3094,11 +3094,12 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
     def test_set_blob_permission(self):
         # Arrange
-        permission = BlobSasPermissions.from_string("wrdx")
+        permission = BlobSasPermissions.from_string("wrdxl")
         assert permission.read == True
         assert permission.delete == True
         assert permission.write == True
-        assert permission._str == "rwdx"
+        assert permission.list == True
+        assert permission._str == "rwdxl"
 
     @BlobPreparer()
     @recorded_by_proxy


### PR DESCRIPTION
# Description

This addresses an issue where `BlobSasPermissions` does not expose the `List` parameter. This resolves #48022. 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
