### PR TITLE
[Storage] CI sample failure fix

### DIFF
--- a/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy.py
@@ -47,7 +47,7 @@ from azure.storage.blob import BlobPrefix
 # Ensure non-ASCII blob/container names don't crash printing on consoles
 # using a limited codec (e.g. cp1252 on Windows).
 if isinstance(sys.stdout, io.TextIOWrapper):
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stdout.reconfigure(encoding="ascii", errors="replace")
 
 try:
     CONNECTION_STRING = os.environ["STORAGE_CONNECTION_STRING"]

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy_async.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy_async.py
@@ -47,7 +47,7 @@ from azure.storage.blob.aio import BlobServiceClient, BlobPrefix
 # Ensure non-ASCII blob/container names don't crash printing on consoles
 # using a limited codec (e.g. cp1252 on Windows).
 if isinstance(sys.stdout, io.TextIOWrapper):
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stdout.reconfigure(encoding="ascii", errors="replace")
 
 
 try:


### PR DESCRIPTION
The test samples have been failing with the output stopping at the same three lines every run, right before a leftover test blob named `dir1/dir2/file\uffff.blob`. Setting the sample's stdout to UTF-8 let that character through to the CI script that relays sample output, which then crashed trying to print it.

Fix: emit pure ASCII, which survives every stage unchanged.