### PR TITLE
Set azure-ai-agentserver-activity 1.0.0b3 release date

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
+## 1.0.0b3 (2026-08-21)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Dates the pending `1.0.0b3` changelog entry for release, following the same pattern as #48678.

- `_version.py` is already at `1.0.0b3`, so no version change is needed here.
- The latest published version on PyPI is `1.0.0b2`, so `1.0.0b3` is still pending.
- `2026-08-21` is the newest date in the file, which the changelog verifier requires.