### PR TITLE
[agentserver] Fix activity typing and claims test broken by M365 SDK 1.4.0

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/azure/ai/agentserver/activity/_foundry_storage.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/azure/ai/agentserver/activity/_foundry_storage.py
@@ -11,7 +11,7 @@ import re
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, TypeVar, cast
 
 from azure.ai.agentserver.core.storage import FoundryStateStore, FoundryStorageEndpoint, FoundryStorageNotFoundError
 from azure.core.credentials_async import AsyncTokenCredential
@@ -327,20 +327,24 @@ class FoundryStorage(AsyncStorageBase):
             item = await store.get_item(_bounded_store_name(key))
         if item is None or target_cls is None:
             return None, None
-        return key, target_cls.from_json_to_store_item(item.value)
+        # ``StoreItem.from_json_to_store_item`` is annotated ``-> StoreItem`` upstream, so
+        # calling it through ``type[StoreItemT]`` does not narrow to the concrete subclass.
+        return key, cast(StoreItemT, target_cls.from_json_to_store_item(item.value))
 
-    async def _write_item(self, key: str, value: StoreItemT) -> None:
+    async def _write_item(self, key: str, value: StoreItem) -> None:
         """Create-or-replace one item, creating its backing store on first write.
 
         :param key: The M365 storage key to write (also the store name).
         :type key: str
         :param value: The ``StoreItem`` to persist.
-        :type value: StoreItemT
+        :type value: ~microsoft_agents.hosting.core.storage.StoreItem
         :return: None.
         :rtype: None
         """
         async with self._use_store(key, ensure_exists=True) as store:
-            await store.set_item(_bounded_store_name(key), value.store_item_to_json())
+            # ``store_item_to_json()`` returns a ``MutableMapping``; the store's public API
+            # takes a concrete ``dict``, so materialize one at the boundary.
+            await store.set_item(_bounded_store_name(key), dict(value.store_item_to_json()))
 
     async def _delete_item(self, key: str) -> None:
         """Delete one item. Missing keys (or stores) are ignored.

--- a/sdk/agentserver/azure-ai-agentserver-activity/tests/test_bridge_turn.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/tests/test_bridge_turn.py
@@ -142,9 +142,11 @@ def test_claims_authenticated_with_empty_bot_app_id_has_empty_claims():
     but with no appid/audience entries."""
     claims = bridge._build_outbound_claims(ClaimsIdentity, digital_worker=False, is_hosted=True, bot_app_id="")
 
-    assert claims.is_authenticated is True
+    # ``is_authenticated`` is deprecated upstream and now derives from the claim
+    # dict being non-empty, so assert on the authentication type instead.
     assert claims.authentication_type == OutboundAuth.AUTH_TYPE_BEARER
     assert claims.get_claim_value(OutboundAuth.CLAIM_APP_ID) is None
+    assert claims.get_claim_value(OutboundAuth.CLAIM_AUDIENCE) is None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/agentserver/azure-ai-agentserver-activity/tests/test_foundry_storage.py
+++ b/sdk/agentserver/azure-ai-agentserver-activity/tests/test_foundry_storage.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from collections import UserDict
+from typing import Any, MutableMapping
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -25,6 +26,25 @@ class _TestStoreItem:
     @staticmethod
     def from_json_to_store_item(json_data: dict[str, Any]) -> "_TestStoreItem":
         return _TestStoreItem(json_data)
+
+
+class _MappingStoreItem:
+    """A store item whose payload is a non-``dict`` ``MutableMapping``.
+
+    M365's ``StoreItem.store_item_to_json()`` is annotated to return a
+    ``MutableMapping``, not a concrete ``dict``, and implementations are free to
+    honor that literally. ``FoundryStateStore.set_item()`` requires a ``dict``.
+    """
+
+    def __init__(self, value: dict[str, Any]) -> None:
+        self.value: MutableMapping[str, Any] = UserDict(value)
+
+    def store_item_to_json(self) -> MutableMapping[str, Any]:
+        return self.value
+
+    @staticmethod
+    def from_json_to_store_item(json_data: dict[str, Any]) -> "_MappingStoreItem":
+        return _MappingStoreItem(dict(json_data))
 
 
 def _fake_store() -> MagicMock:
