### PR TITLE
Docs: install opentelemetry-sdk in AI Inference tracing guide

### DIFF
--- a/sdk/ai/azure-ai-inference/README.md
+++ b/sdk/ai/azure-ai-inference/README.md
@@ -592,7 +592,7 @@ Check out your observability vendor documentation on how to configure OpenTeleme
 Make sure to install OpenTelemetry and the Azure SDK tracing plugin via
 
 ```bash
-pip install opentelemetry
+pip install opentelemetry-sdk
 pip install azure-core-tracing-opentelemetry
 ```
 


### PR DESCRIPTION
## Summary
Fixes #40617

Replaces the invalid `pip install opentelemetry` instruction in the Azure AI Inference tracing README with `pip install opentelemetry-sdk`, which matches OpenTelemetry Python docs and the package already shown in the nearby sample comments.

## Test plan
* [ ] Confirm the Installation section under Setup with OpenTelemetry installs a real PyPI package
* [ ] Confirm no other README content changed