### PR TITLE
Add Device Registry Software Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -222,6 +222,10 @@
 # PRLabel: %Device Update
 /sdk/deviceupdate/    @dpokluda @sedols
 
+# ServiceLabel: %Device Update
+# PRLabel: %Device Update
+/sdk/deviceregistry/azure-iot-deviceregistrysoftwareupdate/    @devlie @darkoa-msft @wuqiten
+
 # ServiceLabel: %Digital Twins
 # PRLabel: %Digital Twins
 /sdk/digitaltwins/    @Aashish93-stack @johngallardo @Satya-Kolluri @sjiherzig


### PR DESCRIPTION
## Description

Adds package-specific CODEOWNERS coverage for the new Python Device Registry Software Update SDK.

- Reuses the existing `%Device Update` service and PR label.
- Adds `@devlie`, `@darkoa-msft`, and `@wuqiten` as owners for `/sdk/deviceregistry/azure-iot-deviceregistrysoftwareupdate/`.
- Corresponding EngSys path work item: `36258`.

This PR only changes `.github/CODEOWNERS`. Because `Client Libraries` is a protected CODEOWNERS section, this PR may require the approved CODEOWNERS override/automation workflow described at https://aka.ms/azsdk/codeowners.