### PR TITLE
Prepare Agent Server Core, Responses, and Invocations stable releases

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.1.0b3 (Unreleased)
+## 2.1.0 (2026-08-24)
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-core/azure/ai/agentserver/core/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b3"
+VERSION = "2.1.0"

--- a/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-core/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",

--- a/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 1.1.0b2 (Unreleased)
+## 1.1.0 (2026-08-24)
+
+### Features Added
+
+- Added the typed Voice event relay API under `azure.ai.agentserver.invocations.voice`, including `VoiceAgentServerHost`, typed protocol messages, session lifecycle callbacks, response cancellation and timeout handling, and a basic Voice agent sample.
 
 ### Samples
 
@@ -10,6 +14,7 @@
 ### Other Changes
 
 - Constrained runtime, development, and sample dependencies to compatible release lines.
+- Updated the minimum `azure-ai-agentserver-core` dependency to the stable `2.1.0` release.
 
 ## 1.1.0b1 (2026-08-11)
 

--- a/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/azure/ai/agentserver/invocations/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "1.1.0b2"
+VERSION = "1.1.0"

--- a/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-invocations/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ["azure", "azure sdk", "agent", "agentserver", "invocations"]
 
 dependencies = [
-    "azure-ai-agentserver-core>=2.1.0b1,<2.2.0",
+    "azure-ai-agentserver-core>=2.1.0,<2.2.0",
     "azure-core>=1.37.0,<2.0.0",
     # Constraint on the transitive aiohttp: the `--pre` CI install otherwise
     # resolves the unbuildable aiohttp 4.0.0a1 alpha. Cap must be <4.0.0a0
@@ -76,7 +76,7 @@ mypy = true
 pyright = true
 verifytypes = false
 latestdependency = false
-# azure-ai-agentserver-core>=2.1.0b1 is not yet on PyPI
+# azure-ai-agentserver-core>=2.1.0 is not yet on PyPI
 mindependency = false
 pylint = true
 type_check_samples = false

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 2.1.0b3 (2026-08-24)
+## 2.1.0 (2026-08-24)
 
 ### Other Changes
 
 - Constrained runtime, development, and sample dependencies to compatible release lines.
+- Updated the minimum `azure-ai-agentserver-core` dependency to the stable `2.1.0` release.
 
 ## 2.1.0b2 (2026-08-21)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 2.1.0b3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 2.1.0b3 (2026-08-24)
 
 ### Other Changes
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/_version.py
@@ -4,4 +4,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-VERSION = "2.1.0b3"
+VERSION = "2.1.0"

--- a/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
+++ b/sdk/agentserver/azure-ai-agentserver-responses/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Microsoft Corporation" }]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "azure-ai-agentserver-core>=2.1.0b1,<2.2.0",
+    "azure-ai-agentserver-core>=2.1.0,<2.2.0",
     "azure-core>=1.37.0,<2.0.0",
     "isodate>=0.6.1,<1.0.0",
     "aiohttp>=3.10.0,<4.0.0a0",
@@ -76,5 +76,5 @@ in_bundle = false
 [tool.azure-sdk-build]
 verifytypes = false
 latestdependency = false
-# azure-ai-agentserver-core>=2.1.0b1 is not yet on PyPI
+# azure-ai-agentserver-core>=2.1.0 is not yet on PyPI
 mindependency = false


### PR DESCRIPTION
## Summary

- promote `azure-ai-agentserver-core` from `2.1.0b3` to stable `2.1.0`
- promote `azure-ai-agentserver-responses` from `2.1.0b3` to stable `2.1.0`
- promote `azure-ai-agentserver-invocations` from `1.1.0b2` to stable `1.1.0`
- mark all three packages as `Development Status :: 5 - Production/Stable`
- require stable Core `>=2.1.0,<2.2.0` from Responses and Invocations
- set all release dates to 2026-08-24

Core 2.1.0 includes the resilient-task and Foundry State Store changes introduced in the 2.1 previews. Responses 2.1.0 includes the durable-response fixes and hardened dependency ranges. Invocations 1.1.0 publishes the typed Voice event relay API, current resilient LangGraph dependencies, and hardened dependency ranges.

## Checks

- Core changelog validation
- Responses changelog validation
- Invocations changelog validation