### PR TITLE
[EngSys] Add fallback owner and approver for ESRP publishing

### DIFF
--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -83,5 +83,3 @@ extends:
                   - template: /eng/pipelines/templates/steps/esrp-publish.yml
                     parameters:
                       targetFolder: $(Pipeline.Workspace)/esrp-release/
-                      owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                      approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}

--- a/eng/pipelines/templates/steps/esrp-publish.yml
+++ b/eng/pipelines/templates/steps/esrp-publish.yml
@@ -1,12 +1,6 @@
 parameters:
   - name: targetFolder
     type: string
-  - name: owners
-    type: string
-    default: $(Build.RequestedForEmail)
-  - name: approvers
-    type: string
-    default: $(Build.RequestedForEmail)
 steps:
   - task: EsrpRelease@11
     displayName: 'Publish to ESRP'
@@ -20,7 +14,7 @@ steps:
       Intent: 'PackageDistribution'
       ContentType: 'PyPI'
       FolderLocation: ${{parameters.targetFolder}}
-      Owners: ${{parameters.owners}}
-      Approvers: ${{parameters.approvers}}
+      Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+      Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
       ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
       MainPublisher: 'ESRPRELPACMANTEST'


### PR DESCRIPTION
# Description

Adds `azuresdk@microsoft.com` as the fallback owner and approver for the shared ESRP publish step when `Build.RequestedForEmail` is unavailable. This centralizes the fallback in `esrp-publish.yml` and removes the redundant parameters from the partner release stage.

# All SDK Contribution checklist

- [x] The pull request does not introduce breaking changes.
- [x] A CHANGELOG update is not required because this only changes engineering pipeline templates.
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).

## General Guidelines and Best Practices

- [x] The pull request title is clear and informative.
- [x] The pull request contains one commit with an informative message.

### Testing Guidelines

- [x] Test coverage is not applicable to this pipeline-template-only change.