### PR TITLE
Fix response history limit ordering

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Restored JSON-string encoding for response-level `internal_metadata` so resilient response checkpoints round-trip through Foundry storage.
 - Restored `get_request_context()` identity values while stored Responses handlers run inside durable tasks.
+- Fixed local response providers to retain the newest conversation history items when applying the history limit.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.1.0b2 (2026-08-19)
+
+### Bugs Fixed
+
+- Fixed local response providers to retain the newest conversation history items when applying the history limit.
+
 ## 2.1.0b1 (2026-08-11)
 
 ### Breaking Changes
@@ -23,7 +29,6 @@
 
 - Restored JSON-string encoding for response-level `internal_metadata` so resilient response checkpoints round-trip through Foundry storage.
 - Restored `get_request_context()` identity values while stored Responses handlers run inside durable tasks.
-- Fixed local response providers to retain the newest conversation history items when applying the history limit.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.1.0b2 (2026-08-19)
+## 2.1.0b2 (unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b1"
+VERSION = "2.1.0b2"

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_file.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_file.py
@@ -579,7 +579,7 @@ class FileResponseStore(ResponseProviderProtocol):
 
             if limit <= 0:
                 return []
-            return resolved[:limit]
+            return resolved[-limit:]
 
     # ------------------------------------------------------------------
     # Internal helpers (must be called with self._lock held)

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_memory.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/store/_memory.py
@@ -325,7 +325,7 @@ class InMemoryResponseProvider(ResponseProviderProtocol):
 
             if limit <= 0:
                 return []
-            return resolved[:limit]
+            return resolved[-limit:]
 
     async def create_execution(self, execution: ResponseExecution, *, ttl_seconds: int | None = None) -> None:
         """Create a new execution and replay container for ``execution.response_id``.

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_file_response_store_parity.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_file_response_store_parity.py
@@ -327,7 +327,7 @@ async def test_history_respects_limit(tmp_path: Path) -> None:
             history_item_ids=["hist1", "hist2"],
         )
         ids = await provider.get_history_item_ids("r_prev", None, limit=3)
-        assert ids == ["hist1", "hist2", "in1"]
+        assert ids == ["out1", "out2", "out3"]
         # Non-positive limit returns empty.
         ids_zero = await provider.get_history_item_ids("r_prev", None, limit=0)
         assert ids_zero == []

--- a/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_in_memory_provider_crud.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/tests/unit/test_in_memory_provider_crud.py
@@ -373,7 +373,7 @@ def test_history__respects_limit() -> None:
     asyncio.run(provider.create_response(_response("resp_lim"), many_inputs, None))
 
     ids = asyncio.run(provider.get_history_item_ids("resp_lim", None, 3))
-    assert len(ids) == 3
+    assert ids == ["in_lim_7", "in_lim_8", "in_lim_9"]
 
 
 def test_history__zero_limit_returns_empty() -> None:


### PR DESCRIPTION
Fixes #48514

## Description
- retain the newest history item IDs when in-memory and file-backed response providers apply a limit
- update provider parity tests to assert chronological tail truncation
- document the fix in the package changelog

The Foundry provider is unchanged because it forwards `limit` to the Foundry history endpoint and does not truncate a local `resolved` list.

## Testing
- `python -m pytest tests/unit/test_in_memory_provider_crud.py tests/unit/test_file_response_store_parity.py -q`