### PR TITLE
Update test decorators to use HTTPX2 transport

### DIFF
--- a/eng/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -11,21 +11,21 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 from azure.core.pipeline.transport import AioHttpTransport
 
 try:
-    import httpx
+    import httpx2
 
-    AsyncHTTPXTransport = httpx.AsyncHTTPTransport
+    AsyncHTTPX2Transport = httpx2.AsyncHTTPTransport
 except ImportError:
-    httpx = None
-    AsyncHTTPXTransport = None
+    httpx2 = None
+    AsyncHTTPX2Transport = None
 
 from ..helpers import is_live_and_not_recording, trim_kwargs_from_test_function
 from ..proxy_testcase import (
     RecordedTransport,
     _transform_args,
-    _transform_httpx_args,
+    _transform_httpx2_args,
     get_test_id,
     start_record_or_playback,
-    restore_httpx_response_url,
+    restore_httpx2_response_url,
     stop_record_or_playback,
 )
 
@@ -38,8 +38,8 @@ def recorded_by_proxy_async(*transports):
         *transports: Which transport(s) to record. Pass one or more comma separated RecordedTransport enum values.
             - No args (default): Record AioHttpTransport.send calls (azure.core).
             - RecordedTransport.AZURE_CORE: Record AioHttpTransport.send calls. Same as the default above.
-            - RecordedTransport.HTTPX: Record AsyncHTTPXTransport.handle_async_request calls.
-            - RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX: Record both transports.
+            - RecordedTransport.HTTPX2: Record AsyncHTTPX2Transport.handle_async_request calls.
+            - RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2: Record both transports.
 
     Usages:
 
@@ -54,12 +54,12 @@ def recorded_by_proxy_async(*transports):
       @recorded_by_proxy_async(RecordedTransport.AZURE_CORE)
       async def test(...): ...
 
-      # If your test uses httpx only for network calls
-      @recorded_by_proxy_async(RecordedTransport.HTTPX)
+      # If your test uses httpx2 only for network calls
+      @recorded_by_proxy_async(RecordedTransport.HTTPX2)
       async def test(...): ...
 
-      # If your test uses both azure.core and httpx for network calls
-      @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+      # If your test uses both azure.core and httpx2 for network calls
+      @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
       async def test(...): ...
     """
 
@@ -82,11 +82,11 @@ def recorded_by_proxy_async(*transports):
             isinstance(transport, str) and transport == RecordedTransport.AZURE_CORE.value
         ):
             transport_list.append((AioHttpTransport, "send"))
-        elif transport == RecordedTransport.HTTPX or (
-            isinstance(transport, str) and transport == RecordedTransport.HTTPX.value
+        elif transport == RecordedTransport.HTTPX2 or (
+            isinstance(transport, str) and transport == RecordedTransport.HTTPX2.value
         ):
-            if AsyncHTTPXTransport is not None:
-                transport_list.append((AsyncHTTPXTransport, "handle_async_request"))
+            if AsyncHTTPX2Transport is not None:
+                transport_list.append((AsyncHTTPX2Transport, "handle_async_request"))
 
     # If still no transports, fall back to azure.core
     if not transport_list:
@@ -110,12 +110,12 @@ def _make_proxy_decorator_async(transports):
             recording_id, variables = start_record_or_playback(test_id)
 
             # Build a wrapper factory so each patched method closes over its own original
-            def make_combined_call(original_transport_func, is_httpx=False):
+            def make_combined_call(original_transport_func, is_httpx2=False):
                 async def combined_call(*call_args, **call_kwargs):
-                    if is_httpx:
-                        adjusted_args, adjusted_kwargs = _transform_httpx_args(recording_id, *call_args, **call_kwargs)
+                    if is_httpx2:
+                        adjusted_args, adjusted_kwargs = _transform_httpx2_args(recording_id, *call_args, **call_kwargs)
                         result = await original_transport_func(*adjusted_args, **adjusted_kwargs)
-                        restore_httpx_response_url(result)
+                        restore_httpx2_response_url(result)
                     else:
                         adjusted_args, adjusted_kwargs = _transform_args(recording_id, *call_args, **call_kwargs)
                         result = await original_transport_func(*adjusted_args, **adjusted_kwargs)
@@ -136,11 +136,11 @@ def _make_proxy_decorator_async(transports):
             # monkeypatch all requested transports
             for owner, name in transports:
                 original = getattr(owner, name)
-                # Check if this is an httpx transport by comparing with httpx transport classes
-                is_httpx_transport = (AsyncHTTPXTransport is not None and owner is AsyncHTTPXTransport) or (
-                    httpx is not None and owner.__module__.startswith("httpx")
+                # Check if this is an httpx2 transport by comparing with httpx2 transport classes
+                is_httpx2_transport = (AsyncHTTPX2Transport is not None and owner is AsyncHTTPX2Transport) or (
+                    httpx2 is not None and owner.__module__.startswith("httpx2")
                 )
-                setattr(owner, name, make_combined_call(original, is_httpx=is_httpx_transport))
+                setattr(owner, name, make_combined_call(original, is_httpx2=is_httpx2_transport))
                 originals.append((owner, name, original))
 
             try:

--- a/eng/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/eng/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -19,14 +19,15 @@ except:
     pass
 
 try:
-    import httpx
+    import httpx2
 
-    HTTPXTransport = httpx.HTTPTransport
-    AsyncHTTPXTransport = httpx.AsyncHTTPTransport
+    HTTPX2Transport = httpx2.HTTPTransport
+    AsyncHTTPX2Transport = httpx2.AsyncHTTPTransport
+
 except ImportError:
-    httpx = None
-    HTTPXTransport = None
-    AsyncHTTPXTransport = None
+    httpx2 = None
+    HTTPX2Transport = None
+    AsyncHTTPX2Transport = None
 
 from .config import PROXY_URL
 from .helpers import (
@@ -56,7 +57,7 @@ class RecordedTransport(str, Enum):
     """Enum for specifying which transports to record in the test proxy."""
 
     AZURE_CORE = "azure_core"
-    HTTPX = "httpx"
+    HTTPX2 = "httpx2"
 
 
 def get_recording_assets(test_id: str) -> Optional[str]:
@@ -176,8 +177,8 @@ def transform_request(request: "HttpRequest", recording_id: str) -> None:
     request.url = updated_target
 
 
-def transform_httpx_request(request, recording_id: str) -> None:
-    """Transform an httpx.Request to route through the test proxy."""
+def transform_httpx2_request(request, recording_id: str) -> None:
+    """Transform an httpx2.Request to route through the test proxy."""
     parsed_result = url_parse.urlparse(str(request.url))
 
     # Store original upstream URI
@@ -190,10 +191,10 @@ def transform_httpx_request(request, recording_id: str) -> None:
 
     # Rewrite URL to proxy
     updated_target = parsed_result._replace(**get_proxy_netloc()).geturl()
-    request.url = httpx.URL(updated_target)
+    request.url = type(request.url)(updated_target)
 
 
-def restore_httpx_response_url(response) -> None:
+def restore_httpx2_response_url(response) -> None:
     """Restore the response's request URL to the original upstream target."""
     try:
         parsed_resp = url_parse.urlparse(str(response.request.url))
@@ -203,7 +204,7 @@ def restore_httpx_response_url(response) -> None:
             original_target = parsed_resp._replace(
                 scheme=upstream_uri.scheme or parsed_resp.scheme, netloc=upstream_uri.netloc
             ).geturl()
-            response.request.url = httpx.URL(original_target)
+            response.request.url = type(response.request.url)(original_target)
     except Exception:
         # Best-effort restore; don't fail the call if something goes wrong
         pass
@@ -220,14 +221,14 @@ def _transform_args(recording_id: str, *call_args, **call_kwargs):
     return tuple(copied_positional_args), call_kwargs
 
 
-def _transform_httpx_args(recording_id: str, *call_args, **call_kwargs):
-    """Transform httpx transport call arguments to route through the test proxy.
+def _transform_httpx2_args(recording_id: str, *call_args, **call_kwargs):
+    """Transform httpx2 transport call arguments to route through the test proxy.
 
     Used by both sync and async decorators.
     """
     copied_positional_args = list(call_args)
     request = copied_positional_args[1]
-    transform_httpx_request(request, recording_id)
+    transform_httpx2_request(request, recording_id)
     return tuple(copied_positional_args), call_kwargs
 
 
@@ -239,8 +240,8 @@ def recorded_by_proxy(*transports):
         *transports: Which transport(s) to record. Pass one or more comma separated RecordedTransport enum values.
             - No args (default): Record RequestsTransport.send calls (azure.core).
             - RecordedTransport.AZURE_CORE: Record RequestsTransport.send calls. Same as the default above.
-            - RecordedTransport.HTTPX: Record HTTPXTransport.handle_request calls.
-            - RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX: Record both transports.
+            - RecordedTransport.HTTPX2: Record HTTPX2Transport.handle_request calls.
+            - RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2: Record both transports.
 
     Usages:
       from devtools_testutils import recorded_by_proxy, RecordedTransport
@@ -253,12 +254,12 @@ def recorded_by_proxy(*transports):
       @recorded_by_proxy(RecordedTransport.AZURE_CORE)
       def test(...): ...
 
-      # If your test uses httpx only for network calls
-      @recorded_by_proxy(RecordedTransport.HTTPX)
+      # If your test uses httpx2 only for network calls
+      @recorded_by_proxy(RecordedTransport.HTTPX2)
       def test(...): ...
 
-      # If your test uses both azure.core and httpx for network calls
-      @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+      # If your test uses both azure.core and httpx2 for network calls
+      @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
       def test(...): ...
     """
 
@@ -281,11 +282,11 @@ def recorded_by_proxy(*transports):
             isinstance(transport, str) and transport == RecordedTransport.AZURE_CORE.value
         ):
             transport_list.append((RequestsTransport, "send"))
