### PR TITLE
Prepare azure-ai-agentserver-core 2.1.0b2 release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.1.0b2 (2026-08-18)
+
+### Other Changes
+
+- Updated the hosted task provider's `Foundry-Features` opt-in header from `Routines=V1Preview` to `Routines=V2Preview` to align with the `agentserver-persistence` contract. #48617
+
 ## 2.1.0b1 (2026-08-11)
 
 ### Features Added

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b1"
+VERSION = "2.1.0b2"


### PR DESCRIPTION
Sets the azure-ai-agentserver-core 2.1.0b2 release date to 2026-08-18 and documents the Routines=V2Preview opt-in header change from #48617.