### PR TITLE
Add positive-path challenge cache test for Key Vault keys and certificates

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_challenge_auth.py
@@ -38,6 +38,65 @@ def get_random_url():
 
 
 @empty_challenge_cache
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_valid_challenge_is_cached(token_type):
+    """After a valid challenge, later requests to the same vault are authorized immediately from the
+    cached challenge, without eliciting another 401.
+
+    This is the positive-path counterpart to test_rejected_challenge_is_not_cached. That test would
+    still pass if challenge caching were removed entirely, so this test guards that a validated
+    challenge is cached and reused for subsequent requests.
+    """
+
+    expected_token = "expected_token"
+    url = get_random_url()
+    challenge = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": 'Bearer authorization="https://authority.net/tenant", resource=https://vault.azure.net'},
+    )
+
+    class Requests:
+        count = 0
+
+    def send(request):
+        Requests.count += 1
+        if Requests.count == 1:
+            # first request is stripped and unauthenticated to elicit the challenge
+            assert "Authorization" not in request.headers
+            assert not request.body
+            assert request.headers["Content-Length"] == "0"
+            return challenge
+        # the retried first request and the entire second request must already be authorized from the
+        # cached challenge; no further challenge is expected
+        assert expected_token in request.headers["Authorization"]
+        return Mock(status_code=200)
+
+    def get_token(*_, **__):
+        return token_type(expected_token, time.time() + 3600)
+
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
+
+    pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+
+    for _ in range(2):
+        request = HttpRequest("POST", url)
+        request.set_bytes_body(b"secret")
+        pipeline.run(request)
+
+    # three sends total: challenge + retry for the first request, then a single cached-auth send for the
+    # second request, which must not trigger another challenge
+    assert Requests.count == 3
+    assert HttpChallengeCache.get_challenge_for_url(url)
+    if token_type == AccessToken:
+        assert credential.get_token.call_count == 1
+    else:
+        assert credential.get_token_info.call_count == 1
+
+
+@empty_challenge_cache
 def test_rejected_challenge_is_not_cached():
     url = "https://example.net/certificates/canary"
     challenge = Mock(

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_challenge_auth_async.py
@@ -32,6 +32,66 @@ def empty_challenge_cache(fn):
 
 @pytest.mark.asyncio
 @empty_challenge_cache
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+async def test_valid_challenge_is_cached(token_type):
+    """After a valid challenge, later requests to the same vault are authorized immediately from the
+    cached challenge, without eliciting another 401.
+
+    This is the positive-path counterpart to test_rejected_challenge_is_not_cached. That test would
+    still pass if challenge caching were removed entirely, so this test guards that a validated
+    challenge is cached and reused for subsequent requests.
+    """
+
+    expected_token = "expected_token"
+    url = get_random_url()
+    challenge = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": 'Bearer authorization="https://authority.net/tenant", resource=https://vault.azure.net'},
+    )
+
+    class Requests:
+        count = 0
+
+    async def send(request):
+        Requests.count += 1
+        if Requests.count == 1:
+            # first request is stripped and unauthenticated to elicit the challenge
+            assert "Authorization" not in request.headers
+            assert not request.body
+            assert request.headers["Content-Length"] == "0"
+            return challenge
+        # the retried first request and the entire second request must already be authorized from the
+        # cached challenge; no further challenge is expected
+        assert expected_token in request.headers["Authorization"]
+        return Mock(status_code=200)
+
+    async def get_token(*_, **__):
+        return token_type(expected_token, time.time() + 3600)
+
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
+
+    pipeline = AsyncPipeline(policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+
+    for _ in range(2):
+        request = HttpRequest("POST", url)
+        request.set_bytes_body(b"secret")
+        await pipeline.run(request)
+
+    # three sends total: challenge + retry for the first request, then a single cached-auth send for the
+    # second request, which must not trigger another challenge
+    assert Requests.count == 3
+    assert HttpChallengeCache.get_challenge_for_url(url)
+    if token_type == AccessToken:
+        assert credential.get_token.call_count == 1
+    else:
+        assert credential.get_token_info.call_count == 1
+
+
+@pytest.mark.asyncio
+@empty_challenge_cache
 async def test_rejected_challenge_is_not_cached():
     url = "https://example.net/certificates/canary"
     challenge = Mock(

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -111,6 +111,65 @@ KV_CHALLENGE_RESPONSE = Mock(
 
 
 @empty_challenge_cache
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+def test_valid_challenge_is_cached(token_type):
+    """After a valid challenge, later requests to the same vault are authorized immediately from the
+    cached challenge, without eliciting another 401.
+
+    This is the positive-path counterpart to test_rejected_challenge_is_not_cached. That test would
+    still pass if challenge caching were removed entirely, so this test guards that a validated
+    challenge is cached and reused for subsequent requests.
+    """
+
+    expected_token = "expected_token"
+    url = get_random_url()
+    challenge = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": 'Bearer authorization="https://authority.net/tenant", resource=https://vault.azure.net'},
+    )
+
+    class Requests:
+        count = 0
+
+    def send(request):
+        Requests.count += 1
+        if Requests.count == 1:
+            # first request is stripped and unauthenticated to elicit the challenge
+            assert "Authorization" not in request.headers
+            assert not request.body
+            assert request.headers["Content-Length"] == "0"
+            return challenge
+        # the retried first request and the entire second request must already be authorized from the
+        # cached challenge; no further challenge is expected
+        assert expected_token in request.headers["Authorization"]
+        return Mock(status_code=200)
+
+    def get_token(*_, **__):
+        return token_type(expected_token, time.time() + 3600)
+
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
+
+    pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+
+    for _ in range(2):
+        request = HttpRequest("POST", url)
+        request.set_bytes_body(b"secret")
+        pipeline.run(request)
+
+    # three sends total: challenge + retry for the first request, then a single cached-auth send for the
+    # second request, which must not trigger another challenge
+    assert Requests.count == 3
+    assert HttpChallengeCache.get_challenge_for_url(url)
+    if token_type == AccessToken:
+        assert credential.get_token.call_count == 1
+    else:
+        assert credential.get_token_info.call_count == 1
+
+
+@empty_challenge_cache
 def test_rejected_challenge_is_not_cached():
     url = "https://example.net/keys/canary"
     challenge = Mock(

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -95,6 +95,66 @@ def empty_challenge_cache(fn):
 
 @pytest.mark.asyncio
 @empty_challenge_cache
+@pytest.mark.parametrize("token_type", TOKEN_TYPES)
+async def test_valid_challenge_is_cached(token_type):
+    """After a valid challenge, later requests to the same vault are authorized immediately from the
+    cached challenge, without eliciting another 401.
+
+    This is the positive-path counterpart to test_rejected_challenge_is_not_cached. That test would
+    still pass if challenge caching were removed entirely, so this test guards that a validated
+    challenge is cached and reused for subsequent requests.
+    """
+
+    expected_token = "expected_token"
+    url = get_random_url()
+    challenge = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": 'Bearer authorization="https://authority.net/tenant", resource=https://vault.azure.net'},
+    )
+
+    class Requests:
+        count = 0
+
+    async def send(request):
+        Requests.count += 1
+        if Requests.count == 1:
+            # first request is stripped and unauthenticated to elicit the challenge
+            assert "Authorization" not in request.headers
+            assert not request.body
+            assert request.headers["Content-Length"] == "0"
+            return challenge
+        # the retried first request and the entire second request must already be authorized from the
+        # cached challenge; no further challenge is expected
+        assert expected_token in request.headers["Authorization"]
+        return Mock(status_code=200)
+
+    async def get_token(*_, **__):
+        return token_type(expected_token, time.time() + 3600)
+
+    if token_type == AccessToken:
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
+    else:
+        credential = Mock(spec_set=["get_token_info"], get_token_info=Mock(wraps=get_token))
+
+    pipeline = AsyncPipeline(policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+
+    for _ in range(2):
+        request = HttpRequest("POST", url)
+        request.set_bytes_body(b"secret")
+        await pipeline.run(request)
+
+    # three sends total: challenge + retry for the first request, then a single cached-auth send for the
+    # second request, which must not trigger another challenge
+    assert Requests.count == 3
+    assert HttpChallengeCache.get_challenge_for_url(url)
+    if token_type == AccessToken:
+        assert credential.get_token.call_count == 1
+    else:
+        assert credential.get_token_info.call_count == 1
+
+
+@pytest.mark.asyncio
+@empty_challenge_cache
 async def test_rejected_challenge_is_not_cached():
     url = "https://example.net/keys/canary"
     challenge = Mock(


### PR DESCRIPTION
## Summary
Follow-up to #48710 (now merged), addressing review feedback: add an explicit **positive-path** challenge cache test so the suite proves that a *validated* challenge is cached and reused, not just that a *rejected* challenge is not cached.

- Add 	est_valid_challenge_is_cached (sync and async) to `azure-keyvault-keys` and `azure-keyvault-certificates`.
- The test drives one request through the full challenge flow (401 -> verify -> cache -> authorized retry), then issues a second request to the same vault and asserts it is authorized **up front from the cached challenge with no second 401** (exactly 3 transport sends, `get_token` called once, challenge present in the cache).

## Why
The existing `test_rejected_challenge_is_not_cached` would still pass even if challenge caching were removed entirely -- which is why the initial async caching omission escaped the tests and was caught only in review. This positive-path test closes that gap.

**Verified:** all four new tests pass on `main`; and when the async cache write is temporarily removed, `test_valid_challenge_is_cached` fails (both token types) while `test_rejected_challenge_is_not_cached` still passes -- confirming the new test guards the exact behavior.

## Tests
- `pytest test_challenge_auth.py test_challenge_auth_async.py -k test_valid_challenge_is_cached` in both `azure-keyvault-keys` and `azure-keyvault-certificates` (4 passed each).