### PR TITLE
Update emitter package skill to use CFS feed

### DIFF
--- a/.github/skills/emitter-package-update/SKILL.md
+++ b/.github/skills/emitter-package-update/SKILL.md
@@ -18,7 +18,15 @@ When `eng/emitter-package.json` is updated on `main`, the [TypeSpec Python Regen
 
 ## Prerequisites
 
-Before running this workflow, verify the following tools are installed:
+Use the Azure SDK CFS feed for every npm operation in this workflow. This is the same
+registry configured by [`create-authenticated-npmrc.yml`](../../../eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml):
+
+```bash
+export NPM_CONFIG_REGISTRY="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+```
+
+Before running this workflow, verify the following tools are installed with the CFS feed
+configured:
 
 ```bash
 # Check npm-check-updates
@@ -32,8 +40,8 @@ gh --version
 ```
 
 If any tool is missing:
-- **npm-check-updates**: Install via `npm install -g npm-check-updates`
-- **tsp-client**: Install via `npm install -g @azure-tools/typespec-client-generator-cli`
+- **npm-check-updates**: Install via `npm install --registry "$NPM_CONFIG_REGISTRY" -g npm-check-updates`
+- **tsp-client**: Install via `npm install --registry "$NPM_CONFIG_REGISTRY" -g @azure-tools/typespec-client-generator-cli`
 - **GitHub CLI**: Install from https://cli.github.com/ or via `winget install GitHub.cli`
 
 ## Workflow
@@ -60,11 +68,11 @@ The goal is to update **every** package across **both** the `dependencies` and
 sections by default:
 
 ```bash
-npx npm-check-updates --packageFile eng/emitter-package.json -u
+npx --registry "$NPM_CONFIG_REGISTRY" npm-check-updates --packageFile eng/emitter-package.json -u
 ```
 
 > **Restricted-network fallback (e.g. the coding-agent sandbox):** `npm-check-updates`
-> needs access to the npm registry, which may be firewalled. If it cannot reach the registry,
+> needs access to the CFS feed, which may be firewalled. If it cannot reach the feed,
 > determine the latest `@azure-tools/typespec-python` version from GitHub instead — the
 > newest published tag in [Azure/typespec-azure](https://github.com/Azure/typespec-azure/tags)
 > (cross-checked against `packages/typespec-python/package.json` on `main`) — and edit
@@ -130,11 +138,11 @@ tsp-client generate-lock-file
 This regenerates `eng/emitter-package-lock.json`.
 
 > **Restricted-network note:** `tsp-client generate-lock-file` also resolves packages
-> from the npm registry. If the registry is unreachable, the lock file cannot be
+> from the configured CFS feed. If the feed is unreachable, the lock file cannot be
 > regenerated in the sandbox. In that case commit only the `eng/emitter-package.json`
 > change (skip the lock file in step 6), and call out in the PR body that
 > `eng/emitter-package-lock.json` still needs to be regenerated in an environment with
-> npm-registry access before merge.
+> CFS-feed access before merge.
 
 ### 6. Commit Changes
 


### PR DESCRIPTION
## Summary

- configure the emitter package update skill to use the Azure SDK CFS npm feed
- use the configured feed when installing and running npm tooling
- update restricted-network guidance to refer to CFS feed access