@@ -110,6 +130,20 @@ async def test_write_creates_the_store_then_sets_the_item(monkeypatch: pytest.Mo
 
     mock_cls.get_or_create.assert_awaited_once()
     store.set_item.assert_awaited_once_with("k", {"turn": 4})
+
+
+@pytest.mark.asyncio
+async def test_write_materializes_a_dict_from_a_non_dict_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``set_item()`` must receive a real ``dict``, not whatever ``Mapping`` the item returned."""
+    store = _fake_store()
+    _patch_stores(monkeypatch, {"k": store})
+    storage = FoundryStorage()
+
+    await storage.write({"k": _MappingStoreItem({"turn": 4})})
+
+    _, payload = store.set_item.await_args.args
+    assert type(payload) is dict
+    assert payload == {"turn": 4}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The `python - agentserver` CI pipeline started failing on `main` with no corresponding repo change. `git diff` between the last green build (`ec6daf8257`) and the first red one (`bc99dcd2`) across `core/` and `activity/` is **empty**.

The cause is an external release. `microsoft-agents-hosting-core` is pinned open-ended as `>=1.1.0` in `azure-ai-agentserver-activity/pyproject.toml`, so CI resolves the newest version. **1.4.0 was published 2026-08-18 21:07Z**, cleanly between the green and red builds, and introduced two breaks.

### 1. mypy failures in `FoundryStorage` (2 errors)

```
_foundry_storage.py:330: error: Incompatible return value type  [return-value]
_foundry_storage.py:343: error: Argument 2 has incompatible type  [arg-type]
```

The non-obvious part: **1.4.0 added a `py.typed` marker that 1.3.0 did not have.** Under `--ignore-missing-imports`, an untyped package degrades to `Any`, so `StoreItem` and friends were never actually checked. With the marker present mypy resolves the real signatures. The `JSON = MutableMapping[str, Any]` alias is byte-identical across 1.1.0 → 1.4.0 — nothing about the types changed, they simply became *visible*. **These two errors were latent all along.**

### 2. Test failure on all 6 platforms

`test_claims_authenticated_with_empty_bot_app_id_has_empty_claims` — `assert claims.is_authenticated is True` → `assert False is True`.

In 1.4.0 `ClaimsIdentity.is_authenticated` changed from a stored attribute into a deprecated computed property returning `bool(self.claims)`, and the constructor kwarg became a no-op. An empty `bot_app_id` yields an empty claim dict, so it is now `False`.

## Fix

Both failures originate in this package's adapter over the third-party SDK, so the fix is contained here and **`azure-ai-agentserver-core` is untouched**.

- `_write_item` materializes a `dict` from `store_item_to_json()` (which returns a `MutableMapping`) at the call into `FoundryStateStore.set_item`.
- `_write_item` no longer narrows its parameter to `StoreItemT`, matching the `AsyncStorageBase` signature. The TypeVar bought nothing and the narrowing violated LSP.
- `_read_item` casts the deserialized item. `StoreItem.from_json_to_store_item` is annotated `-> StoreItem` on the base ABC upstream, so it does not narrow through `type[StoreItemT]`. The cast is sound because `target_cls` *is* `type[StoreItemT]`; the upstream fix would be `-> Self`.
- The test asserts on `authentication_type` and the claim values instead of the deprecated `is_authenticated`.

No public API changes, so no changelog entry or version bump is required.

## Verification

Run locally with `microsoft-agents-hosting-core==1.4.0` installed to reproduce CI:

- mypy `azure-ai-agentserver-activity`: **Success, 11 files, 0 errors** (was 2)
- mypy `azure-ai-agentserver-core` storage: **Success, 14 files, 0 errors**
- pytest activity: **105 passed, 1 skipped**

## Follow-ups (not in this PR)

- **The systemic cause is the uncapped pin.** `microsoft-agents-* >=1.1.0` in `pyproject.toml` means any upstream release can turn `main` red without a repo change. Worth an upper bound or a pinned CI resolution.
- `FoundryStateStore.set_item()` / `create_item()` require a concrete `dict` for `value`, but only ever serialize it and never mutate it. Widening to `Mapping[str, JSONValue]` would accept valid callers like `store_item_to_json()` without the copy. That is a real improvement, but it is a deliberate core API change and belongs in its own PR rather than in a CI hotfix.
