### PR TITLE
Hotfix: Key Vault challenge cache validation (keys 4.11.2, administration 4.7.1)

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.7.1 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the authentication challenge only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 4.7.0 (2026-05-18)
 
 ### Features Added

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -214,6 +214,8 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
 
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
+
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:
             request.http_request = self._request_copy

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -58,7 +58,7 @@ def _has_claims(challenge: str) -> bool:
 
 
 def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) -> HttpChallenge:
-    """Parse challenge from a challenge response, cache it, and return it.
+    """Parse challenge from a challenge response and return it.
 
     :param request: The pipeline request that prompted the challenge response.
     :type request: ~azure.core.pipeline.PipelineRequest
@@ -74,7 +74,6 @@ def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) ->
         challenger.http_response.headers.get("WWW-Authenticate"),
         response_headers=challenger.http_response.headers,
     )
-    ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
     return challenge
 
 
@@ -226,6 +225,8 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                     "`verify_challenge_resource=False` to your client's constructor to disable this verification. "
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
+
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
 
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.7.0"
+VERSION = "4.7.1"

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.11.2 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the authentication challenge only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 4.11.1 (2026-05-18)
 
 ### Features Added

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -214,6 +214,8 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
 
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
+
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:
             request.http_request = self._request_copy

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -58,7 +58,7 @@ def _has_claims(challenge: str) -> bool:
 
 
 def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) -> HttpChallenge:
-    """Parse challenge from a challenge response, cache it, and return it.
+    """Parse challenge from a challenge response and return it.
 
     :param request: The pipeline request that prompted the challenge response.
     :type request: ~azure.core.pipeline.PipelineRequest
@@ -74,7 +74,6 @@ def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) ->
         challenger.http_response.headers.get("WWW-Authenticate"),
         response_headers=challenger.http_response.headers,
     )
-    ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
     return challenge
 
 
@@ -226,6 +225,8 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                     "`verify_challenge_resource=False` to your client's constructor to disable this verification. "
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
+
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
 
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.11.1"
+VERSION = "4.11.2"


### PR DESCRIPTION
## Summary
Security hotfix backporting the Key Vault challenge-cache-after-validation fix (MSRC / ICM 31000000679759) to released stable versions. Targets the `hotfix/keyvault` branch per the [hotfix policy](https://azure.github.io/azure-sdk/policies_repobranching.html#hotfix-branches).

The shared challenge auth policy now caches the authentication challenge **only after** the challenge resource is verified -- in **both** the sync and async policies -- so a rejected challenge is not cached and reused by later requests.

## Packages
- `azure-keyvault-keys` 4.11.1 -> **4.11.2**
- `azure-keyvault-administration` 4.7.0 -> **4.7.1**

(Both packages share this branch because their release tags point at the same commit.)

## Changes (per package)
- Remove the cache write from the shared `_update_challenge` helper.
- Add the cache write to `on_challenge` after `verify_challenge_resource` succeeds, in the sync **and** async policies (the async policy previously relied on the helper to cache).
- Bump version + CHANGELOG entry.

## Tests
`pytest test_challenge_auth.py test_challenge_auth_async.py` for azure-keyvault-keys -> **57 passed, 4 skipped**, including `test_policy_updates_cache` (confirms caching still works after the move) and the `verify_challenge_resource` tests. Administration's policy is byte-identical to keys', so that coverage applies.

The same fix is in `main` via #48710 (merged).