### PR TITLE
[Service Bus] Clarify and sample session listing

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Added `ServiceBusReceivedMessage.from_bytes()` classmethod to construct a `ServiceBusReceivedMessage` from raw AMQP payload bytes without requiring the deprecated `uamqp` library. ([#43979](https://github.com/Azure/azure-sdk-for-python/issues/43979))
-- Added `ServiceBusClient.list_queue_sessions()` and `ServiceBusClient.list_subscription_sessions()` (sync and async) to list session IDs for entities with active messages, with optional filtering by session-state update timestamp. The methods return an `ItemPaged[str]` (`AsyncItemPaged[str]` on the async client) so callers can iterate every session transparently or page with `by_page()`. Implements the `com.microsoft:get-message-sessions` management operation. ([#46575](https://github.com/Azure/azure-sdk-for-python/pull/46575))
+- Added `ServiceBusClient.list_queue_sessions()` and `ServiceBusClient.list_subscription_sessions()` (sync and async) to list session IDs for entities with active messages or stored session state, with optional filtering by session-state update timestamp. The methods return an `ItemPaged[str]` (`AsyncItemPaged[str]` on the async client) so callers can iterate every session transparently or page with `by_page()`. Implements the `com.microsoft:get-message-sessions` management operation. ([#46575](https://github.com/Azure/azure-sdk-for-python/pull/46575))
 - Added `sql_filter_count` and `correlation_filter_count` properties to `TopicRuntimeProperties`, exposing the total number of SQL filters and correlation filters across all of a topic's subscriptions.
 - Added API version `2024-05` and made it the default for the management client, which is required for the topic filter counts above.
 

--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -164,7 +164,7 @@ The following sections provide several code snippets covering some of the most c
 * [Send and receive a message from a session enabled queue](#send-and-receive-a-message-from-a-session-enabled-queue "Send and receive a message from a session enabled queue")
 * List session IDs with active messages or stored session state using `list_queue_sessions` and
     `list_subscription_sessions` with the
-    [sync](samples/sync_samples/list_sessions.py) or [async](samples/async_samples/list_sessions_async.py) sample for
+    [sync](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/samples/sync_samples/list_sessions.py) or [async](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/samples/async_samples/list_sessions_async.py) sample for
     session-enabled queues and subscriptions.
 * [Working with topics and subscriptions](#working-with-topics-and-subscriptions "Working with topics and subscriptions")
 * [Settle a message after receipt](#settle-a-message-after-receipt "Settle a message after receipt")

--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -162,6 +162,10 @@ The following sections provide several code snippets covering some of the most c
 * [Send messages to a queue](#send-messages-to-a-queue "Send messages to a queue")
 * [Receive messages from a queue](#receive-messages-from-a-queue "Receive messages from a queue")
 * [Send and receive a message from a session enabled queue](#send-and-receive-a-message-from-a-session-enabled-queue "Send and receive a message from a session enabled queue")
+* List session IDs with active messages or stored session state using `list_queue_sessions` and
+    `list_subscription_sessions` with the
+    [sync](samples/sync_samples/list_sessions.py) or [async](samples/async_samples/list_sessions_async.py) sample for
+    session-enabled queues and subscriptions.
 * [Working with topics and subscriptions](#working-with-topics-and-subscriptions "Working with topics and subscriptions")
 * [Settle a message after receipt](#settle-a-message-after-receipt "Settle a message after receipt")
 * [Automatically renew Message or Session locks](#automatically-renew-message-or-session-locks "Automatically renew Message or Session locks")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -49,7 +49,9 @@ NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 _LOGGER = logging.getLogger(__name__)
 
 
-class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-keyword,too-many-instance-attributes
+class ServiceBusClient(
+    object
+):  # pylint: disable=client-accepts-api-version-keyword,too-many-instance-attributes
     """The ServiceBusClient class defines a high level interface for
     getting ServiceBusSender and ServiceBusReceiver.
 
@@ -113,7 +115,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
     def __init__(
         self,
         fully_qualified_namespace: str,
-        credential: Union["TokenCredential", "AzureSasCredential", "AzureNamedKeyCredential"],
+        credential: Union[
+            "TokenCredential", "AzureSasCredential", "AzureNamedKeyCredential"
+        ],
         *,
         retry_total: int = 3,
         retry_backoff_factor: float = 0.8,
@@ -122,7 +126,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         **kwargs: Any,
     ) -> None:
         uamqp_transport = kwargs.pop("uamqp_transport", False)
-        amqp_transport: Union[Type[PyamqpTransport], Type["UamqpTransport"]] = PyamqpTransport
+        amqp_transport: Union[Type[PyamqpTransport], Type["UamqpTransport"]] = (
+            PyamqpTransport
+        )
 
         if uamqp_transport:
             # Deprecation of uamqp transport
@@ -132,13 +138,17 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 "to use the pure Python AMQP transport. "
                 "If you rely on this, please comment on [this issue]"
                 "(https://github.com/Azure/azure-sdk-for-python/issues/40347) ",
-                DeprecationWarning, stacklevel=2
+                DeprecationWarning,
+                stacklevel=2,
             )
             try:
                 from ._transport._uamqp_transport import UamqpTransport
+
                 amqp_transport = UamqpTransport
             except ImportError:
-                raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.") from None
+                raise ValueError(
+                    "To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`."
+                ) from None
 
         self._amqp_transport = amqp_transport
 
@@ -219,7 +229,7 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             self._connection.close()
 
     @classmethod
-    def from_connection_string( # pylint: disable=docstring-keyword-should-match-keyword-only
+    def from_connection_string(  # pylint: disable=docstring-keyword-should-match-keyword-only
         cls,
         conn_str: str,
         *,
@@ -279,7 +289,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 :caption: Create a new instance of the ServiceBusClient from connection string.
 
         """
-        host, policy, key, entity_in_conn_str, token, token_expiry, emulator = _parse_conn_str(conn_str)
+        host, policy, key, entity_in_conn_str, token, token_expiry, emulator = (
+            _parse_conn_str(conn_str)
+        )
         kwargs["use_tls"] = not emulator
         credential: Union[ServiceBusSASTokenCredential, ServiceBusSharedKeyCredential]
         if token and token_expiry:
@@ -298,13 +310,13 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         )
 
     def get_queue_sender(
-            self,
-            queue_name: str,
-            *,
-            client_identifier: Optional[str] = None,
-            socket_timeout: Optional[float] = None,
-            **kwargs: Any
-        ) -> ServiceBusSender:
+        self,
+        queue_name: str,
+        *,
+        client_identifier: Optional[str] = None,
+        socket_timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> ServiceBusSender:
         """Get ServiceBusSender for the specific queue.
 
         :param str queue_name: The path of specific Service Bus Queue the client connects to.
@@ -368,7 +380,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         socket_timeout: Optional[float] = None,
         session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
-        receive_mode: Union[ServiceBusReceiveMode, str] = ServiceBusReceiveMode.PEEK_LOCK,
+        receive_mode: Union[
+            ServiceBusReceiveMode, str
+        ] = ServiceBusReceiveMode.PEEK_LOCK,
         max_wait_time: Optional[float] = None,
         auto_lock_renewer: Optional[AutoLockRenewer] = None,
         prefetch_count: int = 0,
@@ -450,10 +464,15 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         try:
             queue_name = generate_dead_letter_entity_name(
                 queue_name=queue_name,
-                transfer_deadletter=(ServiceBusSubQueue(sub_queue) == ServiceBusSubQueue.TRANSFER_DEAD_LETTER),
+                transfer_deadletter=(
+                    ServiceBusSubQueue(sub_queue)
+                    == ServiceBusSubQueue.TRANSFER_DEAD_LETTER
+                ),
             )
         except ValueError:
-            if sub_queue:  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
+            if (
+                sub_queue
+            ):  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
                 raise
         handler = ServiceBusReceiver(
             fully_qualified_namespace=self.fully_qualified_namespace,
@@ -558,7 +577,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         socket_timeout: Optional[float] = None,
         session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
-        receive_mode: Union[ServiceBusReceiveMode, str] = ServiceBusReceiveMode.PEEK_LOCK,
+        receive_mode: Union[
+            ServiceBusReceiveMode, str
+        ] = ServiceBusReceiveMode.PEEK_LOCK,
         max_wait_time: Optional[float] = None,
         auto_lock_renewer: Optional[AutoLockRenewer] = None,
         prefetch_count: int = 0,
@@ -643,7 +664,10 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             entity_name = generate_dead_letter_entity_name(
                 topic_name=topic_name,
                 subscription_name=subscription_name,
-                transfer_deadletter=(ServiceBusSubQueue(sub_queue) == ServiceBusSubQueue.TRANSFER_DEAD_LETTER),
+                transfer_deadletter=(
+                    ServiceBusSubQueue(sub_queue)
+                    == ServiceBusSubQueue.TRANSFER_DEAD_LETTER
+                ),
             )
             handler = ServiceBusReceiver(
                 fully_qualified_namespace=self.fully_qualified_namespace,
@@ -674,7 +698,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs,
             )
         except ValueError:
-            if sub_queue:  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
+            if (
+                sub_queue
+            ):  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
                 raise
             handler = ServiceBusReceiver(
                 fully_qualified_namespace=self.fully_qualified_namespace,
@@ -747,11 +773,12 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         state_updated_after: Optional[datetime] = None,
         timeout: Optional[float] = None,
     ) -> ItemPaged[str]:
-        """List session IDs with active messages in a session-enabled queue.
+        """List session IDs with active messages or stored session state in a session-enabled queue.
 
         If ``state_updated_after`` is specified, only sessions whose
         session state was set or updated after that time are returned. If not specified, returns
-        sessions with active messages in the queue.
+        sessions with active messages or stored session state in the queue. Sessions with neither
+        are excluded.
 
         :param str queue_name: The name of the session-enabled queue.
         :keyword ~datetime.datetime state_updated_after: If specified, only sessions whose
@@ -769,7 +796,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             raise ValueError("The timeout must be greater than 0.")
 
         browser = self._create_session_browser(queue_name)
-        return browser.list_sessions(state_updated_after=state_updated_after, timeout=timeout)
+        return browser.list_sessions(
+            state_updated_after=state_updated_after, timeout=timeout
+        )
 
     def list_subscription_sessions(
         self,
@@ -779,11 +808,12 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         state_updated_after: Optional[datetime] = None,
         timeout: Optional[float] = None,
     ) -> ItemPaged[str]:
-        """List session IDs with active messages in a session-enabled subscription.
+        """List session IDs with active messages or stored session state in a session-enabled subscription.
 
         If ``state_updated_after`` is specified, only sessions whose
         session state was set or updated after that time are returned. If not specified, returns
-        sessions with active messages in the subscription.
+        sessions with active messages or stored session state in the subscription. Sessions with
+        neither are excluded.
 
         :param str topic_name: The name of the topic.
         :param str subscription_name: The name of the subscription.
@@ -801,5 +831,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
 
-        browser = self._create_session_browser(topic_name, subscription_name=subscription_name)
-        return browser.list_sessions(state_updated_after=state_updated_after, timeout=timeout)
+        browser = self._create_session_browser(
+            topic_name, subscription_name=subscription_name
+        )
+        return browser.list_sessions(
+            state_updated_after=state_updated_after, timeout=timeout
+        )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_session_browser.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_session_browser.py
@@ -18,7 +18,8 @@ from ._common import mgmt_handlers
 from .exceptions import OperationTimeoutError
 
 # The service checks `lastUpdatedTime != DateTime.MaxValue` (exact equality) to switch
-# between "active messages" mode and "updated since" mode. The .NET AMQP library encodes
+# between default listing mode and updated-since mode. Default listing mode returns sessions
+# with active messages or stored session state. The .NET AMQP library encodes
 # DateTime.MaxValue as 253402300800000 ms (10000-01-01T00:00:00Z) due to double-to-long
 # rounding in TimeSpan.TotalMilliseconds, and its decoder clamps values beyond
 # DateTime.MaxValue.Ticks back to DateTime.MaxValue. This matches Track 1 Java's
@@ -31,7 +32,7 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 def _to_last_updated_ms(state_updated_after: Optional[datetime]) -> int:
     """Convert an optional filter datetime to the wire millisecond value.
 
-    Returns the DateTime.MaxValue sentinel (active-messages mode) when no filter
+    Returns the DateTime.MaxValue sentinel (default listing mode) when no filter
     is given; otherwise the UTC-normalized millisecond timestamp.
 
     :param state_updated_after: The optional filter datetime.
@@ -40,7 +41,7 @@ def _to_last_updated_ms(state_updated_after: Optional[datetime]) -> int:
     :rtype: int
     """
     if state_updated_after is None:
-        # DateTime.MaxValue triggers "active messages" mode on the service side.
+        # DateTime.MaxValue triggers default listing mode on the service side.
         return _MAX_DATETIME_MS
     # Normalize naive datetimes to UTC. Python's datetime.timestamp() interprets
     # naive values as local time, which would make the wire value depend on the
@@ -54,13 +55,15 @@ def _to_last_updated_ms(state_updated_after: Optional[datetime]) -> int:
     # Compute milliseconds with integer timedelta arithmetic rather than float
     # `timestamp() * 1000`. The float path rounds the maximum representable
     # datetime up to _MAX_DATETIME_MS, which would silently switch an explicit
-    # filter into active-messages mode, and truncates pre-epoch fractional
+    # filter into default listing mode, and truncates pre-epoch fractional
     # milliseconds toward zero. Floor division keeps datetime.max at
     # 253402300799999 and rounds consistently downward.
     return (normalized - _EPOCH) // timedelta(milliseconds=1)
 
 
-def _page_request_body(amqp_transport: Any, last_updated_time_ms: int, skip: int) -> Dict[str, Any]:
+def _page_request_body(
+    amqp_transport: Any, last_updated_time_ms: int, skip: int
+) -> Dict[str, Any]:
     """Build the get-message-sessions request body with transport-neutral value
     factories.
 
@@ -146,7 +149,8 @@ class _SessionBrowser(BaseHandler):
 
         :keyword ~datetime.datetime state_updated_after: If specified, only sessions whose
             session state was set or updated after this time are returned. If not specified,
-            returns sessions with active messages in the entity.
+            returns sessions with active messages or stored session state in the entity. Sessions
+            with neither are excluded.
         :keyword float timeout: The total operation timeout in seconds, spent across
             every page of the enumeration.
         :keyword _now: Monotonic clock function, injectable for tests. Internal.
@@ -182,7 +186,9 @@ class _SessionBrowser(BaseHandler):
                     raise OperationTimeoutError(
                         message="Listing sessions did not complete within the specified timeout."
                     )
-            message = _page_request_body(self._amqp_transport, last_updated_time_ms, skip)
+            message = _page_request_body(
+                self._amqp_transport, last_updated_time_ms, skip
+            )
             result = self._mgmt_request_response_with_retry(
                 REQUEST_RESPONSE_GET_MESSAGE_SESSIONS_OPERATION,
                 message,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -41,7 +41,9 @@ NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 _LOGGER = logging.getLogger(__name__)
 
 
-class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-keyword,too-many-instance-attributes
+class ServiceBusClient(
+    object
+):  # pylint: disable=client-accepts-api-version-keyword,too-many-instance-attributes
     """The ServiceBusClient class defines a high level interface for
     getting ServiceBusSender and ServiceBusReceiver.
 
@@ -105,7 +107,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
     def __init__(
         self,
         fully_qualified_namespace: str,
-        credential: Union["AsyncTokenCredential", AzureSasCredential, AzureNamedKeyCredential],
+        credential: Union[
+            "AsyncTokenCredential", AzureSasCredential, AzureNamedKeyCredential
+        ],
         *,
         retry_total: int = 3,
         retry_backoff_factor: float = 0.8,
@@ -114,7 +118,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         **kwargs: Any,
     ) -> None:
         uamqp_transport = kwargs.pop("uamqp_transport", False)
-        amqp_transport: Union[Type[PyamqpTransportAsync], Type["UamqpTransportAsync"]] = PyamqpTransportAsync
+        amqp_transport: Union[
+            Type[PyamqpTransportAsync], Type["UamqpTransportAsync"]
+        ] = PyamqpTransportAsync
 
         if uamqp_transport:
             # Deprecation of uamqp transport
@@ -124,13 +130,17 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 "to use the pure Python AMQP transport. "
                 "If you rely on this, please comment on [this issue]"
                 "(https://github.com/Azure/azure-sdk-for-python/issues/40347) ",
-                DeprecationWarning, stacklevel=2
+                DeprecationWarning,
+                stacklevel=2,
             )
             try:
                 from ._transport._uamqp_transport_async import UamqpTransportAsync
+
                 amqp_transport = UamqpTransportAsync
             except ImportError:
-                raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.") from None
+                raise ValueError(
+                    "To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`."
+                ) from None
 
         self._amqp_transport = amqp_transport
         # Keep the port for the non-TLS emulator; strip scheme/port/path otherwise.
@@ -185,7 +195,7 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         )
 
     @classmethod
-    def from_connection_string( # pylint: disable=docstring-keyword-should-match-keyword-only
+    def from_connection_string(  # pylint: disable=docstring-keyword-should-match-keyword-only
         cls,
         conn_str: str,
         *,
@@ -245,7 +255,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 :caption: Create a new instance of the ServiceBusClient from connection string.
 
         """
-        host, policy, key, entity_in_conn_str, token, token_expiry, emulator = _parse_conn_str(conn_str)
+        host, policy, key, entity_in_conn_str, token, token_expiry, emulator = (
+            _parse_conn_str(conn_str)
+        )
         kwargs["use_tls"] = not emulator
         credential: Union[ServiceBusSASTokenCredential, ServiceBusSharedKeyCredential]
         if token and token_expiry:
@@ -285,13 +297,13 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             await self._connection.close()
 
     def get_queue_sender(
-            self,
-            queue_name: str,
-            *,
-            client_identifier: Optional[str] = None,
-            socket_timeout: Optional[float] = None,
-            **kwargs: Any
-        ) -> ServiceBusSender:
+        self,
+        queue_name: str,
+        *,
+        client_identifier: Optional[str] = None,
+        socket_timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> ServiceBusSender:
         """Get ServiceBusSender for the specific queue.
 
         :param str queue_name: The path of specific Service Bus Queue the client connects to.
@@ -355,7 +367,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         socket_timeout: Optional[float] = None,
         session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
-        receive_mode: Union[ServiceBusReceiveMode, str] = ServiceBusReceiveMode.PEEK_LOCK,
+        receive_mode: Union[
+            ServiceBusReceiveMode, str
+        ] = ServiceBusReceiveMode.PEEK_LOCK,
         max_wait_time: Optional[float] = None,
         auto_lock_renewer: Optional["AutoLockRenewer"] = None,
         prefetch_count: int = 0,
@@ -437,10 +451,15 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         try:
             queue_name = generate_dead_letter_entity_name(
                 queue_name=queue_name,
-                transfer_deadletter=(ServiceBusSubQueue(sub_queue) == ServiceBusSubQueue.TRANSFER_DEAD_LETTER),
+                transfer_deadletter=(
+                    ServiceBusSubQueue(sub_queue)
+                    == ServiceBusSubQueue.TRANSFER_DEAD_LETTER
+                ),
             )
         except ValueError:
-            if sub_queue:  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
+            if (
+                sub_queue
+            ):  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
                 raise
         handler = ServiceBusReceiver(
             fully_qualified_namespace=self.fully_qualified_namespace,
@@ -479,7 +498,7 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         *,
         client_identifier: Optional[str] = None,
         socket_timeout: Optional[float] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> ServiceBusSender:
         """Get ServiceBusSender for the specific topic.
 
@@ -543,7 +562,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         *,
         session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
-        receive_mode: Union[ServiceBusReceiveMode, str] = ServiceBusReceiveMode.PEEK_LOCK,
+        receive_mode: Union[
+            ServiceBusReceiveMode, str
+        ] = ServiceBusReceiveMode.PEEK_LOCK,
         max_wait_time: Optional[float] = None,
         auto_lock_renewer: Optional["AutoLockRenewer"] = None,
         prefetch_count: int = 0,
@@ -631,7 +652,10 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             entity_name = generate_dead_letter_entity_name(
                 topic_name=topic_name,
                 subscription_name=subscription_name,
-                transfer_deadletter=(ServiceBusSubQueue(sub_queue) == ServiceBusSubQueue.TRANSFER_DEAD_LETTER),
+                transfer_deadletter=(
+                    ServiceBusSubQueue(sub_queue)
+                    == ServiceBusSubQueue.TRANSFER_DEAD_LETTER
+                ),
             )
             handler = ServiceBusReceiver(
                 fully_qualified_namespace=self.fully_qualified_namespace,
@@ -662,7 +686,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs,
             )
         except ValueError:
-            if sub_queue:  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
+            if (
+                sub_queue
+            ):  # If we got here and sub_queue is defined, it's an incorrect value or something unrelated.
                 raise
             handler = ServiceBusReceiver(
                 fully_qualified_namespace=self.fully_qualified_namespace,
@@ -735,11 +761,12 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         state_updated_after: Optional[datetime] = None,
         timeout: Optional[float] = None,
     ) -> AsyncItemPaged[str]:
-        """List session IDs with active messages in a session-enabled queue.
+        """List session IDs with active messages or stored session state in a session-enabled queue.
 
         If ``state_updated_after`` is specified, only sessions whose
         session state was set or updated after that time are returned. If not specified, returns
-        sessions with active messages in the queue.
+        sessions with active messages or stored session state in the queue. Sessions with neither
+        are excluded.
 
         :param str queue_name: The name of the session-enabled queue.
         :keyword ~datetime.datetime state_updated_after: If specified, only sessions whose
@@ -757,7 +784,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
             raise ValueError("The timeout must be greater than 0.")
 
         browser = self._create_session_browser(queue_name)
-        return browser.list_sessions(state_updated_after=state_updated_after, timeout=timeout)
+        return browser.list_sessions(
+            state_updated_after=state_updated_after, timeout=timeout
+        )
 
     def list_subscription_sessions(
         self,
@@ -767,11 +796,12 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         state_updated_after: Optional[datetime] = None,
         timeout: Optional[float] = None,
     ) -> AsyncItemPaged[str]:
-        """List session IDs with active messages in a session-enabled subscription.
+        """List session IDs with active messages or stored session state in a session-enabled subscription.
 
         If ``state_updated_after`` is specified, only sessions whose
         session state was set or updated after that time are returned. If not specified, returns
-        sessions with active messages in the subscription.
+        sessions with active messages or stored session state in the subscription. Sessions with
+        neither are excluded.
 
         :param str topic_name: The name of the topic.
         :param str subscription_name: The name of the subscription.
@@ -789,5 +819,9 @@ class ServiceBusClient(object):  # pylint: disable=client-accepts-api-version-ke
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
 
-        browser = self._create_session_browser(topic_name, subscription_name=subscription_name)
-        return browser.list_sessions(state_updated_after=state_updated_after, timeout=timeout)
+        browser = self._create_session_browser(
+            topic_name, subscription_name=subscription_name
+        )
+        return browser.list_sessions(
+            state_updated_after=state_updated_after, timeout=timeout
+        )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_session_browser_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_session_browser_async.py
@@ -76,7 +76,8 @@ class _SessionBrowserAsync(AsyncBaseHandler):
 
         :keyword ~datetime.datetime state_updated_after: If specified, only sessions whose
             session state was set or updated after this time are returned. If not specified,
-            returns sessions with active messages in the entity.
+            returns sessions with active messages or stored session state in the entity. Sessions
+            with neither are excluded.
         :keyword float timeout: The total operation timeout in seconds, spent across
             every page of the enumeration.
         :keyword _now: Monotonic clock function, injectable for tests. Internal.
@@ -112,7 +113,9 @@ class _SessionBrowserAsync(AsyncBaseHandler):
                     raise OperationTimeoutError(
                         message="Listing sessions did not complete within the specified timeout."
                     )
-            message = _page_request_body(self._amqp_transport, last_updated_time_ms, skip)
+            message = _page_request_body(
+                self._amqp_transport, last_updated_time_ms, skip
+            )
             result = await self._mgmt_request_response_with_retry(
                 REQUEST_RESPONSE_GET_MESSAGE_SESSIONS_OPERATION,
                 message,

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/list_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/list_sessions_async.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""List sessions asynchronously using both supported modes.
+
+Default listing returns sessions with active messages or stored session state and excludes
+sessions with neither. A cutoff returns only sessions whose stored state was set or updated
+after that time.
+"""
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+
+from azure.identity.aio import DefaultAzureCredential
+from azure.servicebus.aio import ServiceBusClient
+
+
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
+SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
+TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
+SUBSCRIPTION_NAME = os.environ["SERVICEBUS_SUBSCRIPTION_NAME"]
+
+
+async def list_queue_sessions(servicebus_client):
+    async for session_id in servicebus_client.list_queue_sessions(SESSION_QUEUE_NAME):
+        print("Queue session:", session_id)
+
+
+async def list_subscription_sessions(servicebus_client):
+    async for session_id in servicebus_client.list_subscription_sessions(
+        TOPIC_NAME, SUBSCRIPTION_NAME
+    ):
+        print("Subscription session:", session_id)
+
+
+async def list_recently_updated_queue_sessions(servicebus_client):
+    state_updated_after = datetime.now(timezone.utc) - timedelta(days=7)
+    async for session_id in servicebus_client.list_queue_sessions(
+        SESSION_QUEUE_NAME, state_updated_after=state_updated_after
+    ):
+        print("Recently updated queue session:", session_id)
+
+
+async def main():
+    async with DefaultAzureCredential() as credential:
+        async with ServiceBusClient(
+            FULLY_QUALIFIED_NAMESPACE, credential
+        ) as servicebus_client:
+            await list_queue_sessions(servicebus_client)
+            await list_subscription_sessions(servicebus_client)
+            await list_recently_updated_queue_sessions(servicebus_client)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/list_sessions.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/list_sessions.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""List sessions using both supported modes.
+
+Default listing returns sessions with active messages or stored session state and excludes
+sessions with neither. A cutoff returns only sessions whose stored state was set or updated
+after that time.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+from azure.identity import DefaultAzureCredential
+from azure.servicebus import ServiceBusClient
+
+
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
+SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
+TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
+SUBSCRIPTION_NAME = os.environ["SERVICEBUS_SUBSCRIPTION_NAME"]
+
+
+def list_queue_sessions(servicebus_client):
+    for session_id in servicebus_client.list_queue_sessions(SESSION_QUEUE_NAME):
+        print("Queue session:", session_id)
+
+
+def list_subscription_sessions(servicebus_client):
+    for session_id in servicebus_client.list_subscription_sessions(
+        TOPIC_NAME, SUBSCRIPTION_NAME
+    ):
+        print("Subscription session:", session_id)
+
+
+def list_recently_updated_queue_sessions(servicebus_client):
+    state_updated_after = datetime.now(timezone.utc) - timedelta(days=7)
+    for session_id in servicebus_client.list_queue_sessions(
+        SESSION_QUEUE_NAME, state_updated_after=state_updated_after
+    ):
+        print("Recently updated queue session:", session_id)
+
+
+def main():
+    with DefaultAzureCredential() as credential:
+        with ServiceBusClient(
+            FULLY_QUALIFIED_NAMESPACE, credential
+        ) as servicebus_client:
+            list_queue_sessions(servicebus_client)
+            list_subscription_sessions(servicebus_client)
+            list_recently_updated_queue_sessions(servicebus_client)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/servicebus/azure-servicebus/tests/unittests/test_session_browser.py
+++ b/sdk/servicebus/azure-servicebus/tests/unittests/test_session_browser.py
@@ -7,7 +7,7 @@
 """Unit tests for the _SessionBrowser sentinel value, page size, and
 management response handling.
 
-These tests verify the active-messages sentinel matches the value the service
+These tests verify the default-listing sentinel matches the value the service
 expects, and that the list_sessions_op handler covers all response branches,
 without requiring Azure credentials or a live Service Bus namespace.
 """
@@ -38,10 +38,11 @@ from azure.servicebus._common.constants import (
 
 
 class TestSessionBrowserSentinel:
-    """Verify the active-messages sentinel value is correct.
+    """Verify the default-listing sentinel value is correct.
 
     The service checks `lastUpdatedTime != DateTime.MaxValue` (exact equality)
-    to switch between "active messages" mode and "updated since" mode. The .NET
+    to switch between default listing mode and updated-since mode. The default
+    listing mode returns sessions with active messages or stored session state. The .NET
     AMQP library (TimeStampEncoding.cs) encodes DateTime.MaxValue as
     253402300800000 ms (10000-01-01T00:00:00Z) due to double-to-long rounding
     in TimeSpan.TotalMilliseconds, and its decoder clamps values exceeding
@@ -50,7 +51,7 @@ class TestSessionBrowserSentinel:
     Sending 253402300799999 (1 ms less) decodes to a DateTime that is NOT
     DateTime.MaxValue, causing the service to use "updated-since" mode with
     a far-future timestamp, which returns empty results instead of sessions
-    with active messages.
+    with active messages or stored session state.
     """
 
     def test_sentinel_value_matches_dotnet_amqp_encoding_of_datetime_maxvalue(self):
@@ -204,19 +205,24 @@ class TestListSessionsPagination:
 
     def test_paginates_full_first_page_then_partial_second(self):
         page1 = [f"session-{i}" for i in range(_PAGE_SIZE)]  # full page -> fetch next
-        page2 = [f"session-{i}" for i in range(_PAGE_SIZE, _PAGE_SIZE + 30)]  # partial -> stop
+        page2 = [
+            f"session-{i}" for i in range(_PAGE_SIZE, _PAGE_SIZE + 30)
+        ]  # partial -> stop
         skips = []
         serve = _paged_mgmt_stub({0: page1, _PAGE_SIZE: page2}, skips)
 
         browser = _live_browser(_SessionBrowser)
-        browser._mgmt_request_response_with_retry = lambda operation, message, callback, **kwargs: serve(
-            message["skip"][VALUE]
+        browser._mgmt_request_response_with_retry = (
+            lambda operation, message, callback, **kwargs: serve(message["skip"][VALUE])
         )
 
         result = list(browser.list_sessions())
 
         assert result == page1 + page2  # every ID from both pages, in order
-        assert skips == [0, _PAGE_SIZE]  # skip advanced by len(page1)=100, stopped after the partial page
+        assert skips == [
+            0,
+            _PAGE_SIZE,
+        ]  # skip advanced by len(page1)=100, stopped after the partial page
 
 
 class TestListSessionsPaginationAsync:
@@ -270,7 +276,9 @@ class TestListSessionsTimeoutBudget:
         browser = _live_browser(_SessionBrowser)
 
         def _should_not_run(*args, **kwargs):
-            raise AssertionError("management request should not be issued after the budget is spent")
+            raise AssertionError(
+                "management request should not be issued after the budget is spent"
+            )
 
         browser._mgmt_request_response_with_retry = _should_not_run
         # base 1000 -> deadline 1005; first page check at 1006 -> -1 remaining -> raise.
@@ -300,7 +308,10 @@ class TestListSessionsTimeoutBudgetAsync:
         browser = _live_browser(_SessionBrowserAsync)
         browser._mgmt_request_response_with_retry = serve
         clock = iter([1000.0, 1000.0, 1003.0])
-        _ = [sid async for sid in browser.list_sessions(timeout=10, _now=lambda: next(clock))]
+        _ = [
+            sid
+            async for sid in browser.list_sessions(timeout=10, _now=lambda: next(clock))
+        ]
 
         assert seen == [10.0, 7.0]
 
@@ -309,12 +320,19 @@ class TestListSessionsTimeoutBudgetAsync:
         browser = _live_browser(_SessionBrowserAsync)
 
         async def _should_not_run(*args, **kwargs):
-            raise AssertionError("management request should not be issued after the budget is spent")
+            raise AssertionError(
+                "management request should not be issued after the budget is spent"
+            )
 
         browser._mgmt_request_response_with_retry = _should_not_run
         clock = iter([1000.0, 1006.0])
         with pytest.raises(OperationTimeoutError):
-            _ = [sid async for sid in browser.list_sessions(timeout=5, _now=lambda: next(clock))]
+            _ = [
+                sid
+                async for sid in browser.list_sessions(
+                    timeout=5, _now=lambda: next(clock)
+                )
+            ]
 
 
 def _capture_last_updated_ms(browser):
@@ -330,17 +348,21 @@ def _capture_last_updated_ms(browser):
 
 
 class TestUpdatedAfterSentinelBoundary:
-    """An explicit filter timestamp must never collide with the active-messages sentinel.
+    """An explicit filter timestamp must never collide with the default-listing sentinel.
 
     `datetime.max` in UTC is 1 ms below `_MAX_DATETIME_MS`. Float `timestamp() * 1000`
     rounds it up onto the sentinel, which would silently switch the request into
-    active-messages mode. Integer arithmetic must keep it at `_MAX_DATETIME_MS - 1`.
+    default listing mode. Integer arithmetic must keep it at `_MAX_DATETIME_MS - 1`.
     """
 
     def test_datetime_max_stays_below_sentinel(self):
         browser = _live_browser(_SessionBrowser)
         captured = _capture_last_updated_ms(browser)
-        list(browser.list_sessions(state_updated_after=datetime.max.replace(tzinfo=timezone.utc)))
+        list(
+            browser.list_sessions(
+                state_updated_after=datetime.max.replace(tzinfo=timezone.utc)
+            )
+        )
         assert captured["ms"] == _MAX_DATETIME_MS - 1
         assert captured["ms"] != _MAX_DATETIME_MS
 
@@ -354,8 +376,12 @@ class TestUpdatedAfterSentinelBoundary:
             return []
 
         browser._mgmt_request_response_with_retry = _serve
-        _ = [sid async for sid in browser.list_sessions(
-            state_updated_after=datetime.max.replace(tzinfo=timezone.utc))]
+        _ = [
+            sid
+            async for sid in browser.list_sessions(
+                state_updated_after=datetime.max.replace(tzinfo=timezone.utc)
+            )
+        ]
         assert captured["ms"] == _MAX_DATETIME_MS - 1
         assert captured["ms"] != _MAX_DATETIME_MS
 
@@ -406,7 +432,7 @@ class TestToLastUpdatedMs:
     """The shared `_to_last_updated_ms` helper is used by both the sync and async
     browsers, so a drift between the two copies cannot change the query mode."""
 
-    def test_none_returns_active_messages_sentinel(self):
+    def test_none_returns_default_listing_sentinel(self):
         assert _to_last_updated_ms(None) == _MAX_DATETIME_MS
 
     def test_naive_datetime_is_treated_as_utc(self):
@@ -451,7 +477,9 @@ class TestBrowserEagerClose:
 
     def test_close_called_once_on_terminal_page_only(self):
         page1 = [f"session-{i}" for i in range(_PAGE_SIZE)]  # full -> continue
-        page2 = [f"session-{i}" for i in range(_PAGE_SIZE, _PAGE_SIZE + 3)]  # partial -> close
+        page2 = [
+            f"session-{i}" for i in range(_PAGE_SIZE, _PAGE_SIZE + 3)
+        ]  # partial -> close
         pages = {0: page1, _PAGE_SIZE: page2}
         close_calls = []
 
@@ -460,7 +488,9 @@ class TestBrowserEagerClose:
         browser._amqp_transport = PyamqpTransport
         browser.close = lambda: close_calls.append(1)
         browser._mgmt_request_response_with_retry = (
-            lambda operation, message, callback, **kwargs: pages.get(message["skip"][VALUE], [])
+            lambda operation, message, callback, **kwargs: pages.get(
+                message["skip"][VALUE], []
+            )
         )
 
         pager = browser.list_sessions().by_page()
@@ -485,7 +515,9 @@ class TestBrowserEagerClose:
         browser._amqp_transport = PyamqpTransport
         browser.close = lambda: close_calls.append(1)
         browser._mgmt_request_response_with_retry = (
-            lambda operation, message, callback, **kwargs: pages.get(message["skip"][VALUE], [])
+            lambda operation, message, callback, **kwargs: pages.get(
+                message["skip"][VALUE], []
+            )
         )
 
         pager = browser.list_sessions().by_page()
@@ -531,7 +563,9 @@ class TestBrowserShutdownGuard:
         browser._shutdown = threading.Event()
         browser._shutdown.set()
         requested = []
-        browser._mgmt_request_response_with_retry = lambda *a, **k: requested.append(1) or []
+        browser._mgmt_request_response_with_retry = (
+            lambda *a, **k: requested.append(1) or []
+        )
 
         with pytest.raises(ValueError, match="already been shutdown"):
             list(browser.list_sessions())
@@ -552,5 +586,3 @@ class TestBrowserShutdownGuard:
         with pytest.raises(ValueError, match="already been shutdown"):
             _ = [sid async for sid in browser.list_sessions()]
         assert requested == []
-
-


### PR DESCRIPTION
# Description

Adds synchronous and asynchronous samples for both list-session modes and corrects list-session wording throughout the package:

- Default listing returns sessions with active messages or stored session state.
- `state_updated_after` returns sessions whose stored state was set or updated after the cutoff.

The examples use a real seven-day cutoff and keep the internal sentinel out of customer guidance. No runtime behavior or public API changes.

Related implementation: Azure/azure-sdk-for-python#46575

# Testing

- Black passes for all touched Python files.
- Focused session-browser tests pass.
- Package Pylint score: 10/10.
- New samples compile successfully.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There is one focused commit with an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
