### PR TITLE
[commvaultcontentstore] Set planned release date for azure-mgmt-commvaultcontentstore 1.0.0b1

### DIFF
--- a/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/CHANGELOG.md
+++ b/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b1 (2026-08-18)
+## 1.0.0b1 (2026-08-20)
 
 ### Other Changes
 

--- a/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/CHANGELOG.md
+++ b/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b1 (2026-06-25)
+## 1.0.0b1 (2026-08-18)
 
 ### Other Changes
 

--- a/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/api.metadata.yml
+++ b/sdk/commvaultcontentstore/azure-mgmt-commvaultcontentstore/api.metadata.yml
@@ -1,3 +1,3 @@
 apiMdSha256: dcf03aa8db2a48c067356ec2cf5a58f392d41093917f153a7372c753242dbf48
-parserVersion: 0.3.28
-pythonVersion: 3.13.13
+parserVersion: 0.3.31
+pythonVersion: 3.14.5


### PR DESCRIPTION
Updates CHANGELOG.md with a planned release date (2026-08-18) so the release pipeline readiness check passes for release plan 2101.
## Release Plan Details
- Release Plan: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=2101
- Work Item Link: https://dev.azure.com/azure-sdk/fe81d705-3c06-41e5-bf7c-5ebea18efe89/_workitems/edit/32864
- Spec Pull Request: https://github.com/Azure/azure-rest-api-specs/pull/43838
- Spec API version: 2025-01-01-preview