### PR TITLE
Fix repeatable APIStub changelog generation

### DIFF
--- a/scripts/breaking_changes_checker/detect_breaking_changes.py
+++ b/scripts/breaking_changes_checker/detect_breaking_changes.py
@@ -775,6 +775,15 @@ def build_report_from_apistub(
     return report
 
 
+def _uninstall_package(package_name: str, pkg_dir: str) -> None:
+    """Remove an installed package so APIStub cannot reuse a same-version distribution."""
+    subprocess.run(
+        [sys.executable, "-m", "pip", "uninstall", "-y", package_name],
+        cwd=pkg_dir,
+        check=False,
+    )
+
+
 def _resolve_pypi_version(package_name: str, latest_pypi_version: bool) -> str:
     """Resolve the PyPI version to compare against.
 
@@ -838,12 +847,16 @@ def main(
         # match "current", producing an empty changelog.
         if not version:
             version = _resolve_pypi_version(package_name, latest_pypi_version)
-        # "current" is generated from the local source, "stable" from the
-        # resolved PyPI version.
-        current = build_report_from_apistub(package_name, pkg_dir, debug=debug, label="current", from_pypi=False)
+        # APIStub installs each target into this Python environment, and pip skips
+        # replacement when local and PyPI distributions have the same name/version.
+        # Clear both snapshots for repeatable runs, then install local last so it
+        # remains available to downstream SDK generation steps.
+        _uninstall_package(package_name, pkg_dir)
         stable = build_report_from_apistub(
             package_name, pkg_dir, version=version, debug=debug, label="stable", from_pypi=True
         )
+        _uninstall_package(package_name, pkg_dir)
+        current = build_report_from_apistub(package_name, pkg_dir, debug=debug, label="current", from_pypi=False)
         checker = compare_report_dicts(stable, current, package_name, changelog)
         print(checker.report_changes())
         if not changelog and checker.breaking_changes:

--- a/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
@@ -445,6 +445,7 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
     checker = mock.MagicMock()
     checker.report_changes.return_value = ""
     checker.breaking_changes = []
+    events = mock.Mock()
 
     with mock.patch("pypi_tools.pypi.PyPIClient", return_value=pypi_client) as pypi_client_cls, mock.patch.object(
         detect_breaking_changes, "_uninstall_package"
@@ -453,6 +454,8 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
     ) as build_report, mock.patch.object(
         detect_breaking_changes, "compare_report_dicts", return_value=checker
     ) as compare:
+        events.attach_mock(uninstall_package, "uninstall")
+        events.attach_mock(build_report, "build_report")
         detect_breaking_changes.main(
             package_name="azure-mgmt-network",
             target_module="azure.mgmt.network",
@@ -468,18 +471,28 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
         )
 
     assert build_report.call_count == 2, "Expected separate apistub reports for current and stable"
-    assert uninstall_package.call_count == 2, "Expected cleanup before both apistub reports"
-    uninstall_package.assert_has_calls(
+    events.assert_has_calls(
         [
-            mock.call("azure-mgmt-network", "/tmp/azure-mgmt-network"),
-            mock.call("azure-mgmt-network", "/tmp/azure-mgmt-network"),
-        ]
+            mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+            mock.call.build_report(
+                "azure-mgmt-network",
+                "/tmp/azure-mgmt-network",
+                version="30.2.0",
+                debug=False,
+                label="stable",
+                from_pypi=True,
+            ),
+            mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+            mock.call.build_report(
+                "azure-mgmt-network",
+                "/tmp/azure-mgmt-network",
+                debug=False,
+                label="current",
+                from_pypi=False,
+            ),
+        ],
+        any_order=False,
     )
-
-    # Generate the released snapshot first and local source last. Clearing the
-    # package before both calls makes repeated runs deterministic while leaving
-    # the local package installed for downstream generation steps.
-    assert [call.kwargs["label"] for call in build_report.call_args_list] == ["stable", "current"]
 
     # The resolver must force the public PyPI backend: in CI PIP_INDEX_URL points
     # at the curated Azure Artifacts feed, which is not a full mirror of PyPI.

--- a/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
@@ -414,6 +414,19 @@ def test_compare_code_reports_for_azure_mgmt_apimanagement_apistub():
     )
 
 
+def test_uninstall_package_uses_active_python_environment():
+    from breaking_changes_checker import detect_breaking_changes
+
+    with mock.patch.object(detect_breaking_changes.subprocess, "run") as run:
+        detect_breaking_changes._uninstall_package("azure-mgmt-network", "/tmp/azure-mgmt-network")
+
+    run.assert_called_once_with(
+        [sys.executable, "-m", "pip", "uninstall", "-y", "azure-mgmt-network"],
+        cwd="/tmp/azure-mgmt-network",
+        check=False,
+    )
+
+
 def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local():
     """``--use-apistub`` without ``-s`` must diff local source against the previous PyPI release.
 
@@ -434,6 +447,8 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
     checker.breaking_changes = []
 
     with mock.patch("pypi_tools.pypi.PyPIClient", return_value=pypi_client) as pypi_client_cls, mock.patch.object(
+        detect_breaking_changes, "_uninstall_package"
+    ) as uninstall_package, mock.patch.object(
         detect_breaking_changes, "build_report_from_apistub", return_value={}
     ) as build_report, mock.patch.object(
         detect_breaking_changes, "compare_report_dicts", return_value=checker
@@ -453,6 +468,18 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
         )
 
     assert build_report.call_count == 2, "Expected separate apistub reports for current and stable"
+    assert uninstall_package.call_count == 2, "Expected cleanup before both apistub reports"
+    uninstall_package.assert_has_calls(
+        [
+            mock.call("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+            mock.call("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+        ]
+    )
+
+    # Generate the released snapshot first and local source last. Clearing the
+    # package before both calls makes repeated runs deterministic while leaving
+    # the local package installed for downstream generation steps.
+    assert [call.kwargs["label"] for call in build_report.call_args_list] == ["stable", "current"]
 
     # The resolver must force the public PyPI backend: in CI PIP_INDEX_URL points
     # at the curated Azure Artifacts feed, which is not a full mirror of PyPI.

--- a/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_code_report_changelog.py
@@ -471,28 +471,25 @@ def test_use_apistub_changelog_resolves_stable_from_pypi_and_current_from_local(
         )
 
     assert build_report.call_count == 2, "Expected separate apistub reports for current and stable"
-    events.assert_has_calls(
-        [
-            mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
-            mock.call.build_report(
-                "azure-mgmt-network",
-                "/tmp/azure-mgmt-network",
-                version="30.2.0",
-                debug=False,
-                label="stable",
-                from_pypi=True,
-            ),
-            mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
-            mock.call.build_report(
-                "azure-mgmt-network",
-                "/tmp/azure-mgmt-network",
-                debug=False,
-                label="current",
-                from_pypi=False,
-            ),
-        ],
-        any_order=False,
-    )
+    assert events.mock_calls == [
+        mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+        mock.call.build_report(
+            "azure-mgmt-network",
+            "/tmp/azure-mgmt-network",
+            version="30.2.0",
+            debug=False,
+            label="stable",
+            from_pypi=True,
+        ),
+        mock.call.uninstall("azure-mgmt-network", "/tmp/azure-mgmt-network"),
+        mock.call.build_report(
+            "azure-mgmt-network",
+            "/tmp/azure-mgmt-network",
+            debug=False,
+            label="current",
+            from_pypi=False,
+        ),
+    ]
 
     # The resolver must force the public PyPI backend: in CI PIP_INDEX_URL points
     # at the curated Azure Artifacts feed, which is not a full mirror of PyPI.


### PR DESCRIPTION
## Summary

- uninstall the target distribution before generating each APIStub snapshot so equal local and PyPI versions cannot be reused by pip
- generate the released snapshot first and local snapshot last, leaving the local package installed for downstream SDK generation
- add regression coverage for snapshot ordering, repeated cleanup, and use of the active Python environment

## Context

When a generated local package and its latest PyPI release have the same distribution version, pip skips the second installation. APIStub can consequently compare the same package twice and emit an empty changelog. Cleanup is required before both snapshots so repeated invocations remain deterministic.

For #48565

## Validation

```bash
python -m pytest scripts/breaking_changes_checker/tests/test_code_report_changelog.py -q -m "not slow"
```

Result: `6 passed, 8 deselected`.