### PR TITLE
Update apistub.py

### DIFF
--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -115,6 +115,7 @@ class apistub(Check):
                 "--only-binary=:all:",
                 "-d",
                 staging_directory,
+                "--index-url=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/",
             ],
             cwd=staging_directory,
             check=True,


### PR DESCRIPTION
Download the SDK package from the internal feed to bypass the exception:
<img width="1210" height="40" alt="image" src="https://github.com/user-attachments/assets/59158cf4-c362-4f5c-a10b-17676521c7ea" />
https://dev.azure.com/azure-sdk/public/_build/results?buildId=6697246&view=logs&j=406f67d9-8952-5074-7a53-dcb346cb6a5f&t=ccc7497c-4498-591f-65a2-fc3e28e61219&l=1050