### PR TITLE
[agentserver] Gate blocking boot-time task recovery scan on the enablement flag

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_base.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_base.py
@@ -356,8 +356,26 @@ class AgentServerHost(Starlette):
                 set_task_manager(task_manager)
 
                 if _resilient_tasks_enabled() or _has_registered_tasks():
-                    await task_manager.startup()
-                    logger.info("TaskManager initialized with startup recovery")
+                    # The blocking cold-start recovery scan (Layer 1) runs only
+                    # when recovery was explicitly enabled. When a task subsystem
+                    # is present but the switch is off (e.g. a plain responses
+                    # host whose protocol registers internal primitives, or a
+                    # developer @task app that did not force-enable), Layer 1 is
+                    # skipped so boot is not gated on a task-store list() +
+                    # credential-token acquisition. Recovery is still provided by
+                    # the periodic background loop (Layer 2) and request-time
+                    # inline reclaim (Layer 3).
+                    _run_initial_scan = _resilient_tasks_enabled()
+                    await task_manager.startup(run_initial_scan=_run_initial_scan)
+                    if _run_initial_scan:
+                        logger.info("TaskManager initialized with startup recovery")
+                    else:
+                        logger.info(
+                            "TaskManager initialized (initial scan skipped; background recovery active; "
+                            "enabled=%s, tasks_declared=%s)",
+                            _resilient_tasks_enabled(),
+                            _has_registered_tasks(),
+                        )
                 else:
                     logger.info(
                         "TaskManager initialized (recovery deferred; enabled=%s, tasks_declared=%s)",

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/tasks/_manager.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/tasks/_manager.py
@@ -725,16 +725,31 @@ class TaskManager:  # pylint: disable=too-many-instance-attributes,protected-acc
         if not future.done():
             future.set_exception(TaskCancelled())
 
-    async def startup(self) -> None:
-        """Initialize the manager and recover stale tasks.
+    async def startup(self, *, run_initial_scan: bool = True) -> None:
+        """Initialize the manager and (optionally) recover stale tasks.
 
         Called by ``AgentServerHost`` during lifespan startup.
+
+        :keyword run_initial_scan: When True (default), run the blocking
+            cold-start recovery scan (Layer 1) before returning — this
+            preserves the historical contract relied on by direct callers
+            and the recovery test-suite, which assert the initial reclaim
+            has already happened once ``startup()`` awaits. When False, the
+            blocking scan is skipped so server boot is not gated on a
+            task-store ``list()`` + credential-token acquisition; recovery
+            is still provided by the periodic background loop (Layer 2,
+            always started here) and by request-time inline reclaim
+            (Layer 3). The hosted lifespan passes ``False`` unless resilient
+            tasks were explicitly enabled, so a plain host boots fast while
+            keeping Layers 2 and 3 available.
+        :paramtype run_initial_scan: bool
         """
         logger.info(
-            "TaskManager starting (owner=%s, instance=%s, hosted=%s)",
+            "TaskManager starting (owner=%s, instance=%s, hosted=%s, initial_scan=%s)",
             self._lease_owner,
             self._instance_id,
             self._config.is_hosted,
+            run_initial_scan,
         )
         # Pick up descriptors registered at import time (for recovery)
         from ._decorator import (  # pylint: disable=import-outside-toplevel
@@ -745,7 +760,11 @@ class TaskManager:  # pylint: disable=too-many-instance-attributes,protected-acc
             self._resume_callbacks[fn_name] = fn
             self._resume_opts[fn_name] = opts
 
-        await self._recover_stale_tasks()
+        #   Layer 1: blocking cold-start recovery scan. Gated so it is
+        # skipped when recovery was not explicitly enabled — the periodic
+        # loop (Layer 2) below still covers reclaim in the background.
+        if run_initial_scan:
+            await self._recover_stale_tasks()
 
         #   Layer 2: start the periodic recovery task.
         # Reads _PERIODIC_RECOVERY_INTERVAL_SECONDS at spawn time;

--- a/sdk/agentserver/azure-ai-agentserver-core/tests/tasks/test_task_manager_optin.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/tests/tasks/test_task_manager_optin.py
@@ -69,8 +69,9 @@ class _FakeTaskManager:
         self.shutdown_called = False
         _FakeTaskManager.instances.append(self)
 
-    async def startup(self) -> None:
+    async def startup(self, *, run_initial_scan: bool = True) -> None:
         self.startup_called = True
+        self.run_initial_scan = run_initial_scan
 
     async def shutdown(self) -> None:
         self.shutdown_called = True
@@ -163,8 +164,10 @@ class TestLifespanManagerAndRecovery:
 
     @pytest.mark.asyncio
     async def test_task_declared_runs_recovery_without_switch(self, _clean_state, _fake_task_manager) -> None:
-        """A declared task alone runs recovery (backward compatible — an
-        existing ``@task`` app gets recovery without calling the switch)."""
+        """A declared task alone starts the manager's recovery machinery, but
+        WITHOUT the switch the blocking cold-start scan (Layer 1) is skipped —
+        recovery falls to the background loop (Layer 2) + inline reclaim
+        (Layer 3). ``startup()`` is still invoked (spawns Layer 2)."""
         from azure.ai.agentserver.core import AgentServerHost
 
         _declare_task()
@@ -174,11 +177,14 @@ class TestLifespanManagerAndRecovery:
             pass
         assert len(_fake_task_manager.instances) == 1
         assert _fake_task_manager.instances[0].startup_called is True
+        # Switch off -> Layer 1 skipped.
+        assert _fake_task_manager.instances[0].run_initial_scan is False
 
     @pytest.mark.asyncio
     async def test_switch_alone_runs_recovery_without_task(self, _clean_state, _fake_task_manager) -> None:
-        """The switch alone runs recovery (force-enable) — starting the
-        periodic recovery loop so a task declared later is picked up."""
+        """The switch alone runs recovery (force-enable) — the blocking
+        cold-start scan (Layer 1) runs and the periodic recovery loop starts
+        so a task declared later is picked up."""
         from azure.ai.agentserver.core import AgentServerHost
 
         set_resilient_tasks_enabled(True)
@@ -187,6 +193,8 @@ class TestLifespanManagerAndRecovery:
             pass
         assert len(_fake_task_manager.instances) == 1
         assert _fake_task_manager.instances[0].startup_called is True
+        # Switch on -> Layer 1 runs.
+        assert _fake_task_manager.instances[0].run_initial_scan is True
 
     @pytest.mark.asyncio
     async def test_switch_and_task_runs_recovery(
@@ -206,6 +214,7 @@ class TestLifespanManagerAndRecovery:
         assert len(_fake_task_manager.instances) == 1
         mgr = _fake_task_manager.instances[0]
         assert mgr.startup_called is True
+        assert mgr.run_initial_scan is True
         assert mgr.shutdown_called is True
         assert any("TaskManager initialized with startup recovery" in r.message for r in caplog.records)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_langgraph/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_langgraph/app.py
@@ -67,6 +67,7 @@ from azure.ai.agentserver.core.streaming import (
     EventStreamNotFoundError,
     streams,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -82,6 +83,13 @@ logger = logging.getLogger(__name__)
 streams.use_in_memory_replay(ttl_seconds=600)
 
 app = InvocationAgentServerHost()
+
+# Explicitly opt into the resilient-task startup recovery scan. Declaring a
+# ``@multi_turn_task`` makes the framework recovery-capable, but the eager
+# boot-time reclaim of tasks orphaned by a prior crash is gated on this switch
+# (background + request-time recovery still run without it). Enabling it here
+# means a fresh process reclaims in-flight sessions at startup.
+set_resilient_tasks_enabled(True)
 
 
 async def _sse_from_stream(

--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_multiturn/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_multiturn/app.py
@@ -37,7 +37,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from azure.ai.agentserver.core.storage import FoundryStateStore
-from azure.ai.agentserver.core.tasks import TaskConflictError
+from azure.ai.agentserver.core.tasks import TaskConflictError, set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -46,6 +46,13 @@ except ImportError:  # allows `python app.py` from inside this directory
     from agent import invocation_state_store_name, session_workflow
 
 app = InvocationAgentServerHost()
+
+# Explicitly opt into the resilient-task startup recovery scan. Declaring a
+# ``@multi_turn_task`` makes the framework recovery-capable, but the eager
+# boot-time reclaim of tasks orphaned by a prior crash is gated on this switch
+# (background + request-time recovery still run without it). Enabling it here
+# means a fresh process reclaims in-flight sessions at startup.
+set_resilient_tasks_enabled(True)
 
 
 @app.invoke_handler

--- a/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_research/app.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/samples/resilient_research/app.py
@@ -77,6 +77,7 @@ from azure.ai.agentserver.core.streaming import (
     EventStreamNotFoundError,
     streams,
 )
+from azure.ai.agentserver.core.tasks import set_resilient_tasks_enabled
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 
 try:
@@ -100,6 +101,13 @@ logger = logging.getLogger(__name__)
 streams.use_file_backed_replay(cursor_fn=lambda ev: ev["sequence_number"])
 
 app = InvocationAgentServerHost()
+
+# Explicitly opt into the resilient-task startup recovery scan. Declaring a
+# ``@multi_turn_task`` makes the framework recovery-capable, but the eager
+# boot-time reclaim of tasks orphaned by a prior crash is gated on this switch
+# (background + request-time recovery still run without it). Enabling it here
+# means a fresh process reclaims in-flight sessions at startup.
+set_resilient_tasks_enabled(True)
 
 
 # --- SSE rendering ---------------------------------------------------------


### PR DESCRIPTION
## Summary

The resilient `TaskManager`'s cold-start recovery scan (**Layer 1**) blocks server lifespan startup on a task-store `list()` + credential-token acquisition. It previously ran whenever **either** a durable task was registered **or** the enablement switch was set.

Because the **responses** protocol registers internal `@task` / `@multi_turn_task` primitives at host construction, `_has_registered_tasks()` was always `True` — so **every responses host, even a plain one that opted into no resilient features, paid the blocking boot-time scan**.

This PR makes the blocking Layer 1 scan **opt-in via the existing `set_resilient_tasks_enabled()` switch**, while keeping background (Layer 2) and request-time (Layer 3) recovery always available.

## Changes

**Core**
- `TaskManager.startup()` gains `run_initial_scan` (default `True` — preserves the contract for direct callers and the recovery test-suite). When `False`, the blocking cold-start scan is skipped; the periodic background loop (**Layer 2**) and request-time inline reclaim (**Layer 3**) still provide recovery.
- The hosted lifespan (`_base.py`) passes `run_initial_scan=_resilient_tasks_enabled()` — a host that did not enable resilient tasks boots fast, keeping Layers 2 and 3 available.

**Samples**
- The invocations resilient samples (`resilient_research`, `resilient_multiturn`, `resilient_langgraph`) declare developer `@multi_turn_task`s and now call `set_resilient_tasks_enabled(True)` to retain eager boot recovery — matching the responses resilient samples (19–22), which already do this.

## Behavior

| Deployment | Layer 1 (boot scan) | Layers 2 + 3 |
| --- | --- | --- |
| Switch ON (`set_resilient_tasks_enabled(True)`) | runs at boot (unchanged) | available |
| Switch OFF (plain responses host, or `@task` app that didn't opt in) | **skipped** (was: ran) | available |

**Trade-off:** for switch-off hosts, proactive reclaim of orphans from a prior crash moves from boot-time to the background loop (~interval) — anything re-requested is still reclaimed immediately by Layer 3. Ideal practice is to enable the switch; this change makes the un-enabled path degrade gracefully instead of blocking boot.

## Backward compatibility
- No public API break: `startup()` only gains an optional keyword defaulting to today's behavior; it is internal (called by `_base.py`).
- No decorator / `TaskOptions` changes; no version-pin bump (`set_resilient_tasks_enabled` already shipped).

## Tests
- `test_task_manager_optin.py` updated: fake `startup` accepts the kwarg; added `run_initial_scan` assertions (skipped when switch off, runs when on). **11 passed.**
- Core recovery suite unaffected (default `run_initial_scan=True`): `test_inline_recovery` / `test_recovery_lease_etag` / `test_lifecycle` — **28 passed.**