### PR TITLE
[KeyVault] Disable verifytypes for administration on the hotfix branch

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/pyproject.toml
+++ b/sdk/keyvault/azure-keyvault-administration/pyproject.toml
@@ -1,5 +1,11 @@
 [tool.azure-sdk-build]
 pyright = false
+# This hotfix branch ships the 4.7.0-based code plus the challenge-cache security
+# fix. verifytypes compares the type-completeness score against the code in main
+# (the regenerated 4.8.0b line), so the intentionally older code here false-positives
+# as a regression. The type gaps are pre-existing in 4.7.0 (_models.py) and untouched
+# by the fix. Disable verifytypes for this hotfix release only.
+verifytypes = false
 
 [tool.azure-sdk-conda]
 in_bundle = true


### PR DESCRIPTION
## Why

The **keys + administration hotfix** release pipeline (`python - keyvault` on `hotfix/keyvault`, e.g. build [6744402](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6744402)) fails on **exactly one task**: `Run verifytypes` for `azure-keyvault-administration`. Every other analyze check (pylint, mypy, bandit, snippets), all tests, and the keys package **pass**.

The verifytypes error is:
> `Type completeness score: 31.3%` … *The type completeness score of azure-keyvault-administration has significantly decreased compared to the score in main.*

verifytypes compares against **the code in `main`** — which carries the regenerated `4.8.0b3` administration line with far higher type completeness. This hotfix branch intentionally ships the older **4.7.0-based** code plus the challenge-cache security fix, so its score is lower and the check **false-positives** as a regression.

The reported gaps are all **pre-existing** in the 4.7.0 code (`_models.py`, `client_base.py`) and are **untouched by the security fix**.

## Why not another approach

- **Scoping (BuildTargetingString)** — used for the certificates hotfix — doesn't help here: `administration` is a **shipped** package, so it can't be excluded from analysis.
- **Re-annotating the old models** is out of scope for a security hotfix.

## What

Add `verifytypes = false` to `azure-keyvault-administration`'s `pyproject.toml` `[tool.azure-sdk-build]` — the standard per-package toggle (already used here for `pyright`; `verifytypes = false` is used by 200+ packages repo-wide). Scoped to **this hotfix branch only**; `main` keeps full verifytypes coverage.

No product code changes; the security fix and the keys package are untouched.