### PR TITLE
Add daily CFS feed warm-up and make azpysdk tool pins scannable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,21 @@ export PIP_INDEX_URL="https://your-azure-username:your-pat-token@pkgs.dev.azure.
 uv pip install <package> --index-url https://pypi.org/simple/
 ```
 
+#### Keeping the CFS feed warm
+
+Because CFS only serves versions it has already cached (and unauthenticated CI
+runs cannot trigger an upstream pull-through), a scheduled pipeline keeps the feed
+warm. `eng/scripts/warm_cfs_feed.py` scans every declared dependency in the repo —
+all `dev_requirements.txt` files, every `pyproject.toml`, the shared `eng/*.txt`
+requirement files, and the `azpysdk` tool pins in `eng/tool_requirements/` — and
+runs `pip download` (including transitive dependencies) against CFS so the latest
+versions are cached before an unauthenticated build needs them.
+
+The static-analysis tools that `azpysdk` installs at runtime (mypy, pylint,
+pyright, sphinx, black, bandit, ...) are pinned in `eng/tool_requirements/*.txt`.
+That is the single source of truth for those versions; bump a tool by editing the
+relevant file there rather than hardcoding a version in the check modules.
+
 ### Dev Feed
 Daily dev build version of Azure sdk packages for python are available and are uploaded to Azure devops feed daily. Below is the link to Azure devops feed.
 [`https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-python`](https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,14 @@ requirement files, and the `azpysdk` tool pins in `eng/tool_requirements/` — a
 runs `pip download` (including transitive dependencies) against CFS so the latest
 versions are cached before an unauthenticated build needs them.
 
+Because our CI runs a matrix of Python versions across Linux, Windows and macOS,
+the script also does a cross-target pass: for every resolved package that ships
+compiled, platform-specific wheels (for example `cryptography`, `aiohttp`,
+`mypy`), it fetches the wheels for each configured `(python version, platform)`
+target so those are cached too. Pure-Python (`py3-none-any`) packages are covered
+by their single universal wheel. Use `--no-platform-matrix`, `--python-versions`
+and `--platforms` to control this pass.
+
 The static-analysis tools that `azpysdk` installs at runtime (mypy, pylint,
 pyright, sphinx, black, bandit, ...) are pinned in `eng/tool_requirements/*.txt`.
 That is the single source of truth for those versions; bump a tool by editing the

--- a/eng/pipelines/warm-cfs-feed.yml
+++ b/eng/pipelines/warm-cfs-feed.yml
@@ -1,0 +1,99 @@
+# Daily job that keeps the Central Feed Services (CFS) feed warm.
+#
+# CFS is an upstream pull-through cache for PyPI. Authenticated requests for a
+# not-yet-cached package version pull it through from PyPI and cache it forever;
+# unauthenticated pipelines (e.g. fork PR CI) can only read what is already
+# cached. This job runs authenticated on a daily schedule and `pip download`s the
+# full transitive closure of every dependency declared in the repo (including the
+# azpysdk static-analysis tool pins in eng/tool_requirements/), so the latest
+# transitive versions are cached before an unauthenticated CI run needs them.
+#
+# See eng/scripts/warm_cfs_feed.py for the scanning/download logic.
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 8 * * *"
+    displayName: Daily CFS feed warm-up (08:00 UTC)
+    branches:
+      include:
+        - main
+    always: true
+
+parameters:
+  - name: dryRun
+    displayName: Dry Run (discover dependencies without downloading)
+    type: boolean
+    default: false
+  - name: failOnError
+    displayName: Fail the job if any dependency could not be warmed
+    type: boolean
+    default: false
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: WarmCfsFeed
+        displayName: Warm CFS Feed
+
+        jobs:
+          - job: WarmCfsFeedJob
+            timeoutInMinutes: 180
+            displayName: Scan dependencies and warm CFS feed
+            variables:
+              - template: /eng/pipelines/templates/variables/globals.yml
+              - name: dryRunArg
+                ${{ if eq(parameters.dryRun, true) }}:
+                  value: '--dry-run'
+                ${{ else }}:
+                  value: ''
+              - name: failOnErrorArg
+                ${{ if eq(parameters.failOnError, true) }}:
+                  value: '--fail-on-error'
+                ${{ else }}:
+                  value: ''
+
+            pool:
+              name: azsdk-pool
+              image: ubuntu-24.04
+              os: linux
+
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: '$(Build.ArtifactStagingDirectory)/cfs-warm-report'
+                  artifactName: 'cfs-warm-report'
+                  condition: succeededOrFailed()
+                  sbomEnabled: false
+
+            steps:
+              - checkout: self
+
+              - template: /eng/pipelines/templates/steps/use-python-version.yml
+                parameters:
+                  versionSpec: '3.11'
+
+              # Authenticate to the feed so pip download can pull-through from PyPI upstream.
+              - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+                parameters:
+                  EnableTwineAuth: false
+                  EnableUvAuth: false
+
+              - script: |
+                  python -m pip install --upgrade pip
+                  python -m pip install "eng/tools/azure-sdk-tools"
+                displayName: 'Prep Environment'
+
+              - script: |
+                  mkdir -p "$(Build.ArtifactStagingDirectory)/cfs-warm-report"
+                  python eng/scripts/warm_cfs_feed.py \
+                    $(dryRunArg) \
+                    $(failOnErrorArg) \
+                    --report "$(Build.ArtifactStagingDirectory)/cfs-warm-report/report.json"
+                displayName: 'Warm CFS feed'
+                env:
+                  # PIP_INDEX_URL is set (with embedded credentials) by the auth step above;
+                  # warm_cfs_feed.py defaults --index-url to it.
+                  PIP_INDEX_URL: $(PIP_INDEX_URL)

--- a/eng/scripts/warm_cfs_feed.py
+++ b/eng/scripts/warm_cfs_feed.py
@@ -46,6 +46,26 @@ The script aggregates requirement specifiers from:
 First-party / local entries (editable installs, relative paths, and the
 first-party ``azure-*`` packages that live in this repo) are skipped: they are
 built and published by our own pipelines and are not pulled from PyPI upstream.
+
+Python-version and platform-specific wheels
+-------------------------------------------
+``pip download`` only fetches the artifacts compatible with the interpreter and
+platform it runs on, and it evaluates environment markers for *that* environment.
+On its own that leaves gaps, because our CI runs a matrix of Python versions
+(3.10 - 3.14) across Linux, Windows and macOS, and packages such as
+``cryptography``, ``aiohttp`` and ``mypy`` ship compiled, per-``(python, platform)``
+wheels (``cp312-...-win_amd64``, ``cp310-...-manylinux_...`` and so on).
+
+To cover that, after the primary "native" download (which resolves the full
+dependency closure and caches sdists plus the runner-native wheels), the script
+does a second **cross-target** pass: for every resolved ``name==version`` that is
+*not* a universal ``py3-none-any`` wheel, it runs a targeted
+``pip download --no-deps --only-binary=:all: --python-version <v> --platform <p>``
+for each configured ``(python version, platform)`` target so the corresponding
+wheels get pulled through and cached too. Universal (pure-Python) packages are
+skipped in this pass because a single ``*-none-any`` wheel already serves every
+target. Missing wheels for a given target are expected (many packages do not
+publish one) and are not treated as errors.
 """
 
 from __future__ import annotations
@@ -60,6 +80,13 @@ from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
 
 from ci_tools.functions import discover_targeted_packages
 from ci_tools.parsing import ParsedSetup
@@ -67,6 +94,22 @@ from ci_tools.parsing.parse_functions import get_pyproject_dict
 from ci_tools.variables import discover_repo_root
 
 CFS_INDEX_URL = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+
+# Default cross-target matrix, grounded in eng/pipelines/templates/stages/platform-matrix.json
+# (Linux + Windows on 3.10/3.12, macOS on 3.11, Linux on 3.13/3.14). These are the
+# CPython (python_version, pip --platform tag) pairs whose binary wheels we warm.
+DEFAULT_TARGET_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+DEFAULT_TARGET_PLATFORMS = [
+    # Linux (manylinux). The 2014 tag is compatible with older tags too; pip picks
+    # the most-specific available wheel for each.
+    "manylinux2014_x86_64",
+    "manylinux_2_17_x86_64",
+    # Windows
+    "win_amd64",
+    # macOS (both Apple Silicon and Intel)
+    "macosx_11_0_arm64",
+    "macosx_10_9_x86_64",
+]
 
 # Requirement files at well-known locations that are not attached to a single package.
 SHARED_REQUIREMENT_FILES = [
@@ -293,6 +336,97 @@ def pip_download(spec: str, dest: str, index_url: str, python_executable: str) -
     return False, (result.stderr or result.stdout).strip()
 
 
+def _abi_for_python(python_version: str) -> str:
+    """Return the CPython ABI tag for a dotted python version (e.g. '3.12' -> 'cp312')."""
+    return "cp" + python_version.replace(".", "")
+
+
+def classify_downloaded(dest: str) -> Tuple[Set[Tuple[str, str]], Set[Tuple[str, str]]]:
+    """Inspect files in *dest* produced by the native pass.
+
+    :returns: a tuple ``(universal, needs_cross_target)`` of ``(canonical_name, version)``
+        pairs. ``universal`` are packages already covered by a ``py3-none-any`` wheel;
+        ``needs_cross_target`` are packages that resolved to a platform-specific wheel or
+        to an sdist only (so per-target binary wheels may exist and should be warmed).
+    """
+    universal: Set[Tuple[str, str]] = set()
+    platform_specific: Set[Tuple[str, str]] = set()
+    sdist_only: Set[Tuple[str, str]] = set()
+
+    for entry in os.listdir(dest):
+        if entry.endswith(".whl"):
+            try:
+                name, version, _build, tags = parse_wheel_filename(entry)
+            except InvalidWheelFilename:
+                continue
+            key = (str(name), str(version))
+            # A universal wheel has platform tag "any" and an abi of "none".
+            if any(tag.platform == "any" and tag.abi == "none" for tag in tags):
+                universal.add(key)
+            else:
+                platform_specific.add(key)
+        elif entry.endswith((".tar.gz", ".zip")):
+            try:
+                name, version = parse_sdist_filename(entry)
+            except (InvalidSdistFilename, ValueError):
+                continue
+            sdist_only.add((str(name), str(version)))
+
+    # Anything with a universal wheel is fully covered regardless of an also-present sdist.
+    needs_cross_target = (platform_specific | sdist_only) - universal
+    return universal, needs_cross_target
+
+
+def pip_download_target(
+    name: str,
+    version: str,
+    dest: str,
+    index_url: str,
+    python_executable: str,
+    python_version: str,
+    platform_tag: str,
+) -> Tuple[bool, str]:
+    """Download the wheel of ``name==version`` for a specific (python, platform) target.
+
+    Uses ``--no-deps --only-binary=:all:`` because cross-target resolution cannot
+    build sdists; the exact version is already known from the native pass, so no
+    dependency resolution is needed. A missing wheel for the target is a normal,
+    expected outcome (returned as a soft failure for reporting only).
+    """
+    command = [
+        python_executable,
+        "-m",
+        "pip",
+        "download",
+        f"{name}=={version}",
+        "--dest",
+        dest,
+        "--index-url",
+        index_url,
+        "--no-deps",
+        "--only-binary=:all:",
+        "--python-version",
+        python_version,
+        "--implementation",
+        "cp",
+        "--abi",
+        _abi_for_python(python_version),
+        "--platform",
+        platform_tag,
+        "--pre",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode == 0:
+        return True, ""
+    return False, (result.stderr or result.stdout).strip()
+
+
+def _parse_csv_option(value: Optional[str], default: List[str]) -> List[str]:
+    if value is None:
+        return list(default)
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
@@ -319,6 +453,29 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--fail-on-error",
         action="store_true",
         help="Exit non-zero if any requirement failed to download. By default the daily job exits 0 and just reports.",
+    )
+    parser.add_argument(
+        "--no-platform-matrix",
+        dest="platform_matrix",
+        action="store_false",
+        default=True,
+        help="Disable the cross-target pass that warms per-(python version, platform) binary wheels.",
+    )
+    parser.add_argument(
+        "--python-versions",
+        default=None,
+        help=(
+            "Comma-separated CPython versions to warm binary wheels for "
+            f"(default: {','.join(DEFAULT_TARGET_PYTHON_VERSIONS)})."
+        ),
+    )
+    parser.add_argument(
+        "--platforms",
+        default=None,
+        help=(
+            "Comma-separated pip platform tags to warm binary wheels for "
+            f"(default: {','.join(DEFAULT_TARGET_PLATFORMS)})."
+        ),
     )
     return parser
 
@@ -363,6 +520,55 @@ def main(argv: Optional[List[str]] = None) -> int:
             else:
                 print(f"[warn] failed to warm {spec}: {error.splitlines()[-1] if error else 'unknown error'}")
                 failed.append({"spec": spec, "origins": spec_to_origins[spec], "error": error})
+
+        # Cross-target pass: warm per-(python, platform) binary wheels for packages
+        # that are not already covered by a universal py3-none-any wheel.
+        matrix_summary: Dict[str, object] = {"enabled": args.platform_matrix}
+        if args.platform_matrix:
+            target_python_versions = _parse_csv_option(args.python_versions, DEFAULT_TARGET_PYTHON_VERSIONS)
+            target_platforms = _parse_csv_option(args.platforms, DEFAULT_TARGET_PLATFORMS)
+            universal, needs_cross_target = classify_downloaded(dest)
+            targets = [(pv, plat) for pv in target_python_versions for plat in target_platforms]
+
+            print(
+                f"[info] cross-target pass: {len(needs_cross_target)} binary packages "
+                f"x {len(targets)} targets "
+                f"({len(universal)} universal packages skipped)"
+            )
+
+            wheels_warmed = 0
+            targets_missing = 0
+            for name, version in sorted(needs_cross_target):
+                for python_version, platform_tag in targets:
+                    ok, _error = pip_download_target(
+                        name,
+                        version,
+                        dest,
+                        args.index_url,
+                        sys.executable,
+                        python_version,
+                        platform_tag,
+                    )
+                    if ok:
+                        wheels_warmed += 1
+                    else:
+                        # A missing wheel for a given target is expected, not an error.
+                        targets_missing += 1
+
+            matrix_summary.update(
+                {
+                    "python_versions": target_python_versions,
+                    "platforms": target_platforms,
+                    "binary_packages": len(needs_cross_target),
+                    "universal_packages_skipped": len(universal),
+                    "target_wheels_warmed": wheels_warmed,
+                    "target_wheels_missing": targets_missing,
+                }
+            )
+            print(
+                f"[info] cross-target pass done: {wheels_warmed} wheels warmed, "
+                f"{targets_missing} (package, target) combinations had no wheel"
+            )
     finally:
         if dest_context is not None:
             dest_context.cleanup()
@@ -374,6 +580,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "succeeded": len(succeeded),
         "failed": len(failed),
         "skipped_first_party": len(skipped_first_party),
+        "cross_target": matrix_summary,
         "failures": failed,
     }
 

--- a/eng/scripts/warm_cfs_feed.py
+++ b/eng/scripts/warm_cfs_feed.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Warm the Azure SDK Central Feed Services (CFS) feed with every third-party
+dependency declared anywhere in this repository.
+
+Background
+----------
+This repository installs all packages from the CFS feed
+(``https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/``)
+instead of directly from PyPI. CFS is an *upstream pull-through* cache: an
+**authenticated** request for a package version that CFS has not seen yet causes
+CFS to fetch (and permanently cache) it from PyPI. **Unauthenticated** pipelines
+(for example CI runs for pull requests from forks) can only read versions that
+CFS has *already* cached -- they cannot trigger a pull-through.
+
+That asymmetry is the failure mode this script exists to prevent. A tool such as
+``mypy`` has transitive dependencies that are not strictly pinned. When one of
+those transitive dependencies publishes a new release, an unauthenticated CI job
+that resolves ``mypy`` to that brand-new (uncached) transitive version fails,
+because CFS does not have it and the job cannot authenticate to pull it through.
+
+Running this script on a daily authenticated schedule keeps CFS warm: for every
+dependency declared in the repo we run ``pip download`` (which resolves and
+downloads the **full transitive closure**) against the CFS feed. Because we do
+*not* pass ``--no-deps``, the current-latest transitive versions get pulled
+through and cached, so the next unauthenticated CI run finds them already present.
+
+What counts as a "declared dependency"
+--------------------------------------
+The script aggregates requirement specifiers from:
+
+* every ``dev_requirements.txt`` in the repo,
+* every package's ``pyproject.toml`` (``[project].dependencies`` and
+  ``[project.optional-dependencies]``),
+* the shared/engineering requirement files
+  (``shared_requirements.txt``, ``eng/ci_tools.txt``, ``eng/test_tools.txt``,
+  ``eng/dependency_tools.txt``, ``eng/release_requirements.txt``),
+* the ``azpysdk`` static-analysis tool pins in ``eng/tool_requirements/*.txt``
+  (mypy, pylint, pyright, sphinx, black, bandit, ... -- this is precisely the set
+  that used to be invisible because it was hardcoded in Python).
+
+First-party / local entries (editable installs, relative paths, and the
+first-party ``azure-*`` packages that live in this repo) are skipped: they are
+built and published by our own pipelines and are not pulled from PyPI upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+from ci_tools.functions import discover_targeted_packages
+from ci_tools.parsing import ParsedSetup
+from ci_tools.parsing.parse_functions import get_pyproject_dict
+from ci_tools.variables import discover_repo_root
+
+CFS_INDEX_URL = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+
+# Requirement files at well-known locations that are not attached to a single package.
+SHARED_REQUIREMENT_FILES = [
+    "shared_requirements.txt",
+    os.path.join("eng", "ci_tools.txt"),
+    os.path.join("eng", "test_tools.txt"),
+    os.path.join("eng", "dependency_tools.txt"),
+    os.path.join("eng", "release_requirements.txt"),
+]
+
+# Directory names that never contain declared dependencies we care about.
+_PRUNE_DIRS = {
+    ".git",
+    ".venv",
+    ".tox",
+    "node_modules",
+    "build",
+    "dist",
+    ".eggs",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+
+
+class RequirementSource:
+    """A single requirement specifier and where it came from (for reporting)."""
+
+    __slots__ = ("spec", "name", "origin")
+
+    def __init__(self, spec: str, name: str, origin: str) -> None:
+        self.spec = spec
+        self.name = name
+        self.origin = origin
+
+
+def _looks_like_local(line: str) -> bool:
+    """Return True for editable installs, path installs, and pip control flags.
+
+    These are first-party or local references that are not pulled from PyPI and
+    therefore should not be sent to ``pip download`` against the CFS feed.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return True
+    # editable installs / nested-or-constraint file includes
+    if stripped.startswith(("-e ", "--editable")):
+        return True
+    if stripped.startswith(("-r ", "--requirement", "-c ", "--constraint", "-f ", "--find-links")):
+        return True
+    # bare pip options (e.g. --index-url=...); the caller controls the index
+    if stripped.startswith("-"):
+        return True
+    # relative / absolute path references (../../core/azure-core, ./foo, C:\...)
+    if stripped.startswith((".", "/")) or (len(stripped) > 1 and stripped[1] == ":"):
+        return True
+    # URL / VCS installs
+    if "://" in stripped:
+        return True
+    return False
+
+
+def _parse_requirement_line(line: str) -> Optional[Requirement]:
+    """Parse a single requirements-file line into a Requirement, or None to skip."""
+    # strip inline comments and environment-marker-safe trailing whitespace
+    content = line.split(" #", 1)[0].strip()
+    if _looks_like_local(content):
+        return None
+    try:
+        return Requirement(content)
+    except InvalidRequirement:
+        return None
+
+
+def _is_first_party(name: str, first_party: Set[str]) -> bool:
+    return name.lower() in first_party
+
+
+def iter_requirement_files(repo_root: str) -> Iterable[str]:
+    """Yield the absolute path of every ``dev_requirements.txt`` in the repo."""
+    for current, dirnames, filenames in os.walk(repo_root):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        if "dev_requirements.txt" in filenames:
+            yield os.path.join(current, "dev_requirements.txt")
+
+
+def collect_from_requirement_file(path: str, origin: str) -> List[RequirementSource]:
+    sources: List[RequirementSource] = []
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                requirement = _parse_requirement_line(line)
+                if requirement is not None:
+                    sources.append(RequirementSource(str(requirement), requirement.name, origin))
+    except OSError as exc:
+        print(f"[warn] could not read {path}: {exc}", file=sys.stderr)
+    return sources
+
+
+def collect_from_pyproject(package_dir: str) -> List[RequirementSource]:
+    """Collect [project].dependencies and [project.optional-dependencies]."""
+    sources: List[RequirementSource] = []
+    pyproject_path = os.path.join(package_dir, "pyproject.toml")
+    if not os.path.exists(pyproject_path):
+        return sources
+    try:
+        pyproject = get_pyproject_dict(pyproject_path)
+    except Exception as exc:  # pragma: no cover - malformed toml
+        print(f"[warn] could not parse {pyproject_path}: {exc}", file=sys.stderr)
+        return sources
+
+    project = pyproject.get("project", {}) if isinstance(pyproject, dict) else {}
+    if not project:
+        return sources
+    origin = pyproject_path
+
+    def _add(specifiers: Iterable[str]) -> None:
+        for spec in specifiers:
+            requirement = _parse_requirement_line(spec)
+            if requirement is not None:
+                sources.append(RequirementSource(str(requirement), requirement.name, origin))
+
+    _add(project.get("dependencies", []) or [])
+    for extra_specs in (project.get("optional-dependencies", {}) or {}).values():
+        _add(extra_specs or [])
+    return sources
+
+
+def discover_first_party_names(repo_root: str) -> Set[str]:
+    """Return the lowercased names of every package built from this repo.
+
+    These are skipped because they are published by our own pipelines, not pulled
+    from PyPI upstream.
+    """
+    names: Set[str] = set()
+    sdk_root = os.path.join(repo_root, "sdk")
+    search_root = sdk_root if os.path.isdir(sdk_root) else repo_root
+    try:
+        for package_dir in discover_targeted_packages("azure*", search_root, compatibility_filter=False):
+            try:
+                names.add(ParsedSetup.from_path(package_dir).name.lower())
+            except Exception:  # pragma: no cover - best effort discovery
+                continue
+    except Exception as exc:  # pragma: no cover - best effort discovery
+        print(f"[warn] first-party discovery failed: {exc}", file=sys.stderr)
+    return names
+
+
+def collect_all_sources(repo_root: str) -> List[RequirementSource]:
+    sources: List[RequirementSource] = []
+
+    # 1) dev_requirements.txt everywhere
+    for req_file in iter_requirement_files(repo_root):
+        sources.extend(collect_from_requirement_file(req_file, req_file))
+
+    # 2) pyproject.toml dependencies for every discovered package
+    sdk_root = os.path.join(repo_root, "sdk")
+    search_root = sdk_root if os.path.isdir(sdk_root) else repo_root
+    try:
+        package_dirs = discover_targeted_packages("azure*", search_root, compatibility_filter=False)
+    except Exception as exc:  # pragma: no cover - best effort discovery
+        print(f"[warn] package discovery failed: {exc}", file=sys.stderr)
+        package_dirs = []
+    for package_dir in package_dirs:
+        sources.extend(collect_from_pyproject(package_dir))
+
+    # 3) shared / engineering requirement files
+    for relative in SHARED_REQUIREMENT_FILES:
+        absolute = os.path.join(repo_root, relative)
+        if os.path.exists(absolute):
+            sources.extend(collect_from_requirement_file(absolute, absolute))
+
+    # 4) azpysdk static-analysis tool pins (formerly hardcoded in Python)
+    tool_requirements_dir = os.path.join(repo_root, "eng", "tool_requirements")
+    if os.path.isdir(tool_requirements_dir):
+        for entry in sorted(os.listdir(tool_requirements_dir)):
+            if entry.endswith(".txt"):
+                path = os.path.join(tool_requirements_dir, entry)
+                sources.extend(collect_from_requirement_file(path, path))
+
+    return sources
+
+
+def dedupe_specs(sources: List[RequirementSource], first_party: Set[str]) -> Tuple[Dict[str, List[str]], List[str]]:
+    """Return (spec -> [origins]) for third-party specs, and the skipped first-party names.
+
+    Specs are de-duplicated on their exact text so that distinct version
+    constraints for the same distribution are all warmed.
+    """
+    spec_to_origins: Dict[str, List[str]] = {}
+    skipped_first_party: Set[str] = set()
+    for source in sources:
+        if _is_first_party(source.name, first_party):
+            skipped_first_party.add(source.name.lower())
+            continue
+        spec_to_origins.setdefault(source.spec, [])
+        if source.origin not in spec_to_origins[source.spec]:
+            spec_to_origins[source.spec].append(source.origin)
+    return spec_to_origins, sorted(skipped_first_party)
+
+
+def pip_download(spec: str, dest: str, index_url: str, python_executable: str) -> Tuple[bool, str]:
+    """Download *spec* and its full transitive closure into *dest* from *index_url*.
+
+    Dependencies are intentionally included (no ``--no-deps``) so the whole
+    closure is pulled through into the CFS cache.
+    """
+    command = [
+        python_executable,
+        "-m",
+        "pip",
+        "download",
+        spec,
+        "--dest",
+        dest,
+        "--index-url",
+        index_url,
+        # allow pre-releases; some tool pins (and their deps) are pre-release
+        "--pre",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode == 0:
+        return True, ""
+    return False, (result.stderr or result.stdout).strip()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--index-url",
+        default=os.environ.get("PIP_INDEX_URL", CFS_INDEX_URL),
+        help="Feed to warm. Defaults to $PIP_INDEX_URL (set by the pipeline auth step) or the public CFS URL.",
+    )
+    parser.add_argument(
+        "--dest",
+        default=None,
+        help="Directory to download into. Defaults to a temporary directory that is removed afterwards.",
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="Optional path to write a JSON summary report (published as a pipeline artifact).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover and print the requirement set without downloading anything.",
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help="Exit non-zero if any requirement failed to download. By default the daily job exits 0 and just reports.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    repo_root = discover_repo_root()
+
+    print(f"[info] scanning repository for declared dependencies: {repo_root}")
+    first_party = discover_first_party_names(repo_root)
+    print(f"[info] discovered {len(first_party)} first-party packages (these are skipped)")
+
+    sources = collect_all_sources(repo_root)
+    spec_to_origins, skipped_first_party = dedupe_specs(sources, first_party)
+    specs = sorted(spec_to_origins)
+
+    print(f"[info] collected {len(sources)} requirement references")
+    print(f"[info] {len(specs)} unique third-party specifiers to warm")
+
+    if args.dry_run:
+        for spec in specs:
+            print(f"  {spec}")
+        print(f"[info] dry-run: skipped {len(skipped_first_party)} first-party distributions")
+        return 0
+
+    dest_context: Optional[tempfile.TemporaryDirectory] = None
+    if args.dest:
+        os.makedirs(args.dest, exist_ok=True)
+        dest = args.dest
+    else:
+        dest_context = tempfile.TemporaryDirectory(prefix="cfs-warm-")
+        dest = dest_context.name
+
+    succeeded: List[str] = []
+    failed: List[Dict[str, str]] = []
+    try:
+        for index, spec in enumerate(specs, start=1):
+            print(f"[{index}/{len(specs)}] pip download {spec}")
+            ok, error = pip_download(spec, dest, args.index_url, sys.executable)
+            if ok:
+                succeeded.append(spec)
+            else:
+                print(f"[warn] failed to warm {spec}: {error.splitlines()[-1] if error else 'unknown error'}")
+                failed.append({"spec": spec, "origins": spec_to_origins[spec], "error": error})
+    finally:
+        if dest_context is not None:
+            dest_context.cleanup()
+
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "index_url": args.index_url,
+        "total_unique_specs": len(specs),
+        "succeeded": len(succeeded),
+        "failed": len(failed),
+        "skipped_first_party": len(skipped_first_party),
+        "failures": failed,
+    }
+
+    print(
+        f"[info] done: {len(succeeded)} warmed, {len(failed)} failed, "
+        f"{len(skipped_first_party)} first-party skipped"
+    )
+
+    if args.report:
+        with open(args.report, "w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2)
+        print(f"[info] wrote report to {args.report}")
+
+    if failed and args.fail_on_error:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eng/tool_requirements/README.md
+++ b/eng/tool_requirements/README.md
@@ -1,0 +1,26 @@
+# Static-analysis tool pins (`eng/tool_requirements/`)
+
+Pinned versions of the third-party tools that the `azpysdk` checks install at
+runtime (mypy, pylint, pyright, sphinx, black, bandit, breaking-change checker).
+
+Historically these versions were hardcoded as constants inside each check module
+(for example `MYPY_VERSION = "1.19.1"` in `azpysdk/mypy.py`). That made them
+invisible to any tool that scans the repository's declared dependencies, so the
+daily CFS warm-up (`eng/scripts/warm_cfs_feed.py`) could not pre-cache the tools
+or — more importantly — their transitive dependencies. When an unpinned
+transitive dependency released a new version, unauthenticated PR pipelines (which
+can only read what CFS has already cached) failed.
+
+These files are the single source of truth for those pins:
+
+- The `azpysdk` checks load them via `azpysdk._tool_reqs`.
+- The daily warm-up script scans them (alongside every `dev_requirements.txt` and
+  `pyproject.toml`) and runs `pip download` so the full transitive closure is
+  pulled through into the CFS feed.
+
+Each file is an ordinary pip requirements file (one requirement per line, `#`
+comments allowed). Files suffixed `_next` hold the "next"/vNext tool versions
+tested by the `next-*` checks.
+
+To bump a tool version, edit the relevant file here — do not add the version back
+into the Python check modules.

--- a/eng/tool_requirements/bandit.txt
+++ b/eng/tool_requirements/bandit.txt
@@ -1,0 +1,3 @@
+# Pins for the azpysdk `bandit` check. Single source of truth (see README.md).
+bandit==1.6.2
+pbr

--- a/eng/tool_requirements/black.txt
+++ b/eng/tool_requirements/black.txt
@@ -1,0 +1,2 @@
+# Pins for the azpysdk `black` check. Single source of truth (see README.md).
+black==24.4.0

--- a/eng/tool_requirements/breaking.txt
+++ b/eng/tool_requirements/breaking.txt
@@ -1,0 +1,3 @@
+# Pins for the azpysdk `breaking` change check. Single source of truth (see README.md).
+# The breaking-change checker itself is installed from a local path (`-e`) in code.
+jsondiff==1.2.0

--- a/eng/tool_requirements/mypy.txt
+++ b/eng/tool_requirements/mypy.txt
@@ -1,0 +1,6 @@
+# Pins for the azpysdk `mypy` check. Single source of truth (see README.md).
+mypy==1.19.1
+types-chardet==5.0.4.6
+types-requests==2.31.0.6
+types-six==1.16.21.9
+types-redis==4.6.0.7

--- a/eng/tool_requirements/mypy_next.txt
+++ b/eng/tool_requirements/mypy_next.txt
@@ -1,0 +1,6 @@
+# Pins for the azpysdk `next-mypy` check. Single source of truth (see README.md).
+mypy==2.1.0
+types-chardet==5.0.4.6
+types-requests==2.31.0.6
+types-six==1.16.21.9
+types-redis==4.6.0.7

--- a/eng/tool_requirements/pylint.txt
+++ b/eng/tool_requirements/pylint.txt
@@ -1,0 +1,3 @@
+# Pins for the azpysdk `pylint` check. Single source of truth (see README.md).
+pylint==4.0.4
+azure-pylint-guidelines-checker==0.5.7

--- a/eng/tool_requirements/pylint_next.txt
+++ b/eng/tool_requirements/pylint_next.txt
@@ -1,0 +1,3 @@
+# Pins for the azpysdk `next-pylint` check. Single source of truth (see README.md).
+pylint==4.0.6
+azure-pylint-guidelines-checker==0.5.9

--- a/eng/tool_requirements/pyright.txt
+++ b/eng/tool_requirements/pyright.txt
@@ -1,0 +1,2 @@
+# Pins for the azpysdk `pyright` and `verifytypes` checks. Single source of truth (see README.md).
+pyright==1.1.407

--- a/eng/tool_requirements/pyright_next.txt
+++ b/eng/tool_requirements/pyright_next.txt
@@ -1,0 +1,2 @@
+# Pins for the azpysdk `next-pyright` check. Single source of truth (see README.md).
+pyright==1.1.411

--- a/eng/tool_requirements/sphinx.txt
+++ b/eng/tool_requirements/sphinx.txt
@@ -1,0 +1,5 @@
+# Pins for the azpysdk `sphinx` check. Single source of truth (see README.md).
+sphinx==8.2.0
+sphinx_rtd_theme==3.0.2
+myst_parser==4.0.1
+sphinxcontrib-jquery==4.1

--- a/eng/tool_requirements/sphinx_next.txt
+++ b/eng/tool_requirements/sphinx_next.txt
@@ -1,0 +1,5 @@
+# Pins for the azpysdk `next-sphinx` check. Single source of truth (see README.md).
+sphinx==8.2.0
+sphinx_rtd_theme==3.0.2
+myst_parser==4.0.1
+sphinxcontrib-jquery==4.1

--- a/eng/tools/azure-sdk-tools/azpysdk/_tool_reqs.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/_tool_reqs.py
@@ -1,0 +1,96 @@
+"""Helpers for loading the pinned versions of the third-party tools that the
+``azpysdk`` checks install at runtime (mypy, pylint, pyright, sphinx, ...).
+
+The pins live in ``eng/tool_requirements/<name>.txt`` so they are a single,
+machine-scannable source of truth. Keeping them out of the Python modules lets
+the daily CFS warm-up (``eng/scripts/warm_cfs_feed.py``) discover the tools and
+pre-cache their full transitive dependency closures in the CFS feed, which is
+what prevents unauthenticated PR pipelines from failing when an unpinned
+transitive dependency releases a new version.
+
+Each requirements file is an ordinary pip requirements file: one requirement per
+line, ``#`` comments and blank lines allowed.
+"""
+
+import os
+from typing import List
+
+from ci_tools.variables import discover_repo_root
+
+REPO_ROOT = discover_repo_root()
+
+# Folder that holds the pinned tool requirement files.
+TOOL_REQUIREMENTS_DIR = os.path.join(REPO_ROOT, "eng", "tool_requirements")
+
+
+def requirements_path(name: str) -> str:
+    """Return the absolute path to ``eng/tool_requirements/<name>.txt``.
+
+    :param str name: The requirements file stem (e.g. ``"mypy"`` or ``"pylint_next"``).
+    :rtype: str
+    """
+    return os.path.join(TOOL_REQUIREMENTS_DIR, f"{name}.txt")
+
+
+def load_requirements(name: str) -> List[str]:
+    """Load the requirement specifiers from ``eng/tool_requirements/<name>.txt``.
+
+    Comments (``#``) and blank lines are stripped. The returned list is suitable
+    for passing directly to :func:`ci_tools.functions.install_into_venv`.
+
+    :param str name: The requirements file stem (e.g. ``"mypy"`` or ``"pylint_next"``).
+    :return: The list of requirement specifiers, in file order.
+    :rtype: List[str]
+    """
+    path = requirements_path(name)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"No tool requirements file found at {path}")
+
+    specifiers: List[str] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            stripped = line.split("#", 1)[0].strip()
+            if stripped:
+                specifiers.append(stripped)
+    return specifiers
+
+
+def _requirement_name(specifier: str) -> str:
+    """Return the lowercased distribution name from a requirement specifier."""
+    from packaging.requirements import Requirement
+
+    return Requirement(specifier).name.lower()
+
+
+def pin(name: str, package: str) -> str:
+    """Return the single requirement specifier for ``package`` from ``<name>.txt``.
+
+    Useful when a check installs the packages from one file across multiple pip
+    invocations (e.g. pylint installs ``azure-pylint-guidelines-checker`` before
+    building the target package and ``pylint`` itself afterwards).
+
+    :param str name: The requirements file stem (e.g. ``"pylint"``).
+    :param str package: The distribution name to look up (e.g. ``"pylint"``).
+    :return: The full requirement specifier (e.g. ``"pylint==4.0.4"``).
+    :rtype: str
+    """
+    target = package.lower()
+    for specifier in load_requirements(name):
+        if _requirement_name(specifier) == target:
+            return specifier
+    raise KeyError(f"'{package}' is not listed in tool requirements file '{name}.txt'")
+
+
+def pinned_version(name: str, package: str) -> str:
+    """Return just the pinned version string for ``package`` from ``<name>.txt``.
+
+    :param str name: The requirements file stem (e.g. ``"mypy"``).
+    :param str package: The distribution name to look up (e.g. ``"mypy"``).
+    :return: The pinned version (e.g. ``"1.19.1"``), or empty string if unpinned.
+    :rtype: str
+    """
+    from packaging.requirements import Requirement
+
+    requirement = Requirement(pin(name, package))
+    specifiers = list(requirement.specifier)
+    return specifiers[0].version if specifiers else ""

--- a/eng/tools/azure-sdk-tools/azpysdk/bandit.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/bandit.py
@@ -6,12 +6,15 @@ import subprocess
 from subprocess import check_call, CalledProcessError
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.environment_exclusions import is_check_enabled
 from ci_tools.variables import in_ci, set_envvar_defaults
 from ci_tools.logging import logger
 from ci_tools.functions import install_into_venv, get_pip_command
 
-BANDIT_VERSION = "1.6.2"
+# Tool version is pinned in eng/tool_requirements/bandit.txt (single source of
+# truth). Constant is derived for backwards compatibility.
+BANDIT_VERSION = pinned_version("bandit", "bandit")
 
 
 class bandit(Check):
@@ -55,7 +58,7 @@ class bandit(Check):
 
             try:
                 # pbr is required by the pinned version of bandit
-                install_into_venv(executable, [f"bandit=={BANDIT_VERSION}", "pbr"], package_dir)
+                install_into_venv(executable, load_requirements("bandit"), package_dir)
             except CalledProcessError as e:
                 logger.error(f"Failed to install bandit and dependencies: {e}")
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/azpysdk/black.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/black.py
@@ -12,8 +12,11 @@ from ci_tools.environment_exclusions import is_check_enabled
 from ci_tools.logging import logger
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 
-BLACK_VERSION = "24.4.0"
+# Tool version is pinned in eng/tool_requirements/black.txt (single source of
+# truth). Constant is derived for backwards compatibility.
+BLACK_VERSION = pinned_version("black", "black")
 REPO_ROOT = discover_repo_root()
 
 
@@ -115,7 +118,7 @@ class black(Check):
         issues without modifying files.
         """
         try:
-            install_into_venv(executable, [f"black=={BLACK_VERSION}"], target_dir)
+            install_into_venv(executable, load_requirements("black"), target_dir)
         except CalledProcessError as e:
             logger.error(f"Failed to install black, skipping formatting: {e}")
             return None

--- a/eng/tools/azure-sdk-tools/azpysdk/breaking.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/breaking.py
@@ -7,12 +7,15 @@ from typing import Optional, List
 from subprocess import CalledProcessError, check_call
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.functions import install_into_venv
 from ci_tools.scenario.generation import create_package_and_install
 from ci_tools.variables import discover_repo_root, set_envvar_defaults
 from ci_tools.logging import logger
 
-JSONDIFF_VERSION = "1.2.0"
+# Tool version is pinned in eng/tool_requirements/breaking.txt (single source of
+# truth). Constant is derived for backwards compatibility.
+JSONDIFF_VERSION = pinned_version("breaking", "jsondiff")
 REPO_ROOT = discover_repo_root()
 BREAKING_CHECKER_PATH = os.path.join(REPO_ROOT, "scripts", "breaking_changes_checker")
 
@@ -141,7 +144,7 @@ class breaking(Check):
             try:
                 install_into_venv(
                     executable,
-                    [f"jsondiff=={JSONDIFF_VERSION}", "-e", BREAKING_CHECKER_PATH],
+                    load_requirements("breaking") + ["-e", BREAKING_CHECKER_PATH],
                     package_dir,
                 )
             except CalledProcessError as e:

--- a/eng/tools/azure-sdk-tools/azpysdk/mypy.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/mypy.py
@@ -7,20 +7,17 @@ from typing import Optional, List
 from subprocess import CalledProcessError, check_call
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.functions import install_into_venv
 from ci_tools.variables import in_ci, set_envvar_defaults
 from ci_tools.environment_exclusions import is_check_enabled, is_typing_ignored
 from ci_tools.logging import logger
 
 PYTHON_VERSION = "3.10"
-MYPY_VERSION = "1.19.1"
-NEXT_MYPY_VERSION = "2.1.0"
-ADDITIONAL_LOCKED_DEPENDENCIES = [
-    "types-chardet==5.0.4.6",
-    "types-requests==2.31.0.6",
-    "types-six==1.16.21.9",
-    "types-redis==4.6.0.7",
-]
+# Tool versions are pinned in eng/tool_requirements/{mypy,mypy_next}.txt (single
+# source of truth). Constants are derived for backwards compatibility.
+MYPY_VERSION = pinned_version("mypy", "mypy")
+NEXT_MYPY_VERSION = pinned_version("mypy_next", "mypy")
 
 
 class mypy(Check):
@@ -52,7 +49,6 @@ class mypy(Check):
                 os.chdir(parsed.folder)
             package_dir = parsed.folder
             package_name = parsed.name
-            additional_requirements = ADDITIONAL_LOCKED_DEPENDENCIES
 
             executable, staging_directory = self.get_executable(
                 args.isolate,
@@ -66,13 +62,10 @@ class mypy(Check):
             # # need to install dev_requirements to ensure that type-hints properly resolve
             self.install_dev_reqs(executable, args, package_dir)
 
-            # install mypy
+            # install mypy (and locked type stubs) from the pinned requirements file
             try:
-                if args.next:
-                    # use latest version of mypy
-                    install_into_venv(executable, [f"mypy=={NEXT_MYPY_VERSION}"] + additional_requirements, package_dir)
-                else:
-                    install_into_venv(executable, [f"mypy=={MYPY_VERSION}"] + additional_requirements, package_dir)
+                requirements = load_requirements("mypy_next" if args.next else "mypy")
+                install_into_venv(executable, requirements, package_dir)
             except CalledProcessError as e:
                 logger.error(f"Failed to install mypy: {e}")
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/azpysdk/pylint.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pylint.py
@@ -7,6 +7,7 @@ from typing import Optional, List
 from subprocess import CalledProcessError, check_call
 
 from .Check import Check
+from ._tool_reqs import pin, pinned_version
 from ci_tools.functions import install_into_venv
 from ci_tools.scenario.generation import create_package_and_install
 from ci_tools.variables import discover_repo_root, in_ci, set_envvar_defaults
@@ -14,10 +15,12 @@ from ci_tools.environment_exclusions import is_check_enabled
 from ci_tools.logging import logger, run_logged
 
 REPO_ROOT = discover_repo_root()
-PYLINT_VERSION = "4.0.4"
-PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.7"
-NEXT_PYLINT_VERSION = "4.0.6"
-NEXT_PYLINT_GUIDELINES_CHECKER_VERSION = "0.5.9"
+# Tool versions are pinned in eng/tool_requirements/{pylint,pylint_next}.txt
+# (single source of truth). Constants are derived for backwards compatibility.
+PYLINT_VERSION = pinned_version("pylint", "pylint")
+PYLINT_GUIDELINES_CHECKER_VERSION = pinned_version("pylint", "azure-pylint-guidelines-checker")
+NEXT_PYLINT_VERSION = pinned_version("pylint_next", "pylint")
+NEXT_PYLINT_GUIDELINES_CHECKER_VERSION = pinned_version("pylint_next", "azure-pylint-guidelines-checker")
 # README snippet files can contain independent code blocks, so imports may be
 # repeated or appear after executable statements when the blocks share a file.
 SNIPPET_SAMPLE_IMPORT_DISABLES = (
@@ -100,15 +103,10 @@ class pylint(Check):
             # install dependencies
             self.install_dev_reqs(executable, args, package_dir)
             try:
-                if args.next:
-                    # use latest version of azure-pylint-guidelines-checker for next pylint checks
-                    cmds = [
-                        f"azure-pylint-guidelines-checker=={NEXT_PYLINT_GUIDELINES_CHECKER_VERSION}",
-                    ]
-                else:
-                    cmds = [
-                        f"azure-pylint-guidelines-checker=={PYLINT_GUIDELINES_CHECKER_VERSION}",
-                    ]
+                req_file = "pylint_next" if args.next else "pylint"
+                cmds = [
+                    pin(req_file, "azure-pylint-guidelines-checker"),
+                ]
                 cmds.append(
                     "--index-url=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
                 )
@@ -136,11 +134,7 @@ class pylint(Check):
 
             # install pylint
             try:
-                if args.next:
-                    # use latest version of pylint
-                    install_into_venv(executable, [f"pylint=={NEXT_PYLINT_VERSION}"], package_dir)
-                else:
-                    install_into_venv(executable, [f"pylint=={PYLINT_VERSION}"], package_dir)
+                install_into_venv(executable, [pin(req_file, "pylint")], package_dir)
             except CalledProcessError as e:
                 logger.error(f"Failed to install pylint: {e}")
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/azpysdk/pyright.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/pyright.py
@@ -7,6 +7,7 @@ from typing import Optional, List
 from subprocess import CalledProcessError
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.functions import install_into_venv
 from ci_tools.variables import in_ci, set_envvar_defaults, discover_repo_root
 from ci_tools.environment_exclusions import is_check_enabled, is_typing_ignored
@@ -14,8 +15,10 @@ from ci_tools.scenario.generation import create_package_and_install
 
 from ci_tools.logging import logger
 
-PYRIGHT_VERSION = "1.1.407"
-NEXT_PYRIGHT_VERSION = "1.1.411"
+# Tool versions are pinned in eng/tool_requirements/{pyright,pyright_next}.txt
+# (single source of truth). Constants are derived for backwards compatibility.
+PYRIGHT_VERSION = pinned_version("pyright", "pyright")
+NEXT_PYRIGHT_VERSION = pinned_version("pyright_next", "pyright")
 REPO_ROOT = discover_repo_root()
 
 
@@ -89,11 +92,8 @@ class pyright(Check):
             logger.info(f"Processing {package_name} for pyright check")
 
             try:
-                if args.next:
-                    # use latest version of pyright
-                    install_into_venv(executable, [f"pyright=={NEXT_PYRIGHT_VERSION}"], package_dir)
-                else:
-                    install_into_venv(executable, [f"pyright=={PYRIGHT_VERSION}"], package_dir)
+                requirements = load_requirements("pyright_next" if args.next else "pyright")
+                install_into_venv(executable, requirements, package_dir)
             except CalledProcessError as e:
                 logger.error("Failed to install pyright:", e)
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/azpysdk/sphinx.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/sphinx.py
@@ -11,21 +11,23 @@ from subprocess import CalledProcessError, check_call
 from pathlib import Path
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.functions import install_into_venv, unzip_file_to_directory
 from ci_tools.scenario.generation import create_package_and_install
 from ci_tools.variables import in_ci, set_envvar_defaults, discover_repo_root, in_analyze_weekly
 
 from ci_tools.logging import logger
 
-# dependencies
-SPHINX_VERSION = "8.2.0"
-NEXT_SPHINX_VERSION = "8.2.0"
-SPHINX_RTD_THEME_VERSION = "3.0.2"
-NEXT_SPHINX_RTD_THEME_VERSION = "3.0.2"
-MYST_PARSER_VERSION = "4.0.1"
-NEXT_MYST_PARSER_VERSION = "4.0.1"
-SPHINX_CONTRIB_JQUERY_VERSION = "4.1"
-NEXT_SPHINX_CONTRIB_JQUERY_VERSION = "4.1"
+# Tool versions are pinned in eng/tool_requirements/{sphinx,sphinx_next}.txt
+# (single source of truth). Constants are derived for backwards compatibility.
+SPHINX_VERSION = pinned_version("sphinx", "sphinx")
+NEXT_SPHINX_VERSION = pinned_version("sphinx_next", "sphinx")
+SPHINX_RTD_THEME_VERSION = pinned_version("sphinx", "sphinx_rtd_theme")
+NEXT_SPHINX_RTD_THEME_VERSION = pinned_version("sphinx_next", "sphinx_rtd_theme")
+MYST_PARSER_VERSION = pinned_version("sphinx", "myst_parser")
+NEXT_MYST_PARSER_VERSION = pinned_version("sphinx_next", "myst_parser")
+SPHINX_CONTRIB_JQUERY_VERSION = pinned_version("sphinx", "sphinxcontrib-jquery")
+NEXT_SPHINX_CONTRIB_JQUERY_VERSION = pinned_version("sphinx_next", "sphinxcontrib-jquery")
 
 RST_EXTENSION_FOR_INDEX = """
 
@@ -257,28 +259,8 @@ class sphinx(Check):
 
             # install sphinx
             try:
-                if args.next:
-                    install_into_venv(
-                        executable,
-                        [
-                            f"sphinx=={NEXT_SPHINX_VERSION}",
-                            f"sphinx_rtd_theme=={NEXT_SPHINX_RTD_THEME_VERSION}",
-                            f"myst_parser=={NEXT_MYST_PARSER_VERSION}",
-                            f"sphinxcontrib-jquery=={NEXT_SPHINX_CONTRIB_JQUERY_VERSION}",
-                        ],
-                        package_dir,
-                    )
-                else:
-                    install_into_venv(
-                        executable,
-                        [
-                            f"sphinx=={SPHINX_VERSION}",
-                            f"sphinx_rtd_theme=={SPHINX_RTD_THEME_VERSION}",
-                            f"myst_parser=={MYST_PARSER_VERSION}",
-                            f"sphinxcontrib-jquery=={SPHINX_CONTRIB_JQUERY_VERSION}",
-                        ],
-                        package_dir,
-                    )
+                requirements = load_requirements("sphinx_next" if args.next else "sphinx")
+                install_into_venv(executable, requirements, package_dir)
             except CalledProcessError as e:
                 logger.error(f"Failed to install sphinx: {e}")
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/azpysdk/verifytypes.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/verifytypes.py
@@ -11,6 +11,7 @@ from typing import Optional, List
 from subprocess import CalledProcessError
 
 from .Check import Check
+from ._tool_reqs import load_requirements, pinned_version
 from ci_tools.functions import install_into_venv
 from ci_tools.scenario.generation import create_package_and_install
 from ci_tools.variables import discover_repo_root, in_ci, set_envvar_defaults
@@ -18,7 +19,9 @@ from ci_tools.environment_exclusions import is_check_enabled, is_typing_ignored
 from ci_tools.functions import get_pip_command
 from ci_tools.logging import logger
 
-PYRIGHT_VERSION = "1.1.407"
+# verifytypes uses the same pyright pin as the pyright check; the version is
+# pinned in eng/tool_requirements/pyright.txt (single source of truth).
+PYRIGHT_VERSION = pinned_version("pyright", "pyright")
 REPO_ROOT = discover_repo_root()
 
 
@@ -64,7 +67,7 @@ class verifytypes(Check):
 
             # install pyright
             try:
-                install_into_venv(executable, [f"pyright=={PYRIGHT_VERSION}"], package_dir)
+                install_into_venv(executable, load_requirements("pyright"), package_dir)
             except CalledProcessError as e:
                 logger.error(f"Failed to install pyright: {e}")
                 return e.returncode

--- a/eng/tools/azure-sdk-tools/tests/test_tool_reqs.py
+++ b/eng/tools/azure-sdk-tools/tests/test_tool_reqs.py
@@ -1,0 +1,38 @@
+from azpysdk import _tool_reqs
+
+
+def test_load_requirements_strips_comments_and_blanks():
+    specs = _tool_reqs.load_requirements("mypy")
+    assert "mypy==1.19.1" in specs
+    # the locked type stubs travel with the mypy pin
+    assert "types-requests==2.31.0.6" in specs
+    # comment lines and blank lines are not returned
+    assert all(not spec.startswith("#") for spec in specs)
+    assert all(spec.strip() for spec in specs)
+
+
+def test_pin_returns_single_specifier():
+    assert _tool_reqs.pin("pylint", "pylint") == "pylint==4.0.4"
+    assert _tool_reqs.pin("pylint", "azure-pylint-guidelines-checker") == "azure-pylint-guidelines-checker==0.5.7"
+
+
+def test_pin_is_case_insensitive():
+    assert _tool_reqs.pin("pylint", "PyLint") == "pylint==4.0.4"
+
+
+def test_pin_missing_package_raises():
+    try:
+        _tool_reqs.pin("black", "not-a-real-tool")
+    except KeyError:
+        return
+    raise AssertionError("expected KeyError for a package not listed in the file")
+
+
+def test_pinned_version_returns_version_only():
+    assert _tool_reqs.pinned_version("mypy", "mypy") == "1.19.1"
+    assert _tool_reqs.pinned_version("sphinx", "sphinxcontrib-jquery") == "4.1"
+
+
+def test_verifytypes_and_pyright_share_a_single_pin():
+    # verifytypes intentionally reuses pyright.txt so the pin lives in one place
+    assert _tool_reqs.load_requirements("pyright") == ["pyright==1.1.407"]

--- a/eng/tools/azure-sdk-tools/tests/test_warm_cfs_feed.py
+++ b/eng/tools/azure-sdk-tools/tests/test_warm_cfs_feed.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+
+import pytest
+
+# warm_cfs_feed.py is a standalone script under eng/scripts, not an installed
+# module, so load it by path. Its imports (ci_tools, packaging) are available
+# because these tests run with azure-sdk-tools installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+_SCRIPT_PATH = os.path.join(_REPO_ROOT, "eng", "scripts", "warm_cfs_feed.py")
+
+_spec = importlib.util.spec_from_file_location("warm_cfs_feed", _SCRIPT_PATH)
+warm_cfs_feed = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(warm_cfs_feed)
+
+
+def test_abi_for_python():
+    assert warm_cfs_feed._abi_for_python("3.12") == "cp312"
+    assert warm_cfs_feed._abi_for_python("3.9") == "cp39"
+
+
+def test_parse_csv_option_defaults_and_override():
+    assert warm_cfs_feed._parse_csv_option(None, ["3.10", "3.11"]) == ["3.10", "3.11"]
+    assert warm_cfs_feed._parse_csv_option("3.12, 3.13 ,", ["x"]) == ["3.12", "3.13"]
+
+
+def test_classify_downloaded_separates_universal_from_binary(tmp_path):
+    for filename in [
+        "mypy-1.19.1-cp312-cp312-win_amd64.whl",  # platform-specific wheel
+        "cryptography-44.0.3-cp39-abi3-manylinux2014_x86_64.whl",  # platform-specific wheel
+        "six-1.16.0-py2.py3-none-any.whl",  # universal wheel
+        "jsondiff-1.2.0.tar.gz",  # sdist only
+        "not-a-package.txt",  # ignored
+    ]:
+        (tmp_path / filename).write_text("", encoding="utf-8")
+
+    universal, needs_cross_target = warm_cfs_feed.classify_downloaded(str(tmp_path))
+
+    assert ("six", "1.16.0") in universal
+    assert ("six", "1.16.0") not in needs_cross_target
+    assert ("mypy", "1.19.1") in needs_cross_target
+    assert ("cryptography", "44.0.3") in needs_cross_target
+    assert ("jsondiff", "1.2.0") in needs_cross_target
+
+
+def test_classify_downloaded_universal_wins_over_sdist(tmp_path):
+    # A package that ships both a universal wheel and an sdist is fully covered.
+    (tmp_path / "click-8.1.7-py3-none-any.whl").write_text("", encoding="utf-8")
+    (tmp_path / "click-8.1.7.tar.gz").write_text("", encoding="utf-8")
+
+    universal, needs_cross_target = warm_cfs_feed.classify_downloaded(str(tmp_path))
+
+    assert ("click", "8.1.7") in universal
+    assert ("click", "8.1.7") not in needs_cross_target


### PR DESCRIPTION
# Add daily CFS feed warm-up and make azpysdk tool pins scannable

## Problem
This repo installs everything from the CFS pull-through feed instead of PyPI. CFS only serves versions it has already cached, and **unauthenticated** pipelines (fork PR CI) cannot trigger an upstream pull-through — they can only read what is already cached.

The static-analysis tools that `azpysdk` installs at runtime (mypy, pylint, pyright, sphinx, black, bandit, breaking) had their versions **hardcoded in Python** (e.g. `MYPY_VERSION = "1.19.1"`), invisible to any dependency scanner. When a tool's *unpinned transitive* dependency (e.g. one of mypy's deps) publishes a new release, an unauthenticated CI job resolves to that brand-new, uncached version and fails.

## Fix

### Part A — Make azpysdk tool deps scannable (single source of truth)
- Move the tool version pins out of the Python check modules into **`eng/tool_requirements/*.txt`** (`mypy`, `mypy_next`, `pylint`, `pylint_next`, `pyright`, `pyright_next`, `sphinx`, `sphinx_next`, `black`, `bandit`, `breaking`, + README).
- New loader **`azpysdk/_tool_reqs.py`** (`load_requirements`, `pin`, `pinned_version`) reads them from `REPO_ROOT/eng/tool_requirements/` — the same pattern `Check.py` already uses for `eng/test_tools.txt`/`pylintrc`, so **no packaging changes**.
- Refactored all 8 check modules to install from these files. The module-level `*_VERSION` constants are kept but derived from the files for backwards compatibility (nothing else imports them). `verifytypes` now reuses `pyright.txt`, removing a duplicate pin.

### Part B — Daily CFS warm-up
- **`eng/scripts/warm_cfs_feed.py`**: scans every declared dependency in the repo — all `dev_requirements.txt`, every `pyproject.toml` (deps + optional-deps), the shared `eng/*.txt` requirement files, and the new tool-requirement files — then runs `pip download` **with transitive dependencies** against the CFS feed. Continue-on-error, JSON report, `--dry-run` / `--index-url` / `--dest` / `--fail-on-error`.
- **`eng/pipelines/warm-cfs-feed.yml`**: runs the script daily, authenticated (via `auth-dev-feed.yml`, required for pull-through), and publishes the report artifact.

Because the daily authenticated job downloads each tool's **full closure at latest**, the unpinned transitive dep gets cached before unauthenticated PR pipelines resolve it.

## Validation
- New `tests/test_tool_reqs.py` (6 tests) + existing `test_pylint.py` / `test_breaking.py` pass.
- Full `azpysdk` CLI parser builds; all refactored modules import.
- Scanner `--dry-run` confirmed it discovers the tool pins (`mypy==1.19.1`/`2.1.0`, `pyright==1.1.407`/`1.1.411`, `black==24.4.0`, `sphinx==8.2.0`) alongside `pyproject.toml` deps (275 unique third-party specs; 416 first-party skipped).

## Notes / open questions
- Daily cadence leaves a small window if a transitive dep releases between runs (inherent to pull-through warming). Happy to add a lighter `--only-tool-requirements` fast path for a more frequent tools-only job if desired.
- Draft for review — please sanity-check the pipeline schedule/pool and the 1ES artifact output block.
