### PR TITLE
docs: validate conda recipe changes via internal pipeline

### DIFF
--- a/doc/dev/conda-release.md
+++ b/doc/dev/conda-release.md
@@ -52,7 +52,7 @@ The auto-generated PR includes:
 ### Review, Approve, and Cleanup (manual)
 
 1. **Review the PR.** Check the report in the pipeline output for any packages that encountered unexpected behavior and may need manual fixes.
-   - The PR triggers a [public build](https://dev.azure.com/azure-sdk/public/_build?definitionId=8092) which validates the changes to the Conda recipes.
+   - ⚠️ **Note:** The public conda validation pipeline has been disabled. The internal validation pipeline remains active and will validate changes during the build phase.
 
 2. **Merge the PR** into `main`.
 

--- a/doc/dev/conda-release.md
+++ b/doc/dev/conda-release.md
@@ -52,7 +52,7 @@ The auto-generated PR includes:
 ### Review, Approve, and Cleanup (manual)
 
 1. **Review the PR.** Check the report in the pipeline output for any packages that encountered unexpected behavior and may need manual fixes.
-   - ⚠️ **Note:** The public conda validation pipeline has been disabled. The internal validation pipeline remains active and will validate changes during the build phase.
+   - To validate the Conda recipe changes, manually queue a run of the internal **[Conda Build/Release Pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=6321)** against the PR branch.
 
 2. **Merge the PR** into `main`.
 


### PR DESCRIPTION
update conda release doc

we're getting rid of the public conda validation pipeline, so update doc accordingly