### PR TITLE
[AgentServer] Set StateStore release dates

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.1.0b1 (2026-08-06)
+## 2.1.0b1 (2026-08-11)
 
 ### Features Added
 
@@ -13,11 +13,6 @@
   and no longer shares task lifecycle PATCHes or lease renewal. Typed task
   inputs may carry a top-level `call_id`, which the framework restores in
   `FoundryAgentRequestContext` for every handler attempt.
-
-### Other Changes
-
-- Updated AgentServer durability guidance to use explicit `FoundryStateStore`
-  application state across Core, Invocations, and Responses.
 
 ## 2.0.0 (2026-08-05)
 

--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -14,6 +14,11 @@
   inputs may carry a top-level `call_id`, which the framework restores in
   `FoundryAgentRequestContext` for every handler attempt.
 
+### Other Changes
+
+- Updated AgentServer durability guidance to use explicit `FoundryStateStore`
+  application state across Core, Invocations, and Responses.
+
 ## 2.0.0 (2026-08-05)
 
 ### Other Changes

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Samples
 
 - Simplified the resilient samples to use conversation-scoped `FoundryStateStore` instances directly for application state.
+- Migrated the resilient LangGraph, multi-turn, and research samples from task
+  metadata and custom file stores to direct State Store checkpoints.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 1.1.0b1 (2026-08-07)
+## 1.1.0b1 (2026-08-11)
 
 ### Samples
 
 - Simplified the resilient samples to use conversation-scoped `FoundryStateStore` instances directly for application state.
-- Migrated the resilient LangGraph, multi-turn, and research samples from task
-  metadata and custom file stores to direct State Store checkpoints.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.1.0b1 (2026-08-07)
+## 2.1.0b1 (2026-08-11)
 
 ### Breaking Changes
 
@@ -13,9 +13,6 @@
 
 - Updated the resilient Responses samples to use conversation-scoped
   `FoundryStateStore` instances directly.
-- Updated resilient response guidance to use framework response checkpoints for
-  response-local recovery and explicit State Store persistence for cross-turn
-  application state.
 - Bumped the minimum `azure-ai-agentserver-core` dependency to `>=2.1.0b1`,
   which adds the local `FoundryStateStore` fallback used by the samples.
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 - Updated the resilient Responses samples to use conversation-scoped
   `FoundryStateStore` instances directly.
+- Updated resilient response guidance to use framework response checkpoints for
+  response-local recovery and explicit State Store persistence for cross-turn
+  application state.
 - Bumped the minimum `azure-ai-agentserver-core` dependency to `>=2.1.0b1`,
   which adds the local `FoundryStateStore` fallback used by the samples.
 


### PR DESCRIPTION
## Summary

- set the `azure-ai-agentserver-core` 2.1.0b1 release date to 2026-08-11
- set the `azure-ai-agentserver-invocations` 1.1.0b1 release date to 2026-08-11
- set the `azure-ai-agentserver-responses` 2.1.0b1 release date to 2026-08-11