### PR TITLE
Improve Conda sync pipeline error handling

### DIFF
--- a/conda/conda_helper_functions.py
+++ b/conda/conda_helper_functions.py
@@ -304,14 +304,7 @@ def get_valid_package_imports(package_name: str) -> list[str]:
         )
         return [package_name.replace("-", ".")]
     else:
-        try:
-            parsed = ParsedSetup.from_path(package_path)
-        except Exception as e:
-            # package is missing pyproject.toml or setup.py
-            logger.error(
-                f"Failed to parse setup for {package_name} at {package_path}: {e}"
-            )
-            raise
+        parsed = ParsedSetup.from_path(package_path)
         if not parsed or not parsed.namespace:
             logger.warning(
                 f"Could not parse namespace for {package_name}, using fallback"

--- a/conda/conda_helper_functions.py
+++ b/conda/conda_helper_functions.py
@@ -304,7 +304,14 @@ def get_valid_package_imports(package_name: str) -> list[str]:
         )
         return [package_name.replace("-", ".")]
     else:
-        parsed = ParsedSetup.from_path(package_path)
+        try:
+            parsed = ParsedSetup.from_path(package_path)
+        except Exception as e:
+            # package is missing pyproject.toml or setup.py
+            logger.error(
+                f"Failed to parse setup for {package_name} at {package_path}: {e}"
+            )
+            raise
         if not parsed or not parsed.namespace:
             logger.warning(
                 f"Could not parse namespace for {package_name}, using fallback"

--- a/conda/update_conda_files.py
+++ b/conda/update_conda_files.py
@@ -672,8 +672,14 @@ def add_new_mgmt_plane_packages(new_mgmt_plane_names: list[str]) -> list[str]:
         if not package_name:
             logger.warning("Skipping package with missing name")
             continue
-
-        imports = get_valid_package_imports(package_name)
+        try:
+            imports = get_valid_package_imports(package_name)
+        except Exception as e:
+            logger.error(
+                f"Failed to get valid imports for {package_name}, skipping addition: {e}"
+            )
+            result.append(package_name)
+            continue
         # Format imports for YAML with "- " prefix
         formatted = [f"- {imp}" for imp in imports]
         new_imports.extend(formatted)

--- a/doc/dev/conda-release.md
+++ b/doc/dev/conda-release.md
@@ -52,7 +52,7 @@ The auto-generated PR includes:
 ### Review, Approve, and Cleanup (manual)
 
 1. **Review the PR.** Check the report in the pipeline output for any packages that encountered unexpected behavior and may need manual fixes.
-   - The PR triggers a [public build](https://dev.azure.com/azure-sdk/public/_build?definitionId=8092) which validates the changes to the Conda recipes.
+   - To validate the Conda recipe changes, manually queue a run of the internal **[Conda Build/Release Pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=6321)** against the PR branch.
 
 2. **Merge the PR** into `main`.
 


### PR DESCRIPTION
conda sync was throwing exception trying to parse missing setup.py/pyproject.toml for azure-mgmt-trustedsigning

updated to handle that case

also, updated conda docs because we got rid of the public build pipeline due to CFS