### PR TITLE
[ContentUnderstanding] Set 1.2.0b3 release date to 2026-08-11

### DIFF
--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0b3 (Unreleased)
+## 1.2.0b3 (2026-08-11)
 
 ### Features Added
 

--- a/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/azure-ai-contentunderstanding/CHANGELOG.md
@@ -16,10 +16,6 @@
   - Troubleshoot analyses with diagnostic information from `AnalysisResult.infos`. See [sample_analysis_diagnostics.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/contentunderstanding/azure-ai-contentunderstanding/samples/sample_analysis_diagnostics.py).
   - Track inline page usage and agentic workflow token consumption with expanded `UsageDetails`, available from `AnalyzeLROPoller.usage`, `AnalyzeAsyncLROPoller.usage`, and `ContentAnalyzerInlineResponse.usage`. See [sample_analyze_invoice.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/contentunderstanding/azure-ai-contentunderstanding/samples/sample_analyze_invoice.py), [sample_analyze_inline.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/contentunderstanding/azure-ai-contentunderstanding/samples/sample_analyze_inline.py), and [sample_analyze_binary_inline.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/contentunderstanding/azure-ai-contentunderstanding/samples/sample_analyze_binary_inline.py).
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - Renamed the optional `to_llm_input` caller dictionary from `metadata` to `custom_metadata`; it is emitted under a nested `customMetadata:` front-matter block.


### PR DESCRIPTION
Updates the `azure-ai-contentunderstanding` CHANGELOG header from `## 1.2.0b3 (Unreleased)` to `## 1.2.0b3 (2026-08-11)` so the [python - contentunderstanding](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8029) release pipeline will accept the release.

Companion to #48516, which contains the `2026-06-01-preview` SDK changes for `1.2.0b3`.

## Validation

- Version: `1.2.0b3`
- Classifier: Beta
- Package CI for #48516: passed