### PR TITLE
[agentserver] Fix storage typing and claims test broken by microsoft-agents-hosting-core 1.4.0

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/azure/ai/agentserver/activity/_foundry_storage.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/azure/ai/agentserver/activity/_foundry_storage.py
@@ -11,7 +11,7 @@ import re
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, TypeVar, cast
 
 from azure.ai.agentserver.core.storage import FoundryStateStore, FoundryStorageEndpoint, FoundryStorageNotFoundError
 from azure.core.credentials_async import AsyncTokenCredential
@@ -327,15 +327,17 @@ class FoundryStorage(AsyncStorageBase):
             item = await store.get_item(_bounded_store_name(key))
         if item is None or target_cls is None:
             return None, None
-        return key, target_cls.from_json_to_store_item(item.value)
+        # ``StoreItem.from_json_to_store_item`` is annotated ``-> StoreItem`` upstream, so
+        # calling it through ``type[StoreItemT]`` does not narrow to the concrete subclass.
+        return key, cast(StoreItemT, target_cls.from_json_to_store_item(item.value))
 
-    async def _write_item(self, key: str, value: StoreItemT) -> None:
+    async def _write_item(self, key: str, value: StoreItem) -> None:
         """Create-or-replace one item, creating its backing store on first write.
 
         :param key: The M365 storage key to write (also the store name).
         :type key: str
         :param value: The ``StoreItem`` to persist.
-        :type value: StoreItemT
+        :type value: ~microsoft_agents.hosting.core.storage.StoreItem
         :return: None.
         :rtype: None
         """

