### PR TITLE
Fix emitter update pull request body

### DIFF
--- a/eng/pipelines/post-publish-emitter.yml
+++ b/eng/pipelines/post-publish-emitter.yml
@@ -107,6 +107,6 @@ extends:
                   CommitMsg: '[Automation] Update emitter package dependencies'
                   PRTitle: '[Automation] Update emitter package dependencies'
                   PRBody: |
-                    This automated PR updates "eng/emitter-package.json" dependencies through the authenticated Azure SDK CFS feed and regenerates "eng/emitter-package-lock.json".
+                    This automated PR updates the emitter package dependencies through the authenticated Azure SDK CFS feed and regenerates the lock file.
                   OpenAsDraft: true
                   AuthToken: ''


### PR DESCRIPTION
Fix https://github.com/Azure/azure-sdk-for-python/pull/48718

## Summary

- remove embedded quotes from the automated emitter-update pull request body
- prevent the shared PowerShell pull-request step from splitting the body into unintended parameters

The embedded quotes caused argument parsing to shift trailing body text into `AddBuildSummary`, producing a Boolean conversion failure.