-        elif transport == RecordedTransport.HTTPX or (
-            isinstance(transport, str) and transport == RecordedTransport.HTTPX.value
+        elif transport == RecordedTransport.HTTPX2 or (
+            isinstance(transport, str) and transport == RecordedTransport.HTTPX2.value
         ):
-            if HTTPXTransport is not None:
-                transport_list.append((HTTPXTransport, "handle_request"))
+            if HTTPX2Transport is not None:
+                transport_list.append((HTTPX2Transport, "handle_request"))
 
     # If still no transports, fall back to azure.core
     if not transport_list:
@@ -309,12 +310,12 @@ def _make_proxy_decorator(transports):
             recording_id, variables = start_record_or_playback(test_id)
 
             # Build a wrapper factory so each patched method closes over its own original
-            def make_combined_call(original_transport_func, is_httpx=False):
+            def make_combined_call(original_transport_func, is_httpx2=False):
                 def combined_call(*call_args, **call_kwargs):
-                    if is_httpx:
-                        adjusted_args, adjusted_kwargs = _transform_httpx_args(recording_id, *call_args, **call_kwargs)
+                    if is_httpx2:
+                        adjusted_args, adjusted_kwargs = _transform_httpx2_args(recording_id, *call_args, **call_kwargs)
                         result = original_transport_func(*adjusted_args, **adjusted_kwargs)
-                        restore_httpx_response_url(result)
+                        restore_httpx2_response_url(result)
                     else:
                         adjusted_args, adjusted_kwargs = _transform_args(recording_id, *call_args, **call_kwargs)
                         result = original_transport_func(*adjusted_args, **adjusted_kwargs)
@@ -335,13 +336,13 @@ def _make_proxy_decorator(transports):
             # monkeypatch all requested transports
             for owner, name in transports:
                 original = getattr(owner, name)
-                # Check if this is an httpx transport by comparing with httpx transport classes
-                is_httpx_transport = (
-                    (HTTPXTransport is not None and owner is HTTPXTransport)
-                    or (AsyncHTTPXTransport is not None and owner is AsyncHTTPXTransport)
-                    or (httpx is not None and owner.__module__.startswith("httpx"))
+                # Check if this is an httpx2 transport by comparing with httpx2 transport classes
+                is_httpx2_transport = (
+                    (HTTPX2Transport is not None and owner is HTTPX2Transport)
+                    or (AsyncHTTPX2Transport is not None and owner is AsyncHTTPX2Transport)
+                    or (httpx2 is not None and owner.__module__.startswith("httpx2"))
                 )
-                setattr(owner, name, make_combined_call(original, is_httpx=is_httpx_transport))
+                setattr(owner, name, make_combined_call(original, is_httpx2=is_httpx2_transport))
                 originals.append((owner, name, original))
 
             try:

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_ai_agents_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_ai_agents_instrumentor.py
@@ -232,7 +232,7 @@ class TestAiAgentsInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disable
             baggage_kwarg: Value passed as enable_baggage_propagation to instrument(), or None to omit.
             expected_baggage: Whether baggage should appear in outgoing request headers.
         """
-        import httpx
+        import httpx2
         from openai import OpenAI
         from opentelemetry import baggage as otel_baggage
         from opentelemetry import trace
@@ -287,16 +287,16 @@ class TestAiAgentsInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disable
             )
 
             # ---- Mock transport: capture outgoing HTTP request headers ----
-            class CapturingTransport(httpx.BaseTransport):
+            class CapturingTransport(httpx2.BaseTransport):
                 def __init__(self):
-                    self.last_request: Optional[httpx.Request] = None
+                    self.last_request: Optional[httpx2.Request] = None
 
-                def handle_request(self, request: httpx.Request) -> httpx.Response:
+                def handle_request(self, request: httpx2.Request) -> httpx2.Response:
                     self.last_request = request
-                    return httpx.Response(200, content=b"{}")
+                    return httpx2.Response(200, content=b"{}")
 
             transport = CapturingTransport()
-            http_client = httpx.Client(transport=transport)
+            http_client = httpx2.Client(transport=transport)
             openai_client = OpenAI(api_key="fake-key", base_url="http://fake.test/", http_client=http_client)
 
             # Exercise the same wrapper that get_openai_client() uses after instrumentation.

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor.py
@@ -312,14 +312,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_with_content_recording_events(self, **kwargs):
         """Test synchronous non-streaming responses with content recording enabled (event mode)."""
         self._test_sync_non_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_with_content_recording_attributes(self, **kwargs):
         """Test synchronous non-streaming responses with content recording enabled (attribute mode)."""
         self._test_sync_non_streaming_with_content_recording_impl(False, **kwargs)
@@ -433,14 +433,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_without_content_recording_events(self, **kwargs):
         """Test synchronous non-streaming responses with content recording disabled (event mode)."""
         self._test_sync_non_streaming_without_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_without_content_recording_attributes(self, **kwargs):
         """Test synchronous non-streaming responses with content recording disabled (attribute mode)."""
         self._test_sync_non_streaming_without_content_recording_impl(False, **kwargs)
@@ -564,21 +564,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_non_streaming_events(self, **kwargs):
         """Test synchronous function tool usage with content recording enabled, non-streaming (event mode)."""
         self._test_sync_function_tool_with_content_recording_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_non_streaming_attributes(self, **kwargs):
         """Test synchronous function tool usage with content recording enabled, non-streaming (attribute mode)."""
         self._test_sync_function_tool_with_content_recording_non_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_non_streaming_simple_format_events(self, **kwargs):
         """Test synchronous function tool usage with content recording, non-streaming, simple OTEL format (event mode)."""
         self._test_sync_function_tool_with_content_recording_non_streaming_impl(
@@ -587,7 +587,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_non_streaming_simple_format_attributes(self, **kwargs):
         """Test synchronous function tool usage with content recording, non-streaming, simple OTEL format (attribute mode)."""
         self._test_sync_function_tool_with_content_recording_non_streaming_impl(
@@ -596,35 +596,35 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_without_conversation_events(self, **kwargs):
         """Test synchronous non-streaming responses without conversation parameter (event mode)."""
         self._test_sync_non_streaming_without_conversation_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_non_streaming_without_conversation_attributes(self, **kwargs):
         """Test synchronous non-streaming responses without conversation parameter (attribute mode)."""
         self._test_sync_non_streaming_without_conversation_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_streaming_with_content_recording_events(self, **kwargs):
         """Test synchronous streaming responses with content recording enabled (event mode)."""
         self._test_sync_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_streaming_with_content_recording_attributes(self, **kwargs):
         """Test synchronous streaming responses with content recording enabled (attribute mode)."""
         self._test_sync_streaming_with_content_recording_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_conversations_create(self, **kwargs):
         """Test synchronous conversations.create() method."""
         self.cleanup()
@@ -667,7 +667,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_list_conversation_items_with_content_recording(self, **kwargs):
         """Test synchronous list_conversation_items with content recording enabled."""
         self.cleanup()
@@ -744,7 +744,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_list_conversation_items_without_content_recording(self, **kwargs):
         """Test synchronous list_conversation_items with content recording disabled."""
         self.cleanup()
@@ -1509,21 +1509,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_streaming_events(self, **kwargs):
         """Test synchronous function tool usage with content recording enabled, streaming (event mode)."""
         self._test_sync_function_tool_with_content_recording_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_streaming_attributes(self, **kwargs):
         """Test synchronous function tool usage with content recording enabled, streaming (attribute mode)."""
         self._test_sync_function_tool_with_content_recording_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_streaming_simple_format_events(self, **kwargs):
         """Test synchronous function tool usage with content recording, streaming, simple OTEL format (event mode)."""
         self._test_sync_function_tool_with_content_recording_streaming_impl(
@@ -1532,7 +1532,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_with_content_recording_streaming_simple_format_attributes(self, **kwargs):
         """Test synchronous function tool usage with content recording, streaming, simple OTEL format (attribute mode)."""
         self._test_sync_function_tool_with_content_recording_streaming_impl(
@@ -2031,21 +2031,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_non_streaming_events(self, **kwargs):
         """Test synchronous function tool usage without content recording, non-streaming (event mode)."""
         self._test_sync_function_tool_without_content_recording_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_non_streaming_attributes(self, **kwargs):
         """Test synchronous function tool usage without content recording, non-streaming (attribute mode)."""
         self._test_sync_function_tool_without_content_recording_non_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_non_streaming_simple_format_events(self, **kwargs):
         """Test synchronous function tool usage without content recording, non-streaming, simple OTEL format (event mode)."""
         self._test_sync_function_tool_without_content_recording_non_streaming_impl(
@@ -2054,7 +2054,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_non_streaming_simple_format_attributes(self, **kwargs):
         """Test synchronous function tool usage without content recording, non-streaming, simple OTEL format (attribute mode)."""
         self._test_sync_function_tool_without_content_recording_non_streaming_impl(
@@ -2063,21 +2063,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_streaming_events(self, **kwargs):
         """Test synchronous function tool usage without content recording, streaming (event mode)."""
         self._test_sync_function_tool_without_content_recording_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_streaming_attributes(self, **kwargs):
         """Test synchronous function tool usage without content recording, streaming (attribute mode)."""
         self._test_sync_function_tool_without_content_recording_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_streaming_simple_format_events(self, **kwargs):
         """Test synchronous function tool usage without content recording, streaming, simple OTEL format (event mode)."""
         self._test_sync_function_tool_without_content_recording_streaming_impl(
@@ -2086,7 +2086,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_without_content_recording_streaming_simple_format_attributes(self, **kwargs):
         """Test synchronous function tool usage without content recording, streaming, simple OTEL format (attribute mode)."""
         self._test_sync_function_tool_without_content_recording_streaming_impl(
@@ -2095,7 +2095,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_list_conversation_items_with_content_recording(self, **kwargs):
         """Test listing conversation items after function tool usage with content recording enabled."""
         from openai.types.responses.response_input_param import FunctionCallOutput
@@ -2245,7 +2245,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_function_tool_list_conversation_items_without_content_recording(self, **kwargs):
         """Test listing conversation items after function tool usage without content recording."""
         from openai.types.responses.response_input_param import FunctionCallOutput
@@ -2395,7 +2395,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_multiple_text_inputs_with_content_recording_non_streaming(self, **kwargs):
         """Test synchronous non-streaming responses with multiple text inputs and content recording enabled."""
         self.cleanup()
@@ -2492,7 +2492,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_multiple_text_inputs_with_content_recording_streaming(self, **kwargs):
         """Test synchronous streaming responses with multiple text inputs and content recording enabled."""
         self.cleanup()
@@ -2597,7 +2597,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_multiple_text_inputs_without_content_recording_non_streaming(self, **kwargs):
         """Test synchronous non-streaming responses with multiple text inputs and content recording disabled."""
         self.cleanup()
@@ -2694,7 +2694,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_multiple_text_inputs_without_content_recording_streaming(self, **kwargs):
         """Test synchronous streaming responses with multiple text inputs and content recording disabled."""
         self.cleanup()
@@ -2885,14 +2885,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_off_non_streaming_events(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (non-streaming, event-based messages)."""
         self._test_image_only_content_off_binary_off_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_off_non_streaming_attributes(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (non-streaming, attribute-based messages)."""
         self._test_image_only_content_off_binary_off_non_streaming_impl(False, **kwargs)
@@ -2989,14 +2989,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_on_non_streaming_events(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (non-streaming, event-based messages)."""
         self._test_image_only_content_off_binary_on_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_on_non_streaming_attributes(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (non-streaming, attribute-based messages)."""
         self._test_image_only_content_off_binary_on_non_streaming_impl(False, **kwargs)
@@ -3093,14 +3093,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_off_non_streaming_events(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (non-streaming, event-based messages)."""
         self._test_image_only_content_on_binary_off_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_off_non_streaming_attributes(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (non-streaming, attribute-based messages)."""
         self._test_image_only_content_on_binary_off_non_streaming_impl(False, **kwargs)
@@ -3197,14 +3197,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_on_non_streaming_events(self, **kwargs):
         """Test image only with content recording ON and binary data ON (non-streaming, event-based messages)."""
         self._test_image_only_content_on_binary_on_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_on_non_streaming_attributes(self, **kwargs):
         """Test image only with content recording ON and binary data ON (non-streaming, attribute-based messages)."""
         self._test_image_only_content_on_binary_on_non_streaming_impl(False, **kwargs)
@@ -3310,14 +3310,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_off_non_streaming_events(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (non-streaming, event-based messages)."""
         self._test_text_and_image_content_off_binary_off_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_off_non_streaming_attributes(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (non-streaming, attribute-based messages)."""
         self._test_text_and_image_content_off_binary_off_non_streaming_impl(False, **kwargs)
@@ -3419,14 +3419,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_on_non_streaming_events(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (non-streaming, event-based messages)."""
         self._test_text_and_image_content_off_binary_on_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_on_non_streaming_attributes(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (non-streaming, attribute-based messages)."""
         self._test_text_and_image_content_off_binary_on_non_streaming_impl(False, **kwargs)
@@ -3527,14 +3527,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_off_non_streaming_events(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (non-streaming, event-based messages)."""
         self._test_text_and_image_content_on_binary_off_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_off_non_streaming_attributes(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (non-streaming, attribute-based messages)."""
         self._test_text_and_image_content_on_binary_off_non_streaming_impl(False, **kwargs)
@@ -3635,14 +3635,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_on_non_streaming_events(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (non-streaming, event-based messages)."""
         self._test_text_and_image_content_on_binary_on_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_on_non_streaming_attributes(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (non-streaming, attribute-based messages)."""
         self._test_text_and_image_content_on_binary_on_non_streaming_impl(False, **kwargs)
@@ -3752,14 +3752,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_off_streaming_events(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (streaming, event-based messages)."""
         self._test_image_only_content_off_binary_off_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_off_streaming_attributes(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (streaming, attribute-based messages)."""
         self._test_image_only_content_off_binary_off_streaming_impl(False, **kwargs)
@@ -3864,14 +3864,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_on_streaming_events(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (streaming, event-based messages)."""
         self._test_image_only_content_off_binary_on_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_off_binary_on_streaming_attributes(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (streaming, attribute-based messages)."""
         self._test_image_only_content_off_binary_on_streaming_impl(False, **kwargs)
@@ -3976,14 +3976,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_off_streaming_events(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (streaming, event-based messages)."""
         self._test_image_only_content_on_binary_off_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_off_streaming_attributes(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (streaming, attribute-based messages)."""
         self._test_image_only_content_on_binary_off_streaming_impl(False, **kwargs)
@@ -4088,14 +4088,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_on_streaming_events(self, **kwargs):
         """Test image only with content recording ON and binary data ON (streaming, event-based messages)."""
         self._test_image_only_content_on_binary_on_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_image_only_content_on_binary_on_streaming_attributes(self, **kwargs):
         """Test image only with content recording ON and binary data ON (streaming, attribute-based messages)."""
         self._test_image_only_content_on_binary_on_streaming_impl(False, **kwargs)
@@ -4209,14 +4209,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_off_streaming_events(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (streaming, event-based messages)."""
         self._test_text_and_image_content_off_binary_off_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_off_streaming_attributes(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (streaming, attribute-based messages)."""
         self._test_text_and_image_content_off_binary_off_streaming_impl(False, **kwargs)
@@ -4326,14 +4326,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_on_streaming_events(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (streaming, event-based messages)."""
         self._test_text_and_image_content_off_binary_on_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_off_binary_on_streaming_attributes(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (streaming, attribute-based messages)."""
         self._test_text_and_image_content_off_binary_on_streaming_impl(False, **kwargs)
@@ -4442,14 +4442,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_off_streaming_events(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (streaming, event-based messages)."""
         self._test_text_and_image_content_on_binary_off_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_off_streaming_attributes(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (streaming, attribute-based messages)."""
         self._test_text_and_image_content_on_binary_off_streaming_impl(False, **kwargs)
@@ -4558,14 +4558,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_on_streaming_events(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (streaming, event-based messages)."""
         self._test_text_and_image_content_on_binary_on_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_text_and_image_content_on_binary_on_streaming_attributes(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (streaming, attribute-based messages)."""
         self._test_text_and_image_content_on_binary_on_streaming_impl(False, **kwargs)
@@ -4576,7 +4576,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_responses_stream_method_with_content_recording(self, **kwargs):
         """Test sync responses.stream() method with content recording enabled."""
         os.environ["AZURE_TRACING_GEN_AI_INSTRUMENT_RESPONSES_API"] = "True"
@@ -4629,7 +4629,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_responses_stream_method_without_content_recording(self, **kwargs):
         """Test sync responses.stream() method without content recording."""
         os.environ["AZURE_TRACING_GEN_AI_INSTRUMENT_RESPONSES_API"] = "True"
@@ -4686,7 +4686,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_responses_stream_method_with_tools_with_content_recording(self, **kwargs):
         """Test sync responses.stream() method with function tools and content recording enabled."""
         from openai.types.responses.response_input_param import FunctionCallOutput
@@ -4797,7 +4797,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_responses_stream_method_with_tools_without_content_recording(self, **kwargs):
         """Test sync responses.stream() method with function tools without content recording."""
         from openai.types.responses.response_input_param import FunctionCallOutput
@@ -4933,7 +4933,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_workflow_agent_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -5137,7 +5137,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_workflow_agent_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -5254,7 +5254,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_workflow_agent_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -5461,7 +5461,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_workflow_agent_streaming_without_content_recording(self, **kwargs):  # pylint: disable=too-many-statements
         """Test workflow agent with streaming and content recording disabled."""
         from azure.ai.projects.models import WorkflowAgentDefinition
@@ -5581,7 +5581,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_prompt_agent_with_responses_non_streaming(self, **kwargs):
         """Test prompt agent with responses API (non-streaming) and verify agent id in traces."""
         self.cleanup()
@@ -5651,7 +5651,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_prompt_agent_with_responses_streaming(self, **kwargs):
         """Test prompt agent with responses API (streaming) and verify agent id in traces."""
         self.cleanup()
@@ -5732,7 +5732,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_with_raw_response_streaming_with_content_recording(self, **kwargs):
         """Test with_raw_response.create(stream=True) with content recording enabled."""
         self.cleanup()
@@ -5796,7 +5796,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_sync_with_raw_response_streaming_without_content_recording(self, **kwargs):
         """Test with_raw_response.create(stream=True) with content recording disabled."""
         self.cleanup()

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_async.py
@@ -134,14 +134,14 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_non_streaming_with_content_recording_events(self, **kwargs):
         """Test asynchronous non-streaming responses with content recording enabled (event-based messages)."""
         await self._test_async_non_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_non_streaming_with_content_recording_attributes(self, **kwargs):
         """Test asynchronous non-streaming responses with content recording enabled (attribute-based messages)."""
         await self._test_async_non_streaming_with_content_recording_impl(False, **kwargs)
@@ -248,21 +248,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_streaming_with_content_recording_events(self, **kwargs):
         """Test asynchronous streaming responses with content recording enabled (event-based messages)."""
         await self._test_async_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_streaming_with_content_recording_attributes(self, **kwargs):
         """Test asynchronous streaming responses with content recording enabled (attribute-based messages)."""
         await self._test_async_streaming_with_content_recording_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_conversations_create(self, **kwargs):
         """Test asynchronous conversations.create() method."""
         self.cleanup()
@@ -308,7 +308,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_list_conversation_items_with_content_recording(self, **kwargs):
         """Test asynchronous list_conversation_items with content recording enabled."""
         self.cleanup()
@@ -618,21 +618,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_with_content_recording_streaming_events(self, **kwargs):
         """Test asynchronous function tool usage with content recording enabled (streaming, event-based messages)."""
         await self._test_async_function_tool_with_content_recording_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_with_content_recording_streaming_attributes(self, **kwargs):
         """Test asynchronous function tool usage with content recording enabled (streaming, attribute-based messages)."""
         await self._test_async_function_tool_with_content_recording_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_with_content_recording_streaming_simple_format_events(self, **kwargs):
         """Test async function tool with content recording, streaming, simple OTEL format (event mode)."""
         await self._test_async_function_tool_with_content_recording_streaming_impl(
@@ -641,7 +641,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_with_content_recording_streaming_simple_format_attributes(self, **kwargs):
         """Test async function tool with content recording, streaming, simple OTEL format (attribute mode)."""
         await self._test_async_function_tool_with_content_recording_streaming_impl(
@@ -873,21 +873,21 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_without_content_recording_streaming_events(self, **kwargs):
         """Test asynchronous function tool usage without content recording (streaming, event-based messages)."""
         await self._test_async_function_tool_without_content_recording_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_without_content_recording_streaming_attributes(self, **kwargs):
         """Test asynchronous function tool usage without content recording (streaming, attribute-based messages)."""
         await self._test_async_function_tool_without_content_recording_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_without_content_recording_streaming_simple_format_events(self, **kwargs):
         """Test async function tool without content recording, streaming, simple OTEL format (event mode)."""
         await self._test_async_function_tool_without_content_recording_streaming_impl(
@@ -896,7 +896,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_function_tool_without_content_recording_streaming_simple_format_attributes(self, **kwargs):
         """Test async function tool without content recording, streaming, simple OTEL format (attribute mode)."""
         await self._test_async_function_tool_without_content_recording_streaming_impl(
@@ -905,7 +905,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_multiple_text_inputs_with_content_recording_non_streaming(self, **kwargs):
         """Test asynchronous non-streaming responses with multiple text inputs and content recording enabled."""
         self.cleanup()
@@ -1002,7 +1002,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_multiple_text_inputs_with_content_recording_streaming(self, **kwargs):
         """Test asynchronous streaming responses with multiple text inputs and content recording enabled."""
         self.cleanup()
@@ -1107,7 +1107,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_multiple_text_inputs_without_content_recording_non_streaming(self, **kwargs):
         """Test asynchronous non-streaming responses with multiple text inputs and content recording disabled."""
         self.cleanup()
@@ -1208,7 +1208,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_off_binary_off_non_streaming(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (non-streaming)."""
         self.cleanup()
@@ -1280,7 +1280,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_off_binary_on_non_streaming(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (non-streaming)."""
         self.cleanup()
@@ -1351,7 +1351,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_on_binary_off_non_streaming(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (non-streaming)."""
         self.cleanup()
@@ -1422,7 +1422,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_on_binary_on_non_streaming(self, **kwargs):
         """Test image only with content recording ON and binary data ON (non-streaming)."""
         self.cleanup()
@@ -1497,7 +1497,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_off_binary_off_non_streaming(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (non-streaming)."""
         self.cleanup()
@@ -1573,7 +1573,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_off_binary_on_non_streaming(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (non-streaming)."""
         self.cleanup()
@@ -1648,7 +1648,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_on_binary_off_non_streaming(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (non-streaming)."""
         self.cleanup()
@@ -1723,7 +1723,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_on_binary_on_non_streaming(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (non-streaming)."""
         self.cleanup()
@@ -1802,7 +1802,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_off_binary_off_streaming(self, **kwargs):
         """Test image only with content recording OFF and binary data OFF (streaming)."""
         self.cleanup()
@@ -1882,7 +1882,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_off_binary_on_streaming(self, **kwargs):
         """Test image only with content recording OFF and binary data ON (streaming)."""
         self.cleanup()
@@ -1961,7 +1961,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_on_binary_off_streaming(self, **kwargs):
         """Test image only with content recording ON and binary data OFF (streaming)."""
         self.cleanup()
@@ -2040,7 +2040,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_image_only_content_on_binary_on_streaming(self, **kwargs):
         """Test image only with content recording ON and binary data ON (streaming)."""
         self.cleanup()
@@ -2123,7 +2123,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_off_binary_off_streaming(self, **kwargs):
         """Test text + image with content recording OFF and binary data OFF (streaming)."""
         self.cleanup()
@@ -2206,7 +2206,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_off_binary_on_streaming(self, **kwargs):
         """Test text + image with content recording OFF and binary data ON (streaming)."""
         self.cleanup()
@@ -2289,7 +2289,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_on_binary_off_streaming(self, **kwargs):
         """Test text + image with content recording ON and binary data OFF (streaming)."""
         self.cleanup()
@@ -2372,7 +2372,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_text_and_image_content_on_binary_on_streaming(self, **kwargs):
         """Test text + image with content recording ON and binary data ON (streaming)."""
         self.cleanup()
@@ -2455,7 +2455,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_multiple_text_inputs_without_content_recording_streaming(self, **kwargs):
         """Test asynchronous streaming responses with multiple text inputs and content recording disabled."""
         self.cleanup()
@@ -2564,7 +2564,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_content_recording(self, **kwargs):
         """Test async responses.stream() method with content recording enabled."""
         self.cleanup()
@@ -2645,7 +2645,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_without_content_recording(self, **kwargs):
         """Test async responses.stream() method without content recording."""
         self.cleanup()
@@ -2928,7 +2928,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_with_content_recording_events(self, **kwargs):
         """Test async responses.stream() with tools and content recording (event-based messages)."""
         await self._test_async_responses_stream_method_with_tools_with_content_recording_impl(True, **kwargs)
@@ -2939,7 +2939,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_with_content_recording_attributes(self, **kwargs):
         """Test async responses.stream() with tools and content recording (attribute-based messages)."""
         await self._test_async_responses_stream_method_with_tools_with_content_recording_impl(False, **kwargs)
@@ -2950,7 +2950,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_with_content_recording_simple_format_events(self, **kwargs):
         """Test async responses.stream() with tools, content recording, simple OTEL format (event mode)."""
         await self._test_async_responses_stream_method_with_tools_with_content_recording_impl(
@@ -2963,7 +2963,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_with_content_recording_simple_format_attributes(
         self, **kwargs
     ):
@@ -3177,7 +3177,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_without_content_recording_events(self, **kwargs):
         """Test async responses.stream() with tools, without content recording (event-based messages)."""
         await self._test_async_responses_stream_method_with_tools_without_content_recording_impl(True, **kwargs)
@@ -3188,7 +3188,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_without_content_recording_attributes(self, **kwargs):
         """Test async responses.stream() with tools, without content recording (attribute-based messages)."""
         await self._test_async_responses_stream_method_with_tools_without_content_recording_impl(False, **kwargs)
@@ -3199,7 +3199,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_without_content_recording_simple_format_events(
         self, **kwargs
     ):
@@ -3214,7 +3214,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
     )
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_responses_stream_method_with_tools_without_content_recording_simple_format_attributes(
         self, **kwargs
     ):
@@ -3229,7 +3229,7 @@ class TestResponsesInstrumentor(TestAiAgentsInstrumentorBase):  # pylint: disabl
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_agent_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -3347,7 +3347,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_agent_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -3471,7 +3471,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_agent_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -3593,7 +3593,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_agent_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -3828,21 +3828,21 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_non_streaming_events(self, **kwargs):
         """Test async prompt agent with responses (non-streaming, event-based messages)."""
         await self._test_async_prompt_agent_with_responses_non_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_non_streaming_attributes(self, **kwargs):
         """Test async prompt agent with responses (non-streaming, attribute-based messages)."""
         await self._test_async_prompt_agent_with_responses_non_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_non_streaming_simple_format_events(self, **kwargs):
         """Test async prompt agent with responses (non-streaming, simple OTEL format, event mode)."""
         await self._test_async_prompt_agent_with_responses_non_streaming_impl(
@@ -3851,7 +3851,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_non_streaming_simple_format_attributes(self, **kwargs):
         """Test async prompt agent with responses (non-streaming, simple OTEL format, attribute mode)."""
         await self._test_async_prompt_agent_with_responses_non_streaming_impl(
@@ -3975,21 +3975,21 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_streaming_events(self, **kwargs):
         """Test async prompt agent with responses (streaming, event-based messages)."""
         await self._test_async_prompt_agent_with_responses_streaming_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_streaming_attributes(self, **kwargs):
         """Test async prompt agent with responses (streaming, attribute-based messages)."""
         await self._test_async_prompt_agent_with_responses_streaming_impl(False, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_streaming_simple_format_events(self, **kwargs):
         """Test async prompt agent with responses (streaming, simple OTEL format, event mode)."""
         await self._test_async_prompt_agent_with_responses_streaming_impl(
@@ -3998,7 +3998,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_prompt_agent_with_responses_streaming_simple_format_attributes(self, **kwargs):
         """Test async prompt agent with responses (streaming, simple OTEL format, attribute mode)."""
         await self._test_async_prompt_agent_with_responses_streaming_impl(
@@ -4009,7 +4009,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_with_raw_response_streaming_with_content_recording(self, **kwargs):
         """Test async with_raw_response.create(stream=True) with content recording enabled."""
         self.cleanup()
@@ -4078,7 +4078,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_async_with_raw_response_streaming_without_content_recording(self, **kwargs):
         """Test async with_raw_response.create(stream=True) with content recording disabled."""
         self.cleanup()

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_browser_automation.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_browser_automation.py
@@ -44,7 +44,7 @@ class TestResponsesInstrumentorBrowserAutomation(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_browser_automation_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -182,7 +182,7 @@ class TestResponsesInstrumentorBrowserAutomation(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_browser_automation_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -314,7 +314,7 @@ class TestResponsesInstrumentorBrowserAutomation(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_browser_automation_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -444,7 +444,7 @@ class TestResponsesInstrumentorBrowserAutomation(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_browser_automation_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_browser_automation_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_browser_automation_async.py
@@ -46,7 +46,7 @@ class TestResponsesInstrumentorBrowserAutomationAsync(TestAiAgentsInstrumentorBa
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_browser_automation_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -180,7 +180,7 @@ class TestResponsesInstrumentorBrowserAutomationAsync(TestAiAgentsInstrumentorBa
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_browser_automation_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -308,7 +308,7 @@ class TestResponsesInstrumentorBrowserAutomationAsync(TestAiAgentsInstrumentorBa
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_browser_automation_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
@@ -435,7 +435,7 @@ class TestResponsesInstrumentorBrowserAutomationAsync(TestAiAgentsInstrumentorBa
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_browser_automation_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_code_interpreter.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_code_interpreter.py
@@ -51,7 +51,7 @@ class TestResponsesInstrumentorCodeInterpreter(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_code_interpreter_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -241,7 +241,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_code_interpreter_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -434,7 +434,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_code_interpreter_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -627,7 +627,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_code_interpreter_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_code_interpreter_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_code_interpreter_async.py
@@ -52,7 +52,7 @@ class TestResponsesInstrumentorCodeInterpreterAsync(TestAiAgentsInstrumentorBase
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_code_interpreter_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -241,7 +241,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_code_interpreter_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -434,7 +434,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_code_interpreter_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -627,7 +627,7 @@ TRANSPORTATION,Contoso air,1100000
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_code_interpreter_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_file_search.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_file_search.py
@@ -38,7 +38,7 @@ class TestResponsesInstrumentorFileSearch(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_file_search_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -249,7 +249,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_file_search_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -458,7 +458,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_file_search_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -665,7 +665,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_file_search_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_file_search_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_file_search_async.py
@@ -39,7 +39,7 @@ class TestResponsesInstrumentorFileSearchAsync(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_file_search_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -250,7 +250,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_file_search_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -459,7 +459,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_file_search_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -666,7 +666,7 @@ Return Policy: 30-day return policy with no questions asked
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_file_search_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_mcp.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_mcp.py
@@ -360,14 +360,14 @@ class TestResponsesInstrumentorMCP(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_non_streaming_with_content_recording_events(self, **kwargs):
         """Test synchronous MCP agent with non-streaming and content recording enabled (event-based messages)."""
         self._test_sync_mcp_non_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_non_streaming_with_content_recording_attributes(self, **kwargs):
         """Test synchronous MCP agent with non-streaming and content recording enabled (attribute-based messages)."""
         self._test_sync_mcp_non_streaming_with_content_recording_impl(False, **kwargs)
@@ -675,14 +675,14 @@ class TestResponsesInstrumentorMCP(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_non_streaming_without_content_recording_events(self, **kwargs):
         """Test synchronous MCP agent with non-streaming and content recording disabled (event-based messages)."""
         self._test_sync_mcp_non_streaming_without_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_non_streaming_without_content_recording_attributes(self, **kwargs):
         """Test synchronous MCP agent with non-streaming and content recording disabled (attribute-based messages)."""
         self._test_sync_mcp_non_streaming_without_content_recording_impl(False, **kwargs)
@@ -957,14 +957,14 @@ class TestResponsesInstrumentorMCP(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_streaming_with_content_recording_events(self, **kwargs):
         """Test synchronous MCP agent with streaming and content recording enabled (event-based messages)."""
         self._test_sync_mcp_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_streaming_with_content_recording_attributes(self, **kwargs):
         """Test synchronous MCP agent with streaming and content recording enabled (attribute-based messages)."""
         self._test_sync_mcp_streaming_with_content_recording_impl(False, **kwargs)
@@ -1233,14 +1233,14 @@ class TestResponsesInstrumentorMCP(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_streaming_without_content_recording_events(self, **kwargs):
         """Test synchronous MCP agent with streaming and content recording disabled (event-based messages)."""
         self._test_sync_mcp_streaming_without_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_mcp_streaming_without_content_recording_attributes(self, **kwargs):
         """Test synchronous MCP agent with streaming and content recording disabled (attribute-based messages)."""
         self._test_sync_mcp_streaming_without_content_recording_impl(False, **kwargs)

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_mcp_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_mcp_async.py
@@ -360,14 +360,14 @@ class TestResponsesInstrumentorMCPAsync(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_non_streaming_with_content_recording_events(self, **kwargs):
         """Test asynchronous MCP agent with non-streaming and content recording enabled (event-based messages)."""
         await self._test_async_mcp_non_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_non_streaming_with_content_recording_attributes(self, **kwargs):
         """Test asynchronous MCP agent with non-streaming and content recording enabled (attribute-based messages)."""
         await self._test_async_mcp_non_streaming_with_content_recording_impl(False, **kwargs)
@@ -677,14 +677,14 @@ class TestResponsesInstrumentorMCPAsync(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_non_streaming_without_content_recording_events(self, **kwargs):
         """Test asynchronous MCP agent with non-streaming and content recording disabled (event-based messages)."""
         await self._test_async_mcp_non_streaming_without_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_non_streaming_without_content_recording_attributes(self, **kwargs):
         """Test asynchronous MCP agent with non-streaming and content recording disabled (attribute-based messages)."""
         await self._test_async_mcp_non_streaming_without_content_recording_impl(False, **kwargs)
@@ -962,14 +962,14 @@ class TestResponsesInstrumentorMCPAsync(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_streaming_with_content_recording_events(self, **kwargs):
         """Test asynchronous MCP agent with streaming and content recording enabled (event-based messages)."""
         await self._test_async_mcp_streaming_with_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_streaming_with_content_recording_attributes(self, **kwargs):
         """Test asynchronous MCP agent with streaming and content recording enabled (attribute-based messages)."""
         await self._test_async_mcp_streaming_with_content_recording_impl(False, **kwargs)
@@ -1241,14 +1241,14 @@ class TestResponsesInstrumentorMCPAsync(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_streaming_without_content_recording_events(self, **kwargs):
         """Test asynchronous MCP agent with streaming and content recording disabled (event-based messages)."""
         await self._test_async_mcp_streaming_without_content_recording_impl(True, **kwargs)
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_mcp_streaming_without_content_recording_attributes(self, **kwargs):
         """Test asynchronous MCP agent with streaming and content recording disabled (attribute-based messages)."""
         await self._test_async_mcp_streaming_without_content_recording_impl(False, **kwargs)

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_metrics.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_metrics.py
@@ -65,7 +65,7 @@ class TestResponsesInstrumentorMetrics(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_metrics_collection_non_streaming_responses(self, **kwargs):
         """Test that metrics are collected for non-streaming responses API calls."""
         self.cleanup()
@@ -112,7 +112,7 @@ class TestResponsesInstrumentorMetrics(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_metrics_collection_streaming_responses(self, **kwargs):
         """Test that metrics are collected for streaming responses API calls."""
         self.cleanup()
@@ -165,7 +165,7 @@ class TestResponsesInstrumentorMetrics(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_metrics_collection_conversation_create(self, **kwargs):
         """Test that metrics are collected for conversation creation calls."""
         self.cleanup()
@@ -202,7 +202,7 @@ class TestResponsesInstrumentorMetrics(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_metrics_collection_multiple_operations(self, **kwargs):
         """Test that metrics are collected correctly for multiple operations."""
         self.cleanup()
@@ -254,7 +254,7 @@ class TestResponsesInstrumentorMetrics(TestAiAgentsInstrumentorBase):
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_metrics_collection_without_content_recording(self, **kwargs):
         """Test that metrics are still collected when content recording is disabled."""
         self.cleanup()

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_raw_response.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_raw_response.py
@@ -27,7 +27,6 @@ from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.ai.projects.telemetry import AIProjectInstrumentor
 from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 
-
 CONTENT_TRACING_ENV_VARIABLE = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 EXPERIMENTAL_ENABLE_GENAI_TRACING_ENV_VARIABLE = "AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING"
 

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_workflow.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_workflow.py
@@ -189,7 +189,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_workflow_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -356,7 +356,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_workflow_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -525,7 +525,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_workflow_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -695,7 +695,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_sync_workflow_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements

--- a/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_workflow_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/telemetry/test_responses_instrumentor_workflow_async.py
@@ -187,7 +187,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_non_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -350,7 +350,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_non_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -517,7 +517,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_with_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_streaming_with_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements
@@ -685,7 +685,7 @@ trigger:
 
     @pytest.mark.usefixtures("instrument_without_content")
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_async_workflow_streaming_without_content_recording(
         self, **kwargs
     ):  # pylint: disable=too-many-locals,too-many-statements

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_responses_crud.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_responses_crud.py
@@ -20,7 +20,7 @@ class TestAgentResponsesCrud(TestBase):
     # To run this test:
     # pytest tests/agents/test_agent_responses_crud.py::TestAgentResponsesCrud::test_agent_responses_crud -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_responses_crud(self, **kwargs):
         """
         Test two-turn Responses with Agent reference and Conversation.
@@ -155,7 +155,7 @@ class TestAgentResponsesCrud(TestBase):
     # To run this test:
     # pytest tests\agents\test_agent_responses_crud.py::TestAgentResponsesCrud::test_agent_responses_with_structured_output -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_responses_with_structured_output(self, **kwargs):
         model = kwargs.get("foundry_model_name")
 

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agent_responses_crud_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agent_responses_crud_async.py
@@ -19,7 +19,7 @@ from azure.ai.projects.models import (
 class TestAgentResponsesCrudAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_responses_crud_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")
@@ -126,7 +126,7 @@ class TestAgentResponsesCrudAsync(TestBase):
     # To run this test:
     # pytest tests\agents\test_agent_responses_crud_async.py::TestAgentResponsesCrudAsync::test_agent_responses_with_structured_output_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_responses_with_structured_output_async(self, **kwargs):
         model = kwargs.get("foundry_model_name")
 

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agents_crud.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agents_crud.py
@@ -126,7 +126,7 @@ class TestAgentCrud(TestBase):
     # To run this test:
     # pytest tests\agents\test_agents_crud.py::TestAgentCrud::test_agent_disable_enable -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_disable_enable(self, **kwargs):
         """
         Test disable and enable operations for Agents.
@@ -216,7 +216,7 @@ class TestAgentCrud(TestBase):
     # To run this test:
     # pytest tests\agents\test_agents_crud.py::TestAgentCrud::test_prompt_agent_endpoint_responses -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_prompt_agent_endpoint_responses(self, **kwargs):
         """
         Test prompt-agent endpoint routing for the Responses protocol.

--- a/sdk/ai/azure-ai-projects/tests/agents/test_agents_crud_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_agents_crud_async.py
@@ -116,7 +116,7 @@ class TestAgentCrudAsync(TestBase):
     # To run this test:
     # pytest tests\agents\test_agents_crud_async.py::TestAgentCrudAsync::test_agent_disable_enable_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_disable_enable_async(self, **kwargs):
         """
         Test disable and enable operations for Agents.
@@ -208,7 +208,7 @@ class TestAgentCrudAsync(TestBase):
     # To run this test:
     # pytest tests\agents\test_agents_crud_async.py::TestAgentCrudAsync::test_prompt_agent_endpoint_responses_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_prompt_agent_endpoint_responses_async(self, **kwargs):
         """
         Test prompt-agent endpoint routing for the Responses protocol.

--- a/sdk/ai/azure-ai-projects/tests/agents/test_conversation_crud.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_conversation_crud.py
@@ -19,7 +19,7 @@ class TestConversationCrud(TestBase):
     # To run only this test:
     # pytest tests/agents/test_conversation_crud.py::TestConversationCrud::test_conversation_crud -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_conversation_crud(self, **kwargs):
         """
         Test CRUD operations for Conversations.

--- a/sdk/ai/azure-ai-projects/tests/agents/test_conversation_crud_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_conversation_crud_async.py
@@ -17,7 +17,7 @@ class TestConversationCrudAsync(TestBase):
     # To run only this test:
     # pytest tests/agents/test_conversation_crud_async.py::TestConversationCrudAsync::test_conversation_crud_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_conversation_crud_async(self, **kwargs):
 
         async with self.create_async_client(operation_group="agents", **kwargs).get_openai_client() as client:

--- a/sdk/ai/azure-ai-projects/tests/agents/test_conversation_items_crud.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_conversation_items_crud.py
@@ -12,7 +12,7 @@ from devtools_testutils import recorded_by_proxy, RecordedTransport
 class TestConversationItemsCrud(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_conversation_items_crud(self, **kwargs):
         """
         Test CRUD operations for Conversation Items.

--- a/sdk/ai/azure-ai-projects/tests/agents/test_conversation_items_crud_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/test_conversation_items_crud_async.py
@@ -13,7 +13,7 @@ from devtools_testutils import RecordedTransport
 class TestConversationItemsCrudAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_conversation_items_crud_async(self, **kwargs):
 
         async with self.create_async_client(operation_group="agents", **kwargs).get_openai_client() as client:

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_code_interpreter_and_function.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_code_interpreter_and_function.py
@@ -26,7 +26,7 @@ class TestAgentCodeInterpreterAndFunction(TestBase):
     """Tests for agents using Code Interpreter + Function Tool combination."""
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_calculate_and_save(self, **kwargs):
         """
         Test calculation with Code Interpreter and saving with Function Tool.
@@ -86,7 +86,7 @@ class TestAgentCodeInterpreterAndFunction(TestBase):
         project_client.agents.delete_version(agent_name=agent.name, agent_version=agent.version)
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_generate_data_and_report(self, **kwargs):
         """
         Test generating data with Code Interpreter and reporting with Function.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_and_code_interpreter.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_and_code_interpreter.py
@@ -27,7 +27,7 @@ class TestAgentFileSearchAndCodeInterpreter(TestBase):
     """Tests for agents using File Search + Code Interpreter combination."""
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_find_and_analyze_data(self, **kwargs):
         """
         Test finding data with File Search and analyzing with Code Interpreter.
@@ -109,7 +109,7 @@ End of sensor log.
         openai_client.vector_stores.delete(vector_store.id)
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_analyze_code_file(self, **kwargs):
         """
         Test finding code file and running it with Code Interpreter.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_and_function.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_and_function.py
@@ -24,7 +24,7 @@ class TestAgentFileSearchAndFunction(TestBase):
     """Tests for agents using File Search + Function Tool combination."""
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_data_analysis_workflow(self, **kwargs):
         """
         Test data analysis workflow: upload data, search, save results.
@@ -155,7 +155,7 @@ Overall Total Revenue: $129,000
         print("Cleanup completed")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_empty_vector_store_handling(self, **kwargs):
         """
         Test how agent handles empty vector store (no files uploaded).
@@ -230,7 +230,7 @@ Overall Total Revenue: $129,000
         print("Cleanup completed")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_python_code_file_search(self, **kwargs):
         """
         Test searching for Python code files and saving findings.
@@ -359,7 +359,7 @@ print(f"Sum: {result}")
         print("Cleanup completed")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_multi_turn_search_and_save_workflow(self, **kwargs):  # pylint: disable=too-many-statements,too-many-locals
         """
         Test multi-turn workflow: search documents, ask follow-ups, save findings.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_code_interpreter_function.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_agent_file_search_code_interpreter_function.py
@@ -27,7 +27,7 @@ class TestAgentFileSearchCodeInterpreterFunction(TestBase):
     """Tests for agents using File Search + Code Interpreter + Function Tool."""
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_complete_analysis_workflow(self, **kwargs):
         """
         Test complete workflow: find data, analyze it, save results.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_multitool_with_conversations.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/multitool/test_multitool_with_conversations.py
@@ -24,7 +24,7 @@ from azure.ai.projects.models import (
 class TestMultiToolWithConversations(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_file_search_and_function_with_conversation(self, **kwargs):  # pylint: disable=too-many-statements
         """
         Test using multiple tools (FileSearch + Function) within one conversation.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_code_interpreter.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_code_interpreter.py
@@ -19,7 +19,7 @@ from azure.ai.projects.models import (
 class TestAgentCodeInterpreter(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_code_interpreter_simple_math(self, **kwargs):
         """
         Test agent with Code Interpreter for simple Python code execution.
@@ -98,7 +98,7 @@ class TestAgentCodeInterpreter(TestBase):
     @pytest.mark.skip(
         reason="Skipped due to known server bug. Enable once https://msdata.visualstudio.com/Vienna/_workitems/edit/4841313 is resolved"
     )
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_code_interpreter_file_generation(self, **kwargs):
         """
         Test agent with Code Interpreter for file upload, processing, and download.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_code_interpreter_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_code_interpreter_async.py
@@ -18,7 +18,7 @@ from azure.ai.projects.models import (
 class TestAgentCodeInterpreterAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_code_interpreter_simple_math_async(self, **kwargs):
         """
         Test agent with Code Interpreter for simple Python code execution (async version).

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search.py
@@ -18,7 +18,7 @@ class TestAgentFileSearch(TestBase):
     # To only run this test:
     # pytest tests/agents/tools/test_agent_file_search.py::TestAgentFileSearch::test_agent_file_search -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_file_search(self, **kwargs):
         """
         Test agent with File Search tool for document Q&A.
@@ -122,7 +122,7 @@ class TestAgentFileSearch(TestBase):
             print("Vector store deleted")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_agent_file_search_unsupported_file_type(self, **kwargs):
         """
         Negative test: Verify that unsupported file types are rejected with clear error messages.
@@ -194,7 +194,7 @@ Widget B,Q2,25000"""
             print("\nVector store deleted")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_file_search_multi_turn_conversation(self, **kwargs):
         """
         Test multi-turn conversation with File Search.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_async.py
@@ -16,7 +16,7 @@ from azure.ai.projects.models import PromptAgentDefinition, FileSearchTool
 class TestAgentFileSearchAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_file_search_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")
@@ -96,7 +96,7 @@ class TestAgentFileSearchAsync(TestBase):
             print("Vector store deleted")
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_file_search_multi_turn_conversation_async(self, **kwargs):
         """
         Test multi-turn conversation with File Search (async version).

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_stream.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_stream.py
@@ -14,7 +14,7 @@ from azure.ai.projects.models import PromptAgentDefinition, FileSearchTool
 class TestAgentFileSearchStream(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_file_search_stream(self, **kwargs):
         """
         Test agent with File Search tool using streaming responses.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_stream_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_file_search_stream_async.py
@@ -15,7 +15,7 @@ from azure.ai.projects.models import PromptAgentDefinition, FileSearchTool
 class TestAgentFileSearchStreamAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_file_search_stream_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_function_tool.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_function_tool.py
@@ -15,7 +15,7 @@ from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
 class TestAgentFunctionTool(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_function_tool(self, **kwargs):
         """
         Test agent with custom function tool.
@@ -160,7 +160,7 @@ class TestAgentFunctionTool(TestBase):
         print("Agent deleted")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_function_tool_multi_turn_with_multiple_calls(self, **kwargs):  # pylint: disable=too-many-statements
         """
         Test multi-turn conversation where agent calls functions multiple times.
@@ -371,7 +371,7 @@ class TestAgentFunctionTool(TestBase):
             print("Agent deleted")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_function_tool_context_dependent_followup(self, **kwargs):
         """
         Test deeply context-dependent follow-ups (e.g., unit conversion, clarification).

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_function_tool_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_function_tool_async.py
@@ -16,7 +16,7 @@ from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
 class TestAgentFunctionToolAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_function_tool_async(self, **kwargs):
         """
         Test agent with custom function tool (async version).
@@ -148,7 +148,7 @@ class TestAgentFunctionToolAsync(TestBase):
         print("Agent deleted")
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_function_tool_multi_turn_with_multiple_calls_async(
         self, **kwargs
     ):  # pylint: disable=too-many-statements
@@ -362,7 +362,7 @@ class TestAgentFunctionToolAsync(TestBase):
             print("Agent deleted")
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_function_tool_context_dependent_followup_async(self, **kwargs):
         """
         Test deeply context-dependent follow-ups (e.g., unit conversion, clarification) (async version).

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation.py
@@ -17,7 +17,7 @@ from azure.core.exceptions import ResourceNotFoundError
 class TestAgentImageGeneration(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_image_generation(self, **kwargs):
         """
         Test agent with Image Generation tool.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_image_generation_async.py
@@ -18,7 +18,7 @@ from azure.core.exceptions import ResourceNotFoundError
 class TestAgentImageGenerationAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_image_generation_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_mcp.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_mcp.py
@@ -18,7 +18,7 @@ class TestAgentMCP(TestBase):
     # To run only this test:
     # pytest tests/agents/tools/test_agent_mcp.py::TestAgentMCP::test_agent_mcp_basic -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_mcp_basic(self, **kwargs):
         """
         Test agent with MCP (Model Context Protocol) tool for external API access.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_mcp_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_mcp_async.py
@@ -17,7 +17,7 @@ class TestAgentMCPAsync(TestBase):
     # To run only this test:
     # pytest tests/agents/tools/test_agent_mcp_async.py::TestAgentMCPAsync::test_agent_mcp_basic_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_mcp_basic_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_memory_search.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_memory_search.py
@@ -25,7 +25,7 @@ class TestAgentMemorySearch(TestBase):
         reason="Skipped until re-enabled and recorded on Foundry endpoint that supports the new versioning schema"
     )
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_memory_search(self, **kwargs):  # pylint: disable=too-many-statements
         """
         Test agent with Memory Search tool for contextual memory retrieval.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_memory_search_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_memory_search_async.py
@@ -26,7 +26,7 @@ class TestAgentMemorySearchAsync(TestBase):
         reason="Skipped until re-enabled and recorded on Foundry endpoint that supports the new versioning schema"
     )
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_memory_search_async(self, **kwargs):  # pylint: disable=too-many-statements
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_openapi.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_openapi.py
@@ -27,7 +27,7 @@ class TestAgentOpenApi(TestBase):
     # To run this test:
     # pytest tests/agents/tools/test_agent_openapi.py::TestAgentOpenApi::test_agent_openapi -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_openapi(self, **kwargs):
         """
         Test agent with OpenAPI tool capabilities.
@@ -124,6 +124,6 @@ class TestAgentOpenApi(TestBase):
     # pytest tests/agents/tools/test_agent_openapi.py::TestAgentOpenApi::test_agent_openapi_with_auth -s
     @servicePreparer()
     @pytest.mark.skip(reason="Add test here once we have a Foundry Project with a connection with auth credentials")
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_openapi_with_auth(self, **kwargs):
         pass

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_openapi_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_openapi_async.py
@@ -28,7 +28,7 @@ class TestAgentOpenApiAsync(TestBase):
     # To run this test:
     # pytest tests/agents/tools/test_agent_openapi_async.py::TestAgentOpenApiAsync::test_agent_openapi_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_openapi_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")
@@ -104,6 +104,6 @@ class TestAgentOpenApiAsync(TestBase):
     # pytest tests/agents/tools/test_agent_openapi_async.py::TestAgentOpenApiAsync::test_agent_openapi_with_auth_async -s
     @servicePreparer()
     @pytest.mark.skip(reason="Add test here once we have a Foundry Project with a connection with auth credentials")
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_openapi_with_auth_async(self, **kwargs):
         pass

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_tools_with_conversations.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_tools_with_conversations.py
@@ -27,7 +27,7 @@ from azure.ai.projects.models import (
 class TestAgentToolsWithConversations(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_function_tool_with_conversation(self, **kwargs):  # pylint: disable=too-many-statements
         """
         Test using FunctionTool within a conversation.
@@ -189,7 +189,7 @@ class TestAgentToolsWithConversations(TestBase):
             print("Cleanup completed")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_file_search_with_conversation(self, **kwargs):
         """
         Test using FileSearchTool within a conversation.
@@ -306,7 +306,7 @@ Widget C:
             print("Cleanup completed")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_code_interpreter_with_conversation(self, **kwargs):
         """
         Test using CodeInterpreterTool within a conversation.
@@ -388,7 +388,7 @@ Widget C:
     # To run this test only:
     # pytest tests/agents/tools/test_agent_tools_with_conversations.py::TestAgentToolsWithConversations::test_code_interpreter_with_file_in_conversation -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_code_interpreter_with_file_in_conversation(self, **kwargs):
         """
         Test using CodeInterpreterTool with file upload within a conversation.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_web_search.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_web_search.py
@@ -13,7 +13,7 @@ from azure.ai.projects.models import PromptAgentDefinition, WebSearchPreviewTool
 class TestAgentWebSearch(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_web_search(self, **kwargs):
         """
         Test agent with Web Search tool for real-time information.

--- a/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_web_search_async.py
+++ b/sdk/ai/azure-ai-projects/tests/agents/tools/test_agent_web_search_async.py
@@ -14,7 +14,7 @@ from azure.ai.projects.models import PromptAgentDefinition, WebSearchPreviewTool
 class TestAgentWebSearchAsync(TestBase):
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_web_search_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/conftest.py
+++ b/sdk/ai/azure-ai-projects/tests/conftest.py
@@ -7,13 +7,6 @@
 # Register MIME types before any other imports to ensure consistent Content-Type detection
 # across Windows, macOS, and Linux when uploading files in tests
 import mimetypes
-import sys
-
-import httpx2
-
-# devtools_testutils imports httpx when test decorators are created. OpenAI 3 uses
-# httpx2, so expose that backend under the legacy module name for this test process.
-sys.modules["httpx"] = httpx2
 
 mimetypes.add_type("text/csv", ".csv")
 mimetypes.add_type("text/markdown", ".md")
@@ -31,14 +24,6 @@ from devtools_testutils import (
     add_body_key_sanitizer,
     add_remove_header_sanitizer,
 )
-from devtools_testutils import proxy_testcase
-from devtools_testutils.aio import proxy_testcase_async
-
-proxy_testcase.httpx = httpx2
-proxy_testcase.HTTPXTransport = httpx2.HTTPTransport
-proxy_testcase.AsyncHTTPXTransport = httpx2.AsyncHTTPTransport
-proxy_testcase_async.httpx = httpx2
-proxy_testcase_async.AsyncHTTPXTransport = httpx2.AsyncHTTPTransport
 
 if not load_dotenv(find_dotenv(), override=True):
     print("Did not find a .env file. Using default environment variable values for tests.")

--- a/sdk/ai/azure-ai-projects/tests/files/test_files.py
+++ b/sdk/ai/azure-ai-projects/tests/files/test_files.py
@@ -13,7 +13,7 @@ class TestFiles(TestBase):
     # To run this test, use the following command in the \sdk\ai\azure-ai-projects folder:
     # cls & pytest tests\test_files.py::TestFiles::test_files -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_files(self, **kwargs):
 
         file_purpose = self.test_files_params["file_purpose"]

--- a/sdk/ai/azure-ai-projects/tests/files/test_files_async.py
+++ b/sdk/ai/azure-ai-projects/tests/files/test_files_async.py
@@ -14,7 +14,7 @@ class TestFilesAsync(TestBase):
     # To run this test, use the following command in the \sdk\ai\azure-ai-projects folder:
     # cls & pytest tests\test_files_async.py::TestFilesAsync::test_files_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_files_async(self, **kwargs):
 
         file_purpose = self.test_files_params["file_purpose"]

--- a/sdk/ai/azure-ai-projects/tests/finetuning/test_finetuning.py
+++ b/sdk/ai/azure-ai-projects/tests/finetuning/test_finetuning.py
@@ -423,7 +423,7 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_create_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_create_job(self, job_type, model_type, training_type, **kwargs):
         if job_type == SFT_JOB_TYPE:
             self._test_sft_create_job_helper(model_type, training_type, **kwargs)
@@ -452,7 +452,7 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_create_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_create_job_live_extended(self, job_type, model_type, training_type, **kwargs):
         if job_type == SFT_JOB_TYPE:
             self._test_sft_create_job_helper(model_type, training_type, **kwargs)
@@ -471,7 +471,7 @@ class TestFineTuning(TestBase):
         ],
     )
     @_pass_retrieve_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_retrieve_job(self, job_type, expected_method_type, **kwargs):
         with self.create_client(**kwargs) as project_client:
             with project_client.get_openai_client() as openai_client:
@@ -525,7 +525,7 @@ class TestFineTuning(TestBase):
         ],
     )
     @_pass_retrieve_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_retrieve_job_live_extended(self, job_type, expected_method_type, **kwargs):
         with self.create_client(**kwargs) as project_client:
             with project_client.get_openai_client() as openai_client:
@@ -567,7 +567,7 @@ class TestFineTuning(TestBase):
                 self._cleanup_test_file(openai_client, validation_file.id)
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_list_jobs(self, **kwargs):
         with self.create_client(**kwargs) as project_client:
             with project_client.get_openai_client() as openai_client:
@@ -592,7 +592,7 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_cancel_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_cancel_job(self, job_type, model_type, training_type, expected_method_type, **kwargs):
         self._test_cancel_job_helper(job_type, model_type, training_type, expected_method_type, **kwargs)
 
@@ -616,12 +616,12 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_cancel_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_cancel_job_live_extended(self, job_type, model_type, training_type, expected_method_type, **kwargs):
         self._test_cancel_job_helper(job_type, model_type, training_type, expected_method_type, **kwargs)
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_list_events(self, **kwargs):
 
         with self.create_client(**kwargs) as project_client:
@@ -664,7 +664,7 @@ class TestFineTuning(TestBase):
         reason="Skipped extended FT live tests. Those only run live, without recordings, when RUN_EXTENDED_FINE_TUNING_LIVE_TESTS=true",
     )
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_pause_job(self, **kwargs):
         running_job_id = kwargs.get("running_fine_tuning_job_id")
 
@@ -698,7 +698,7 @@ class TestFineTuning(TestBase):
         reason="Skipped extended FT live tests. Those only run live, without recordings, when RUN_EXTENDED_FINE_TUNING_LIVE_TESTS=true",
     )
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_resume_job(self, **kwargs):
         paused_job_id = kwargs.get("paused_fine_tuning_job_id")
 
@@ -727,7 +727,7 @@ class TestFineTuning(TestBase):
                 print(f"[test_finetuning_resume_job] Successfully resumed and verified job: {paused_job_id}")
 
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_list_checkpoints(self, **kwargs):
         completed_job_id = kwargs.get("completed_oai_model_sft_fine_tuning_job_id")
 
@@ -780,7 +780,7 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_deploy_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_deploy_and_infer_job(
         self, job_id_env_var, deployment_format, deployment_capacity, test_prefix, inference_content, **kwargs
     ):
@@ -826,7 +826,7 @@ class TestFineTuning(TestBase):
     )
     @servicePreparer()
     @_pass_deploy_args
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_deploy_and_infer_job_live_extended(
         self, job_id_env_var, deployment_format, deployment_capacity, test_prefix, inference_content, **kwargs
     ):

--- a/sdk/ai/azure-ai-projects/tests/finetuning/test_finetuning_async.py
+++ b/sdk/ai/azure-ai-projects/tests/finetuning/test_finetuning_async.py
@@ -434,7 +434,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_create_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_create_job_async(self, job_type, model_type, training_type, **kwargs):
         if job_type == SFT_JOB_TYPE:
             await self._test_sft_create_job_helper_async(model_type, training_type, **kwargs)
@@ -463,7 +463,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_create_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_create_job_async_live_extended(self, job_type, model_type, training_type, **kwargs):
         if job_type == SFT_JOB_TYPE:
             await self._test_sft_create_job_helper_async(model_type, training_type, **kwargs)
@@ -482,7 +482,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_retrieve_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_retrieve_job_async(self, job_type, expected_method_type, **kwargs):
         project_client = self.create_async_client(**kwargs)
         openai_client = project_client.get_openai_client()
@@ -538,7 +538,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_retrieve_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_retrieve_job_async_live_extended(self, job_type, expected_method_type, **kwargs):
         project_client = self.create_async_client(**kwargs)
         openai_client = project_client.get_openai_client()
@@ -582,7 +582,7 @@ class TestFineTuningAsync(TestBase):
             await self._cleanup_test_file_async(openai_client, validation_file.id)
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_finetuning_list_jobs_async(self, **kwargs):
         project_client = self.create_async_client(**kwargs)
         openai_client = project_client.get_openai_client()
@@ -612,7 +612,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_cancel_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_cancel_job_async(self, job_type, model_type, training_type, expected_method_type, **kwargs):
         await self._test_cancel_job_helper_async(job_type, model_type, training_type, expected_method_type, **kwargs)
 
@@ -636,14 +636,14 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_cancel_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_cancel_job_async_live_extended(
         self, job_type, model_type, training_type, expected_method_type, **kwargs
     ):
         await self._test_cancel_job_helper_async(job_type, model_type, training_type, expected_method_type, **kwargs)
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_finetuning_list_events_async(self, **kwargs):
 
         project_client = self.create_async_client(**kwargs)
@@ -690,7 +690,7 @@ class TestFineTuningAsync(TestBase):
         reason="Skipped extended FT live tests. Those only run live, without recordings, when RUN_EXTENDED_FINE_TUNING_LIVE_TESTS=true",
     )
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_finetuning_pause_job_async(self, **kwargs):
         running_job_id = kwargs.get("running_fine_tuning_job_id")
 
@@ -725,7 +725,7 @@ class TestFineTuningAsync(TestBase):
         reason="Skipped extended FT live tests. Those only run live, without recordings, when RUN_EXTENDED_FINE_TUNING_LIVE_TESTS=true",
     )
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_finetuning_resume_job_async(self, **kwargs):
         paused_job_id = kwargs.get("paused_fine_tuning_job_id")
 
@@ -756,7 +756,7 @@ class TestFineTuningAsync(TestBase):
             print(f"[test_finetuning_resume_job] Successfully resumed and verified job: {paused_job_id}")
 
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_finetuning_list_checkpoints_async(self, **kwargs):
         completed_job_id = kwargs.get("completed_oai_model_sft_fine_tuning_job_id")
 
@@ -812,7 +812,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_deploy_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_deploy_and_infer_job_async(
         self, job_id_env_var, deployment_format, deployment_capacity, test_prefix, inference_content, **kwargs
     ):
@@ -858,7 +858,7 @@ class TestFineTuningAsync(TestBase):
     )
     @servicePreparer()
     @_pass_deploy_args_async
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_deploy_and_infer_job_async_live_extended(
         self, job_id_env_var, deployment_format, deployment_capacity, test_prefix, inference_content, **kwargs
     ):

--- a/sdk/ai/azure-ai-projects/tests/responses/test_responses.py
+++ b/sdk/ai/azure-ai-projects/tests/responses/test_responses.py
@@ -46,7 +46,7 @@ class TestResponses(TestBase):
     # To run this test:
     # pytest tests\responses\test_responses.py::TestResponses::test_responses -s
     @servicePreparer()
-    @recorded_by_proxy(RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.HTTPX2)
     def test_responses(self, **kwargs):
         """
         Test creating a responses call (no Agents, no Conversation).

--- a/sdk/ai/azure-ai-projects/tests/responses/test_responses_async.py
+++ b/sdk/ai/azure-ai-projects/tests/responses/test_responses_async.py
@@ -42,7 +42,7 @@ class TestResponsesAsync(TestBase):
     # To run this test:
     # pytest tests\responses\test_responses_async.py::TestResponsesAsync::test_responses_async -s
     @servicePreparer()
-    @recorded_by_proxy_async(RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.HTTPX2)
     async def test_responses_async(self, **kwargs):
 
         model = kwargs.get("foundry_model_name")

--- a/sdk/ai/azure-ai-projects/tests/samples/README.md
+++ b/sdk/ai/azure-ai-projects/tests/samples/README.md
@@ -49,7 +49,7 @@ class TestSamples(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_tools_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(
@@ -85,7 +85,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_tools_samples_async(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(
@@ -131,7 +131,7 @@ servicePreparer = functools.partial(
 
 - `@pytest.mark.parametrize`: Drives one test per sample file. Use `samples_to_test` or `samples_to_skip` with `get_sample_paths` / `get_async_sample_paths`.
 - `@SamplePathPasser`: Forwards the sample path to the recorder decorators.
-- `recorded_by_proxy` / `recorded_by_proxy_async`: Wrap tests for recording/playback. Include `RecordedTransport.HTTPX` when samples use httpx2 in addition to the default `RecordedTransport.AZURE_CORE`.
+- `recorded_by_proxy` / `recorded_by_proxy_async`: Wrap tests for recording/playback. Include `RecordedTransport.HTTPX2` when samples use httpx2 in addition to the default `RecordedTransport.AZURE_CORE`.
 - `execute` / `execute_async`: Run the sample; any exception fails the test.
 - `validate_print_calls_by_llm` / `validate_print_calls_by_llm_async`: Validate captured print output with LLM instructions resolved automatically from the sample folder. You can still pass an explicit `instructions` override when needed.
 - `kwargs` in the test function: A dictionary with environment variables in key and value pairs.
@@ -182,7 +182,7 @@ from sample_executor import AdditionalSampleTestDetail, additionalSampleTests
     ),
 )
 @SamplePathPasser()
-@recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+@recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
 def test_agent_tools_samples(self, sample_path: str, **kwargs) -> None:
     ...
 ```

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples.py
@@ -53,7 +53,7 @@ class TestSamples(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agent_tools_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -69,7 +69,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     # To run this test: pytest tests/samples/test_samples.py::TestSamples::test_memory_samples -s
     def test_memory_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
@@ -90,7 +90,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agents_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -106,7 +106,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_connections_samples(self, sample_path: str, **kwargs) -> None:
         kwargs = kwargs.copy()
         kwargs["connection_name"] = "mcp"
@@ -124,7 +124,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_files_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -140,7 +140,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_deployments_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -162,7 +162,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @modelsServicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_models_samples(self, sample_path: str, **kwargs) -> None:
         import secrets  # local import to avoid module-level dep
 
@@ -209,7 +209,7 @@ class TestSamples(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     # To run this test: pytest tests/samples/test_samples.py::TestSamples::test_datasets_samples[sample_dataset_generation_job_simpleqna_with_prompt_source] -s
     def test_datasets_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
@@ -226,7 +226,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_chat_completions_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -306,7 +306,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @SamplePathPasser()
     # To run a single sample: pytest tests\samples\test_samples.py::TestSamples::test_hosted_agents_samples[sample_agent_endpoint] -s
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_hosted_agents_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -342,7 +342,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_skills_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -358,7 +358,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_toolboxes_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -377,7 +377,7 @@ class TestSamples(AzureRecordedTestCase):
     )
     @fineTuningServicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_finetuning_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_fine_tuning_sample_env_vars(sample_path, kwargs)
         executor = SyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples_async.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples_async.py
@@ -34,7 +34,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agent_tools_samples_async(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(
@@ -55,7 +55,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     # To run this test: pytest tests/samples/test_samples_async.py::TestSamplesAsync::test_memory_samples -s
     async def test_memory_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
@@ -75,7 +75,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_agents_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -91,7 +91,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_connections_samples(self, sample_path: str, **kwargs) -> None:
         kwargs = kwargs.copy()
         kwargs["connection_name"] = "mcp"
@@ -111,7 +111,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_files_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -127,7 +127,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_deployments_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -145,7 +145,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @modelsServicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_models_samples(self, sample_path: str, **kwargs) -> None:
         import secrets  # local import to avoid module-level dep
 
@@ -174,7 +174,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_datasets_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -193,7 +193,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_chat_completions_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -261,7 +261,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_hosted_agents_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -290,7 +290,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_skills_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)
@@ -306,7 +306,7 @@ class TestSamplesAsync(AzureRecordedTestCase):
     )
     @servicePreparer()
     @SamplePathPasser()
-    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy_async(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     async def test_toolboxes_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = AsyncSampleExecutor(self, sample_path, env_vars=env_vars, **kwargs)

--- a/sdk/ai/azure-ai-projects/tests/samples/test_samples_evaluations.py
+++ b/sdk/ai/azure-ai-projects/tests/samples/test_samples_evaluations.py
@@ -176,7 +176,7 @@ class TestSamplesEvaluations(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_evaluation_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(
@@ -205,7 +205,7 @@ class TestSamplesEvaluations(AzureRecordedTestCase):
         ),
     )
     @SamplePathPasser()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_agentic_evaluator_samples(self, sample_path: str, **kwargs) -> None:
         env_vars = get_sample_env_vars(kwargs)
         executor = SyncSampleExecutor(
@@ -221,7 +221,7 @@ class TestSamplesEvaluations(AzureRecordedTestCase):
     # To run this test, use:
     # pytest tests/samples/test_samples_evaluations.py::TestSamplesEvaluations::test_generic_agentic_evaluator_sample
     @evaluationsPreparer()
-    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX)
+    @recorded_by_proxy(RecordedTransport.AZURE_CORE, RecordedTransport.HTTPX2)
     def test_generic_agentic_evaluator_sample(self, **kwargs) -> None:
         # Manually construct path to nested sample
         current_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
- Changed recorded_by_proxy and recorded_by_proxy_async decorators in various test files to use RecordedTransport.HTTPX2 instead of RecordedTransport.HTTPX.
- This update affects tests related to agent tools, memory search, OpenAPI, web search, file handling, fine-tuning, and sample evaluations.
- Ensures compatibility with the new HTTPX2 transport for improved performance and reliability in test recordings.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