--- a/sdk/agentserver/azure-ai-agentserver-activity/tests/test_bridge_turn.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/tests/test_bridge_turn.py
@@ -142,9 +142,11 @@ def test_claims_authenticated_with_empty_bot_app_id_has_empty_claims():
     but with no appid/audience entries."""
     claims = bridge._build_outbound_claims(ClaimsIdentity, digital_worker=False, is_hosted=True, bot_app_id="")
 
-    assert claims.is_authenticated is True
+    # ``is_authenticated`` is deprecated upstream and now derives from the claim
+    # dict being non-empty, so assert on the authentication type instead.
     assert claims.authentication_type == OutboundAuth.AUTH_TYPE_BEARER
     assert claims.get_claim_value(OutboundAuth.CLAIM_APP_ID) is None
+    assert claims.get_claim_value(OutboundAuth.CLAIM_AUDIENCE) is None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.1.0b3 (Unreleased)
+
+### Other Changes
+
+- `FoundryStateStore.set_item()` and `create_item()` now accept any `Mapping[str, JSONValue]` for `value` instead of requiring a concrete `dict`. The payload is never mutated, only serialized, so the narrower `dict` requirement rejected valid callers (for example M365 `StoreItem.store_item_to_json()`, which returns a `MutableMapping`). Widening a parameter type is backward compatible for all existing callers.
+
 ## 2.1.0b2 (2026-08-18)
 
 ### Other Changes

--- a/sdk/agentserver/azure-ai-agentserver-core/api.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/api.md
@@ -252,7 +252,7 @@ namespace azure.ai.agentserver.core.storage
         async def create_item(
                 self, 
                 key: str, 
-                value: JSONObject, 
+                value: Mapping[str, JSONValue], 
                 *, 
                 call_id: str | None = ..., 
                 tags: Mapping[str, str] | None = ...
@@ -291,7 +291,7 @@ namespace azure.ai.agentserver.core.storage
         async def set_item(
                 self, 
                 key: str, 
-                value: JSONObject, 
+                value: Mapping[str, JSONValue], 
                 *, 
                 call_id: str | None = ..., 
                 if_match: str | None = ..., 

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b2"
+VERSION = "2.1.0b3"

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_local_state.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_local_state.py
@@ -22,7 +22,7 @@ from ._errors import (
 from ._state_serializer import (
     DeletedStateStore,
     DeletedStateStoreItem,
-    JSONObject,
+    JSONValue,
     Order,
     StateStore,
     StateStoreItem,
@@ -139,7 +139,7 @@ class LocalStateStoreBackend:
     def create_item(
         self,
         key: str,
-        value: JSONObject,
+        value: Mapping[str, JSONValue],
         tags: Mapping[str, str] | None,
     ) -> StateStoreItemRef:
         with self._lock:
@@ -159,7 +159,7 @@ class LocalStateStoreBackend:
     def set_item(
         self,
         key: str,
-        value: JSONObject,
+        value: Mapping[str, JSONValue],
         tags: Mapping[str, str] | None,
         if_match: str | None,
     ) -> StateStoreItemRef:
@@ -296,7 +296,7 @@ class LocalStateStoreBackend:
     def _new_item(
         self,
         key: str,
-        value: JSONObject,
+        value: Mapping[str, JSONValue],
         tags: Mapping[str, str] | None,
     ) -> dict[str, Any]:
         now = _now()

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_state.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_state.py
@@ -28,7 +28,7 @@ from ._state_serializer import (
     _UNSET,
     DeletedStateStore,
     DeletedStateStoreItem,
-    JSONObject,
+    JSONValue,
     StateStoreItemKeyPage,
     Order,
     StateStore,
@@ -374,7 +374,7 @@ class FoundryStateStore(FoundryStorageClient):
     async def create_item(
         self,
         key: str,
-        value: JSONObject,
+        value: Mapping[str, JSONValue],
         *,
         tags: Mapping[str, str] | None = None,
         call_id: str | None = None,
@@ -384,7 +384,7 @@ class FoundryStateStore(FoundryStorageClient):
         :param key: The item key to create.
         :type key: str
         :param value: The item payload as a JSON object.
-        :type value: dict[str, any]
+        :type value: ~collections.abc.Mapping[str, any]
         :keyword tags: Optional string labels stored with the item and used to
             filter :meth:`list_keys`.
         :paramtype tags: ~collections.abc.Mapping[str, str] or None
@@ -412,7 +412,7 @@ class FoundryStateStore(FoundryStorageClient):
     async def set_item(
         self,
         key: str,
-        value: JSONObject,
+        value: Mapping[str, JSONValue],
         *,
         tags: Mapping[str, str] | None = None,
         if_match: str | None = None,
@@ -424,7 +424,7 @@ class FoundryStateStore(FoundryStorageClient):
         :param key: The item key to create or replace.
         :type key: str
         :param value: The item payload as a JSON object.
-        :type value: dict[str, any]
+        :type value: ~collections.abc.Mapping[str, any]
         :keyword tags: Optional string labels stored with the item and used to
             filter :meth:`list_keys`.
         :paramtype tags: ~collections.abc.Mapping[str, str] or None

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_state_serializer.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/storage/_state_serializer.py
@@ -136,13 +136,13 @@ def serialize_store_update_request(description: str | None | object, tags: Mappi
     return json.dumps(dict(request)).encode("utf-8")
 
 
-def serialize_item_create_request(key: str, value: JSONObject, tags: Mapping[str, str] | None) -> bytes:
-    request = CreateItemRequest(key=key, value=value, tags=_to_wire_tags(tags))
+def serialize_item_create_request(key: str, value: Mapping[str, JSONValue], tags: Mapping[str, str] | None) -> bytes:
+    request = CreateItemRequest(key=key, value=dict(value), tags=_to_wire_tags(tags))
     return json.dumps(dict(request)).encode("utf-8")
 
 
-def serialize_item_put_request(value: JSONObject, tags: Mapping[str, str] | None) -> bytes:
-    request = PutItemRequest(value=value, tags=_to_wire_tags(tags))
+def serialize_item_put_request(value: Mapping[str, JSONValue], tags: Mapping[str, str] | None) -> bytes:
+    request = PutItemRequest(value=dict(value), tags=_to_wire_tags(tags))
     return json.dumps(dict(request)).encode("utf-8")
 
 


### PR DESCRIPTION
## Problem

The `python - agentserver` pipeline ([build 6724107](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6724107)) started failing on `main` **without any repo change**. The last green run (`ec6daf825`) and the first red run (`bc99dcd26`) have a completely empty diff across both affected packages:

```
git diff --stat ec6daf825 bc99dcd26 -- sdk/agentserver/azure-ai-agentserver-core/ \
                                       sdk/agentserver/azure-ai-agentserver-activity/
(empty)
```

The trigger is external. `microsoft-agents-hosting-core` is pinned open-ended as `>=1.1.0`, so CI resolves the newest release. **1.4.0 was published 2026-08-18 21:07 UTC** — the last green build finished 13:13 UTC that day, and everything after it is red.

1.4.0 introduced two changes that broke us:

**1. The package added a `py.typed` marker.**

```
1.3.0: no py.typed
1.4.0: microsoft_agents/hosting/core/py.typed
```

Previously mypy ran against it with `--ignore-missing-imports`, so `StoreItem` and friends silently degraded to `Any` and nothing was checked. With the marker present mypy resolves the real signatures and surfaces two **latent, pre-existing** type errors in `FoundryStorage`:

```
_foundry_storage.py:330: error: Incompatible return value type (got "tuple[str, StoreItem]",
    expected "tuple[str | None, StoreItemT | None]")  [return-value]
_foundry_storage.py:343: error: Argument 2 to "set_item" of "FoundryStateStore" has
    incompatible type "MutableMapping[str, Any]"; expected "dict[str, JSONValue]"  [arg-type]
```

Note the `JSON = MutableMapping[str, Any]` alias is **identical** across 1.1.0 → 1.4.0. This was never a signature change, purely a visibility change.

**2. `ClaimsIdentity.is_authenticated` became a deprecated computed property.**

```python
@property
def is_authenticated(self) -> bool:   # 1.4.0
    return bool(self.claims)          # constructor arg is now a deprecated no-op
```

It was a stored attribute in 1.1.0 / 1.2.0 / 1.3.0. `test_claims_authenticated_with_empty_bot_app_id_has_empty_claims` passes `bot_app_id=""`, which produces an empty claim dict, so the assertion now evaluates `False` on all 6 platforms.

## Fix

**`set_item` / `create_item` — widened, no cast.** These are our own APIs and they only serialize `value`, never mutate it, so the concrete `dict` requirement was needlessly narrow and rejected valid callers:

```python
value: Mapping[str, JSONValue]     # was: JSONObject (= dict[str, JSONValue])
```

`Mapping` is covariant in its value type, so `MutableMapping[str, Any]` now satisfies it. **Widening a parameter type is backward compatible** — every existing caller still type-checks. The same widening is applied to `LocalStateStoreBackend`, and the two `serialize_item_*` helpers now materialize a `dict` at the wire boundary (a genuine defensive copy before `json.dumps`, not a type-system workaround). The adapter call site is then plain:

```python
await store.set_item(_bounded_store_name(key), value.store_item_to_json())
```

**`_write_item` — narrowing removed.** Now matches the `AsyncStorageBase` signature (`value: StoreItem`). The TypeVar appeared only once so it bought nothing, and narrowing a parameter in an override violates LSP.

**`_read_item` — the one remaining `cast`, with an explanatory comment.** Unavoidable locally: `StoreItem.from_json_to_store_item` is annotated `-> StoreItem` in the third-party M365 SDK and does not narrow through `type[StoreItemT]`. We also can't widen our own return type, since return types are covariant in overrides. The cast is sound — `target_cls` *is* `type[StoreItemT]`, so the runtime object genuinely is a `StoreItemT`. The upstream fix would be annotating it `-> Self`.

**Test** — asserts on `authentication_type` and the claim values instead of the now-deprecated `is_authenticated`.

## Verification

Run locally with `microsoft-agents-hosting-core==1.4.0` (and siblings) installed, which is what CI resolves:

| Check | Result |
| --- | --- |
| mypy — `azure-ai-agentserver-activity` | 11 files, 0 errors (was 2) |
| mypy — `azure-ai-agentserver-core` storage | 14 files, 0 errors |
| pytest — activity | 105 passed, 1 skipped (was 1 failed) |
| pytest — core | 903 passed, 57 skipped |
| pylint | 10.00/10 |

The two remaining core failures (`test_otlp_protocol.py::test_otlp_protocol_exports_all_signals[grpc]` and `test_tracing.py::TestSetupDistroExport::test_managed_otlp_handles_mixed_signal_protocols`) are **pre-existing and unrelated** — verified failing on a clean tree at this same base. Likewise the two pre-existing `black` violations in `_state.py` / `_local_state.py`; none of the reformatted lines are touched by this PR.

## Follow-up (not in this PR)

The root cause is an **uncapped transitive dependency**. Worth considering an upper bound on the `microsoft-agents-*` pins so a minor upstream release can't turn `main` red with no repo change. An upstream issue for `from_json_to_store_item` returning `Self` would let us delete the remaining cast.
