### PR TITLE
[Service Bus] Prepare azure-servicebus 7.15.0b2 release

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.15.0b1 (Unreleased)
+## 7.15.0b2 (2026-08-21)
 
 ### Features Added
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "7.15.0b1"
+VERSION = "7.15.0b2"


### PR DESCRIPTION
## Summary

Prepares `azure-servicebus` `7.15.0b2` for the planned August 21, 2026
release.

## Changes

- `sdk/servicebus/azure-servicebus/CHANGELOG.md`
- `sdk/servicebus/azure-servicebus/azure/servicebus/_version.py`

Advances the target from `7.15.0b1` to `7.15.0b2` because the `7.15.0b1` tag
already exists from an earlier unpublished release attempt. No product code
changes.

## Cross-SDK release set

| SDK | Package | Version | PR |
|-----|---------|---------|----|
| .NET | `Azure.Messaging.ServiceBus` | `7.21.0-beta.1` | [#62282](https://github.com/Azure/azure-sdk-for-net/pull/62282) |
| Java | `azure-messaging-servicebus` | `7.18.0-beta.3` | [#50198](https://github.com/Azure/azure-sdk-for-java/pull/50198) |
| JavaScript | `@azure/service-bus` | `7.10.0-beta.5` | [#39672](https://github.com/Azure/azure-sdk-for-js/pull/39672) |
| Go | `sdk/messaging/azservicebus` | `1.11.0-beta.1` | [#27420](https://github.com/Azure/azure-sdk-for-go/pull/27420) |
| Python | `azure-servicebus` | `7.15.0b2` | [#48649](https://github.com/Azure/azure-sdk-for-python/pull/48649) |

## Validation

- `./eng/common/scripts/Prepare-Release.ps1 -PackageName azure-servicebus -ServiceDirectory servicebus -ReleaseDate '08/21/2026'`
- `git diff --check`
- Metadata-only change; no product tests required.

## Release controls

- Release tracking: [26053 - Python - Service Bus - 7.15](https://dev.azure.com/azure-sdk/Release/_workitems/edit/26053/)
- Release pipeline: Not queued by this PR.
