### PR TITLE
[KeyVault] Scope certificates hotfix pipeline to certificates only

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -32,6 +32,11 @@ extends:
     ServiceDirectory: keyvault
     TestTimeoutInMinutes: 120
     TestProxy: true
+    # Hotfix branch: scope build/analyze/test to the certificates package only.
+    # Sibling KeyVault packages on this old base fail current eng tooling and are not
+    # shipped from this branch. Artifacts controls packaging; BuildTargetingString
+    # controls which packages the Build/Analyze/Test matrix targets.
+    BuildTargetingString: azure-keyvault-certificates
     Artifacts:
     - name: azure-keyvault-certificates
       safeName: azurekeyvaultcertificates


### PR DESCRIPTION
## Why

The **certificates 4.11.2 hotfix** release pipeline (`python - keyvault`, builds [6744401](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6744401) and [6745038](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6745038)) fails on 4 tasks — **all in *sibling* packages; `azure-keyvault-certificates` itself passes every check:**

| Task | Package that fails |
|---|---|
| Run Tests | `azure-keyvault-keys` (mindependency) |
| Run Pylint | `azure-keyvault-securitydomain` (pylint 16) |
| Run verifytypes | `azure-keyvault-administration` |
| Update Snippets | `azure-keyvault-administration` |

Root cause: `ServiceDirectory: keyvault` makes the Analyze/Test matrix scan **every** package under `sdk/keyvault/`. On this old hotfix base, the sibling packages' code doesn't satisfy current eng tooling. None of it is the challenge-cache fix.

Trimming the `Artifacts` list (#48748) didn't help — `Artifacts` only controls **packaging/release**, not analysis. Both builds (before and after that trim) failed identically, proving it.

## What

Set **`BuildTargetingString: azure-keyvault-certificates`** in `sdk/keyvault/ci.yml`. This is the parameter the archetype passes into the build matrix, the **Analyze** job, and the tests — so the entire Build stage is scoped to just the certificates package. Matches the documented single-package pattern used by e.g. `sdk/loganalytics/ci.yml`.

## Safety

- **No product code changes**; the security fix is untouched.
- `Artifacts` (already trimmed to certificates) still governs what's published — now consistent with the build scope.
- Certificates is still fully built, analyzed, and tested.