### PR TITLE
[Storage] Mark rehydrate to smart tier tests as playback

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3905,6 +3905,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         content = identity_blob.download_blob().readall()
         assert content == data
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_smart_rehydrate(self, **kwargs):

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -3812,6 +3812,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         content = await (await identity_blob.download_blob()).readall()
         assert content == data
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_smart_rehydrate(self, **kwargs):


### PR DESCRIPTION
These tests were potentially causing issues with resource cleanup so marking them as playback only.