### PR TITLE
Hotfix: Key Vault challenge cache validation (certificates 4.11.2)

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.11.2 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the authentication challenge only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 4.11.1 (2026-04-29)
 
 ### Bugs Fixed

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -218,6 +218,8 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
 
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
+
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:
             request.http_request = self._request_copy

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -58,7 +58,7 @@ def _has_claims(challenge: str) -> bool:
 
 
 def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) -> HttpChallenge:
-    """Parse challenge from a challenge response, cache it, and return it.
+    """Parse challenge from a challenge response and return it.
 
     :param request: The pipeline request that prompted the challenge response.
     :type request: ~azure.core.pipeline.PipelineRequest
@@ -74,7 +74,6 @@ def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) ->
         challenger.http_response.headers.get("WWW-Authenticate"),
         response_headers=challenger.http_response.headers,
     )
-    ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
     return challenge
 
 
@@ -226,6 +225,8 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                     "`verify_challenge_resource=False` to your client's constructor to disable this verification. "
                     "See https://aka.ms/azsdk/blog/vault-uri for more information."
                 )
+
+        ChallengeCache.set_challenge_for_url(request.http_request.url, challenge)
 
         # If we had created a request copy in on_request, use it now to send along the original body content
         if self._request_copy:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.11.1"
+VERSION = "4.11.2"


### PR DESCRIPTION
## Summary
Security hotfix backporting the Key Vault challenge-cache-after-validation fix (MSRC / ICM 31000000679759) to `azure-keyvault-certificates` **4.11.1 -> 4.11.2**, per the [hotfix policy](https://azure.github.io/azure-sdk/policies_repobranching.html#hotfix-branches). Targets the `hotfix/keyvault-certificates` branch (created from the `azure-keyvault-certificates_4.11.1` tag).

The challenge is now cached **only after** the challenge resource is verified, in **both** the sync and async policies (the async policy previously relied on the shared helper to cache), so a rejected challenge is not cached and reused by later requests.

## Changes
- Remove the cache write from the shared `_update_challenge` helper.
- Add the post-verification cache write to the sync and async `on_challenge`.
- Bump to 4.11.2 + CHANGELOG entry.

## Validation
Policy imports cleanly; cache-after-verify and async-cache placement verified. The identical fix is validated by azure-keyvault-keys' challenge_auth suite (57 passed) and is in `main` via #48710.