### PR TITLE
[agentserver-activity] Release 1.0.0b3

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-activity/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
+## 1.0.0b3 (2026-08-21)
+
+### Features Added
+
+- `FoundryStorage` adapter backed by `FoundryStateStore` — Implements the M365 `AsyncStorageBase` interface on top of the durable Foundry state store KV layer. Each M365 storage key maps to a per-key FoundryStateStore with user-scoped key isolation. Hosted Activity agents default to `FoundryStorage` in Foundry containers and `MemoryStorage` for local development.
 
 ### Breaking Changes
 
 - Removed the `POST /api/messages` route alias. Inbound activities are served only at `POST /activity/messages`, which is the endpoint the Foundry platform routes to. Callers that posted to `/api/messages` must use `/activity/messages`.
+- Removed public SSE keepalive helper.
+
+### Other Changes
+
+- Fixed activity typing and claims test compatibility with M365 SDK 1.4.0. The package now handles the new `py.typed` marker in `microsoft-agents-hosting-core` 1.4.0 and the deprecated `is_authenticated` property.
+- Updated FoundryStorage compatibility with `microsoft-agents-hosting-core` 1.3.0+ (`target_cls` is now a keyword-only argument in `AsyncStorageBase.read`).
 
 ## 1.0.0b2 (2026-07-28)
 


### PR DESCRIPTION
Release of azure-ai-agentserver-activity 1.0.0b3

## Breaking Changes
- Removed the \POST /api/messages\ route alias. Inbound activities are served only at \POST /activity/messages\.

## Changes Since 1.0.0b2 (2026-07-28)
- Fix activity typing and claims test broken by M365 SDK 1.4.0
- Remove /api/messages route alias
- Add FoundryStorage adapter backed by FoundryStateStore
- Remove public SSE keepalive helper