### PR TITLE
Prepare azure-core 1.42.0 release

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.42.0 (Unreleased)
+## 1.42.0 (2026-08-18)
 
 ### Features Added
 


### PR DESCRIPTION
Sets the azure-ai-agentserver-core 2.1.0b2 release date to 2026-08-18.