### PR TITLE
Limit certificates hotfix pipeline to certificates artifact

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -33,15 +33,5 @@ extends:
     TestTimeoutInMinutes: 120
     TestProxy: true
     Artifacts:
-    - name: azure-keyvault-administration
-      safename: azurekeyvaultadministration
     - name: azure-keyvault-certificates
       safeName: azurekeyvaultcertificates
-    - name: azure-keyvault-keys
-      safeName: azurekeyvaultkeys
-    - name: azure-keyvault-secrets
-      safeName: azurekeyvaultsecrets
-    - name: azure-keyvault-securitydomain
-      safeName: azurekeyvaultsecuritydomain
-    - name: azure-mgmt-keyvault
-      safeName: azuremgmtkeyvault


### PR DESCRIPTION
## Summary
- narrow the Key Vault hotfix pipeline artifact list to `azure-keyvault-certificates`
- avoid validating unrelated Key Vault packages while releasing the certificates-only hotfix

## Context
The certificates hotfix is already merged into `hotfix/keyvault-certificates`, but the service-level pipeline still validates all Key Vault artifacts listed in `sdk/keyvault/ci.yml`. This branch limits that hotfix branch pipeline to the certificates package only so the release can proceed independently.