### PR TITLE
Release azure-ai-agentserver-responses 2.1.0b2

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 2.1.0b2 (2026-08-20)
+
+### Bugs Fixed
+
+- Restored JSON-string encoding for response-level `internal_metadata` so resilient response checkpoints round-trip through Foundry storage.
+- Restored `get_request_context()` identity values while stored Responses handlers run inside durable tasks.
+
 ## 2.1.0b1 (2026-08-11)
 
 ### Breaking Changes
@@ -18,11 +25,6 @@
   `ConversationChainMetadataNamespace` protocol. Resilient response
   applications now persist cross-turn state explicitly with
   `FoundryStateStore`.
-
-### Bugs Fixed
-
-- Restored JSON-string encoding for response-level `internal_metadata` so resilient response checkpoints round-trip through Foundry storage.
-- Restored `get_request_context()` identity values while stored Responses handlers run inside durable tasks.
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b1"
+VERSION = "2.1.0b2"


### PR DESCRIPTION
## Summary
- prepare `azure-ai-agentserver-responses` version `2.1.0b2` for release on 2026-08-20
- move the two fixes merged after `2.1.0b1` into the new release entry
- bump the package version from `2.1.0b1` to `2.1.0b2`

## Included fixes
- response-level `internal_metadata` encoding for resilient checkpoints (#48590)
- ambient request identity during durable Responses handler execution (#48605)

## Validation
- confirmed `2.1.0b2` is not already published on PyPI
- `git diff --check`