### PR TITLE
Regenerate AgentServer models from Foundry release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/CHANGELOG.md
@@ -4,11 +4,19 @@
 
 ### Features Added
 
+- Added memory-command, procedural-memory, model-routing, content-filter, and expanded tool configuration models.
+- Added shell command and output-content streaming events.
+
 ### Breaking Changes
+
+- Replaced the legacy memory-search item models with `MemorySearchToolCall`.
+- Updated the WorkIQ preview tool and response compaction request contracts to match the Foundry release specification.
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Regenerated the AgentServer model and validation contracts from the consolidated Foundry release specification.
 
 ## 2.2.0b1 (2026-08-27)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/api.md
+++ b/sdk/agentserver/azure-ai-agentserver-responses/api.md
@@ -3,6 +3,7 @@ namespace azure.ai.agentserver.responses
 
     class azure.ai.agentserver.responses.CreateResponse(TypedDict, total=False):
         key "agent_reference": ForwardRef('AgentReference', module='types')
+        key "agent_session_id": str
         key "background": Optional[bool]
         key "context_management": Optional[list[ContextManagementParam]]
         key "conversation": Optional[ConversationParam]
@@ -33,7 +34,9 @@ namespace azure.ai.agentserver.responses
         key "top_p": Optional[float]
         key "truncation": Optional[Literal["auto", "disabled"]]
         key "user": str
+        key "user_security_context": ForwardRef('AzureUserSecurityContext', module='types')
         agent_reference: AgentReference
+        agent_session_id: str
         background: bool
         context_management: list[ContextManagementParam]
         conversation: ConversationParam
@@ -66,6 +69,7 @@ namespace azure.ai.agentserver.responses
         top_p: float
         truncation: Literal[auto, disabled]
         user: str
+        user_security_context: AzureUserSecurityContext
 
 
     class azure.ai.agentserver.responses.FileResponseStore(ResponseProviderProtocol):
@@ -684,6 +688,7 @@ namespace azure.ai.agentserver.responses
         key "max_tool_calls": Optional[int]
         key "metadata": Optional[Metadata]
         key "model": str
+        key "model_selection_details": ForwardRef('ModelSelectionDetails', module='types')
         key "moderation": Optional[Moderation]
         key "object": Required[Literal["response"]]
         key "output": Required[list[OutputItem]]
@@ -709,6 +714,7 @@ namespace azure.ai.agentserver.responses
         agent_reference: AgentReference
         background: bool
         completed_at: int
+        content_filters: list[ContentFilterResult]
         conversation: ConversationReference
         created_at: int
         error: ResponseErrorInfo
@@ -719,6 +725,7 @@ namespace azure.ai.agentserver.responses
         max_tool_calls: int
         metadata: Metadata
         model: str
+        model_selection_details: ModelSelectionDetails
         moderation: Moderation
         object: Literal[response]
         output: list[OutputItem]
@@ -1727,16 +1734,29 @@ namespace azure.ai.agentserver.responses.models
     class azure.ai.agentserver.responses.models.A2APreviewTool(TypedDict, total=False):
         key "agent_card_path": str
         key "base_url": str
-        key "description": str
-        key "name": str
         key "project_connection_id": str
+        key "send_credentials_for_agent_card": bool
         key "type": Required[Literal["a2a_preview"]]
         agent_card_path: str
         base_url: str
-        description: str
-        name: str
         project_connection_id: str
+        send_credentials_for_agent_card: bool
         type: Literal[a2a_preview]
+
+
+    class azure.ai.agentserver.responses.models.A2ATool(TypedDict, total=False):
+        key "a2a_version": Required[Literal["0"]]
+        key "agent_card_path": str
+        key "base_url": str
+        key "project_connection_id": str
+        key "send_credentials_for_agent_card": bool
+        key "type": Required[Literal["a2a"]]
+        a2a_version: A2AProtocolVersion
+        agent_card_path: str
+        base_url: str
+        project_connection_id: str
+        send_credentials_for_agent_card: bool
+        type: Literal[a2a]
 
 
     class azure.ai.agentserver.responses.models.A2AToolCall(TypedDict, total=False):
@@ -1778,19 +1798,15 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.AISearchIndexResource(TypedDict, total=False):
-        key "description": str
         key "filter": str
         key "index_asset_id": str
         key "index_name": str
-        key "name": str
         key "project_connection_id": str
         key "query_type": Literal["simple", "semantic", "vector", "vector_simple_hybrid", "vector_semantic_hybrid"]
         key "top_k": int
-        description: str
         filter: str
         index_asset_id: str
         index_name: str
-        name: str
         project_connection_id: str
         query_type: AzureAISearchQueryType
         top_k: int
@@ -1939,6 +1955,7 @@ namespace azure.ai.agentserver.responses.models
         azure_ai_search: AzureAISearchToolResource
         description: str
         name: str
+        tool_configs: dict[str, ToolConfig]
         type: Literal[azure_ai_search]
 
 
@@ -1977,12 +1994,131 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.AzureAISearchToolResource(TypedDict, total=False):
-        key "description": str
         key "indexes": Required[list[AISearchIndexResource]]
-        key "name": str
-        description: str
         indexes: list[AISearchIndexResource]
-        name: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterBlocklistIdResult(TypedDict, total=False):
+        key "filtered": Required[bool]
+        key "id": Required[str]
+        filtered: bool
+        id: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterBlocklistResult(TypedDict, total=False):
+        key "filtered": Required[bool]
+        details: list[AzureContentFilterBlocklistIdResult]
+        filtered: bool
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterCitation(TypedDict, total=False):
+        key "license": str
+        key "url": str
+        license: str
+        url: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterCompletionTextSpan(TypedDict, total=False):
+        key "completion_end_offset": Required[int]
+        key "completion_start_offset": Required[int]
+        completion_end_offset: int
+        completion_start_offset: int
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterCompletionTextSpanDetectionResult(TypedDict, total=False):
+        key "details": Required[list[AzureContentFilterCompletionTextSpan]]
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        details: list[AzureContentFilterCompletionTextSpan]
+        detected: bool
+        filtered: bool
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterDetectionResult(TypedDict, total=False):
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        detected: bool
+        filtered: bool
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterDetectionWithCitationResult(TypedDict, total=False):
+        key "citation": ForwardRef('AzureContentFilterCitation', module='types')
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        citation: AzureContentFilterCitation
+        detected: bool
+        filtered: bool
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterDetectionWithReasonResult(TypedDict, total=False):
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        key "reason": str
+        detected: bool
+        filtered: bool
+        reason: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterError(TypedDict, total=False):
+        key "code": Required[int]
+        key "message": Required[str]
+        code: int
+        message: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterPersonallyIdentifiableInformationResult(TypedDict, total=False):
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        detected: bool
+        filtered: bool
+        sub_categories: list[AzureContentFilterPiiSubCategoryResult]
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterPiiSubCategoryResult(TypedDict, total=False):
+        key "detected": Required[bool]
+        key "filtered": Required[bool]
+        key "sub_category": Required[str]
+        detected: bool
+        filtered: bool
+        sub_category: str
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterResultsForResponses(TypedDict, total=False):
+        key "custom_blocklists": ForwardRef('AzureContentFilterBlocklistResult', module='types')
+        key "error": ForwardRef('AzureContentFilterError', module='types')
+        key "hate": ForwardRef('AzureContentFilterSeverityResult', module='types')
+        key "indirect_attack": ForwardRef('AzureContentFilterDetectionResult', module='types')
+        key "jailbreak": ForwardRef('AzureContentFilterDetectionResult', module='types')
+        key "personally_identifiable_information": ForwardRef('AzureContentFilterPersonallyIdentifiableInformationResult', module='types')
+        key "profanity": ForwardRef('AzureContentFilterDetectionResult', module='types')
+        key "protected_material_code": ForwardRef('AzureContentFilterDetectionWithCitationResult', module='types')
+        key "protected_material_text": ForwardRef('AzureContentFilterDetectionResult', module='types')
+        key "self_harm": ForwardRef('AzureContentFilterSeverityResult', module='types')
+        key "sexual": ForwardRef('AzureContentFilterSeverityResult', module='types')
+        key "task_adherence": ForwardRef('AzureContentFilterDetectionWithReasonResult', module='types')
+        key "ungrounded_material": ForwardRef('AzureContentFilterCompletionTextSpanDetectionResult', module='types')
+        key "violence": ForwardRef('AzureContentFilterSeverityResult', module='types')
+        custom_blocklists: AzureContentFilterBlocklistResult
+        error: AzureContentFilterError
+        hate: AzureContentFilterSeverityResult
+        indirect_attack: AzureContentFilterDetectionResult
+        jailbreak: AzureContentFilterDetectionResult
+        personally_identifiable_information: AzureContentFilterPersonallyIdentifiableInformationResult
+        profanity: AzureContentFilterDetectionResult
+        protected_material_code: AzureContentFilterDetectionWithCitationResult
+        protected_material_text: AzureContentFilterDetectionResult
+        self_harm: AzureContentFilterSeverityResult
+        sexual: AzureContentFilterSeverityResult
+        task_adherence: AzureContentFilterDetectionWithReasonResult
+        ungrounded_material: AzureContentFilterCompletionTextSpanDetectionResult
+        violence: AzureContentFilterSeverityResult
+
+
+    class azure.ai.agentserver.responses.models.AzureContentFilterSeverityResult(TypedDict, total=False):
+        key "filtered": Required[bool]
+        key "severity": Required[Literal["safe", "low", "medium", "high"]]
+        filtered: bool
+        severity: AzureContentFilterSeverity
 
 
     class azure.ai.agentserver.responses.models.AzureFunctionBinding(TypedDict, total=False):
@@ -2021,6 +2157,7 @@ namespace azure.ai.agentserver.responses.models
         key "azure_function": Required[AzureFunctionDefinition]
         key "type": Required[Literal["azure_function"]]
         azure_function: AzureFunctionDefinition
+        tool_configs: dict[str, ToolConfig]
         type: Literal[azure_function]
 
 
@@ -2062,33 +2199,36 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[azure_function_call_output]
 
 
+    class azure.ai.agentserver.responses.models.AzureUserSecurityContext(TypedDict, total=False):
+        key "application_name": str
+        key "end_user_id": str
+        key "end_user_tenant_id": str
+        key "source_ip": str
+        application_name: str
+        end_user_id: str
+        end_user_tenant_id: str
+        source_ip: str
+
+
     class azure.ai.agentserver.responses.models.BingCustomSearchConfiguration(TypedDict, total=False):
         key "count": int
-        key "description": str
         key "freshness": str
         key "instance_name": Required[str]
         key "market": str
-        key "name": str
         key "project_connection_id": Required[str]
         key "set_lang": str
         count: int
-        description: str
         freshness: str
         instance_name: str
         market: str
-        name: str
         project_connection_id: str
         set_lang: str
 
 
     class azure.ai.agentserver.responses.models.BingCustomSearchPreviewTool(TypedDict, total=False):
         key "bing_custom_search_preview": Required[BingCustomSearchToolParameters]
-        key "description": str
-        key "name": str
         key "type": Required[Literal["bing_custom_search_preview"]]
         bing_custom_search_preview: BingCustomSearchToolParameters
-        description: str
-        name: str
         type: Literal[bing_custom_search_preview]
 
 
@@ -2127,37 +2267,25 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.BingCustomSearchToolParameters(TypedDict, total=False):
-        key "description": str
-        key "name": str
         key "search_configurations": Required[list[BingCustomSearchConfiguration]]
-        description: str
-        name: str
         search_configurations: list[BingCustomSearchConfiguration]
 
 
     class azure.ai.agentserver.responses.models.BingGroundingSearchConfiguration(TypedDict, total=False):
         key "count": int
-        key "description": str
         key "freshness": str
         key "market": str
-        key "name": str
         key "project_connection_id": Required[str]
         key "set_lang": str
         count: int
-        description: str
         freshness: str
         market: str
-        name: str
         project_connection_id: str
         set_lang: str
 
 
     class azure.ai.agentserver.responses.models.BingGroundingSearchToolParameters(TypedDict, total=False):
-        key "description": str
-        key "name": str
         key "search_configurations": Required[list[BingGroundingSearchConfiguration]]
-        description: str
-        name: str
         search_configurations: list[BingGroundingSearchConfiguration]
 
 
@@ -2169,6 +2297,7 @@ namespace azure.ai.agentserver.responses.models
         bing_grounding: BingGroundingSearchToolParameters
         description: str
         name: str
+        tool_configs: dict[str, ToolConfig]
         type: Literal[bing_grounding]
 
 
@@ -2208,12 +2337,8 @@ namespace azure.ai.agentserver.responses.models
 
     class azure.ai.agentserver.responses.models.BrowserAutomationPreviewTool(TypedDict, total=False):
         key "browser_automation_preview": Required[BrowserAutomationToolParameters]
-        key "description": str
-        key "name": str
         key "type": Required[Literal["browser_automation_preview"]]
         browser_automation_preview: BrowserAutomationToolParameters
-        description: str
-        name: str
         type: Literal[browser_automation_preview]
 
 
@@ -2252,27 +2377,24 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.BrowserAutomationToolConnectionParameters(TypedDict, total=False):
-        key "description": str
-        key "name": str
         key "project_connection_id": Required[str]
-        description: str
-        name: str
         project_connection_id: str
 
 
     class azure.ai.agentserver.responses.models.BrowserAutomationToolParameters(TypedDict, total=False):
         key "connection": Required[BrowserAutomationToolConnectionParameters]
-        key "description": str
-        key "name": str
         connection: BrowserAutomationToolConnectionParameters
-        description: str
-        name: str
 
 
     class azure.ai.agentserver.responses.models.CaptureStructuredOutputsTool(TypedDict, total=False):
+        key "description": str
+        key "name": str
         key "outputs": Required[StructuredOutputDefinition]
         key "type": Required[Literal["capture_structured_outputs"]]
+        description: str
+        name: str
         outputs: StructuredOutputDefinition
+        tool_configs: dict[str, ToolConfig]
         type: Literal[capture_structured_outputs]
 
 
@@ -2326,6 +2448,7 @@ namespace azure.ai.agentserver.responses.models
         container: Union[str, AutoCodeInterpreterToolParam]
         description: str
         name: str
+        tool_configs: dict[str, ToolConfig]
         type: Literal[code_interpreter]
 
 
@@ -2345,7 +2468,7 @@ namespace azure.ai.agentserver.responses.models
     class azure.ai.agentserver.responses.models.CompactResponseMethodPublicBody(TypedDict, total=False):
         key "input": Optional[Union[str, list[Item]]]
         key "instructions": Optional[str]
-        key "model": Required[Optional[Literal["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.5-2026-04-23", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-mini-2026-03-17", "gpt-5.4-nano-2026-03-17", "gpt-5.3-chat-latest", "gpt-5.2", "gpt-5.2-2025-12-11", "gpt-5.2-chat-latest", "gpt-5.2-pro", "gpt-5.2-pro-2025-12-11", "gpt-5.1", "gpt-5.1-2025-11-13", "gpt-5.1-codex", "gpt-5.1-mini", "gpt-5.1-chat-latest", "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-2025-08-07", "gpt-5-mini-2025-08-07", "gpt-5-nano-2025-08-07", "gpt-5-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4.1-2025-04-14", "gpt-4.1-mini-2025-04-14", "gpt-4.1-nano-2025-04-14", "o4-mini", "o4-mini-2025-04-16", "o3", "o3-2025-04-16", "o3-mini", "o3-mini-2025-01-31", "o1", "o1-2024-12-17", "o1-preview", "o1-preview-2024-09-12", "o1-mini", "o1-mini-2024-09-12", "gpt-4o", "gpt-4o-2024-11-20", "gpt-4o-2024-08-06", "gpt-4o-2024-05-13", "gpt-4o-audio-preview", "gpt-4o-audio-preview-2024-10-01", "gpt-4o-audio-preview-2024-12-17", "gpt-4o-audio-preview-2025-06-03", "gpt-4o-mini-audio-preview", "gpt-4o-mini-audio-preview-2024-12-17", "gpt-4o-search-preview", "gpt-4o-mini-search-preview", "gpt-4o-search-preview-2025-03-11", "gpt-4o-mini-search-preview-2025-03-11", "chatgpt-4o-latest", "codex-mini-latest", "gpt-4o-mini", "gpt-4o-mini-2024-07-18", "gpt-4-turbo", "gpt-4-turbo-2024-04-09", "gpt-4-0125-preview", "gpt-4-turbo-preview", "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "gpt-4-0314", "gpt-4-0613", "gpt-4-32k", "gpt-4-32k-0314", "gpt-4-32k-0613", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0301", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125", "gpt-3.5-turbo-16k-0613", "o1-pro", "o1-pro-2025-03-19", "o3-pro", "o3-pro-2025-06-10", "o3-deep-research", "o3-deep-research-2025-06-26", "o4-mini-deep-research", "o4-mini-deep-research-2025-06-26", "computer-use-preview", "computer-use-preview-2025-03-11", "gpt-5.5-pro", "gpt-5.5-pro-2026-04-23", "gpt-5-codex", "gpt-5-pro", "gpt-5-pro-2025-10-06", "gpt-5.1-codex-max", "gpt-daybreak-blue-latest", "gpt-daybreak-red-latest", "gpt-5.6-cyber"]]]
+        key "model": Required[str]
         key "previous_response_id": Optional[str]
         key "prompt_cache_key": Optional[str]
         key "prompt_cache_options": Optional[PromptCacheOptionsParam]
@@ -2353,7 +2476,7 @@ namespace azure.ai.agentserver.responses.models
         key "service_tier": Optional[Literal["auto", "default", "fast", "flex", "priority"]]
         input: Union[str, list[Item]]
         instructions: str
-        model: ModelIdsCompaction
+        model: str
         previous_response_id: str
         prompt_cache_key: str
         prompt_cache_options: PromptCacheOptionsParam
@@ -2503,6 +2626,17 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[container_reference]
 
 
+    class azure.ai.agentserver.responses.models.ContentFilterResult(TypedDict, total=False):
+        key "blocked": Required[bool]
+        key "content_filter_results": Required[AzureContentFilterResultsForResponses]
+        key "source_type": Required[str]
+        key "tool_call_id": str
+        blocked: bool
+        content_filter_results: AzureContentFilterResultsForResponses
+        source_type: str
+        tool_call_id: str
+
+
     class azure.ai.agentserver.responses.models.ContextManagementParam(TypedDict, total=False):
         key "compact_threshold": Optional[int]
         key "type": Required[str]
@@ -2529,6 +2663,7 @@ namespace azure.ai.agentserver.responses.models
 
     class azure.ai.agentserver.responses.models.CreateResponse(TypedDict, total=False):
         key "agent_reference": ForwardRef('AgentReference', module='types')
+        key "agent_session_id": str
         key "background": Optional[bool]
         key "context_management": Optional[list[ContextManagementParam]]
         key "conversation": Optional[ConversationParam]
@@ -2559,7 +2694,9 @@ namespace azure.ai.agentserver.responses.models
         key "top_p": Optional[float]
         key "truncation": Optional[Literal["auto", "disabled"]]
         key "user": str
+        key "user_security_context": ForwardRef('AzureUserSecurityContext', module='types')
         agent_reference: AgentReference
+        agent_session_id: str
         background: bool
         context_management: list[ContextManagementParam]
         conversation: ConversationParam
@@ -2591,6 +2728,155 @@ namespace azure.ai.agentserver.responses.models
         top_logprobs: int
         top_p: float
         truncation: Literal[auto, disabled]
+        user: str
+        user_security_context: AzureUserSecurityContext
+
+
+    class azure.ai.agentserver.responses.models.CreateResponseRequest(TypedDict, total=False):
+        key "agent_reference": ForwardRef('AgentReference', module='types')
+        key "agent_session_id": str
+        key "background": Optional[bool]
+        key "context_management": Optional[list[ContextManagementParam]]
+        key "conversation": Optional[ConversationParam]
+        key "include": Optional[list[Literal["results", "results", "sources", "image_url", "image_url", "outputs", "encrypted_content", "logprobs", "results"]]]
+        key "input": ForwardRef('InputParam', module='types')
+        key "instructions": Optional[str]
+        key "max_output_tokens": Optional[int]
+        key "max_tool_calls": Optional[int]
+        key "metadata": Optional[Metadata]
+        key "model": str
+        key "moderation": Optional[ModerationParam]
+        key "parallel_tool_calls": Optional[bool]
+        key "previous_response_id": Optional[str]
+        key "prompt": ForwardRef('Prompt', module='types')
+        key "prompt_cache_key": Optional[str]
+        key "prompt_cache_options": ForwardRef('PromptCacheOptionsParam', module='types')
+        key "prompt_cache_retention": Optional[Literal["in_memory", "24h"]]
+        key "reasoning": Optional[Reasoning]
+        key "safety_identifier": Optional[str]
+        key "service_tier": Optional[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"]]
+        key "store": Optional[bool]
+        key "stream": Optional[bool]
+        key "stream_options": Optional[ResponseStreamOptions]
+        key "temperature": Optional[float]
+        key "text": ForwardRef('ResponseTextParam', module='types')
+        key "tool_choice": Union[Literal["none", "auto", "required"], ToolChoiceParam]
+        key "top_logprobs": Optional[int]
+        key "top_p": Optional[float]
+        key "truncation": Optional[Literal["auto", "disabled"]]
+        key "user": str
+        key "user_security_context": ForwardRef('AzureUserSecurityContext', module='types')
+        agent_reference: AgentReference
+        agent_session_id: str
+        background: bool
+        context_management: list[ContextManagementParam]
+        conversation: ConversationParam
+        include: list[IncludeEnum]
+        input: InputParam
+        instructions: str
+        max_output_tokens: int
+        max_tool_calls: int
+        metadata: Metadata
+        model: str
+        moderation: ModerationParam
+        parallel_tool_calls: bool
+        previous_response_id: str
+        prompt: Prompt
+        prompt_cache_key: str
+        prompt_cache_options: PromptCacheOptionsParam
+        prompt_cache_retention: Literal[in_memory, 24h]
+        reasoning: Reasoning
+        safety_identifier: str
+        service_tier: Literal[auto, default, flex, scale, priority, fast, ultrafast]
+        store: bool
+        stream: bool
+        stream_options: ResponseStreamOptions
+        structured_inputs: dict[str, Any]
+        temperature: float
+        text: ResponseTextParam
+        tool_choice: Union[ToolChoiceOptions, ToolChoiceParam]
+        tools: list[Tool]
+        top_logprobs: int
+        top_p: float
+        truncation: Literal[auto, disabled]
+        user: str
+        user_security_context: AzureUserSecurityContext
+
+
+    class azure.ai.agentserver.responses.models.CreateResponseResponse(TypedDict, total=False):
+        key "agent_reference": Required[Optional[AgentReference]]
+        key "background": Optional[bool]
+        key "completed_at": Optional[int]
+        key "conversation": Optional[ConversationReference]
+        key "created_at": Required[int]
+        key "error": Required[Optional[ResponseErrorInfo]]
+        key "id": Required[str]
+        key "incomplete_details": Required[Optional[ResponseIncompleteDetails]]
+        key "instructions": Required[Optional[Union[str, list[Item]]]]
+        key "max_output_tokens": Optional[int]
+        key "max_tool_calls": Optional[int]
+        key "metadata": Optional[Metadata]
+        key "model": str
+        key "model_selection_details": ForwardRef('ModelSelectionDetails', module='types')
+        key "moderation": Optional[Moderation]
+        key "object": Required[Literal["response"]]
+        key "output": Required[list[OutputItem]]
+        key "output_text": Optional[str]
+        key "parallel_tool_calls": Required[bool]
+        key "previous_response_id": Optional[str]
+        key "prompt": ForwardRef('Prompt', module='types')
+        key "prompt_cache_key": Optional[str]
+        key "prompt_cache_options": ForwardRef('PromptCacheOptions', module='types')
+        key "prompt_cache_retention": Optional[Literal["in_memory", "24h"]]
+        key "reasoning": Optional[Reasoning]
+        key "safety_identifier": Optional[str]
+        key "service_tier": Optional[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"]]
+        key "status": Literal["completed", "failed", "in_progress", "cancelled", "queued", "incomplete"]
+        key "temperature": Optional[float]
+        key "text": ForwardRef('ResponseTextParam', module='types')
+        key "tool_choice": Union[Literal["none", "auto", "required"], ToolChoiceParam]
+        key "top_logprobs": Optional[int]
+        key "top_p": Optional[float]
+        key "truncation": Optional[Literal["auto", "disabled"]]
+        key "usage": ForwardRef('ResponseUsage', module='types')
+        key "user": str
+        agent_reference: AgentReference
+        background: bool
+        completed_at: int
+        content_filters: list[ContentFilterResult]
+        conversation: ConversationReference
+        created_at: int
+        error: ResponseErrorInfo
+        id: str
+        incomplete_details: ResponseIncompleteDetails
+        instructions: Union[str, list[Item]]
+        max_output_tokens: int
+        max_tool_calls: int
+        metadata: Metadata
+        model: str
+        model_selection_details: ModelSelectionDetails
+        moderation: Moderation
+        object: Literal[response]
+        output: list[OutputItem]
+        output_text: str
+        parallel_tool_calls: bool
+        previous_response_id: str
+        prompt: Prompt
+        prompt_cache_key: str
+        prompt_cache_options: PromptCacheOptions
+        prompt_cache_retention: Literal[in_memory, 24h]
+        reasoning: Reasoning
+        safety_identifier: str
+        service_tier: Literal[auto, default, flex, scale, priority, fast, ultrafast]
+        status: Literal[completed, failed, in_progress, cancelled, queued, incomplete]
+        temperature: float
+        text: ResponseTextParam
+        tool_choice: Union[ToolChoiceOptions, ToolChoiceParam]
+        tools: list[Tool]
+        top_logprobs: int
+        top_p: float
+        truncation: Literal[auto, disabled]
+        usage: ResponseUsage
         user: str
 
 
@@ -2760,11 +3046,20 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.FabricDataAgentToolParameters(TypedDict, total=False):
-        key "description": str
-        key "name": str
-        description: str
-        name: str
         project_connections: list[ToolProjectConnection]
+
+
+    class azure.ai.agentserver.responses.models.FabricIQPreviewTool(TypedDict, total=False):
+        key "project_connection_id": Required[str]
+        key "require_approval": Optional[Union[MCPToolRequireApproval, str]]
+        key "server_label": str
+        key "server_url": str
+        key "type": Required[Literal["fabric_iq_preview"]]
+        project_connection_id: str
+        require_approval: Union[MCPToolRequireApproval, str]
+        server_label: str
+        server_url: str
+        type: Literal[fabric_iq_preview]
 
 
     class azure.ai.agentserver.responses.models.FileCitationBody(TypedDict, total=False):
@@ -2800,6 +3095,7 @@ namespace azure.ai.agentserver.responses.models
         max_num_results: int
         name: str
         ranking_options: RankingOptions
+        tool_configs: dict[str, ToolConfig]
         type: Literal[file_search]
         vector_store_ids: list[str]
 
@@ -2994,6 +3290,7 @@ namespace azure.ai.agentserver.responses.models
         description: str
         environment: FunctionShellToolParamEnvironment
         name: str
+        tool_configs: dict[str, ToolConfig]
         type: Literal[shell]
 
 
@@ -3061,7 +3358,7 @@ namespace azure.ai.agentserver.responses.models
         key "description": str
         key "input_fidelity": Optional[Literal["high", "low"]]
         key "input_image_mask": ForwardRef('ImageGenToolInputImageMask', module='types')
-        key "model": Union[Literal["gpt-image-1"], Literal["gpt-image-1-mini"], Literal["gpt-image-1.5"], str]
+        key "model": Union[Literal["gpt-image-1"], Literal["gpt-image-1-mini"], Literal["gpt-image-5"], str]
         key "moderation": Literal["auto", "low"]
         key "name": str
         key "output_compression": int
@@ -3075,7 +3372,7 @@ namespace azure.ai.agentserver.responses.models
         description: str
         input_fidelity: InputFidelity
         input_image_mask: ImageGenToolInputImageMask
-        model: Union[Literal[gpt-image-1], Literal[gpt-image-1-mini], Literal[gpt-image-1.5], str]
+        model: Union[Literal[gpt-image-1], Literal[gpt-image-1-mini], Literal[gpt-image-5], str]
         moderation: Literal[auto, low]
         name: str
         output_compression: int
@@ -3083,6 +3380,7 @@ namespace azure.ai.agentserver.responses.models
         partial_images: int
         quality: Literal[low, medium, high, auto]
         size: Union[Literal[1024x1024], Literal[1024x1536], Literal[1536x1024], Literal[auto], str]
+        tool_configs: dict[str, ToolConfig]
         type: Literal[image_generation]
 
 
@@ -3879,6 +4177,7 @@ namespace azure.ai.agentserver.responses.models
         key "type": Required[Literal["local_shell"]]
         description: str
         name: str
+        tool_configs: dict[str, ToolConfig]
         type: Literal[local_shell]
 
 
@@ -3957,6 +4256,7 @@ namespace azure.ai.agentserver.responses.models
         server_description: str
         server_label: str
         server_url: str
+        tool_configs: dict[str, ToolConfig]
         tunnel_id: str
         type: Literal[mcp]
 
@@ -3974,9 +4274,36 @@ namespace azure.ai.agentserver.responses.models
         never: MCPToolFilter
 
 
-    class azure.ai.agentserver.responses.models.MemorySearchItem(TypedDict, total=False):
-        key "memory_item": Required[MemoryItem]
-        memory_item: MemoryItem
+    class azure.ai.agentserver.responses.models.MemoryCommandToolCall(TypedDict, total=False):
+        key "agent_reference": ForwardRef('AgentReference', module='types')
+        key "arguments": Required[str]
+        key "call_id": Required[str]
+        key "id": Required[str]
+        key "response_id": str
+        key "status": Required[Literal["in_progress", "completed", "incomplete", "failed"]]
+        key "type": Required[Literal["memory_command_preview_call"]]
+        agent_reference: AgentReference
+        arguments: str
+        call_id: str
+        id: str
+        response_id: str
+        status: ToolCallStatus
+        type: Literal[memory_command_preview_call]
+
+
+    class azure.ai.agentserver.responses.models.MemoryCommandToolCallOutput(TypedDict, total=False):
+        key "agent_reference": ForwardRef('AgentReference', module='types')
+        key "call_id": Required[str]
+        key "id": Required[str]
+        key "response_id": str
+        key "status": Required[Literal["in_progress", "completed", "incomplete", "failed"]]
+        key "type": Required[Literal["memory_command_preview_call_output"]]
+        agent_reference: AgentReference
+        call_id: str
+        id: str
+        response_id: str
+        status: ToolCallStatus
+        type: Literal[memory_command_preview_call_output]
 
 
     class azure.ai.agentserver.responses.models.MemorySearchOptions(TypedDict, total=False):
@@ -3985,41 +4312,30 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.MemorySearchPreviewTool(TypedDict, total=False):
-        key "description": str
         key "memory_store_name": Required[str]
-        key "name": str
         key "scope": Required[str]
         key "search_options": ForwardRef('MemorySearchOptions', module='types')
         key "type": Required[Literal["memory_search_preview"]]
         key "update_delay": int
-        description: str
         memory_store_name: str
-        name: str
         scope: str
         search_options: MemorySearchOptions
         type: Literal[memory_search_preview]
         update_delay: int
 
 
-    class azure.ai.agentserver.responses.models.MemorySearchToolCallItemParam(TypedDict, total=False):
-        key "results": Optional[list[MemorySearchItem]]
-        key "type": Required[Literal["memory_search_call"]]
-        results: list[MemorySearchItem]
-        type: Literal[memory_search_call]
-
-
-    class azure.ai.agentserver.responses.models.MemorySearchToolCallItemResource(TypedDict, total=False):
+    class azure.ai.agentserver.responses.models.MemorySearchToolCall(TypedDict, total=False):
         key "agent_reference": ForwardRef('AgentReference', module='types')
         key "id": Required[str]
+        key "memories": Optional[list[MemoryItem]]
         key "response_id": str
-        key "results": Optional[list[MemorySearchItem]]
-        key "status": Required[Literal["in_progress", "searching", "completed", "incomplete", "failed"]]
+        key "status": Required[Literal["in_progress", "completed", "incomplete", "failed"]]
         key "type": Required[Literal["memory_search_call"]]
         agent_reference: AgentReference
         id: str
+        memories: list[MemoryItem]
         response_id: str
-        results: list[MemorySearchItem]
-        status: Literal[in_progress, searching, completed, incomplete, failed]
+        status: ToolCallStatus
         type: Literal[memory_search_call]
 
 
@@ -4089,14 +4405,44 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.MicrosoftFabricPreviewTool(TypedDict, total=False):
-        key "description": str
         key "fabric_dataagent_preview": Required[FabricDataAgentToolParameters]
-        key "name": str
         key "type": Required[Literal["fabric_dataagent_preview"]]
-        description: str
         fabric_dataagent_preview: FabricDataAgentToolParameters
-        name: str
         type: Literal[fabric_dataagent_preview]
+
+
+    class azure.ai.agentserver.responses.models.ModelRouterAttempt(TypedDict, total=False):
+        key "model": Required[str]
+        key "result": Required[ModelRouterAttemptResult]
+        model: str
+        result: ModelRouterAttemptResult
+
+
+    class azure.ai.agentserver.responses.models.ModelRouterAttemptError(TypedDict, total=False):
+        key "code": str
+        key "message": Required[str]
+        code: str
+        message: str
+
+
+    class azure.ai.agentserver.responses.models.ModelRouterAttemptResult(TypedDict, total=False):
+        key "error": ForwardRef('ModelRouterAttemptError', module='types')
+        key "status": Required[int]
+        error: ModelRouterAttemptError
+        headers: dict[str, ModelRouterResponseHeaderValue]
+        status: int
+
+
+    class azure.ai.agentserver.responses.models.ModelRouterDetails(TypedDict, total=False):
+        key "mode": Required[Literal["balanced", "cost", "quality"]]
+        key "routing_trace": Required[list[RoutingTraceEntry]]
+        mode: ModelRouterMode
+        routing_trace: list[RoutingTraceEntry]
+
+
+    class azure.ai.agentserver.responses.models.ModelSelectionDetails(TypedDict, total=False):
+        key "model_router_details": Required[ModelRouterDetails]
+        model_router_details: ModelRouterDetails
 
 
     class azure.ai.agentserver.responses.models.Moderation(TypedDict, total=False):
@@ -4241,6 +4587,7 @@ namespace azure.ai.agentserver.responses.models
         key "openapi": Required[OpenApiFunctionDefinition]
         key "type": Required[Literal["openapi"]]
         openapi: OpenApiFunctionDefinition
+        tool_configs: dict[str, ToolConfig]
         type: Literal[openapi]
 
 
@@ -4781,6 +5128,19 @@ namespace azure.ai.agentserver.responses.models
         response_id: str
         status: Literal[in_progress, searching, completed, failed, incomplete]
         type: Literal[web_search_call]
+
+
+    class azure.ai.agentserver.responses.models.ProceduralMemoryItem(TypedDict, total=False):
+        key "content": Required[str]
+        key "kind": Required[Literal["procedural"]]
+        key "memory_id": Required[str]
+        key "scope": Required[str]
+        key "updated_at": Required[int]
+        content: str
+        kind: Literal[procedural]
+        memory_id: str
+        scope: str
+        updated_at: int
 
 
     class azure.ai.agentserver.responses.models.ProgramToolCallCaller(TypedDict, total=False):
@@ -5352,6 +5712,7 @@ namespace azure.ai.agentserver.responses.models
         key "max_tool_calls": Optional[int]
         key "metadata": Optional[Metadata]
         key "model": str
+        key "model_selection_details": ForwardRef('ModelSelectionDetails', module='types')
         key "moderation": Optional[Moderation]
         key "object": Required[Literal["response"]]
         key "output": Required[list[OutputItem]]
@@ -5377,6 +5738,7 @@ namespace azure.ai.agentserver.responses.models
         agent_reference: AgentReference
         background: bool
         completed_at: int
+        content_filters: list[ContentFilterResult]
         conversation: ConversationReference
         created_at: int
         error: ResponseErrorInfo
@@ -5387,6 +5749,7 @@ namespace azure.ai.agentserver.responses.models
         max_tool_calls: int
         metadata: Metadata
         model: str
+        model_selection_details: ModelSelectionDetails
         moderation: Moderation
         object: Literal[response]
         output: list[OutputItem]
@@ -5599,6 +5962,77 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[done]
 
 
+    class azure.ai.agentserver.responses.models.ResponseShellCallCommandAddedStreamingEvent(TypedDict, total=False):
+        key "command": Required[str]
+        key "command_index": Required[int]
+        key "output_index": Required[int]
+        key "sequence_number": Required[int]
+        key "type": Required[Literal["added"]]
+        command: str
+        command_index: int
+        output_index: int
+        sequence_number: int
+        type: Literal[added]
+
+
+    class azure.ai.agentserver.responses.models.ResponseShellCallCommandDeltaStreamingEvent(TypedDict, total=False):
+        key "command_index": Required[int]
+        key "delta": Required[str]
+        key "obfuscation": str
+        key "output_index": Required[int]
+        key "sequence_number": Required[int]
+        key "type": Required[Literal["delta"]]
+        command_index: int
+        delta: str
+        obfuscation: str
+        output_index: int
+        sequence_number: int
+        type: Literal[delta]
+
+
+    class azure.ai.agentserver.responses.models.ResponseShellCallCommandDoneStreamingEvent(TypedDict, total=False):
+        key "command": Required[str]
+        key "command_index": Required[int]
+        key "output_index": Required[int]
+        key "sequence_number": Required[int]
+        key "type": Required[Literal["done"]]
+        command: str
+        command_index: int
+        output_index: int
+        sequence_number: int
+        type: Literal[done]
+
+
+    class azure.ai.agentserver.responses.models.ResponseShellCallOutputContentDeltaStreamingEvent(TypedDict, total=False):
+        key "command_index": Required[int]
+        key "delta": Required[ShellCallOutputDelta]
+        key "item_id": Required[str]
+        key "output_index": Required[int]
+        key "sequence_number": Required[int]
+        key "type": Required[Literal["delta"]]
+        command_index: int
+        delta: ShellCallOutputDelta
+        item_id: str
+        output_index: int
+        sequence_number: int
+        type: Literal[delta]
+
+
+    class azure.ai.agentserver.responses.models.ResponseShellCallOutputContentDoneStreamingEvent(TypedDict, total=False):
+        key "command_index": Required[int]
+        key "item_id": Required[str]
+        key "output": Required[list[FunctionShellCallOutputContent]]
+        key "output_index": Required[int]
+        key "sequence_number": Required[int]
+        key "type": Required[Literal["done"]]
+        command_index: int
+        item_id: str
+        output: list[FunctionShellCallOutputContent]
+        output_index: int
+        sequence_number: int
+        type: Literal[done]
+
+
     class azure.ai.agentserver.responses.models.ResponseStreamOptions(TypedDict, total=False):
         key "include_obfuscation": bool
         include_obfuscation: bool
@@ -5703,6 +6137,15 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[searching]
 
 
+    class azure.ai.agentserver.responses.models.RoutingTraceEntry(TypedDict, total=False):
+        key "attempts": Required[list[ModelRouterAttempt]]
+        key "latency_ms": Required[str]
+        key "output_id": str
+        attempts: list[ModelRouterAttempt]
+        latency_ms: str
+        output_id: str
+
+
     class azure.ai.agentserver.responses.models.ScreenshotParam(TypedDict, total=False):
         key "type": Required[Literal["screenshot"]]
         type: Literal[screenshot]
@@ -5758,22 +6201,21 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.SharepointGroundingToolParameters(TypedDict, total=False):
-        key "description": str
-        key "name": str
-        description: str
-        name: str
         project_connections: list[ToolProjectConnection]
 
 
     class azure.ai.agentserver.responses.models.SharepointPreviewTool(TypedDict, total=False):
-        key "description": str
-        key "name": str
         key "sharepoint_grounding_preview": Required[SharepointGroundingToolParameters]
         key "type": Required[Literal["sharepoint_grounding_preview"]]
-        description: str
-        name: str
         sharepoint_grounding_preview: SharepointGroundingToolParameters
         type: Literal[sharepoint_grounding_preview]
+
+
+    class azure.ai.agentserver.responses.models.ShellCallOutputDelta(TypedDict, total=False):
+        key "stderr": str
+        key "stdout": str
+        stderr: str
+        stdout: str
 
 
     class azure.ai.agentserver.responses.models.SkillReferenceParam(TypedDict, total=False):
@@ -5933,12 +6375,15 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[web_search_preview_2025_03_11]
 
 
+    class azure.ai.agentserver.responses.models.ToolConfig(TypedDict, total=False):
+        key "additional_search_text": str
+        key "pin": bool
+        additional_search_text: str
+        pin: bool
+
+
     class azure.ai.agentserver.responses.models.ToolProjectConnection(TypedDict, total=False):
-        key "description": str
-        key "name": str
         key "project_connection_id": Required[str]
-        description: str
-        name: str
         project_connection_id: str
 
 
@@ -6033,6 +6478,17 @@ namespace azure.ai.agentserver.responses.models
         type: Literal[wait]
 
 
+    class azure.ai.agentserver.responses.models.WebIQPreviewTool(TypedDict, total=False):
+        key "project_connection_id": Required[str]
+        key "require_approval": Optional[Union[MCPToolRequireApproval, str]]
+        key "server_label": str
+        key "type": Required[Literal["web_iq_preview"]]
+        project_connection_id: str
+        require_approval: Union[MCPToolRequireApproval, str]
+        server_label: str
+        type: Literal[web_iq_preview]
+
+
     class azure.ai.agentserver.responses.models.WebSearchActionFind(TypedDict, total=False):
         key "pattern": Required[str]
         key "type": Required[Literal["find_in_page"]]
@@ -6079,13 +6535,9 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.WebSearchConfiguration(TypedDict, total=False):
-        key "description": str
         key "instance_name": Required[str]
-        key "name": str
         key "project_connection_id": Required[str]
-        description: str
         instance_name: str
-        name: str
         project_connection_id: str
 
 
@@ -6114,6 +6566,7 @@ namespace azure.ai.agentserver.responses.models
         filters: WebSearchToolFilters
         name: str
         search_context_size: Literal[low, medium, high]
+        tool_configs: dict[str, ToolConfig]
         type: Literal[web_search]
         user_location: WebSearchApproximateLocation
 
@@ -6124,15 +6577,10 @@ namespace azure.ai.agentserver.responses.models
 
 
     class azure.ai.agentserver.responses.models.WorkIQPreviewTool(TypedDict, total=False):
-        key "type": Required[Literal["work_iq_preview"]]
-        key "work_iq_preview": Required[WorkIQPreviewToolParameters]
-        type: Literal[work_iq_preview]
-        work_iq_preview: WorkIQPreviewToolParameters
-
-
-    class azure.ai.agentserver.responses.models.WorkIQPreviewToolParameters(TypedDict, total=False):
         key "project_connection_id": Required[str]
+        key "type": Required[Literal["work_iq_preview"]]
         project_connection_id: str
+        type: Literal[work_iq_preview]
 
 
     class azure.ai.agentserver.responses.models.WorkflowActionOutputItem(TypedDict, total=False):

--- a/sdk/agentserver/azure-ai-agentserver-responses/api.metadata.yml
+++ b/sdk/agentserver/azure-ai-agentserver-responses/api.metadata.yml
@@ -1,3 +1,3 @@
-apiMdSha256: 47c8926a07ceae18da3b5d5e479b7bcbc291c7e397b6c756713d2afc94471af4
+apiMdSha256: 8874e05d2c9ce180535fb36ee2c3573b09fd32fb06200d71353450f99c01eadd
 parserVersion: 0.3.31
 pythonVersion: 3.11.15

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_generated/_unions.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_generated/_unions.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from . import types as _types
 Filters = Union["_types.ComparisonFilter", "_types.CompoundFilter"]
 ToolCallOutputContent = Union[dict[str, Any], str, list[Any]]
+ModelRouterResponseHeaderValue = Union[str, int]
 InputParam = Union[str, list["_types.Item"]]
 ConversationParam = Union[str, "_types.ConversationParam_2"]
 CreateResponseStreamingResponse = Union[

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_generated/types.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_generated/types.py
@@ -13,6 +13,9 @@ from typing_extensions import Required, TypedDict
 if TYPE_CHECKING:
     from . import _unions
 
+A2AProtocolVersion = Literal["1.0"]
+"""Supported A2A protocol versions."""
+
 AnnotationType = Literal["file_citation", "url_citation", "container_file_citation", "file_path"]
 """Type of AnnotationType."""
 
@@ -36,6 +39,9 @@ ApplyPatchOperationParamType = Literal["create_file", "delete_file", "update_fil
 
 AzureAISearchQueryType = Literal["simple", "semantic", "vector", "vector_simple_hybrid", "vector_semantic_hybrid"]
 """Available query types for Azure AI Search tool."""
+
+AzureContentFilterSeverity = Literal["safe", "low", "medium", "high"]
+"""Ratings for the intensity and risk level of harmful content."""
 
 CallableToolAllowedCaller = Literal["direct", "programmatic"]
 """Type of CallableToolAllowedCaller."""
@@ -211,6 +217,8 @@ ItemType = Literal[
     "structured_outputs",
     "oauth_consent_request",
     "memory_search_call",
+    "memory_command_preview_call",
+    "memory_command_preview_call_output",
     "workflow_action",
     "a2a_preview_call",
     "a2a_preview_call_output",
@@ -236,7 +244,7 @@ ItemType = Literal[
 MCPToolCallStatus = Literal["in_progress", "completed", "incomplete", "calling", "failed"]
 """Type of MCPToolCallStatus."""
 
-MemoryItemKind = Literal["user_profile", "chat_summary"]
+MemoryItemKind = Literal["user_profile", "chat_summary", "procedural"]
 """Memory item kind."""
 
 MessageContentType = Literal[
@@ -264,113 +272,8 @@ MessageRole = Literal["unknown", "user", "assistant", "system", "critic", "discr
 MessageStatus = Literal["in_progress", "completed", "incomplete"]
 """Type of MessageStatus."""
 
-ModelIdsCompaction = Literal[
-    "gpt-5.6-sol",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
-    "gpt-5.5",
-    "gpt-5.5-2026-04-23",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.4-nano",
-    "gpt-5.4-mini-2026-03-17",
-    "gpt-5.4-nano-2026-03-17",
-    "gpt-5.3-chat-latest",
-    "gpt-5.2",
-    "gpt-5.2-2025-12-11",
-    "gpt-5.2-chat-latest",
-    "gpt-5.2-pro",
-    "gpt-5.2-pro-2025-12-11",
-    "gpt-5.1",
-    "gpt-5.1-2025-11-13",
-    "gpt-5.1-codex",
-    "gpt-5.1-mini",
-    "gpt-5.1-chat-latest",
-    "gpt-5",
-    "gpt-5-mini",
-    "gpt-5-nano",
-    "gpt-5-2025-08-07",
-    "gpt-5-mini-2025-08-07",
-    "gpt-5-nano-2025-08-07",
-    "gpt-5-chat-latest",
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "gpt-4.1-nano",
-    "gpt-4.1-2025-04-14",
-    "gpt-4.1-mini-2025-04-14",
-    "gpt-4.1-nano-2025-04-14",
-    "o4-mini",
-    "o4-mini-2025-04-16",
-    "o3",
-    "o3-2025-04-16",
-    "o3-mini",
-    "o3-mini-2025-01-31",
-    "o1",
-    "o1-2024-12-17",
-    "o1-preview",
-    "o1-preview-2024-09-12",
-    "o1-mini",
-    "o1-mini-2024-09-12",
-    "gpt-4o",
-    "gpt-4o-2024-11-20",
-    "gpt-4o-2024-08-06",
-    "gpt-4o-2024-05-13",
-    "gpt-4o-audio-preview",
-    "gpt-4o-audio-preview-2024-10-01",
-    "gpt-4o-audio-preview-2024-12-17",
-    "gpt-4o-audio-preview-2025-06-03",
-    "gpt-4o-mini-audio-preview",
-    "gpt-4o-mini-audio-preview-2024-12-17",
-    "gpt-4o-search-preview",
-    "gpt-4o-mini-search-preview",
-    "gpt-4o-search-preview-2025-03-11",
-    "gpt-4o-mini-search-preview-2025-03-11",
-    "chatgpt-4o-latest",
-    "codex-mini-latest",
-    "gpt-4o-mini",
-    "gpt-4o-mini-2024-07-18",
-    "gpt-4-turbo",
-    "gpt-4-turbo-2024-04-09",
-    "gpt-4-0125-preview",
-    "gpt-4-turbo-preview",
-    "gpt-4-1106-preview",
-    "gpt-4-vision-preview",
-    "gpt-4",
-    "gpt-4-0314",
-    "gpt-4-0613",
-    "gpt-4-32k",
-    "gpt-4-32k-0314",
-    "gpt-4-32k-0613",
-    "gpt-3.5-turbo",
-    "gpt-3.5-turbo-16k",
-    "gpt-3.5-turbo-0301",
-    "gpt-3.5-turbo-0613",
-    "gpt-3.5-turbo-1106",
-    "gpt-3.5-turbo-0125",
-    "gpt-3.5-turbo-16k-0613",
-    "o1-pro",
-    "o1-pro-2025-03-19",
-    "o3-pro",
-    "o3-pro-2025-06-10",
-    "o3-deep-research",
-    "o3-deep-research-2025-06-26",
-    "o4-mini-deep-research",
-    "o4-mini-deep-research-2025-06-26",
-    "computer-use-preview",
-    "computer-use-preview-2025-03-11",
-    "gpt-5.5-pro",
-    "gpt-5.5-pro-2026-04-23",
-    "gpt-5-codex",
-    "gpt-5-pro",
-    "gpt-5-pro-2025-10-06",
-    "gpt-5.1-codex-max",
-    "gpt-daybreak-blue-latest",
-    "gpt-daybreak-red-latest",
-    "gpt-5.6-cyber",
-]
-"""Model ID used to generate the response, like ``gpt-5`` or ``o3``. OpenAI offers a wide range of
-models with different capabilities, performance characteristics, and price points. Refer to the
-`model guide </docs/models>`_ to browse and compare available models."""
+ModelRouterMode = Literal["balanced", "cost", "quality"]
+"""The routing mode used by Model Router for the request."""
 
 ModerationEntryType = Literal["moderation_result", "error"]
 """Type of ModerationEntryType."""
@@ -424,6 +327,8 @@ OutputItemType = Literal[
     "structured_outputs",
     "oauth_consent_request",
     "memory_search_call",
+    "memory_command_preview_call",
+    "memory_command_preview_call_output",
     "workflow_action",
     "a2a_preview_call",
     "a2a_preview_call_output",
@@ -636,6 +541,10 @@ ToolType = Literal[
     "sharepoint_grounding_preview",
     "memory_search_preview",
     "work_iq_preview",
+    "fabric_iq_preview",
+    "toolbox_search_preview",
+    "web_iq_preview",
+    "a2a",
     "azure_ai_search",
     "azure_function",
     "bing_grounding",
@@ -650,10 +559,6 @@ class A2APreviewTool(TypedDict, total=False):
 
     :ivar type: The type of the tool. Always ``"a2a_preview``. Required. A2_A_PREVIEW.
     :vartype type: Literal["a2a_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar base_url: Base URL of the agent.
     :vartype base_url: str
     :ivar agent_card_path: The path to the agent card relative to the ``base_url``. If not
@@ -663,14 +568,14 @@ class A2APreviewTool(TypedDict, total=False):
      connection stores authentication and other connection details needed to connect to the A2A
      server.
     :vartype project_connection_id: str
+    :ivar send_credentials_for_agent_card: When ``true``, Foundry sends its credentials when
+     fetching the remote agent's Agent Card. The service defaults to ``false`` if a value is not
+     specified by the caller (anonymous fetch).
+    :vartype send_credentials_for_agent_card: bool
     """
 
     type: Required[Literal["a2a_preview"]]
     """The type of the tool. Always ``\"a2a_preview``. Required. A2_A_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     base_url: str
     """Base URL of the agent."""
     agent_card_path: str
@@ -679,6 +584,48 @@ class A2APreviewTool(TypedDict, total=False):
     project_connection_id: str
     """The connection ID in the project for the A2A server. The connection stores authentication and
      other connection details needed to connect to the A2A server."""
+    send_credentials_for_agent_card: bool
+    """When ``true``, Foundry sends its credentials when fetching the remote agent's Agent Card. The
+     service defaults to ``false`` if a value is not specified by the caller (anonymous fetch)."""
+
+
+class A2ATool(TypedDict, total=False):
+    """An agent implementing the A2A protocol.
+
+    :ivar type: The type of the tool. Always ``"a2a"``. Required. A2_A.
+    :vartype type: Literal["a2a"]
+    :ivar base_url: Base URL of the agent.
+    :vartype base_url: str
+    :ivar agent_card_path: The path to the agent card relative to the ``base_url``. If not
+     provided, defaults to  ``/.well-known/agent-card.json``.
+    :vartype agent_card_path: str
+    :ivar project_connection_id: The connection ID in the project for the A2A server. The
+     connection stores authentication and other connection details needed to connect to the A2A
+     server.
+    :vartype project_connection_id: str
+    :ivar send_credentials_for_agent_card: When ``true``, Foundry sends its credentials when
+     fetching the remote agent's Agent Card. The service defaults to ``false`` if a value is not
+     specified by the caller (anonymous fetch).
+    :vartype send_credentials_for_agent_card: bool
+    :ivar a2a_version: The A2A protocol version supported by the agent. Required. "1.0"
+    :vartype a2a_version: A2AProtocolVersion
+    """
+
+    type: Required[Literal["a2a"]]
+    """The type of the tool. Always ``\"a2a\"``. Required. A2_A."""
+    base_url: str
+    """Base URL of the agent."""
+    agent_card_path: str
+    """The path to the agent card relative to the ``base_url``. If not provided, defaults to
+     ``/.well-known/agent-card.json``."""
+    project_connection_id: str
+    """The connection ID in the project for the A2A server. The connection stores authentication and
+     other connection details needed to connect to the A2A server."""
+    send_credentials_for_agent_card: bool
+    """When ``true``, Foundry sends its credentials when fetching the remote agent's Agent Card. The
+     service defaults to ``false`` if a value is not specified by the caller (anonymous fetch)."""
+    a2a_version: Required[A2AProtocolVersion]
+    """The A2A protocol version supported by the agent. Required. \"1.0\""""
 
 
 class A2AToolCall(TypedDict, total=False):
@@ -814,10 +761,6 @@ class AISearchIndexResource(TypedDict, total=False):
     :vartype project_connection_id: str
     :ivar index_name: The name of an index in an IndexResource attached to this agent.
     :vartype index_name: str
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar query_type: Type of query in an AIIndexResource attached to this agent. Known values are:
      "simple", "semantic", "vector", "vector_simple_hybrid", and "vector_semantic_hybrid".
     :vartype query_type: AzureAISearchQueryType
@@ -833,10 +776,6 @@ class AISearchIndexResource(TypedDict, total=False):
     """An index connection ID in an IndexResource attached to this agent."""
     index_name: str
     """The name of an index in an IndexResource attached to this agent."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     query_type: AzureAISearchQueryType
     """Type of query in an AIIndexResource attached to this agent. Known values are: \"simple\",
      \"semantic\", \"vector\", \"vector_simple_hybrid\", and \"vector_semantic_hybrid\"."""
@@ -1094,10 +1033,14 @@ class AzureAISearchTool(TypedDict, total=False):
 
     :ivar type: The object type, which is always 'azure_ai_search'. Required. AZURE_AI_SEARCH.
     :vartype type: Literal["azure_ai_search"]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar azure_ai_search: The azure ai search index resource. Required.
     :vartype azure_ai_search: "AzureAISearchToolResource"
     """
@@ -1105,9 +1048,11 @@ class AzureAISearchTool(TypedDict, total=False):
     type: Required[Literal["azure_ai_search"]]
     """The object type, which is always 'azure_ai_search'. Required. AZURE_AI_SEARCH."""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     azure_ai_search: Required["AzureAISearchToolResource"]
     """The azure ai search index resource. Required."""
 
@@ -1191,22 +1136,285 @@ class AzureAISearchToolCallOutput(TypedDict, total=False):
 class AzureAISearchToolResource(TypedDict, total=False):
     """A set of index resources used by the ``azure_ai_search`` tool.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar indexes: The indices attached to this agent. There can be a maximum of 1 index resource
      attached to the agent. Required.
     :vartype indexes: list["AISearchIndexResource"]
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     indexes: Required[list["AISearchIndexResource"]]
     """The indices attached to this agent. There can be a maximum of 1 index resource attached to the
      agent. Required."""
+
+
+class AzureContentFilterBlocklistIdResult(TypedDict, total=False):
+    """A content filter blocklist ID result.
+
+    :ivar id: The ID of the custom blocklist. Required.
+    :vartype id: str
+    :ivar filtered: Whether the blocklist resulted in filtering. Required.
+    :vartype filtered: bool
+    """
+
+    id: Required[str]
+    """The ID of the custom blocklist. Required."""
+    filtered: Required[bool]
+    """Whether the blocklist resulted in filtering. Required."""
+
+
+class AzureContentFilterBlocklistResult(TypedDict, total=False):
+    """A collection of filtering results for configured custom blocklists.
+
+    :ivar filtered: Whether any blocklist resulted in filtering. Required.
+    :vartype filtered: bool
+    :ivar details: The pairs of individual blocklist IDs and their filtering results.
+    :vartype details: list["AzureContentFilterBlocklistIdResult"]
+    """
+
+    filtered: Required[bool]
+    """Whether any blocklist resulted in filtering. Required."""
+    details: list["AzureContentFilterBlocklistIdResult"]
+    """The pairs of individual blocklist IDs and their filtering results."""
+
+
+class AzureContentFilterCitation(TypedDict, total=False):
+    """Citation details for protected material detection.
+
+    :ivar license: The license associated with the detection.
+    :vartype license: str
+    :ivar url: The URL associated with the license.
+    :vartype url: str
+    """
+
+    license: str
+    """The license associated with the detection."""
+    url: str
+    """The URL associated with the license."""
+
+
+class AzureContentFilterCompletionTextSpan(TypedDict, total=False):
+    """A representation of a span of completion text as used by Azure OpenAI content filter results.
+
+    :ivar completion_start_offset: Offset of the UTF32 code point which begins the span. Required.
+    :vartype completion_start_offset: int
+    :ivar completion_end_offset: Offset of the first UTF32 code point which is excluded from the
+     span. Required.
+    :vartype completion_end_offset: int
+    """
+
+    completion_start_offset: Required[int]
+    """Offset of the UTF32 code point which begins the span. Required."""
+    completion_end_offset: Required[int]
+    """Offset of the first UTF32 code point which is excluded from the span. Required."""
+
+
+class AzureContentFilterCompletionTextSpanDetectionResult(TypedDict, total=False):  # pylint: disable=name-too-long
+    """A content filter detection result with completion text span details.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether the content category was detected. Required.
+    :vartype detected: bool
+    :ivar details: Detailed information about the detected completion text spans. Required.
+    :vartype details: list["AzureContentFilterCompletionTextSpan"]
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    detected: Required[bool]
+    """Whether the content category was detected. Required."""
+    details: Required[list["AzureContentFilterCompletionTextSpan"]]
+    """Detailed information about the detected completion text spans. Required."""
+
+
+class AzureContentFilterDetectionResult(TypedDict, total=False):
+    """A content filter result indicating whether the content was detected and filtered.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether the content category was detected. Required.
+    :vartype detected: bool
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    detected: Required[bool]
+    """Whether the content category was detected. Required."""
+
+
+class AzureContentFilterDetectionWithCitationResult(TypedDict, total=False):  # pylint: disable=name-too-long
+    """A content filter detection result that includes citation information for protected material.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether the content category was detected. Required.
+    :vartype detected: bool
+    :ivar citation: Citation details describing the associated license and its location.
+    :vartype citation: "AzureContentFilterCitation"
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    detected: Required[bool]
+    """Whether the content category was detected. Required."""
+    citation: "AzureContentFilterCitation"
+    """Citation details describing the associated license and its location."""
+
+
+class AzureContentFilterDetectionWithReasonResult(TypedDict, total=False):  # pylint: disable=name-too-long
+    """A content filter detection result that includes a reason description.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether the content category was detected. Required.
+    :vartype detected: bool
+    :ivar reason: A human-readable explanation of why the detection result was produced.
+    :vartype reason: str
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    detected: Required[bool]
+    """Whether the content category was detected. Required."""
+    reason: str
+    """A human-readable explanation of why the detection result was produced."""
+
+
+class AzureContentFilterError(TypedDict, total=False):
+    """Error details from the content filtering system.
+
+    :ivar code: A machine-readable error code. Required.
+    :vartype code: int
+    :ivar message: A human-readable error message. Required.
+    :vartype message: str
+    """
+
+    code: Required[int]
+    """A machine-readable error code. Required."""
+    message: Required[str]
+    """A human-readable error message. Required."""
+
+
+class AzureContentFilterPersonallyIdentifiableInformationResult(
+    TypedDict, total=False
+):  # pylint: disable=name-too-long
+    """A content filter detection result for Personally Identifiable Information.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether PII was detected in the content. Required.
+    :vartype detected: bool
+    :ivar sub_categories: Detailed results for individual PII subcategories.
+    :vartype sub_categories: list["AzureContentFilterPiiSubCategoryResult"]
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    detected: Required[bool]
+    """Whether PII was detected in the content. Required."""
+    sub_categories: list["AzureContentFilterPiiSubCategoryResult"]
+    """Detailed results for individual PII subcategories."""
+
+
+class AzureContentFilterPiiSubCategoryResult(TypedDict, total=False):
+    """Result details for an individual PII subcategory.
+
+    :ivar sub_category: The PII subcategory that was evaluated. Required.
+    :vartype sub_category: str
+    :ivar filtered: Whether the content was filtered for this subcategory. Required.
+    :vartype filtered: bool
+    :ivar detected: Whether the subcategory was detected in the content. Required.
+    :vartype detected: bool
+    """
+
+    sub_category: Required[str]
+    """The PII subcategory that was evaluated. Required."""
+    filtered: Required[bool]
+    """Whether the content was filtered for this subcategory. Required."""
+    detected: Required[bool]
+    """Whether the subcategory was detected in the content. Required."""
+
+
+class AzureContentFilterResultsForResponses(TypedDict, total=False):
+    """Content filter results for the Responses API.
+
+    :ivar sexual: Severity result for sexual content.
+    :vartype sexual: "AzureContentFilterSeverityResult"
+    :ivar hate: Severity result for hate content.
+    :vartype hate: "AzureContentFilterSeverityResult"
+    :ivar violence: Severity result for violence content.
+    :vartype violence: "AzureContentFilterSeverityResult"
+    :ivar self_harm: Severity result for self-harm content.
+    :vartype self_harm: "AzureContentFilterSeverityResult"
+    :ivar profanity: Detection result for profanity.
+    :vartype profanity: "AzureContentFilterDetectionResult"
+    :ivar custom_blocklists: Results for configured custom blocklists.
+    :vartype custom_blocklists: "AzureContentFilterBlocklistResult"
+    :ivar jailbreak: Detection result for jailbreak attempts.
+    :vartype jailbreak: "AzureContentFilterDetectionResult"
+    :ivar task_adherence: Detection result for task adherence evaluation.
+    :vartype task_adherence: "AzureContentFilterDetectionWithReasonResult"
+    :ivar protected_material_text: Detection result for protected material text.
+    :vartype protected_material_text: "AzureContentFilterDetectionResult"
+    :ivar protected_material_code: Detection result for protected material code with citation.
+    :vartype protected_material_code: "AzureContentFilterDetectionWithCitationResult"
+    :ivar ungrounded_material: Detection result for ungrounded material with completion text span
+     details.
+    :vartype ungrounded_material: "AzureContentFilterCompletionTextSpanDetectionResult"
+    :ivar personally_identifiable_information: Detection result for Personally Identifiable
+     Information.
+    :vartype personally_identifiable_information:
+     "AzureContentFilterPersonallyIdentifiableInformationResult"
+    :ivar indirect_attack: Detection result for indirect attacks.
+    :vartype indirect_attack: "AzureContentFilterDetectionResult"
+    :ivar error: Error details if content filtering evaluation failed.
+    :vartype error: "AzureContentFilterError"
+    """
+
+    sexual: "AzureContentFilterSeverityResult"
+    """Severity result for sexual content."""
+    hate: "AzureContentFilterSeverityResult"
+    """Severity result for hate content."""
+    violence: "AzureContentFilterSeverityResult"
+    """Severity result for violence content."""
+    self_harm: "AzureContentFilterSeverityResult"
+    """Severity result for self-harm content."""
+    profanity: "AzureContentFilterDetectionResult"
+    """Detection result for profanity."""
+    custom_blocklists: "AzureContentFilterBlocklistResult"
+    """Results for configured custom blocklists."""
+    jailbreak: "AzureContentFilterDetectionResult"
+    """Detection result for jailbreak attempts."""
+    task_adherence: "AzureContentFilterDetectionWithReasonResult"
+    """Detection result for task adherence evaluation."""
+    protected_material_text: "AzureContentFilterDetectionResult"
+    """Detection result for protected material text."""
+    protected_material_code: "AzureContentFilterDetectionWithCitationResult"
+    """Detection result for protected material code with citation."""
+    ungrounded_material: "AzureContentFilterCompletionTextSpanDetectionResult"
+    """Detection result for ungrounded material with completion text span details."""
+    personally_identifiable_information: "AzureContentFilterPersonallyIdentifiableInformationResult"
+    """Detection result for Personally Identifiable Information."""
+    indirect_attack: "AzureContentFilterDetectionResult"
+    """Detection result for indirect attacks."""
+    error: "AzureContentFilterError"
+    """Error details if content filtering evaluation failed."""
+
+
+class AzureContentFilterSeverityResult(TypedDict, total=False):
+    """A content filter result indicating severity level and whether content was filtered.
+
+    :ivar filtered: Whether the content was filtered. Required.
+    :vartype filtered: bool
+    :ivar severity: The severity level of the content. Required. Known values are: "safe", "low",
+     "medium", and "high".
+    :vartype severity: AzureContentFilterSeverity
+    """
+
+    filtered: Required[bool]
+    """Whether the content was filtered. Required."""
+    severity: Required[AzureContentFilterSeverity]
+    """The severity level of the content. Required. Known values are: \"safe\", \"low\", \"medium\",
+     and \"high\"."""
 
 
 class AzureFunctionBinding(TypedDict, total=False):
@@ -1292,12 +1500,17 @@ class AzureFunctionTool(TypedDict, total=False):
 
     :ivar type: The object type, which is always 'browser_automation'. Required. AZURE_FUNCTION.
     :vartype type: Literal["azure_function"]
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar azure_function: The Azure Function Tool definition. Required.
     :vartype azure_function: "AzureFunctionDefinition"
     """
 
     type: Required[Literal["azure_function"]]
     """The object type, which is always 'browser_automation'. Required. AZURE_FUNCTION."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     azure_function: Required["AzureFunctionDefinition"]
     """The Azure Function Tool definition. Required."""
 
@@ -1386,13 +1599,44 @@ class AzureFunctionToolCallOutput(TypedDict, total=False):
     """Required."""
 
 
+class AzureUserSecurityContext(TypedDict, total=False):
+    """User security context contains several parameters that describe the application itself, and the
+    end user that interacts with the application. These fields assist your security operations
+    teams to investigate and mitigate security incidents by providing a comprehensive approach to
+    protecting your AI applications. Learn more: https://aka.ms/TP4AI/Documentation/EndUserContext about protecting AI applications using
+    Microsoft Defender for Cloud.
+
+    :ivar application_name: The name of the application. Sensitive personal information should not
+     be included in this field.
+    :vartype application_name: str
+    :ivar end_user_id: This identifier is the Microsoft Entra ID (formerly Azure Active Directory)
+     user object ID used to authenticate end-users within the generative AI application. Sensitive
+     personal information should not be included in this field.
+    :vartype end_user_id: str
+    :ivar end_user_tenant_id: The Microsoft 365 tenant ID the end user belongs to. It's required
+     when the generative AI application is multitenant.
+    :vartype end_user_tenant_id: str
+    :ivar source_ip: Captures the original client's IP address.
+    :vartype source_ip: str
+    """
+
+    application_name: str
+    """The name of the application. Sensitive personal information should not be included in this
+     field."""
+    end_user_id: str
+    """This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used
+     to authenticate end-users within the generative AI application. Sensitive personal information
+     should not be included in this field."""
+    end_user_tenant_id: str
+    """The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI
+     application is multitenant."""
+    source_ip: str
+    """Captures the original client's IP address."""
+
+
 class BingCustomSearchConfiguration(TypedDict, total=False):
     """A bing custom search configuration.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connection_id: Project connection id for grounding with bing search. Required.
     :vartype project_connection_id: str
     :ivar instance_name: Name of the custom configuration instance given to config. Required.
@@ -1408,10 +1652,6 @@ class BingCustomSearchConfiguration(TypedDict, total=False):
     :vartype freshness: str
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connection_id: Required[str]
     """Project connection id for grounding with bing search. Required."""
     instance_name: Required[str]
@@ -1433,10 +1673,6 @@ class BingCustomSearchPreviewTool(TypedDict, total=False):
     :ivar type: The object type, which is always 'bing_custom_search_preview'. Required.
      BING_CUSTOM_SEARCH_PREVIEW.
     :vartype type: Literal["bing_custom_search_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar bing_custom_search_preview: The bing custom search tool parameters. Required.
     :vartype bing_custom_search_preview: "BingCustomSearchToolParameters"
     """
@@ -1444,10 +1680,6 @@ class BingCustomSearchPreviewTool(TypedDict, total=False):
     type: Required[Literal["bing_custom_search_preview"]]
     """The object type, which is always 'bing_custom_search_preview'. Required.
      BING_CUSTOM_SEARCH_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     bing_custom_search_preview: Required["BingCustomSearchToolParameters"]
     """The bing custom search tool parameters. Required."""
 
@@ -1531,19 +1763,11 @@ class BingCustomSearchToolCallOutput(TypedDict, total=False):
 class BingCustomSearchToolParameters(TypedDict, total=False):
     """The bing custom search tool parameters.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar search_configurations: The project connections attached to this tool. There can be a
      maximum of 1 connection resource attached to the tool. Required.
     :vartype search_configurations: list["BingCustomSearchConfiguration"]
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     search_configurations: Required[list["BingCustomSearchConfiguration"]]
     """The project connections attached to this tool. There can be a maximum of 1 connection resource
      attached to the tool. Required."""
@@ -1552,10 +1776,6 @@ class BingCustomSearchToolParameters(TypedDict, total=False):
 class BingGroundingSearchConfiguration(TypedDict, total=False):
     """Search configuration for Bing Grounding.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connection_id: Project connection id for grounding with bing search. Required.
     :vartype project_connection_id: str
     :ivar market: The market where the results come from.
@@ -1569,10 +1789,6 @@ class BingGroundingSearchConfiguration(TypedDict, total=False):
     :vartype freshness: str
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connection_id: Required[str]
     """Project connection id for grounding with bing search. Required."""
     market: str
@@ -1589,19 +1805,11 @@ class BingGroundingSearchConfiguration(TypedDict, total=False):
 class BingGroundingSearchToolParameters(TypedDict, total=False):
     """The bing grounding search tool parameters.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar search_configurations: The search configurations attached to this tool. There can be a
      maximum of 1 search configuration resource attached to the tool. Required.
     :vartype search_configurations: list["BingGroundingSearchConfiguration"]
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     search_configurations: Required[list["BingGroundingSearchConfiguration"]]
     """The search configurations attached to this tool. There can be a maximum of 1 search
      configuration resource attached to the tool. Required."""
@@ -1613,10 +1821,14 @@ class BingGroundingTool(TypedDict, total=False):
 
     :ivar type: The object type, which is always 'bing_grounding'. Required. BING_GROUNDING.
     :vartype type: Literal["bing_grounding"]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar bing_grounding: The bing grounding search tool parameters. Required.
     :vartype bing_grounding: "BingGroundingSearchToolParameters"
     """
@@ -1624,9 +1836,11 @@ class BingGroundingTool(TypedDict, total=False):
     type: Required[Literal["bing_grounding"]]
     """The object type, which is always 'bing_grounding'. Required. BING_GROUNDING."""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     bing_grounding: Required["BingGroundingSearchToolParameters"]
     """The bing grounding search tool parameters. Required."""
 
@@ -1713,10 +1927,6 @@ class BrowserAutomationPreviewTool(TypedDict, total=False):
     :ivar type: The object type, which is always 'browser_automation_preview'. Required.
      BROWSER_AUTOMATION_PREVIEW.
     :vartype type: Literal["browser_automation_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar browser_automation_preview: The Browser Automation Tool parameters. Required.
     :vartype browser_automation_preview: "BrowserAutomationToolParameters"
     """
@@ -1724,10 +1934,6 @@ class BrowserAutomationPreviewTool(TypedDict, total=False):
     type: Required[Literal["browser_automation_preview"]]
     """The object type, which is always 'browser_automation_preview'. Required.
      BROWSER_AUTOMATION_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     browser_automation_preview: Required["BrowserAutomationToolParameters"]
     """The Browser Automation Tool parameters. Required."""
 
@@ -1811,19 +2017,11 @@ class BrowserAutomationToolCallOutput(TypedDict, total=False):
 class BrowserAutomationToolConnectionParameters(TypedDict, total=False):  # pylint: disable=name-too-long
     """Definition of input parameters for the connection used by the Browser Automation Tool.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connection_id: The ID of the project connection to your Azure Playwright
      resource. Required.
     :vartype project_connection_id: str
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connection_id: Required[str]
     """The ID of the project connection to your Azure Playwright resource. Required."""
 
@@ -1831,19 +2029,11 @@ class BrowserAutomationToolConnectionParameters(TypedDict, total=False):  # pyli
 class BrowserAutomationToolParameters(TypedDict, total=False):
     """Definition of input parameters for the Browser Automation Tool.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar connection: The project connection parameters associated with the Browser Automation
      Tool. Required.
     :vartype connection: "BrowserAutomationToolConnectionParameters"
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     connection: Required["BrowserAutomationToolConnectionParameters"]
     """The project connection parameters associated with the Browser Automation Tool. Required."""
 
@@ -1854,6 +2044,14 @@ class CaptureStructuredOutputsTool(TypedDict, total=False):
     :ivar type: The type of the tool. Always ``capture_structured_outputs``. Required.
      CAPTURE_STRUCTURED_OUTPUTS.
     :vartype type: Literal["capture_structured_outputs"]
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
+    :vartype name: str
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar outputs: The structured outputs to capture from the model. Required.
     :vartype outputs: "StructuredOutputDefinition"
     """
@@ -1861,6 +2059,12 @@ class CaptureStructuredOutputsTool(TypedDict, total=False):
     type: Required[Literal["capture_structured_outputs"]]
     """The type of the tool. Always ``capture_structured_outputs``. Required.
      CAPTURE_STRUCTURED_OUTPUTS."""
+    name: str
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    description: str
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     outputs: Required["StructuredOutputDefinition"]
     """The structured outputs to capture from the model. Required."""
 
@@ -1963,10 +2167,14 @@ class CodeInterpreterTool(TypedDict, total=False):
     :vartype type: Literal["code_interpreter"]
     :ivar allowed_callers:
     :vartype allowed_callers: list[CallableToolAllowedCaller]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar container: The code interpreter container. Can be a container ID or an object that
      specifies uploaded file IDs to make available to your code, along with an optional
      ``memory_limit`` setting. If not provided, the service assumes auto. Is either a str type or a
@@ -1978,9 +2186,11 @@ class CodeInterpreterTool(TypedDict, total=False):
     """The type of the code interpreter tool. Always ``code_interpreter``. Required. CODE_INTERPRETER."""
     allowed_callers: Optional[list[CallableToolAllowedCaller]]
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     container: Union[str, "AutoCodeInterpreterToolParam"]
     """The code interpreter container. Can be a container ID or an object that specifies uploaded file
      IDs to make available to your code, along with an optional ``memory_limit`` setting. If not
@@ -2367,6 +2577,32 @@ class ContainerReferenceResource(TypedDict, total=False):
     """Required."""
 
 
+class ContentFilterResult(TypedDict, total=False):
+    """A content filter evaluation result for a specific source in the response.
+
+    :ivar blocked: Whether the content was blocked by the content filter. Required.
+    :vartype blocked: bool
+    :ivar source_type: The source type of the content filter evaluation (e.g., 'prompt',
+     'response', 'pre_tool_call', 'post_tool_call'). Required.
+    :vartype source_type: str
+    :ivar content_filter_results: The content filter results for this evaluation. Required.
+    :vartype content_filter_results: "AzureContentFilterResultsForResponses"
+    :ivar tool_call_id: The ID of the tool call associated with this content filter result, if
+     applicable.
+    :vartype tool_call_id: str
+    """
+
+    blocked: Required[bool]
+    """Whether the content was blocked by the content filter. Required."""
+    source_type: Required[str]
+    """The source type of the content filter evaluation (e.g., 'prompt', 'response', 'pre_tool_call',
+     'post_tool_call'). Required."""
+    content_filter_results: Required["AzureContentFilterResultsForResponses"]
+    """The content filter results for this evaluation. Required."""
+    tool_call_id: str
+    """The ID of the tool call associated with this content filter result, if applicable."""
+
+
 class ContextManagementParam(TypedDict, total=False):
     """ContextManagementParam.
 
@@ -2489,11 +2725,21 @@ class CreateResponse(TypedDict, total=False):
     :vartype context_management: list["ContextManagementParam"]
     :ivar max_output_tokens:
     :vartype max_output_tokens: int
+    :ivar agent_session_id: Optional session identifier for sandbox affinity. Currently only
+     relevant for hosted agents. When provided, the request is routed to the same sandbox. When
+     omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated.
+    :vartype agent_session_id: str
     :ivar agent_reference: The agent to use for generating the response.
     :vartype agent_reference: "AgentReference"
     :ivar structured_inputs: The structured inputs to the response that can participate in prompt
      template substitution or tool argument bindings.
     :vartype structured_inputs: dict[str, Any]
+    :ivar user_security_context: User security context contains several parameters that describe
+     the application itself, and the end user that interacts with the application. These fields
+     assist your security operations teams to investigate and mitigate security incidents by
+     providing a comprehensive approach to protecting your AI applications. Learn more: https://aka.ms/TP4AI/Documentation/EndUserContext about protecting AI applications using
+     Microsoft Defender for Cloud.
+    :vartype user_security_context: "AzureUserSecurityContext"
     """
 
     metadata: Optional["Metadata"]
@@ -2540,11 +2786,184 @@ class CreateResponse(TypedDict, total=False):
     context_management: Optional[list["ContextManagementParam"]]
     """Context management configuration for this request."""
     max_output_tokens: Optional[int]
+    agent_session_id: str
+    """Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+     When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+     conversation_id/prev_response_id or a new UUID is generated."""
     agent_reference: "AgentReference"
     """The agent to use for generating the response."""
     structured_inputs: dict[str, Any]
     """The structured inputs to the response that can participate in prompt template substitution or
      tool argument bindings."""
+    user_security_context: "AzureUserSecurityContext"
+    """User security context contains several parameters that describe the application itself, and the
+     end user that interacts with the application. These fields assist your security operations
+     teams to investigate and mitigate security incidents by providing a comprehensive approach to
+     protecting your AI applications. Learn more: https://aka.ms/TP4AI/Documentation/EndUserContext about protecting AI applications using
+     Microsoft Defender for Cloud."""
+
+
+class CreateResponseResponse(TypedDict, total=False):
+    """CreateResponseResponse.
+
+    :ivar metadata:
+    :vartype metadata: "Metadata"
+    :ivar top_logprobs:
+    :vartype top_logprobs: int
+    :ivar temperature:
+    :vartype temperature: float
+    :ivar top_p:
+    :vartype top_p: float
+    :ivar user: This field is being replaced by ``safety_identifier`` and ``prompt_cache_key``. Use
+     ``prompt_cache_key`` instead to maintain caching optimizations. A stable identifier for your
+     end-users. Used to boost cache hit rates by better bucketing similar requests and  to help
+     OpenAI detect and prevent abuse. Learn more: /docs/guides/safety-best-practices#safety-identifiers.
+    :vartype user: str
+    :ivar safety_identifier:
+    :vartype safety_identifier: str
+    :ivar prompt_cache_key:
+    :vartype prompt_cache_key: str
+    :ivar prompt_cache_retention: Is either a Literal["in_memory"] type or a Literal["24h"] type.
+    :vartype prompt_cache_retention: Literal["in_memory", "24h"]
+    :ivar previous_response_id:
+    :vartype previous_response_id: str
+    :ivar model: The model deployment to use for the creation of this response.
+    :vartype model: str
+    :ivar background:
+    :vartype background: bool
+    :ivar max_tool_calls:
+    :vartype max_tool_calls: int
+    :ivar text:
+    :vartype text: "ResponseTextParam"
+    :ivar tools:
+    :vartype tools: list["Tool"]
+    :ivar tool_choice: Is either a types.ToolChoiceOptions type or a ToolChoiceParam type.
+    :vartype tool_choice: Union[ToolChoiceOptions, "ToolChoiceParam"]
+    :ivar prompt:
+    :vartype prompt: "Prompt"
+    :ivar service_tier: Is one of the following types: Literal["auto"], Literal["default"],
+     Literal["flex"], Literal["scale"], Literal["priority"], Literal["fast"], Literal["ultrafast"]
+    :vartype service_tier: Literal["auto", "default", "flex", "scale", "priority", "fast",
+     "ultrafast"]
+    :ivar truncation: Is either a Literal["auto"] type or a Literal["disabled"] type.
+    :vartype truncation: Literal["auto", "disabled"]
+    :ivar id: Unique identifier for this Response. Required.
+    :vartype id: str
+    :ivar object: The object type of this resource - always set to ``response``. Required. Default
+     value is "response".
+    :vartype object: Literal["response"]
+    :ivar status: The status of the response generation. One of ``completed``, ``failed``,
+     ``in_progress``, ``cancelled``, ``queued``, or ``incomplete``. Is one of the following types:
+     Literal["completed"], Literal["failed"], Literal["in_progress"], Literal["cancelled"],
+     Literal["queued"], Literal["incomplete"]
+    :vartype status: Literal["completed", "failed", "in_progress", "cancelled", "queued",
+     "incomplete"]
+    :ivar created_at: Unix timestamp (in seconds) of when this Response was created. Required.
+    :vartype created_at: int
+    :ivar completed_at:
+    :vartype completed_at: int
+    :ivar error: Required.
+    :vartype error: "ResponseErrorInfo"
+    :ivar incomplete_details: Required.
+    :vartype incomplete_details: "ResponseIncompleteDetails"
+    :ivar output: An array of content items generated by the model. The length and order of items
+     depends on the model response. Use the output_text property instead of assuming the first item
+     is an assistant message. Required.
+    :vartype output: list["OutputItem"]
+    :ivar reasoning:
+    :vartype reasoning: "Reasoning"
+    :ivar instructions: Required. Is either a str type or a [Item] type.
+    :vartype instructions: Union[str, list["Item"]]
+    :ivar output_text:
+    :vartype output_text: str
+    :ivar usage:
+    :vartype usage: "ResponseUsage"
+    :ivar prompt_cache_options:
+    :vartype prompt_cache_options: "PromptCacheOptions"
+    :ivar moderation:
+    :vartype moderation: "Moderation"
+    :ivar parallel_tool_calls: Whether to allow the model to run tool calls in parallel. Required.
+    :vartype parallel_tool_calls: bool
+    :ivar conversation:
+    :vartype conversation: "ConversationReference"
+    :ivar max_output_tokens:
+    :vartype max_output_tokens: int
+    :ivar agent_reference: The agent used for this response. Required.
+    :vartype agent_reference: "AgentReference"
+    :ivar model_selection_details: Model selection metadata providing visibility into routing
+     decisions. Present when the request was handled by Model Router.
+    :vartype model_selection_details: "ModelSelectionDetails"
+    :ivar content_filters: The content filter evaluation results.
+    :vartype content_filters: list["ContentFilterResult"]
+    """
+
+    metadata: Optional["Metadata"]
+    top_logprobs: Optional[int]
+    temperature: Optional[float]
+    top_p: Optional[float]
+    user: str
+    """This field is being replaced by ``safety_identifier`` and ``prompt_cache_key``. Use
+     ``prompt_cache_key`` instead to maintain caching optimizations. A stable identifier for your
+     end-users. Used to boost cache hit rates by better bucketing similar requests and  to help
+     OpenAI detect and prevent abuse. Learn more: /docs/guides/safety-best-practices#safety-identifiers."""
+    safety_identifier: Optional[str]
+    prompt_cache_key: Optional[str]
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]]
+    """Is either a Literal[\"in_memory\"] type or a Literal[\"24h\"] type."""
+    previous_response_id: Optional[str]
+    model: str
+    """The model deployment to use for the creation of this response."""
+    background: Optional[bool]
+    max_tool_calls: Optional[int]
+    text: "ResponseTextParam"
+    tools: list["Tool"]
+    tool_choice: Union[ToolChoiceOptions, "ToolChoiceParam"]
+    """Is either a types.ToolChoiceOptions type or a ToolChoiceParam type."""
+    prompt: "Prompt"
+    service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"]]
+    """Is one of the following types: Literal[\"auto\"], Literal[\"default\"], Literal[\"flex\"],
+     Literal[\"scale\"], Literal[\"priority\"], Literal[\"fast\"], Literal[\"ultrafast\"]"""
+    truncation: Optional[Literal["auto", "disabled"]]
+    """Is either a Literal[\"auto\"] type or a Literal[\"disabled\"] type."""
+    id: Required[str]
+    """Unique identifier for this Response. Required."""
+    object: Required[Literal["response"]]
+    """The object type of this resource - always set to ``response``. Required. Default value is
+     \"response\"."""
+    status: Literal["completed", "failed", "in_progress", "cancelled", "queued", "incomplete"]
+    """The status of the response generation. One of ``completed``, ``failed``, ``in_progress``,
+     ``cancelled``, ``queued``, or ``incomplete``. Is one of the following types:
+     Literal[\"completed\"], Literal[\"failed\"], Literal[\"in_progress\"], Literal[\"cancelled\"],
+     Literal[\"queued\"], Literal[\"incomplete\"]"""
+    created_at: Required[int]
+    """Unix timestamp (in seconds) of when this Response was created. Required."""
+    completed_at: Optional[int]
+    error: Required[Optional["ResponseErrorInfo"]]
+    """Required."""
+    incomplete_details: Required[Optional["ResponseIncompleteDetails"]]
+    """Required."""
+    output: Required[list["OutputItem"]]
+    """An array of content items generated by the model. The length and order of items depends on the
+     model response. Use the output_text property instead of assuming the first item is an assistant
+     message. Required."""
+    reasoning: Optional["Reasoning"]
+    instructions: Required[Optional[Union[str, list["Item"]]]]
+    """Required. Is either a str type or a [Item] type."""
+    output_text: Optional[str]
+    usage: "ResponseUsage"
+    prompt_cache_options: "PromptCacheOptions"
+    moderation: Optional["Moderation"]
+    parallel_tool_calls: Required[bool]
+    """Whether to allow the model to run tool calls in parallel. Required."""
+    conversation: Optional["ConversationReference"]
+    max_output_tokens: Optional[int]
+    agent_reference: Required[Optional["AgentReference"]]
+    """The agent used for this response. Required."""
+    model_selection_details: "ModelSelectionDetails"
+    """Model selection metadata providing visibility into routing decisions. Present when the request
+     was handled by Model Router."""
+    content_filters: list["ContentFilterResult"]
+    """The content filter evaluation results."""
 
 
 class CustomGrammarFormatParam(TypedDict, total=False):
@@ -2931,22 +3350,45 @@ class FabricDataAgentToolCallOutput(TypedDict, total=False):
 class FabricDataAgentToolParameters(TypedDict, total=False):
     """The fabric data agent tool parameters.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connections: The project connections attached to this tool. There can be a
      maximum of 1 connection resource attached to the tool.
     :vartype project_connections: list["ToolProjectConnection"]
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connections: list["ToolProjectConnection"]
     """The project connections attached to this tool. There can be a maximum of 1 connection resource
      attached to the tool."""
+
+
+class FabricIQPreviewTool(TypedDict, total=False):
+    """A FabricIQ server-side tool.
+
+    :ivar type: The object type, which is always 'fabric_iq_preview'. Required. FABRIC_IQ_PREVIEW.
+    :vartype type: Literal["fabric_iq_preview"]
+    :ivar project_connection_id: The ID of the FabricIQ project connection. Required.
+    :vartype project_connection_id: str
+    :ivar server_label: (Optional) The label of the FabricIQ MCP server to connect to.
+    :vartype server_label: str
+    :ivar server_url: (Optional) The URL of the FabricIQ MCP server. If not provided, the URL from
+     the project connection will be used.
+    :vartype server_url: str
+    :ivar require_approval: (Optional) Whether the agent requires approval before executing
+     actions. Default is always. Is either a MCPToolRequireApproval type or a str type.
+    :vartype require_approval: Union["MCPToolRequireApproval", str]
+    """
+
+    type: Required[Literal["fabric_iq_preview"]]
+    """The object type, which is always 'fabric_iq_preview'. Required. FABRIC_IQ_PREVIEW."""
+    project_connection_id: Required[str]
+    """The ID of the FabricIQ project connection. Required."""
+    server_label: str
+    """(Optional) The label of the FabricIQ MCP server to connect to."""
+    server_url: str
+    """(Optional) The URL of the FabricIQ MCP server. If not provided, the URL from the project
+     connection will be used."""
+    require_approval: Optional[Union["MCPToolRequireApproval", str]]
+    """(Optional) Whether the agent requires approval before executing actions. Default is always. Is
+     either a MCPToolRequireApproval type or a str type."""
 
 
 class FileCitationBody(TypedDict, total=False):
@@ -3005,10 +3447,14 @@ class FileSearchTool(TypedDict, total=False):
     :vartype ranking_options: "RankingOptions"
     :ivar filters: Is either a ComparisonFilter type or a CompoundFilter type.
     :vartype filters: "_unions.Filters"
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     """
 
     type: Required[Literal["file_search"]]
@@ -3022,9 +3468,11 @@ class FileSearchTool(TypedDict, total=False):
     filters: Optional["_unions.Filters"]
     """Is either a ComparisonFilter type or a CompoundFilter type."""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
 
 
 class FileSearchToolCallResults(TypedDict, total=False):
@@ -3418,10 +3866,14 @@ class FunctionShellToolParam(TypedDict, total=False):
     :vartype environment: "FunctionShellToolParamEnvironment"
     :ivar allowed_callers:
     :vartype allowed_callers: list[CallableToolAllowedCaller]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     """
 
     type: Required[Literal["shell"]]
@@ -3429,9 +3881,11 @@ class FunctionShellToolParam(TypedDict, total=False):
     environment: Optional["FunctionShellToolParamEnvironment"]
     allowed_callers: Optional[list[CallableToolAllowedCaller]]
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
 
 
 class FunctionShellToolParamEnvironmentContainerReferenceParam(TypedDict, total=False):  # pylint: disable=name-too-long
@@ -3601,10 +4055,14 @@ class ImageGenTool(TypedDict, total=False):
     :ivar action: Whether to generate a new image or edit an existing image. Default: ``auto``.
      Known values are: "generate", "edit", and "auto".
     :vartype action: ImageGenActionEnum
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     """
 
     type: Required[Literal["image_generation"]]
@@ -3650,9 +4108,11 @@ class ImageGenTool(TypedDict, total=False):
     """Whether to generate a new image or edit an existing image. Default: ``auto``. Known values are:
      \"generate\", \"edit\", and \"auto\"."""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
 
 
 class ImageGenToolInputImageMask(TypedDict, total=False):
@@ -5524,18 +5984,24 @@ class LocalShellToolParam(TypedDict, total=False):
 
     :ivar type: The type of the local shell tool. Always ``local_shell``. Required. LOCAL_SHELL.
     :vartype type: Literal["local_shell"]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     """
 
     type: Required[Literal["local_shell"]]
     """The type of the local shell tool. Always ``local_shell``. Required. LOCAL_SHELL."""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
 
 
 class LocalSkillParam(TypedDict, total=False):
@@ -5689,6 +6155,9 @@ class MCPTool(TypedDict, total=False):
      connection stores authentication and other connection details needed to connect to the MCP
      server.
     :vartype project_connection_id: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     """
 
     type: Required[Literal["mcp"]]
@@ -5743,6 +6212,8 @@ class MCPTool(TypedDict, total=False):
     project_connection_id: str
     """The connection ID in the project for the MCP server. The connection stores authentication and
      other connection details needed to connect to the MCP server."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
 
 
 class MCPToolFilter(TypedDict, total=False):
@@ -5779,15 +6250,76 @@ class MCPToolRequireApproval(TypedDict, total=False):
     never: "MCPToolFilter"
 
 
-class MemorySearchItem(TypedDict, total=False):
-    """A retrieved memory item from memory search.
+class MemoryCommandToolCall(TypedDict, total=False):
+    """A memory command tool call.
 
-    :ivar memory_item: Retrieved memory item. Required.
-    :vartype memory_item: "MemoryItem"
+    :ivar agent_reference: The agent that created the item.
+    :vartype agent_reference: "AgentReference"
+    :ivar response_id: The response on which the item is created.
+    :vartype response_id: str
+    :ivar type: Required. MEMORY_COMMAND_PREVIEW_CALL.
+    :vartype type: Literal["memory_command_preview_call"]
+    :ivar call_id: The unique ID of the tool call generated by the model. Required.
+    :vartype call_id: str
+    :ivar arguments: A JSON string of the arguments to pass to the tool, including ``action``
+     (``remember`` or ``forget``) and ``content``. Required.
+    :vartype arguments: str
+    :ivar status: The status of the tool call. Required. Known values are: "in_progress",
+     "completed", "incomplete", and "failed".
+    :vartype status: ToolCallStatus
+    :ivar id: Required.
+    :vartype id: str
     """
 
-    memory_item: Required["MemoryItem"]
-    """Retrieved memory item. Required."""
+    agent_reference: "AgentReference"
+    """The agent that created the item."""
+    response_id: str
+    """The response on which the item is created."""
+    type: Required[Literal["memory_command_preview_call"]]
+    """Required. MEMORY_COMMAND_PREVIEW_CALL."""
+    call_id: Required[str]
+    """The unique ID of the tool call generated by the model. Required."""
+    arguments: Required[str]
+    """A JSON string of the arguments to pass to the tool, including ``action`` (``remember`` or
+     ``forget``) and ``content``. Required."""
+    status: Required[ToolCallStatus]
+    """The status of the tool call. Required. Known values are: \"in_progress\", \"completed\",
+     \"incomplete\", and \"failed\"."""
+    id: Required[str]
+    """Required."""
+
+
+class MemoryCommandToolCallOutput(TypedDict, total=False):
+    """The output of a memory command tool call.
+
+    :ivar agent_reference: The agent that created the item.
+    :vartype agent_reference: "AgentReference"
+    :ivar response_id: The response on which the item is created.
+    :vartype response_id: str
+    :ivar type: Required. MEMORY_COMMAND_PREVIEW_CALL_OUTPUT.
+    :vartype type: Literal["memory_command_preview_call_output"]
+    :ivar call_id: The unique ID of the tool call generated by the model. Required.
+    :vartype call_id: str
+    :ivar status: The status of the tool call. Required. Known values are: "in_progress",
+     "completed", "incomplete", and "failed".
+    :vartype status: ToolCallStatus
+    :ivar id: Required.
+    :vartype id: str
+    """
+
+    agent_reference: "AgentReference"
+    """The agent that created the item."""
+    response_id: str
+    """The response on which the item is created."""
+    type: Required[Literal["memory_command_preview_call_output"]]
+    """Required. MEMORY_COMMAND_PREVIEW_CALL_OUTPUT."""
+    call_id: Required[str]
+    """The unique ID of the tool call generated by the model. Required."""
+    status: Required[ToolCallStatus]
+    """The status of the tool call. Required. Known values are: \"in_progress\", \"completed\",
+     \"incomplete\", and \"failed\"."""
+    id: Required[str]
+    """Required."""
 
 
 class MemorySearchOptions(TypedDict, total=False):
@@ -5807,10 +6339,6 @@ class MemorySearchPreviewTool(TypedDict, total=False):
     :ivar type: The type of the tool. Always ``memory_search_preview``. Required.
      MEMORY_SEARCH_PREVIEW.
     :vartype type: Literal["memory_search_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar memory_store_name: The name of the memory store to use. Required.
     :vartype memory_store_name: str
     :ivar scope: The namespace used to group and isolate memories, such as a user ID. Limits which
@@ -5826,10 +6354,6 @@ class MemorySearchPreviewTool(TypedDict, total=False):
 
     type: Required[Literal["memory_search_preview"]]
     """The type of the tool. Always ``memory_search_preview``. Required. MEMORY_SEARCH_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     memory_store_name: Required[str]
     """The name of the memory store to use. Required."""
     scope: Required[str]
@@ -5842,23 +6366,8 @@ class MemorySearchPreviewTool(TypedDict, total=False):
     """Time to wait before updating memories after inactivity (seconds). Default 300."""
 
 
-class MemorySearchToolCallItemParam(TypedDict, total=False):
-    """MemorySearchToolCallItemParam.
-
-    :ivar type: Required. Default value is "memory_search_call".
-    :vartype type: Literal["memory_search_call"]
-    :ivar results: The results returned from the memory search.
-    :vartype results: list["MemorySearchItem"]
-    """
-
-    type: Required[Literal["memory_search_call"]]
-    """Required. Default value is \"memory_search_call\"."""
-    results: Optional[list["MemorySearchItem"]]
-    """The results returned from the memory search."""
-
-
-class MemorySearchToolCallItemResource(TypedDict, total=False):
-    """MemorySearchToolCallItemResource.
+class MemorySearchToolCall(TypedDict, total=False):
+    """A memory search tool call.
 
     :ivar agent_reference: The agent that created the item.
     :vartype agent_reference: "AgentReference"
@@ -5866,13 +6375,11 @@ class MemorySearchToolCallItemResource(TypedDict, total=False):
     :vartype response_id: str
     :ivar type: Required. MEMORY_SEARCH_CALL.
     :vartype type: Literal["memory_search_call"]
-    :ivar status: The status of the memory search tool call. One of ``in_progress``, ``searching``,
-     ``completed``, ``incomplete`` or ``failed``,. Required. Is one of the following types:
-     Literal["in_progress"], Literal["searching"], Literal["completed"], Literal["incomplete"],
-     Literal["failed"]
-    :vartype status: Literal["in_progress", "searching", "completed", "incomplete", "failed"]
-    :ivar results: The results returned from the memory search.
-    :vartype results: list["MemorySearchItem"]
+    :ivar status: The status of the tool call. Required. Known values are: "in_progress",
+     "completed", "incomplete", and "failed".
+    :vartype status: ToolCallStatus
+    :ivar memories: The results returned from the memory search.
+    :vartype memories: list["MemoryItem"]
     :ivar id: Required.
     :vartype id: str
     """
@@ -5883,12 +6390,10 @@ class MemorySearchToolCallItemResource(TypedDict, total=False):
     """The response on which the item is created."""
     type: Required[Literal["memory_search_call"]]
     """Required. MEMORY_SEARCH_CALL."""
-    status: Required[Literal["in_progress", "searching", "completed", "incomplete", "failed"]]
-    """The status of the memory search tool call. One of ``in_progress``, ``searching``,
-     ``completed``, ``incomplete`` or ``failed``,. Required. Is one of the following types:
-     Literal[\"in_progress\"], Literal[\"searching\"], Literal[\"completed\"],
-     Literal[\"incomplete\"], Literal[\"failed\"]"""
-    results: Optional[list["MemorySearchItem"]]
+    status: Required[ToolCallStatus]
+    """The status of the tool call. Required. Known values are: \"in_progress\", \"completed\",
+     \"incomplete\", and \"failed\"."""
+    memories: Optional[list["MemoryItem"]]
     """The results returned from the memory search."""
     id: Required[str]
     """Required."""
@@ -6049,10 +6554,6 @@ class MicrosoftFabricPreviewTool(TypedDict, total=False):
     :ivar type: The object type, which is always 'fabric_dataagent_preview'. Required.
      FABRIC_DATAAGENT_PREVIEW.
     :vartype type: Literal["fabric_dataagent_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar fabric_dataagent_preview: The fabric data agent tool parameters. Required.
     :vartype fabric_dataagent_preview: "FabricDataAgentToolParameters"
     """
@@ -6060,12 +6561,93 @@ class MicrosoftFabricPreviewTool(TypedDict, total=False):
     type: Required[Literal["fabric_dataagent_preview"]]
     """The object type, which is always 'fabric_dataagent_preview'. Required.
      FABRIC_DATAAGENT_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     fabric_dataagent_preview: Required["FabricDataAgentToolParameters"]
     """The fabric data agent tool parameters. Required."""
+
+
+class ModelRouterAttempt(TypedDict, total=False):
+    """A single routing attempt targeting a specific model.
+
+    :ivar model: The model targeted in this attempt. Required.
+    :vartype model: str
+    :ivar result: How this attempt concluded — whether the model served the request successfully or
+     encountered an error. Required.
+    :vartype result: "ModelRouterAttemptResult"
+    """
+
+    model: Required[str]
+    """The model targeted in this attempt. Required."""
+    result: Required["ModelRouterAttemptResult"]
+    """How this attempt concluded — whether the model served the request successfully or encountered
+     an error. Required."""
+
+
+class ModelRouterAttemptError(TypedDict, total=False):
+    """Error details returned by a model routing attempt.
+
+    :ivar code: A service-defined error code.
+    :vartype code: str
+    :ivar message: A human-readable description of the error. Required.
+    :vartype message: str
+    """
+
+    code: str
+    """A service-defined error code."""
+    message: Required[str]
+    """A human-readable description of the error. Required."""
+
+
+class ModelRouterAttemptResult(TypedDict, total=False):
+    """The HTTP-style result returned by a model routing attempt.
+
+    :ivar status: The HTTP status code returned by the model. Required.
+    :vartype status: int
+    :ivar headers: Response headers returned by the model.
+    :vartype headers: dict[str, "_unions.ModelRouterResponseHeaderValue"]
+    :ivar error: Error details returned when the attempt did not succeed.
+    :vartype error: "ModelRouterAttemptError"
+    """
+
+    status: Required[int]
+    """The HTTP status code returned by the model. Required."""
+    headers: dict[str, "_unions.ModelRouterResponseHeaderValue"]
+    """Response headers returned by the model."""
+    error: "ModelRouterAttemptError"
+    """Error details returned when the attempt did not succeed."""
+
+
+class ModelRouterDetails(TypedDict, total=False):
+    """Routing decision metadata from Model Router.
+
+    :ivar mode: The routing mode for the request. Required. Known values are: "balanced", "cost",
+     and "quality".
+    :vartype mode: ModelRouterMode
+    :ivar routing_trace: Ordered trace of routing decisions. Contains one entry for Chat
+     Completions, and may contain multiple entries for Responses API or agent scenarios where
+     multiple inference turns occur. Required.
+    :vartype routing_trace: list["RoutingTraceEntry"]
+    """
+
+    mode: Required[ModelRouterMode]
+    """The routing mode for the request. Required. Known values are: \"balanced\", \"cost\", and
+     \"quality\"."""
+    routing_trace: Required[list["RoutingTraceEntry"]]
+    """Ordered trace of routing decisions. Contains one entry for Chat Completions, and may contain
+     multiple entries for Responses API or agent scenarios where multiple inference turns occur.
+     Required."""
+
+
+class ModelSelectionDetails(TypedDict, total=False):
+    """Model selection metadata providing visibility into routing decisions.
+
+    :ivar model_router_details: Routing decision metadata from Model Router. Present when the
+     request was handled by Model Router. Required.
+    :vartype model_router_details: "ModelRouterDetails"
+    """
+
+    model_router_details: Required["ModelRouterDetails"]
+    """Routing decision metadata from Model Router. Present when the request was handled by Model
+     Router. Required."""
 
 
 class Moderation(TypedDict, total=False):
@@ -6380,12 +6962,17 @@ class OpenApiTool(TypedDict, total=False):
 
     :ivar type: The object type, which is always 'openapi'. Required. OPENAPI.
     :vartype type: Literal["openapi"]
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar openapi: The openapi function definition. Required.
     :vartype openapi: "OpenApiFunctionDefinition"
     """
 
     type: Required[Literal["openapi"]]
     """The object type, which is always 'openapi'. Required. OPENAPI."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     openapi: Required["OpenApiFunctionDefinition"]
     """The openapi function definition. Required."""
 
@@ -7688,6 +8275,35 @@ class OutputMessageContentRefusalContent(TypedDict, total=False):
     """The type of the refusal. Always ``refusal``. Required. REFUSAL."""
     refusal: Required[str]
     """The refusal explanation from the model. Required."""
+
+
+class ProceduralMemoryItem(TypedDict, total=False):
+    """A memory item containing a procedure extracted from conversations.
+
+    :ivar memory_id: The unique ID of the memory item. Required.
+    :vartype memory_id: str
+    :ivar updated_at: The last update time of the memory item. Required.
+    :vartype updated_at: int
+    :ivar scope: The namespace that logically groups and isolates memories, such as a user ID.
+     Required.
+    :vartype scope: str
+    :ivar content: The content of the memory. Required.
+    :vartype content: str
+    :ivar kind: The kind of the memory item. Required. Routine procedures extracted from
+     conversations.
+    :vartype kind: Literal["procedural"]
+    """
+
+    memory_id: Required[str]
+    """The unique ID of the memory item. Required."""
+    updated_at: Required[int]
+    """The last update time of the memory item. Required."""
+    scope: Required[str]
+    """The namespace that logically groups and isolates memories, such as a user ID. Required."""
+    content: Required[str]
+    """The content of the memory. Required."""
+    kind: Required[Literal["procedural"]]
+    """The kind of the memory item. Required. Routine procedures extracted from conversations."""
 
 
 class ProgrammaticToolCallingParam(TypedDict, total=False):
@@ -9051,6 +9667,11 @@ class ResponseObject(TypedDict, total=False):
     :vartype max_output_tokens: int
     :ivar agent_reference: The agent used for this response. Required.
     :vartype agent_reference: "AgentReference"
+    :ivar model_selection_details: Model selection metadata providing visibility into routing
+     decisions. Present when the request was handled by Model Router.
+    :vartype model_selection_details: "ModelSelectionDetails"
+    :ivar content_filters: The content filter evaluation results.
+    :vartype content_filters: list["ContentFilterResult"]
     """
 
     metadata: Optional["Metadata"]
@@ -9115,6 +9736,11 @@ class ResponseObject(TypedDict, total=False):
     max_output_tokens: Optional[int]
     agent_reference: Required[Optional["AgentReference"]]
     """The agent used for this response. Required."""
+    model_selection_details: "ModelSelectionDetails"
+    """Model selection metadata providing visibility into routing decisions. Present when the request
+     was handled by Model Router."""
+    content_filters: list["ContentFilterResult"]
+    """The content filter evaluation results."""
 
 
 class ResponseOutputItemAddedEvent(TypedDict, total=False):
@@ -9540,6 +10166,163 @@ class ResponseRefusalDoneEvent(TypedDict, total=False):
     """The sequence number of this event. Required."""
 
 
+class ResponseShellCallCommandAddedStreamingEvent(TypedDict, total=False):  # pylint: disable=name-too-long
+    """Response shell command added event.
+
+    :ivar type: The type of the event, always ``response.shell_call_command.added``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_ADDED.
+    :vartype type: Literal["response.shell_call_command.added"]
+    :ivar sequence_number: The sequence number of the event that was emitted. Required.
+    :vartype sequence_number: int
+    :ivar output_index: The index of the output item that was updated. Required.
+    :vartype output_index: int
+    :ivar command_index: The index of the shell command that was added. Required.
+    :vartype command_index: int
+    :ivar command: The shell command that was added. Required.
+    :vartype command: str
+    """
+
+    type: Required[Literal["response.shell_call_command.added"]]
+    """The type of the event, always ``response.shell_call_command.added``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_ADDED."""
+    sequence_number: Required[int]
+    """The sequence number of the event that was emitted. Required."""
+    output_index: Required[int]
+    """The index of the output item that was updated. Required."""
+    command_index: Required[int]
+    """The index of the shell command that was added. Required."""
+    command: Required[str]
+    """The shell command that was added. Required."""
+
+
+class ResponseShellCallCommandDeltaStreamingEvent(TypedDict, total=False):  # pylint: disable=name-too-long
+    """Response shell command delta event.
+
+    :ivar type: The type of the event, always ``response.shell_call_command.delta``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_DELTA.
+    :vartype type: Literal["response.shell_call_command.delta"]
+    :ivar sequence_number: The sequence number of the event that was emitted. Required.
+    :vartype sequence_number: int
+    :ivar output_index: The index of the output item that was updated. Required.
+    :vartype output_index: int
+    :ivar command_index: The index of the shell command that was updated. Required.
+    :vartype command_index: int
+    :ivar delta: The shell command delta that was appended. Required.
+    :vartype delta: str
+    :ivar obfuscation: An obfuscation string that was added to pad the event payload.
+    :vartype obfuscation: str
+    """
+
+    type: Required[Literal["response.shell_call_command.delta"]]
+    """The type of the event, always ``response.shell_call_command.delta``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_DELTA."""
+    sequence_number: Required[int]
+    """The sequence number of the event that was emitted. Required."""
+    output_index: Required[int]
+    """The index of the output item that was updated. Required."""
+    command_index: Required[int]
+    """The index of the shell command that was updated. Required."""
+    delta: Required[str]
+    """The shell command delta that was appended. Required."""
+    obfuscation: str
+    """An obfuscation string that was added to pad the event payload."""
+
+
+class ResponseShellCallCommandDoneStreamingEvent(TypedDict, total=False):  # pylint: disable=name-too-long
+    """Response shell command done event.
+
+    :ivar type: The type of the event, always ``response.shell_call_command.done``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_DONE.
+    :vartype type: Literal["response.shell_call_command.done"]
+    :ivar sequence_number: The sequence number of the event that was emitted. Required.
+    :vartype sequence_number: int
+    :ivar output_index: The index of the output item that was updated. Required.
+    :vartype output_index: int
+    :ivar command_index: The index of the shell command that was completed. Required.
+    :vartype command_index: int
+    :ivar command: The final shell command that was emitted. Required.
+    :vartype command: str
+    """
+
+    type: Required[Literal["response.shell_call_command.done"]]
+    """The type of the event, always ``response.shell_call_command.done``. Required.
+     RESPONSE_SHELL_CALL_COMMAND_DONE."""
+    sequence_number: Required[int]
+    """The sequence number of the event that was emitted. Required."""
+    output_index: Required[int]
+    """The index of the output item that was updated. Required."""
+    command_index: Required[int]
+    """The index of the shell command that was completed. Required."""
+    command: Required[str]
+    """The final shell command that was emitted. Required."""
+
+
+class ResponseShellCallOutputContentDeltaStreamingEvent(TypedDict, total=False):  # pylint: disable=name-too-long
+    """Response shell call output content delta event.
+
+    :ivar type: The type of the event, always ``response.shell_call_output_content.delta``.
+     Required. RESPONSE_SHELL_CALL_OUTPUT_CONTENT_DELTA.
+    :vartype type: Literal["response.shell_call_output_content.delta"]
+    :ivar sequence_number: The sequence number of the event that was emitted. Required.
+    :vartype sequence_number: int
+    :ivar item_id: The ID of the output item that was updated. Required.
+    :vartype item_id: str
+    :ivar output_index: The index of the output item that was updated. Required.
+    :vartype output_index: int
+    :ivar command_index: The index of the shell command that produced output. Required.
+    :vartype command_index: int
+    :ivar delta: The stdout/stderr delta that was emitted. Required.
+    :vartype delta: "ShellCallOutputDelta"
+    """
+
+    type: Required[Literal["response.shell_call_output_content.delta"]]
+    """The type of the event, always ``response.shell_call_output_content.delta``. Required.
+     RESPONSE_SHELL_CALL_OUTPUT_CONTENT_DELTA."""
+    sequence_number: Required[int]
+    """The sequence number of the event that was emitted. Required."""
+    item_id: Required[str]
+    """The ID of the output item that was updated. Required."""
+    output_index: Required[int]
+    """The index of the output item that was updated. Required."""
+    command_index: Required[int]
+    """The index of the shell command that produced output. Required."""
+    delta: Required["ShellCallOutputDelta"]
+    """The stdout/stderr delta that was emitted. Required."""
+
+
+class ResponseShellCallOutputContentDoneStreamingEvent(TypedDict, total=False):  # pylint: disable=name-too-long
+    """Response shell call output content done event.
+
+    :ivar type: The type of the event, always ``response.shell_call_output_content.done``.
+     Required. RESPONSE_SHELL_CALL_OUTPUT_CONTENT_DONE.
+    :vartype type: Literal["response.shell_call_output_content.done"]
+    :ivar sequence_number: The sequence number of the event that was emitted. Required.
+    :vartype sequence_number: int
+    :ivar item_id: The ID of the output item that was updated. Required.
+    :vartype item_id: str
+    :ivar output_index: The index of the output item that was updated. Required.
+    :vartype output_index: int
+    :ivar command_index: The index of the shell command that produced output. Required.
+    :vartype command_index: int
+    :ivar output: The output contents emitted for the shell command. Required.
+    :vartype output: list["FunctionShellCallOutputContent"]
+    """
+
+    type: Required[Literal["response.shell_call_output_content.done"]]
+    """The type of the event, always ``response.shell_call_output_content.done``. Required.
+     RESPONSE_SHELL_CALL_OUTPUT_CONTENT_DONE."""
+    sequence_number: Required[int]
+    """The sequence number of the event that was emitted. Required."""
+    item_id: Required[str]
+    """The ID of the output item that was updated. Required."""
+    output_index: Required[int]
+    """The index of the output item that was updated. Required."""
+    command_index: Required[int]
+    """The index of the shell command that produced output. Required."""
+    output: Required[list["FunctionShellCallOutputContent"]]
+    """The output contents emitted for the shell command. Required."""
+
+
 class ResponseStreamOptions(TypedDict, total=False):
     """Options for streaming responses. Only set this when you set ``stream: true``.
 
@@ -9786,6 +10569,30 @@ class ResponseWebSearchCallSearchingEvent(TypedDict, total=False):
     """The sequence number of the web search call being processed. Required."""
 
 
+class RoutingTraceEntry(TypedDict, total=False):
+    """A single entry in the routing trace representing one inference turn. Each entry contains the
+    latency and the ordered list of attempts for that turn.
+
+    :ivar output_id: Identifier of the output item/turn this routing decision is associated with.
+     This is omitted for Chat Completions.
+    :vartype output_id: str
+    :ivar latency_ms: Time in milliseconds spent in the routing decision for this turn. Required.
+    :vartype latency_ms: str
+    :ivar attempts: Ordered list of routing attempts. First element is the initial selection;
+     subsequent elements are fallback attempts. There is always at least one attempt. Required.
+    :vartype attempts: list["ModelRouterAttempt"]
+    """
+
+    output_id: str
+    """Identifier of the output item/turn this routing decision is associated with. This is omitted
+     for Chat Completions."""
+    latency_ms: Required[str]
+    """Time in milliseconds spent in the routing decision for this turn. Required."""
+    attempts: Required[list["ModelRouterAttempt"]]
+    """Ordered list of routing attempts. First element is the initial selection; subsequent elements
+     are fallback attempts. There is always at least one attempt. Required."""
+
+
 class ScreenshotParam(TypedDict, total=False):
     """Screenshot.
 
@@ -9910,19 +10717,11 @@ class SharepointGroundingToolCallOutput(TypedDict, total=False):
 class SharepointGroundingToolParameters(TypedDict, total=False):
     """The sharepoint grounding tool parameters.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connections: The project connections attached to this tool. There can be a
      maximum of 1 connection resource attached to the tool.
     :vartype project_connections: list["ToolProjectConnection"]
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connections: list["ToolProjectConnection"]
     """The project connections attached to this tool. There can be a maximum of 1 connection resource
      attached to the tool."""
@@ -9934,10 +10733,6 @@ class SharepointPreviewTool(TypedDict, total=False):
     :ivar type: The object type, which is always 'sharepoint_grounding_preview'. Required.
      SHAREPOINT_GROUNDING_PREVIEW.
     :vartype type: Literal["sharepoint_grounding_preview"]
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar sharepoint_grounding_preview: The sharepoint grounding tool parameters. Required.
     :vartype sharepoint_grounding_preview: "SharepointGroundingToolParameters"
     """
@@ -9945,12 +10740,23 @@ class SharepointPreviewTool(TypedDict, total=False):
     type: Required[Literal["sharepoint_grounding_preview"]]
     """The object type, which is always 'sharepoint_grounding_preview'. Required.
      SHAREPOINT_GROUNDING_PREVIEW."""
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     sharepoint_grounding_preview: Required["SharepointGroundingToolParameters"]
     """The sharepoint grounding tool parameters. Required."""
+
+
+class ShellCallOutputDelta(TypedDict, total=False):
+    """Shell call output delta.
+
+    :ivar stdout: The stdout delta that was emitted.
+    :vartype stdout: str
+    :ivar stderr: The stderr delta that was emitted.
+    :vartype stderr: str
+    """
+
+    stdout: str
+    """The stdout delta that was emitted."""
+    stderr: str
+    """The stderr delta that was emitted."""
 
 
 class SkillReferenceParam(TypedDict, total=False):
@@ -10321,22 +11127,35 @@ class ToolChoiceWebSearchPreview20250311(TypedDict, total=False):
     """Required. WEB_SEARCH_PREVIEW2025_03_11."""
 
 
+class ToolConfig(TypedDict, total=False):
+    """Per-tool configuration that controls tool visibility and search behavior.
+
+    :ivar pin: When true, the tool is always included in agent context and visible in
+     ``tools/list``. When false (default), the tool is hidden from ``tools/list`` and only
+     discoverable via ``tool_search``.
+    :vartype pin: bool
+    :ivar additional_search_text: Additional text indexed for tool_search. Supplements the native
+     tool description to improve discoverability. Does not alter ``tools/list`` output.
+    :vartype additional_search_text: str
+    """
+
+    pin: bool
+    """When true, the tool is always included in agent context and visible in ``tools/list``. When
+     false (default), the tool is hidden from ``tools/list`` and only discoverable via
+     ``tool_search``."""
+    additional_search_text: str
+    """Additional text indexed for tool_search. Supplements the native tool description to improve
+     discoverability. Does not alter ``tools/list`` output."""
+
+
 class ToolProjectConnection(TypedDict, total=False):
     """A project connection resource.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connection_id: A project connection in a ToolProjectConnectionList attached to
      this tool. Required.
     :vartype project_connection_id: str
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connection_id: Required[str]
     """A project connection in a ToolProjectConnectionList attached to this tool. Required."""
 
@@ -10542,6 +11361,34 @@ class WaitParam(TypedDict, total=False):
      WAIT."""
 
 
+class WebIQPreviewTool(TypedDict, total=False):
+    """A WebIQ server-side tool.
+
+    :ivar type: The object type, which is always 'web_iq_preview'. Required. WEB_IQ_PREVIEW.
+    :vartype type: Literal["web_iq_preview"]
+    :ivar project_connection_id: The ID of the WebIQ project connection. Required.
+    :vartype project_connection_id: str
+    :ivar server_label: The label of the WebIQ MCP server to connect to. When omitted, the service
+     defaults to connection name extracted from project_connection_id.
+    :vartype server_label: str
+    :ivar require_approval: Whether the agent requires approval before executing actions. When
+     omitted, the service defaults to "always". Is either a MCPToolRequireApproval type or a str
+     type.
+    :vartype require_approval: Union["MCPToolRequireApproval", str]
+    """
+
+    type: Required[Literal["web_iq_preview"]]
+    """The object type, which is always 'web_iq_preview'. Required. WEB_IQ_PREVIEW."""
+    project_connection_id: Required[str]
+    """The ID of the WebIQ project connection. Required."""
+    server_label: str
+    """The label of the WebIQ MCP server to connect to. When omitted, the service defaults to
+     connection name extracted from project_connection_id."""
+    require_approval: Optional[Union["MCPToolRequireApproval", str]]
+    """Whether the agent requires approval before executing actions. When omitted, the service
+     defaults to \"always\". Is either a MCPToolRequireApproval type or a str type."""
+
+
 class WebSearchActionFind(TypedDict, total=False):
     """Find action.
 
@@ -10642,10 +11489,6 @@ class WebSearchApproximateLocation(TypedDict, total=False):
 class WebSearchConfiguration(TypedDict, total=False):
     """A web search configuration for bing custom search.
 
-    :ivar name: Optional user-defined name for this tool or configuration.
-    :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
-    :vartype description: str
     :ivar project_connection_id: Project connection id for grounding with bing custom search.
      Required.
     :vartype project_connection_id: str
@@ -10653,10 +11496,6 @@ class WebSearchConfiguration(TypedDict, total=False):
     :vartype instance_name: str
     """
 
-    name: str
-    """Optional user-defined name for this tool or configuration."""
-    description: str
-    """Optional user-defined description for this tool or configuration."""
     project_connection_id: Required[str]
     """Project connection id for grounding with bing custom search. Required."""
     instance_name: Required[str]
@@ -10708,10 +11547,14 @@ class WebSearchTool(TypedDict, total=False):
      for the search. One of ``low``, ``medium``, or ``high``. ``medium`` is the default. Is one of
      the following types: Literal["low"], Literal["medium"], Literal["high"]
     :vartype search_context_size: Literal["low", "medium", "high"]
-    :ivar name: Optional user-defined name for this tool or configuration.
+    :ivar name: Deprecated. This property is deprecated and will be removed in a future version.
     :vartype name: str
-    :ivar description: Optional user-defined description for this tool or configuration.
+    :ivar description: Deprecated. This property is deprecated and will be removed in a future
+     version.
     :vartype description: str
+    :ivar tool_configs: Deprecated. This property is deprecated and will be removed in a future
+     version.
+    :vartype tool_configs: dict[str, "ToolConfig"]
     :ivar custom_search_configuration: The project connections attached to this tool. There can be
      a maximum of 1 connection resource attached to the tool.
     :vartype custom_search_configuration: "WebSearchConfiguration"
@@ -10730,9 +11573,11 @@ class WebSearchTool(TypedDict, total=False):
      ``low``, ``medium``, or ``high``. ``medium`` is the default. Is one of the following types:
      Literal[\"low\"], Literal[\"medium\"], Literal[\"high\"]"""
     name: str
-    """Optional user-defined name for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     description: str
-    """Optional user-defined description for this tool or configuration."""
+    """Deprecated. This property is deprecated and will be removed in a future version."""
+    tool_configs: dict[str, "ToolConfig"]
+    """Deprecated. This property is deprecated and will be removed in a future version."""
     custom_search_configuration: "WebSearchConfiguration"
     """The project connections attached to this tool. There can be a maximum of 1 connection resource
      attached to the tool."""
@@ -10800,57 +11645,169 @@ class WorkIQPreviewTool(TypedDict, total=False):
 
     :ivar type: The object type, which is always 'work_iq_preview'. Required. WORK_IQ_PREVIEW.
     :vartype type: Literal["work_iq_preview"]
-    :ivar work_iq_preview: The WorkIQ tool parameters. Required.
-    :vartype work_iq_preview: "WorkIQPreviewToolParameters"
-    """
-
-    type: Required[Literal["work_iq_preview"]]
-    """The object type, which is always 'work_iq_preview'. Required. WORK_IQ_PREVIEW."""
-    work_iq_preview: Required["WorkIQPreviewToolParameters"]
-    """The WorkIQ tool parameters. Required."""
-
-
-class WorkIQPreviewToolParameters(TypedDict, total=False):
-    """The WorkIQ tool parameters.
-
     :ivar project_connection_id: The ID of the WorkIQ project connection. Required.
     :vartype project_connection_id: str
     """
 
+    type: Required[Literal["work_iq_preview"]]
+    """The object type, which is always 'work_iq_preview'. Required. WORK_IQ_PREVIEW."""
     project_connection_id: Required[str]
     """The ID of the WorkIQ project connection. Required."""
+
+
+class CreateResponseRequest(TypedDict, total=False):
+    """CreateResponseRequest.
+
+    :ivar metadata:
+    :vartype metadata: "Metadata"
+    :ivar top_logprobs:
+    :vartype top_logprobs: int
+    :ivar temperature:
+    :vartype temperature: float
+    :ivar top_p:
+    :vartype top_p: float
+    :ivar user: This field is being replaced by ``safety_identifier`` and ``prompt_cache_key``. Use
+     ``prompt_cache_key`` instead to maintain caching optimizations. A stable identifier for your
+     end-users. Used to boost cache hit rates by better bucketing similar requests and  to help
+     OpenAI detect and prevent abuse. Learn more: /docs/guides/safety-best-practices#safety-identifiers.
+    :vartype user: str
+    :ivar safety_identifier:
+    :vartype safety_identifier: str
+    :ivar prompt_cache_key:
+    :vartype prompt_cache_key: str
+    :ivar prompt_cache_retention: Is either a Literal["in_memory"] type or a Literal["24h"] type.
+    :vartype prompt_cache_retention: Literal["in_memory", "24h"]
+    :ivar prompt_cache_options:
+    :vartype prompt_cache_options: "PromptCacheOptionsParam"
+    :ivar previous_response_id:
+    :vartype previous_response_id: str
+    :ivar model: The model deployment to use for the creation of this response.
+    :vartype model: str
+    :ivar background:
+    :vartype background: bool
+    :ivar max_tool_calls:
+    :vartype max_tool_calls: int
+    :ivar text:
+    :vartype text: "ResponseTextParam"
+    :ivar tools:
+    :vartype tools: list["Tool"]
+    :ivar tool_choice: Is either a types.ToolChoiceOptions type or a ToolChoiceParam type.
+    :vartype tool_choice: Union[ToolChoiceOptions, "ToolChoiceParam"]
+    :ivar prompt:
+    :vartype prompt: "Prompt"
+    :ivar service_tier: Is one of the following types: Literal["auto"], Literal["default"],
+     Literal["flex"], Literal["scale"], Literal["priority"], Literal["fast"], Literal["ultrafast"]
+    :vartype service_tier: Literal["auto", "default", "flex", "scale", "priority", "fast",
+     "ultrafast"]
+    :ivar truncation: Is either a Literal["auto"] type or a Literal["disabled"] type.
+    :vartype truncation: Literal["auto", "disabled"]
+    :ivar reasoning:
+    :vartype reasoning: "Reasoning"
+    :ivar input: Is either a str type or a [Item] type.
+    :vartype input: "_unions.InputParam"
+    :ivar include:
+    :vartype include: list[IncludeEnum]
+    :ivar parallel_tool_calls:
+    :vartype parallel_tool_calls: bool
+    :ivar store:
+    :vartype store: bool
+    :ivar instructions:
+    :vartype instructions: str
+    :ivar moderation:
+    :vartype moderation: "ModerationParam"
+    :ivar stream:
+    :vartype stream: bool
+    :ivar stream_options:
+    :vartype stream_options: "ResponseStreamOptions"
+    :ivar conversation: Is either a str type or a ConversationParam_2 type.
+    :vartype conversation: "_unions.ConversationParam"
+    :ivar context_management: Context management configuration for this request.
+    :vartype context_management: list["ContextManagementParam"]
+    :ivar max_output_tokens:
+    :vartype max_output_tokens: int
+    :ivar agent_session_id: Optional session identifier for sandbox affinity. Currently only
+     relevant for hosted agents. When provided, the request is routed to the same sandbox. When
+     omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated.
+    :vartype agent_session_id: str
+    :ivar agent_reference: The agent to use for generating the response.
+    :vartype agent_reference: "AgentReference"
+    :ivar structured_inputs: The structured inputs to the response that can participate in prompt
+     template substitution or tool argument bindings.
+    :vartype structured_inputs: dict[str, Any]
+    :ivar user_security_context: User security context contains several parameters that describe
+     the application itself, and the end user that interacts with the application. These fields
+     assist your security operations teams to investigate and mitigate security incidents by
+     providing a comprehensive approach to protecting your AI applications. Learn more: https://aka.ms/TP4AI/Documentation/EndUserContext about protecting AI applications using
+     Microsoft Defender for Cloud.
+    :vartype user_security_context: "AzureUserSecurityContext"
+    """
+
+    metadata: Optional["Metadata"]
+    top_logprobs: Optional[int]
+    temperature: Optional[float]
+    top_p: Optional[float]
+    user: str
+    """This field is being replaced by ``safety_identifier`` and ``prompt_cache_key``. Use
+     ``prompt_cache_key`` instead to maintain caching optimizations. A stable identifier for your
+     end-users. Used to boost cache hit rates by better bucketing similar requests and  to help
+     OpenAI detect and prevent abuse. Learn more: /docs/guides/safety-best-practices#safety-identifiers."""
+    safety_identifier: Optional[str]
+    prompt_cache_key: Optional[str]
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]]
+    """Is either a Literal[\"in_memory\"] type or a Literal[\"24h\"] type."""
+    prompt_cache_options: "PromptCacheOptionsParam"
+    previous_response_id: Optional[str]
+    model: str
+    """The model deployment to use for the creation of this response."""
+    background: Optional[bool]
+    max_tool_calls: Optional[int]
+    text: "ResponseTextParam"
+    tools: list["Tool"]
+    tool_choice: Union[ToolChoiceOptions, "ToolChoiceParam"]
+    """Is either a types.ToolChoiceOptions type or a ToolChoiceParam type."""
+    prompt: "Prompt"
+    service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"]]
+    """Is one of the following types: Literal[\"auto\"], Literal[\"default\"], Literal[\"flex\"],
+     Literal[\"scale\"], Literal[\"priority\"], Literal[\"fast\"], Literal[\"ultrafast\"]"""
+    truncation: Optional[Literal["auto", "disabled"]]
+    """Is either a Literal[\"auto\"] type or a Literal[\"disabled\"] type."""
+    reasoning: Optional["Reasoning"]
+    input: "_unions.InputParam"
+    """Is either a str type or a [Item] type."""
+    include: Optional[list[IncludeEnum]]
+    parallel_tool_calls: Optional[bool]
+    store: Optional[bool]
+    instructions: Optional[str]
+    moderation: Optional["ModerationParam"]
+    stream: Optional[bool]
+    stream_options: Optional["ResponseStreamOptions"]
+    conversation: Optional["_unions.ConversationParam"]
+    """Is either a str type or a ConversationParam_2 type."""
+    context_management: Optional[list["ContextManagementParam"]]
+    """Context management configuration for this request."""
+    max_output_tokens: Optional[int]
+    agent_session_id: str
+    """Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+     When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+     conversation_id/prev_response_id or a new UUID is generated."""
+    agent_reference: "AgentReference"
+    """The agent to use for generating the response."""
+    structured_inputs: dict[str, Any]
+    """The structured inputs to the response that can participate in prompt template substitution or
+     tool argument bindings."""
+    user_security_context: "AzureUserSecurityContext"
+    """User security context contains several parameters that describe the application itself, and the
+     end user that interacts with the application. These fields assist your security operations
+     teams to investigate and mitigate security incidents by providing a comprehensive approach to
+     protecting your AI applications. Learn more: https://aka.ms/TP4AI/Documentation/EndUserContext about protecting AI applications using
+     Microsoft Defender for Cloud."""
 
 
 class CompactResponseMethodPublicBody(TypedDict, total=False):
     """CompactResponseMethodPublicBody.
 
-    :ivar model: Required. Known values are: "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
-     "gpt-5.5", "gpt-5.5-2026-04-23", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
-     "gpt-5.4-mini-2026-03-17", "gpt-5.4-nano-2026-03-17", "gpt-5.3-chat-latest", "gpt-5.2",
-     "gpt-5.2-2025-12-11", "gpt-5.2-chat-latest", "gpt-5.2-pro", "gpt-5.2-pro-2025-12-11",
-     "gpt-5.1", "gpt-5.1-2025-11-13", "gpt-5.1-codex", "gpt-5.1-mini", "gpt-5.1-chat-latest",
-     "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-2025-08-07", "gpt-5-mini-2025-08-07",
-     "gpt-5-nano-2025-08-07", "gpt-5-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
-     "gpt-4.1-2025-04-14", "gpt-4.1-mini-2025-04-14", "gpt-4.1-nano-2025-04-14", "o4-mini",
-     "o4-mini-2025-04-16", "o3", "o3-2025-04-16", "o3-mini", "o3-mini-2025-01-31", "o1",
-     "o1-2024-12-17", "o1-preview", "o1-preview-2024-09-12", "o1-mini", "o1-mini-2024-09-12",
-     "gpt-4o", "gpt-4o-2024-11-20", "gpt-4o-2024-08-06", "gpt-4o-2024-05-13",
-     "gpt-4o-audio-preview", "gpt-4o-audio-preview-2024-10-01", "gpt-4o-audio-preview-2024-12-17",
-     "gpt-4o-audio-preview-2025-06-03", "gpt-4o-mini-audio-preview",
-     "gpt-4o-mini-audio-preview-2024-12-17", "gpt-4o-search-preview", "gpt-4o-mini-search-preview",
-     "gpt-4o-search-preview-2025-03-11", "gpt-4o-mini-search-preview-2025-03-11",
-     "chatgpt-4o-latest", "codex-mini-latest", "gpt-4o-mini", "gpt-4o-mini-2024-07-18",
-     "gpt-4-turbo", "gpt-4-turbo-2024-04-09", "gpt-4-0125-preview", "gpt-4-turbo-preview",
-     "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "gpt-4-0314", "gpt-4-0613", "gpt-4-32k",
-     "gpt-4-32k-0314", "gpt-4-32k-0613", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0301",
-     "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125", "gpt-3.5-turbo-16k-0613",
-     "o1-pro", "o1-pro-2025-03-19", "o3-pro", "o3-pro-2025-06-10", "o3-deep-research",
-     "o3-deep-research-2025-06-26", "o4-mini-deep-research", "o4-mini-deep-research-2025-06-26",
-     "computer-use-preview", "computer-use-preview-2025-03-11", "gpt-5.5-pro",
-     "gpt-5.5-pro-2026-04-23", "gpt-5-codex", "gpt-5-pro", "gpt-5-pro-2025-10-06",
-     "gpt-5.1-codex-max", "gpt-daybreak-blue-latest", "gpt-daybreak-red-latest", and
-     "gpt-5.6-cyber".
-    :vartype model: ModelIdsCompaction
+    :ivar model: The model deployment to use for the compaction of this response. Required.
+    :vartype model: str
     :ivar input: Is either a str type or a [Item] type.
     :vartype input: Union[str, list["Item"]]
     :ivar previous_response_id:
@@ -10867,35 +11824,8 @@ class CompactResponseMethodPublicBody(TypedDict, total=False):
     :vartype service_tier: ServiceTierEnum
     """
 
-    model: Required[Optional[ModelIdsCompaction]]
-    """Required. Known values are: \"gpt-5.6-sol\", \"gpt-5.6-terra\", \"gpt-5.6-luna\", \"gpt-5.5\",
-     \"gpt-5.5-2026-04-23\", \"gpt-5.4\", \"gpt-5.4-mini\", \"gpt-5.4-nano\",
-     \"gpt-5.4-mini-2026-03-17\", \"gpt-5.4-nano-2026-03-17\", \"gpt-5.3-chat-latest\", \"gpt-5.2\",
-     \"gpt-5.2-2025-12-11\", \"gpt-5.2-chat-latest\", \"gpt-5.2-pro\", \"gpt-5.2-pro-2025-12-11\",
-     \"gpt-5.1\", \"gpt-5.1-2025-11-13\", \"gpt-5.1-codex\", \"gpt-5.1-mini\",
-     \"gpt-5.1-chat-latest\", \"gpt-5\", \"gpt-5-mini\", \"gpt-5-nano\", \"gpt-5-2025-08-07\",
-     \"gpt-5-mini-2025-08-07\", \"gpt-5-nano-2025-08-07\", \"gpt-5-chat-latest\", \"gpt-4.1\",
-     \"gpt-4.1-mini\", \"gpt-4.1-nano\", \"gpt-4.1-2025-04-14\", \"gpt-4.1-mini-2025-04-14\",
-     \"gpt-4.1-nano-2025-04-14\", \"o4-mini\", \"o4-mini-2025-04-16\", \"o3\", \"o3-2025-04-16\",
-     \"o3-mini\", \"o3-mini-2025-01-31\", \"o1\", \"o1-2024-12-17\", \"o1-preview\",
-     \"o1-preview-2024-09-12\", \"o1-mini\", \"o1-mini-2024-09-12\", \"gpt-4o\",
-     \"gpt-4o-2024-11-20\", \"gpt-4o-2024-08-06\", \"gpt-4o-2024-05-13\", \"gpt-4o-audio-preview\",
-     \"gpt-4o-audio-preview-2024-10-01\", \"gpt-4o-audio-preview-2024-12-17\",
-     \"gpt-4o-audio-preview-2025-06-03\", \"gpt-4o-mini-audio-preview\",
-     \"gpt-4o-mini-audio-preview-2024-12-17\", \"gpt-4o-search-preview\",
-     \"gpt-4o-mini-search-preview\", \"gpt-4o-search-preview-2025-03-11\",
-     \"gpt-4o-mini-search-preview-2025-03-11\", \"chatgpt-4o-latest\", \"codex-mini-latest\",
-     \"gpt-4o-mini\", \"gpt-4o-mini-2024-07-18\", \"gpt-4-turbo\", \"gpt-4-turbo-2024-04-09\",
-     \"gpt-4-0125-preview\", \"gpt-4-turbo-preview\", \"gpt-4-1106-preview\",
-     \"gpt-4-vision-preview\", \"gpt-4\", \"gpt-4-0314\", \"gpt-4-0613\", \"gpt-4-32k\",
-     \"gpt-4-32k-0314\", \"gpt-4-32k-0613\", \"gpt-3.5-turbo\", \"gpt-3.5-turbo-16k\",
-     \"gpt-3.5-turbo-0301\", \"gpt-3.5-turbo-0613\", \"gpt-3.5-turbo-1106\", \"gpt-3.5-turbo-0125\",
-     \"gpt-3.5-turbo-16k-0613\", \"o1-pro\", \"o1-pro-2025-03-19\", \"o3-pro\",
-     \"o3-pro-2025-06-10\", \"o3-deep-research\", \"o3-deep-research-2025-06-26\",
-     \"o4-mini-deep-research\", \"o4-mini-deep-research-2025-06-26\", \"computer-use-preview\",
-     \"computer-use-preview-2025-03-11\", \"gpt-5.5-pro\", \"gpt-5.5-pro-2026-04-23\",
-     \"gpt-5-codex\", \"gpt-5-pro\", \"gpt-5-pro-2025-10-06\", \"gpt-5.1-codex-max\",
-     \"gpt-daybreak-blue-latest\", \"gpt-daybreak-red-latest\", and \"gpt-5.6-cyber\"."""
+    model: Required[str]
+    """The model deployment to use for the compaction of this response. Required."""
     input: Optional[Union[str, list["Item"]]]
     """Is either a str type or a [Item] type."""
     previous_response_id: Optional[str]
@@ -10909,6 +11839,7 @@ class CompactResponseMethodPublicBody(TypedDict, total=False):
 
 
 Tool = Union[
+    A2ATool,
     A2APreviewTool,
     ApplyPatchToolParam,
     AzureAISearchTool,
@@ -10922,6 +11853,7 @@ Tool = Union[
     ComputerUsePreviewTool,
     CustomToolParam,
     MicrosoftFabricPreviewTool,
+    FabricIQPreviewTool,
     FileSearchTool,
     FunctionTool,
     ImageGenTool,
@@ -10934,6 +11866,7 @@ Tool = Union[
     SharepointPreviewTool,
     FunctionShellToolParam,
     ToolSearchToolParam,
+    WebIQPreviewTool,
     WebSearchTool,
     WebSearchPreviewTool,
     WorkIQPreviewTool,
@@ -10972,7 +11905,9 @@ OutputItem = Union[
     OutputItemMcpApprovalResponseResource,
     OutputItemMcpToolCall,
     OutputItemMcpListTools,
-    MemorySearchToolCallItemResource,
+    MemoryCommandToolCall,
+    MemoryCommandToolCallOutput,
+    MemorySearchToolCall,
     OutputItemMessage,
     OAuthConsentRequestOutputItem,
     OpenApiToolCall,
@@ -11012,7 +11947,6 @@ Item = Union[
     MCPApprovalResponse,
     ItemMcpToolCall,
     ItemMcpListTools,
-    MemorySearchToolCallItemParam,
     ItemMessage,
     ItemOutputMessage,
     ItemProgram,
@@ -11031,7 +11965,7 @@ ApplyPatchFileOperation = Union[
 ApplyPatchOperationParam = Union[
     ApplyPatchCreateFileOperationParam, ApplyPatchDeleteFileOperationParam, ApplyPatchUpdateFileOperationParam
 ]
-MemoryItem = Union[ChatSummaryMemoryItem, UserProfileMemoryItem]
+MemoryItem = Union[ChatSummaryMemoryItem, ProceduralMemoryItem, UserProfileMemoryItem]
 ComputerAction = Union[
     ClickParam,
     DoubleClickAction,
@@ -11164,6 +12098,11 @@ ResponseStreamEvent = Union[
     ResponseReasoningTextDoneEvent,
     ResponseRefusalDeltaEvent,
     ResponseRefusalDoneEvent,
+    ResponseShellCallCommandAddedStreamingEvent,
+    ResponseShellCallCommandDeltaStreamingEvent,
+    ResponseShellCallCommandDoneStreamingEvent,
+    ResponseShellCallOutputContentDeltaStreamingEvent,
+    ResponseShellCallOutputContentDoneStreamingEvent,
     ResponseWebSearchCallCompletedEvent,
     ResponseWebSearchCallInProgressEvent,
     ResponseWebSearchCallSearchingEvent,

--- a/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_request_validators.py
+++ b/sdk/agentserver/azure-ai-agentserver-responses/azure/ai/agentserver/responses/models/_request_validators.py
@@ -156,6 +156,8 @@ def _validate_CreateResponse(value: Any, path: str, errors: list[dict[str, str]]
         _validate_CreateResponse_truncation(value['truncation'], f"{path}.truncation", errors)
     if 'user' in value:
         _validate_CreateResponse_user(value['user'], f"{path}.user", errors)
+    if 'user_security_context' in value:
+        _validate_CreateResponse_user_security_context(value['user_security_context'], f"{path}.user_security_context", errors)
 
 def _validate_CreateResponse_agent(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_CreateResponse_agent_all_of_0(value, path, errors)
@@ -214,6 +216,7 @@ def _validate_CreateResponse_max_output_tokens(value: Any, path: str, errors: li
     if not _is_type(value, 'integer'):
         _append_type_mismatch(errors, path, 'integer', value)
         return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_CreateResponse_metadata(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if value is None:
@@ -297,6 +300,7 @@ def _validate_CreateResponse_temperature(value: Any, path: str, errors: list[dic
     if not _is_type(value, 'number'):
         _append_type_mismatch(errors, path, 'number', value)
         return
+    _validate_CreateResponse_temperature_all_of_0(value, path, errors)
 
 def _validate_CreateResponse_text(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_ResponseTextParam(value, path, errors)
@@ -343,6 +347,9 @@ def _validate_CreateResponse_user(value: Any, path: str, errors: list[dict[str, 
         _append_type_mismatch(errors, path, 'string', value)
         return
 
+def _validate_CreateResponse_user_security_context(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_CreateResponse_user_security_context_all_of_0(value, path, errors)
+
 def _validate_CreateResponse_agent_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_AgentReference(value, path, errors)
 
@@ -383,6 +390,9 @@ def _validate_OpenAI_InputParam(value: Any, path: str, errors: list[dict[str, st
             return
         _append_error(errors, path, f"Expected one of: string, array; got {_type_label(value)}")
         return
+
+def _validate_CreateResponse_max_output_tokens_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_OpenAI_integer(value, path, errors)
 
 def _validate_CreateResponse_metadata_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_Metadata(value, path, errors)
@@ -435,6 +445,9 @@ def _validate_CreateResponse_stream_options_all_of_0(value: Any, path: str, erro
 
 def _validate_CreateResponse_structured_inputs_additional_property(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     return
+
+def _validate_CreateResponse_temperature_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_OpenAI_numeric(value, path, errors)
 
 def _validate_OpenAI_ResponseTextParam(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -524,6 +537,9 @@ def _validate_OpenAI_ToolsArray(value: Any, path: str, errors: list[dict[str, st
     for _idx, _item in enumerate(value):
         _validate_OpenAI_ToolsArray_item(_item, f"{path}[{_idx}]", errors)
 
+def _validate_CreateResponse_user_security_context_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_AzureUserSecurityContext(value, path, errors)
+
 def _validate_AgentReference(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -599,6 +615,11 @@ def _validate_OpenAI_InputParam_array(value: Any, path: str, errors: list[dict[s
     for _idx, _item in enumerate(value):
         _validate_OpenAI_InputParam_array_item(_item, f"{path}[{_idx}]", errors)
 
+def _validate_OpenAI_integer(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'integer'):
+        _append_type_mismatch(errors, path, 'integer', value)
+        return
+
 def _validate_OpenAI_Metadata(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -658,6 +679,11 @@ def _validate_OpenAI_ResponseStreamOptions(value: Any, path: str, errors: list[d
         return
     if 'include_obfuscation' in value:
         _validate_OpenAI_ResponseStreamOptions_include_obfuscation(value['include_obfuscation'], f"{path}.include_obfuscation", errors)
+
+def _validate_OpenAI_numeric(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'number'):
+        _append_type_mismatch(errors, path, 'number', value)
+        return
 
 def _validate_OpenAI_ResponseTextParam_format(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_TextResponseFormatConfiguration(value, path, errors)
@@ -837,6 +863,19 @@ def _validate_OpenAI_ToolChoiceWebSearchPreview20250311(value: Any, path: str, e
 
 def _validate_OpenAI_ToolsArray_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_Tool(value, path, errors)
+
+def _validate_AzureUserSecurityContext(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'application_name' in value:
+        _validate_AzureUserSecurityContext_application_name(value['application_name'], f"{path}.application_name", errors)
+    if 'end_user_id' in value:
+        _validate_AzureUserSecurityContext_end_user_id(value['end_user_id'], f"{path}.end_user_id", errors)
+    if 'end_user_tenant_id' in value:
+        _validate_AzureUserSecurityContext_end_user_tenant_id(value['end_user_tenant_id'], f"{path}.end_user_tenant_id", errors)
+    if 'source_ip' in value:
+        _validate_AzureUserSecurityContext_source_ip(value['source_ip'], f"{path}.source_ip", errors)
 
 def _validate_AgentReference_name(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -1151,6 +1190,9 @@ def _validate_OpenAI_Tool(value: Any, path: str, errors: list[dict[str, str]]) -
     if not isinstance(_disc_value, str):
         _append_error(errors, f"{path}.type", "Required discriminator 'type' is missing or invalid")
         return
+    if _disc_value == 'a2a':
+        _validate_A2ATool(value, path, errors)
+        return
     if _disc_value == 'a2a_preview':
         _validate_A2APreviewTool(value, path, errors)
         return
@@ -1189,6 +1231,9 @@ def _validate_OpenAI_Tool(value: Any, path: str, errors: list[dict[str, str]]) -
         return
     if _disc_value == 'fabric_dataagent_preview':
         _validate_MicrosoftFabricPreviewTool(value, path, errors)
+        return
+    if _disc_value == 'fabric_iq_preview':
+        _validate_FabricIQPreviewTool(value, path, errors)
         return
     if _disc_value == 'file_search':
         _validate_OpenAI_FileSearchTool(value, path, errors)
@@ -1229,6 +1274,9 @@ def _validate_OpenAI_Tool(value: Any, path: str, errors: list[dict[str, str]]) -
     if _disc_value == 'tool_search':
         _validate_OpenAI_ToolSearchToolParam(value, path, errors)
         return
+    if _disc_value == 'web_iq_preview':
+        _validate_WebIQPreviewTool(value, path, errors)
+        return
     if _disc_value == 'web_search':
         _validate_OpenAI_WebSearchTool(value, path, errors)
         return
@@ -1238,7 +1286,27 @@ def _validate_OpenAI_Tool(value: Any, path: str, errors: list[dict[str, str]]) -
     if _disc_value == 'work_iq_preview':
         _validate_WorkIQPreviewTool(value, path, errors)
         return
-    _append_error(errors, f"{path}.type", f"Invalid discriminator '{_disc_value}'. Allowed: a2a_preview, apply_patch, azure_ai_search, azure_function, bing_custom_search_preview, bing_grounding, browser_automation_preview, capture_structured_outputs, code_interpreter, computer, computer_use_preview, custom, fabric_dataagent_preview, file_search, function, image_generation, local_shell, mcp, memory_search, memory_search_preview, namespace, openapi, programmatic_tool_calling, sharepoint_grounding_preview, shell, tool_search, web_search, web_search_preview, work_iq_preview")
+    _append_error(errors, f"{path}.type", f"Invalid discriminator '{_disc_value}'. Allowed: a2a, a2a_preview, apply_patch, azure_ai_search, azure_function, bing_custom_search_preview, bing_grounding, browser_automation_preview, capture_structured_outputs, code_interpreter, computer, computer_use_preview, custom, fabric_dataagent_preview, fabric_iq_preview, file_search, function, image_generation, local_shell, mcp, memory_search, memory_search_preview, namespace, openapi, programmatic_tool_calling, sharepoint_grounding_preview, shell, tool_search, web_iq_preview, web_search, web_search_preview, work_iq_preview")
+
+def _validate_AzureUserSecurityContext_application_name(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_AzureUserSecurityContext_end_user_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_AzureUserSecurityContext_end_user_tenant_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_AzureUserSecurityContext_source_ip(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
 
 def _validate_OpenAI_ConversationParam_2_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -1317,9 +1385,6 @@ def _validate_OpenAI_Item(value: Any, path: str, errors: list[dict[str, str]]) -
     if _disc_value == 'mcp_list_tools':
         _validate_OpenAI_ItemMcpListTools(value, path, errors)
         return
-    if _disc_value == 'memory_search_call':
-        _validate_MemorySearchToolCallItemParam(value, path, errors)
-        return
     if _disc_value == 'message':
         _validate_OpenAI_ItemMessage(value, path, errors)
         return
@@ -1350,7 +1415,7 @@ def _validate_OpenAI_Item(value: Any, path: str, errors: list[dict[str, str]]) -
     if _disc_value == 'web_search_call':
         _validate_OpenAI_ItemWebSearchToolCall(value, path, errors)
         return
-    _append_error(errors, f"{path}.type", f"Invalid discriminator '{_disc_value}'. Allowed: additional_tools, apply_patch_call, apply_patch_call_output, code_interpreter_call, compaction, computer_call, computer_call_output, custom_tool_call, custom_tool_call_output, file_search_call, function_call, function_call_output, image_generation_call, item_reference, local_shell_call, local_shell_call_output, mcp_approval_request, mcp_approval_response, mcp_call, mcp_list_tools, memory_search_call, message, output_message, program, program_output, reasoning, shell_call, shell_call_output, tool_search_call, tool_search_output, web_search_call")
+    _append_error(errors, f"{path}.type", f"Invalid discriminator '{_disc_value}'. Allowed: additional_tools, apply_patch_call, apply_patch_call_output, code_interpreter_call, compaction, computer_call, computer_call_output, custom_tool_call, custom_tool_call_output, file_search_call, function_call, function_call_output, image_generation_call, item_reference, local_shell_call, local_shell_call_output, mcp_approval_request, mcp_approval_response, mcp_call, mcp_list_tools, message, output_message, program, program_output, reasoning, shell_call, shell_call_output, tool_search_call, tool_search_output, web_search_call")
 
 def _validate_OpenAI_ModerationParam_policy_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_ModerationPolicyParam(value, path, errors)
@@ -1468,6 +1533,27 @@ def _validate_OpenAI_Tool_type(value: Any, path: str, errors: list[dict[str, str
         return
     _validate_OpenAI_ToolType(value, path, errors)
 
+def _validate_A2ATool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'type' not in value:
+        _append_error(errors, f"{path}.type", "Required property 'type' is missing")
+    if 'a2a_version' not in value:
+        _append_error(errors, f"{path}.a2a_version", "Required property 'a2a_version' is missing")
+    if 'a2a_version' in value:
+        _validate_A2ATool_a2a_version(value['a2a_version'], f"{path}.a2a_version", errors)
+    if 'agent_card_path' in value:
+        _validate_A2ATool_agent_card_path(value['agent_card_path'], f"{path}.agent_card_path", errors)
+    if 'base_url' in value:
+        _validate_A2ATool_base_url(value['base_url'], f"{path}.base_url", errors)
+    if 'project_connection_id' in value:
+        _validate_A2ATool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
+    if 'send_credentials_for_agent_card' in value:
+        _validate_A2ATool_send_credentials_for_agent_card(value['send_credentials_for_agent_card'], f"{path}.send_credentials_for_agent_card", errors)
+    if 'type' in value:
+        _validate_A2ATool_type(value['type'], f"{path}.type", errors)
+
 def _validate_A2APreviewTool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -1475,15 +1561,13 @@ def _validate_A2APreviewTool(value: Any, path: str, errors: list[dict[str, str]]
     if 'type' not in value:
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
     if 'agent_card_path' in value:
-        _validate_A2APreviewTool_agent_card_path(value['agent_card_path'], f"{path}.agent_card_path", errors)
+        _validate_A2ATool_agent_card_path(value['agent_card_path'], f"{path}.agent_card_path", errors)
     if 'base_url' in value:
-        _validate_A2APreviewTool_base_url(value['base_url'], f"{path}.base_url", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_A2ATool_base_url(value['base_url'], f"{path}.base_url", errors)
     if 'project_connection_id' in value:
-        _validate_A2APreviewTool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
+        _validate_A2ATool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
+    if 'send_credentials_for_agent_card' in value:
+        _validate_A2ATool_send_credentials_for_agent_card(value['send_credentials_for_agent_card'], f"{path}.send_credentials_for_agent_card", errors)
     if 'type' in value:
         _validate_A2APreviewTool_type(value['type'], f"{path}.type", errors)
 
@@ -1509,9 +1593,11 @@ def _validate_AzureAISearchTool(value: Any, path: str, errors: list[dict[str, st
     if 'azure_ai_search' in value:
         _validate_AzureAISearchTool_azure_ai_search(value['azure_ai_search'], f"{path}.azure_ai_search", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_AzureAISearchTool_type(value['type'], f"{path}.type", errors)
 
@@ -1525,6 +1611,8 @@ def _validate_AzureFunctionTool(value: Any, path: str, errors: list[dict[str, st
         _append_error(errors, f"{path}.azure_function", "Required property 'azure_function' is missing")
     if 'azure_function' in value:
         _validate_AzureFunctionTool_azure_function(value['azure_function'], f"{path}.azure_function", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_AzureFunctionTool_type(value['type'], f"{path}.type", errors)
 
@@ -1538,10 +1626,6 @@ def _validate_BingCustomSearchPreviewTool(value: Any, path: str, errors: list[di
         _append_error(errors, f"{path}.bing_custom_search_preview", "Required property 'bing_custom_search_preview' is missing")
     if 'bing_custom_search_preview' in value:
         _validate_BingCustomSearchPreviewTool_bing_custom_search_preview(value['bing_custom_search_preview'], f"{path}.bing_custom_search_preview", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'type' in value:
         _validate_BingCustomSearchPreviewTool_type(value['type'], f"{path}.type", errors)
 
@@ -1556,9 +1640,11 @@ def _validate_BingGroundingTool(value: Any, path: str, errors: list[dict[str, st
     if 'bing_grounding' in value:
         _validate_BingGroundingTool_bing_grounding(value['bing_grounding'], f"{path}.bing_grounding", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_BingGroundingTool_type(value['type'], f"{path}.type", errors)
 
@@ -1572,10 +1658,6 @@ def _validate_BrowserAutomationPreviewTool(value: Any, path: str, errors: list[d
         _append_error(errors, f"{path}.browser_automation_preview", "Required property 'browser_automation_preview' is missing")
     if 'browser_automation_preview' in value:
         _validate_BrowserAutomationPreviewTool_browser_automation_preview(value['browser_automation_preview'], f"{path}.browser_automation_preview", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'type' in value:
         _validate_BrowserAutomationPreviewTool_type(value['type'], f"{path}.type", errors)
 
@@ -1587,8 +1669,14 @@ def _validate_CaptureStructuredOutputsTool(value: Any, path: str, errors: list[d
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
     if 'outputs' not in value:
         _append_error(errors, f"{path}.outputs", "Required property 'outputs' is missing")
+    if 'description' in value:
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
+    if 'name' in value:
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
     if 'outputs' in value:
         _validate_CaptureStructuredOutputsTool_outputs(value['outputs'], f"{path}.outputs", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_CaptureStructuredOutputsTool_type(value['type'], f"{path}.type", errors)
 
@@ -1603,9 +1691,11 @@ def _validate_OpenAI_CodeInterpreterTool(value: Any, path: str, errors: list[dic
     if 'container' in value:
         _validate_OpenAI_CodeInterpreterTool_container(value['container'], f"{path}.container", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_CodeInterpreterTool_type(value['type'], f"{path}.type", errors)
 
@@ -1668,14 +1758,29 @@ def _validate_MicrosoftFabricPreviewTool(value: Any, path: str, errors: list[dic
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
     if 'fabric_dataagent_preview' not in value:
         _append_error(errors, f"{path}.fabric_dataagent_preview", "Required property 'fabric_dataagent_preview' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'fabric_dataagent_preview' in value:
         _validate_MicrosoftFabricPreviewTool_fabric_dataagent_preview(value['fabric_dataagent_preview'], f"{path}.fabric_dataagent_preview", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'type' in value:
         _validate_MicrosoftFabricPreviewTool_type(value['type'], f"{path}.type", errors)
+
+def _validate_FabricIQPreviewTool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'type' not in value:
+        _append_error(errors, f"{path}.type", "Required property 'type' is missing")
+    if 'project_connection_id' not in value:
+        _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
+    if 'project_connection_id' in value:
+        _validate_FabricIQPreviewTool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
+    if 'require_approval' in value:
+        _validate_FabricIQPreviewTool_require_approval(value['require_approval'], f"{path}.require_approval", errors)
+    if 'server_label' in value:
+        _validate_FabricIQPreviewTool_server_label(value['server_label'], f"{path}.server_label", errors)
+    if 'server_url' in value:
+        _validate_FabricIQPreviewTool_server_url(value['server_url'], f"{path}.server_url", errors)
+    if 'type' in value:
+        _validate_FabricIQPreviewTool_type(value['type'], f"{path}.type", errors)
 
 def _validate_OpenAI_FileSearchTool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -1686,15 +1791,17 @@ def _validate_OpenAI_FileSearchTool(value: Any, path: str, errors: list[dict[str
     if 'vector_store_ids' not in value:
         _append_error(errors, f"{path}.vector_store_ids", "Required property 'vector_store_ids' is missing")
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'filters' in value:
         _validate_OpenAI_FileSearchTool_filters(value['filters'], f"{path}.filters", errors)
     if 'max_num_results' in value:
         _validate_OpenAI_FileSearchTool_max_num_results(value['max_num_results'], f"{path}.max_num_results", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
     if 'ranking_options' in value:
         _validate_OpenAI_FileSearchTool_ranking_options(value['ranking_options'], f"{path}.ranking_options", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_FileSearchTool_type(value['type'], f"{path}.type", errors)
     if 'vector_store_ids' in value:
@@ -1736,7 +1843,7 @@ def _validate_OpenAI_ImageGenTool(value: Any, path: str, errors: list[dict[str, 
     if 'background' in value:
         _validate_OpenAI_ImageGenTool_background(value['background'], f"{path}.background", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'input_fidelity' in value:
         _validate_OpenAI_ImageGenTool_input_fidelity(value['input_fidelity'], f"{path}.input_fidelity", errors)
     if 'input_image_mask' in value:
@@ -1746,7 +1853,7 @@ def _validate_OpenAI_ImageGenTool(value: Any, path: str, errors: list[dict[str, 
     if 'moderation' in value:
         _validate_OpenAI_ImageGenTool_moderation(value['moderation'], f"{path}.moderation", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
     if 'output_compression' in value:
         _validate_OpenAI_ImageGenTool_output_compression(value['output_compression'], f"{path}.output_compression", errors)
     if 'output_format' in value:
@@ -1757,6 +1864,8 @@ def _validate_OpenAI_ImageGenTool(value: Any, path: str, errors: list[dict[str, 
         _validate_OpenAI_ImageGenTool_quality(value['quality'], f"{path}.quality", errors)
     if 'size' in value:
         _validate_OpenAI_ImageGenTool_size(value['size'], f"{path}.size", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_ImageGenTool_type(value['type'], f"{path}.type", errors)
 
@@ -1767,9 +1876,11 @@ def _validate_OpenAI_LocalShellToolParam(value: Any, path: str, errors: list[dic
     if 'type' not in value:
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_LocalShellToolParam_type(value['type'], f"{path}.type", errors)
 
@@ -1803,6 +1914,8 @@ def _validate_OpenAI_MCPTool(value: Any, path: str, errors: list[dict[str, str]]
         _validate_OpenAI_MCPTool_server_label(value['server_label'], f"{path}.server_label", errors)
     if 'server_url' in value:
         _validate_OpenAI_MCPTool_server_url(value['server_url'], f"{path}.server_url", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'tunnel_id' in value:
         _validate_OpenAI_MCPTool_tunnel_id(value['tunnel_id'], f"{path}.tunnel_id", errors)
     if 'type' in value:
@@ -1818,12 +1931,8 @@ def _validate_MemorySearchTool(value: Any, path: str, errors: list[dict[str, str
         _append_error(errors, f"{path}.memory_store_name", "Required property 'memory_store_name' is missing")
     if 'scope' not in value:
         _append_error(errors, f"{path}.scope", "Required property 'scope' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'memory_store_name' in value:
         _validate_MemorySearchTool_memory_store_name(value['memory_store_name'], f"{path}.memory_store_name", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'scope' in value:
         _validate_MemorySearchTool_scope(value['scope'], f"{path}.scope", errors)
     if 'search_options' in value:
@@ -1843,12 +1952,8 @@ def _validate_MemorySearchPreviewTool(value: Any, path: str, errors: list[dict[s
         _append_error(errors, f"{path}.memory_store_name", "Required property 'memory_store_name' is missing")
     if 'scope' not in value:
         _append_error(errors, f"{path}.scope", "Required property 'scope' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'memory_store_name' in value:
         _validate_MemorySearchTool_memory_store_name(value['memory_store_name'], f"{path}.memory_store_name", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'scope' in value:
         _validate_MemorySearchTool_scope(value['scope'], f"{path}.scope", errors)
     if 'search_options' in value:
@@ -1889,6 +1994,8 @@ def _validate_OpenApiTool(value: Any, path: str, errors: list[dict[str, str]]) -
         _append_error(errors, f"{path}.openapi", "Required property 'openapi' is missing")
     if 'openapi' in value:
         _validate_OpenApiTool_openapi(value['openapi'], f"{path}.openapi", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenApiTool_type(value['type'], f"{path}.type", errors)
 
@@ -1909,10 +2016,6 @@ def _validate_SharepointPreviewTool(value: Any, path: str, errors: list[dict[str
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
     if 'sharepoint_grounding_preview' not in value:
         _append_error(errors, f"{path}.sharepoint_grounding_preview", "Required property 'sharepoint_grounding_preview' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'sharepoint_grounding_preview' in value:
         _validate_SharepointPreviewTool_sharepoint_grounding_preview(value['sharepoint_grounding_preview'], f"{path}.sharepoint_grounding_preview", errors)
     if 'type' in value:
@@ -1927,11 +2030,13 @@ def _validate_OpenAI_FunctionShellToolParam(value: Any, path: str, errors: list[
     if 'allowed_callers' in value:
         _validate_OpenAI_ApplyPatchToolParam_allowed_callers(value['allowed_callers'], f"{path}.allowed_callers", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'environment' in value:
         _validate_OpenAI_FunctionShellToolParam_environment(value['environment'], f"{path}.environment", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_FunctionShellToolParam_type(value['type'], f"{path}.type", errors)
 
@@ -1950,6 +2055,23 @@ def _validate_OpenAI_ToolSearchToolParam(value: Any, path: str, errors: list[dic
     if 'type' in value:
         _validate_OpenAI_ToolSearchToolParam_type(value['type'], f"{path}.type", errors)
 
+def _validate_WebIQPreviewTool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'type' not in value:
+        _append_error(errors, f"{path}.type", "Required property 'type' is missing")
+    if 'project_connection_id' not in value:
+        _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
+    if 'project_connection_id' in value:
+        _validate_WebIQPreviewTool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
+    if 'require_approval' in value:
+        _validate_WebIQPreviewTool_require_approval(value['require_approval'], f"{path}.require_approval", errors)
+    if 'server_label' in value:
+        _validate_WebIQPreviewTool_server_label(value['server_label'], f"{path}.server_label", errors)
+    if 'type' in value:
+        _validate_WebIQPreviewTool_type(value['type'], f"{path}.type", errors)
+
 def _validate_OpenAI_WebSearchTool(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -1959,15 +2081,17 @@ def _validate_OpenAI_WebSearchTool(value: Any, path: str, errors: list[dict[str,
     if 'custom_search_configuration' in value:
         _validate_OpenAI_WebSearchTool_custom_search_configuration(value['custom_search_configuration'], f"{path}.custom_search_configuration", errors)
     if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
+        _validate_AzureAISearchTool_description(value['description'], f"{path}.description", errors)
     if 'external_web_access' in value:
         _validate_OpenAI_WebSearchTool_external_web_access(value['external_web_access'], f"{path}.external_web_access", errors)
     if 'filters' in value:
         _validate_OpenAI_WebSearchTool_filters(value['filters'], f"{path}.filters", errors)
     if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+        _validate_AzureAISearchTool_description(value['name'], f"{path}.name", errors)
     if 'search_context_size' in value:
         _validate_OpenAI_WebSearchTool_search_context_size(value['search_context_size'], f"{path}.search_context_size", errors)
+    if 'tool_configs' in value:
+        _validate_AzureAISearchTool_tool_configs(value['tool_configs'], f"{path}.tool_configs", errors)
     if 'type' in value:
         _validate_OpenAI_WebSearchTool_type(value['type'], f"{path}.type", errors)
     if 'user_location' in value:
@@ -1994,12 +2118,12 @@ def _validate_WorkIQPreviewTool(value: Any, path: str, errors: list[dict[str, st
         return
     if 'type' not in value:
         _append_error(errors, f"{path}.type", "Required property 'type' is missing")
-    if 'work_iq_preview' not in value:
-        _append_error(errors, f"{path}.work_iq_preview", "Required property 'work_iq_preview' is missing")
+    if 'project_connection_id' not in value:
+        _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
+    if 'project_connection_id' in value:
+        _validate_WorkIQPreviewTool_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
     if 'type' in value:
         _validate_WorkIQPreviewTool_type(value['type'], f"{path}.type", errors)
-    if 'work_iq_preview' in value:
-        _validate_WorkIQPreviewTool_work_iq_preview(value['work_iq_preview'], f"{path}.work_iq_preview", errors)
 
 def _validate_OpenAI_Item_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _matched_union = False
@@ -2489,17 +2613,6 @@ def _validate_OpenAI_ItemMcpListTools(value: Any, path: str, errors: list[dict[s
     if 'type' in value:
         _validate_OpenAI_ItemMcpListTools_type(value['type'], f"{path}.type", errors)
 
-def _validate_MemorySearchToolCallItemParam(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'type' not in value:
-        _append_error(errors, f"{path}.type", "Required property 'type' is missing")
-    if 'results' in value:
-        _validate_MemorySearchToolCallItemParam_results(value['results'], f"{path}.results", errors)
-    if 'type' in value:
-        _validate_MemorySearchToolCallItemParam_type(value['type'], f"{path}.type", errors)
-
 def _validate_OpenAI_ItemMessage(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -2866,27 +2979,33 @@ def _validate_OpenAI_ToolType(value: Any, path: str, errors: list[dict[str, str]
             return
         return
 
-def _validate_A2APreviewTool_agent_card_path(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+def _validate_A2ATool_a2a_version(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_A2ATool_a2a_version_all_of_0(value, path, errors)
+
+def _validate_A2ATool_agent_card_path(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_A2APreviewTool_base_url(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+def _validate_A2ATool_base_url(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_A2APreviewTool_description(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+def _validate_A2ATool_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_A2APreviewTool_name(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
+def _validate_A2ATool_send_credentials_for_agent_card(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'boolean'):
+        _append_type_mismatch(errors, path, 'boolean', value)
         return
 
-def _validate_A2APreviewTool_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+def _validate_A2ATool_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _allowed_values = ('a2a',)
+    if value not in _allowed_values:
+        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
@@ -2918,6 +3037,19 @@ def _validate_OpenAI_ApplyPatchToolParam_type(value: Any, path: str, errors: lis
 
 def _validate_AzureAISearchTool_azure_ai_search(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_AzureAISearchTool_azure_ai_search_all_of_0(value, path, errors)
+
+def _validate_AzureAISearchTool_description(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_AzureAISearchTool_tool_configs(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    for _key, _item in value.items():
+        if _key not in ():
+            _validate_AzureAISearchTool_tool_configs_additional_property(_item, f"{path}.{_key}", errors)
 
 def _validate_AzureAISearchTool_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('azure_ai_search',)
@@ -3023,14 +3155,10 @@ def _validate_OpenAI_ComputerTool_type(value: Any, path: str, errors: list[dict[
         return
 
 def _validate_OpenAI_ComputerUsePreviewTool_display_height(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ComputerUsePreviewTool_display_width(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ComputerUsePreviewTool_environment(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_ComputerUsePreviewTool_environment_all_of_0(value, path, errors)
@@ -3080,15 +3208,60 @@ def _validate_MicrosoftFabricPreviewTool_type(value: Any, path: str, errors: lis
         _append_type_mismatch(errors, path, 'string', value)
         return
 
+def _validate_FabricIQPreviewTool_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_FabricIQPreviewTool_require_approval(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _matched_union = False
+    _best_branch_errors: list[dict[str, str]] | None = None
+    if not _matched_union and _is_type(value, 'object'):
+        _branch_errors_0: list[dict[str, str]] = []
+        _validate_FabricIQPreviewTool_require_approval_object(value, path, _branch_errors_0)
+        if not _branch_errors_0:
+            _matched_union = True
+        elif _best_branch_errors is None or len(_branch_errors_0) < len(_best_branch_errors):
+            _best_branch_errors = _branch_errors_0
+    if not _matched_union and _is_type(value, 'string'):
+        _branch_errors_1: list[dict[str, str]] = []
+        _validate_CreateResponse_instructions(value, path, _branch_errors_1)
+        if not _branch_errors_1:
+            _matched_union = True
+        elif _best_branch_errors is None or len(_branch_errors_1) < len(_best_branch_errors):
+            _best_branch_errors = _branch_errors_1
+    if not _matched_union:
+        if _best_branch_errors is not None:
+            errors.extend(_best_branch_errors)
+            return
+        _append_error(errors, path, f"Expected one of: object, string; got {_type_label(value)}")
+        return
+
+def _validate_FabricIQPreviewTool_server_label(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_FabricIQPreviewTool_server_url(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_FabricIQPreviewTool_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _allowed_values = ('fabric_iq_preview',)
+    if value not in _allowed_values:
+        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
 def _validate_OpenAI_FileSearchTool_filters(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if value is None:
         return
     _validate_OpenAI_FileSearchTool_filters_all_of_0(value, path, errors)
 
 def _validate_OpenAI_FileSearchTool_max_num_results(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_FileSearchTool_ranking_options(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_FileSearchTool_ranking_options_all_of_0(value, path, errors)
@@ -3183,9 +3356,7 @@ def _validate_OpenAI_ImageGenTool_moderation(value: Any, path: str, errors: list
         return
 
 def _validate_OpenAI_ImageGenTool_output_compression(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ImageGenTool_output_format(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('png', 'webp', 'jpeg')
@@ -3196,9 +3367,7 @@ def _validate_OpenAI_ImageGenTool_output_format(value: Any, path: str, errors: l
         return
 
 def _validate_OpenAI_ImageGenTool_partial_images(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ImageGenTool_quality(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('low', 'medium', 'high', 'auto')
@@ -3310,7 +3479,7 @@ def _validate_OpenAI_MCPTool_require_approval(value: Any, path: str, errors: lis
     _best_branch_errors: list[dict[str, str]] | None = None
     if not _matched_union and _is_type(value, 'object'):
         _branch_errors_0: list[dict[str, str]] = []
-        _validate_OpenAI_MCPTool_require_approval_object(value, path, _branch_errors_0)
+        _validate_FabricIQPreviewTool_require_approval_object(value, path, _branch_errors_0)
         if not _branch_errors_0:
             _matched_union = True
         elif _best_branch_errors is None or len(_branch_errors_0) < len(_best_branch_errors):
@@ -3481,6 +3650,48 @@ def _validate_OpenAI_ToolSearchToolParam_type(value: Any, path: str, errors: lis
         _append_type_mismatch(errors, path, 'string', value)
         return
 
+def _validate_WebIQPreviewTool_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_WebIQPreviewTool_require_approval(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _matched_union = False
+    _best_branch_errors: list[dict[str, str]] | None = None
+    if not _matched_union and _is_type(value, 'object'):
+        _branch_errors_0: list[dict[str, str]] = []
+        _validate_FabricIQPreviewTool_require_approval_object(value, path, _branch_errors_0)
+        if not _branch_errors_0:
+            _matched_union = True
+        elif _best_branch_errors is None or len(_branch_errors_0) < len(_best_branch_errors):
+            _best_branch_errors = _branch_errors_0
+    if not _matched_union and _is_type(value, 'string'):
+        _branch_errors_1: list[dict[str, str]] = []
+        _validate_CreateResponse_instructions(value, path, _branch_errors_1)
+        if not _branch_errors_1:
+            _matched_union = True
+        elif _best_branch_errors is None or len(_branch_errors_1) < len(_best_branch_errors):
+            _best_branch_errors = _branch_errors_1
+    if not _matched_union:
+        if _best_branch_errors is not None:
+            errors.extend(_best_branch_errors)
+            return
+        _append_error(errors, path, f"Expected one of: object, string; got {_type_label(value)}")
+        return
+
+def _validate_WebIQPreviewTool_server_label(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_WebIQPreviewTool_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _allowed_values = ('web_iq_preview',)
+    if value not in _allowed_values:
+        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
 def _validate_OpenAI_WebSearchTool_custom_search_configuration(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_WebSearchTool_custom_search_configuration_all_of_0(value, path, errors)
 
@@ -3547,6 +3758,11 @@ def _validate_OpenAI_WebSearchPreviewTool_user_location(value: Any, path: str, e
         return
     _validate_OpenAI_WebSearchPreviewTool_user_location_all_of_0(value, path, errors)
 
+def _validate_WorkIQPreviewTool_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
 def _validate_WorkIQPreviewTool_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('work_iq_preview',)
     if value not in _allowed_values:
@@ -3554,9 +3770,6 @@ def _validate_WorkIQPreviewTool_type(value: Any, path: str, errors: list[dict[st
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
-
-def _validate_WorkIQPreviewTool_work_iq_preview(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_WorkIQPreviewTool_work_iq_preview_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ItemType(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values, _literal_error = _schema_literal_values('ItemType')
@@ -4136,23 +4349,6 @@ def _validate_OpenAI_ItemMcpListTools_type(value: Any, path: str, errors: list[d
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_MemorySearchToolCallItemParam_results(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if value is None:
-        return
-    if not _is_type(value, 'array'):
-        _append_type_mismatch(errors, path, 'array', value)
-        return
-    for _idx, _item in enumerate(value):
-        _validate_MemorySearchToolCallItemParam_results_item(_item, f"{path}[{_idx}]", errors)
-
-def _validate_MemorySearchToolCallItemParam_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _allowed_values = ('memory_search_call',)
-    if value not in _allowed_values:
-        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
 def _validate_OpenAI_ItemMessage_content(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _matched_union = False
     _best_branch_errors: list[dict[str, str]] | None = None
@@ -4508,6 +4704,14 @@ def _validate_OpenAI_ResponseFormatJsonSchemaSchema(value: Any, path: str, error
         if _key not in ():
             _validate_CreateResponse_structured_inputs_additional_property(_item, f"{path}.{_key}", errors)
 
+def _validate_A2ATool_a2a_version_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _allowed_values = _field_literal_values('A2ATool', 'a2a_version_all_of_0')
+    if _allowed_values is not None and value is not None:
+        if value not in _allowed_values:
+            _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
+        return
+    _validate_A2AProtocolVersion(value, path, errors)
+
 def _validate_OpenAI_ApplyPatchToolParam_allowed_callers_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = _field_literal_values('ApplyPatchToolParam', 'allowed_callers_item')
     if _allowed_values is not None and value is not None:
@@ -4518,6 +4722,9 @@ def _validate_OpenAI_ApplyPatchToolParam_allowed_callers_item(value: Any, path: 
 
 def _validate_AzureAISearchTool_azure_ai_search_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_AzureAISearchToolResource(value, path, errors)
+
+def _validate_AzureAISearchTool_tool_configs_additional_property(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_ToolConfig(value, path, errors)
 
 def _validate_AzureFunctionTool_azure_function_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_AzureFunctionDefinition(value, path, errors)
@@ -4562,6 +4769,14 @@ def _validate_OpenAI_CustomToolParam_format_all_of_0(value: Any, path: str, erro
 
 def _validate_MicrosoftFabricPreviewTool_fabric_dataagent_preview_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_FabricDataAgentToolParameters(value, path, errors)
+
+def _validate_FabricIQPreviewTool_require_approval_object(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if value is None:
+        return
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    _validate_FabricIQPreviewTool_require_approval_object_all_of_0(value, path, errors)
 
 def _validate_OpenAI_FileSearchTool_filters_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_Filters(value, path, errors)
@@ -4620,14 +4835,6 @@ def _validate_OpenAI_MCPTool_allowed_tools_object(value: Any, path: str, errors:
         _append_type_mismatch(errors, path, 'object', value)
         return
     _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value, path, errors)
-
-def _validate_OpenAI_MCPTool_require_approval_object(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if value is None:
-        return
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    _validate_OpenAI_MCPTool_require_approval_object_all_of_0(value, path, errors)
 
 def _validate_OpenAI_MCPTool_require_approval_2(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if value is None:
@@ -4713,9 +4920,6 @@ def _validate_OpenAI_WebSearchPreviewTool_search_context_size_all_of_0(value: An
 
 def _validate_OpenAI_WebSearchPreviewTool_user_location_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_ApproximateLocation(value, path, errors)
-
-def _validate_WorkIQPreviewTool_work_iq_preview_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_WorkIQPreviewToolParameters(value, path, errors)
 
 def _validate_OpenAI_ApplyPatchToolCallItemParam_caller_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_ToolCallCallerParam(value, path, errors)
@@ -4912,9 +5116,6 @@ def _validate_OpenAI_RealtimeMCPError(value: Any, path: str, errors: list[dict[s
 def _validate_OpenAI_ItemMcpListTools_tools_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_MCPListToolsTool(value, path, errors)
 
-def _validate_MemorySearchToolCallItemParam_results_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_MemorySearchItem(value, path, errors)
-
 def _validate_OpenAI_ItemMessage_content_array(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'array'):
         _append_type_mismatch(errors, path, 'array', value)
@@ -5078,6 +5279,19 @@ def _validate_OpenAI_InputFileContent_type(value: Any, path: str, errors: list[d
         _append_type_mismatch(errors, path, 'string', value)
         return
 
+def _validate_A2AProtocolVersion(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _allowed_values, _literal_error = _schema_literal_values('A2AProtocolVersion')
+    if _literal_error is not None:
+        _append_error(errors, path, _literal_error)
+        return
+    if _allowed_values is not None:
+        if value not in _allowed_values:
+            _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
+        if not _is_type(value, 'string'):
+            _append_type_mismatch(errors, path, 'string', value)
+            return
+        return
+
 def _validate_OpenAI_CallableToolAllowedCaller(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values, _literal_error = _schema_literal_values('CallableToolAllowedCaller')
     if _literal_error is not None:
@@ -5097,12 +5311,17 @@ def _validate_AzureAISearchToolResource(value: Any, path: str, errors: list[dict
         return
     if 'indexes' not in value:
         _append_error(errors, f"{path}.indexes", "Required property 'indexes' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'indexes' in value:
         _validate_AzureAISearchToolResource_indexes(value['indexes'], f"{path}.indexes", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
+
+def _validate_ToolConfig(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'additional_search_text' in value:
+        _validate_ToolConfig_additional_search_text(value['additional_search_text'], f"{path}.additional_search_text", errors)
+    if 'pin' in value:
+        _validate_ToolConfig_pin(value['pin'], f"{path}.pin", errors)
 
 def _validate_AzureFunctionDefinition(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -5127,10 +5346,6 @@ def _validate_BingCustomSearchToolParameters(value: Any, path: str, errors: list
         return
     if 'search_configurations' not in value:
         _append_error(errors, f"{path}.search_configurations", "Required property 'search_configurations' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'search_configurations' in value:
         _validate_BingCustomSearchToolParameters_search_configurations(value['search_configurations'], f"{path}.search_configurations", errors)
 
@@ -5140,10 +5355,6 @@ def _validate_BingGroundingSearchToolParameters(value: Any, path: str, errors: l
         return
     if 'search_configurations' not in value:
         _append_error(errors, f"{path}.search_configurations", "Required property 'search_configurations' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'search_configurations' in value:
         _validate_BingGroundingSearchToolParameters_search_configurations(value['search_configurations'], f"{path}.search_configurations", errors)
 
@@ -5155,10 +5366,6 @@ def _validate_BrowserAutomationToolParameters(value: Any, path: str, errors: lis
         _append_error(errors, f"{path}.connection", "Required property 'connection' is missing")
     if 'connection' in value:
         _validate_BrowserAutomationToolParameters_connection(value['connection'], f"{path}.connection", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
 
 def _validate_StructuredOutputDefinition(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -5241,12 +5448,11 @@ def _validate_FabricDataAgentToolParameters(value: Any, path: str, errors: list[
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
         return
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connections' in value:
         _validate_FabricDataAgentToolParameters_project_connections(value['project_connections'], f"{path}.project_connections", errors)
+
+def _validate_FabricIQPreviewTool_require_approval_object_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    _validate_OpenAI_MCPToolRequireApproval(value, path, errors)
 
 def _validate_OpenAI_Filters(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _matched_union = False
@@ -5321,9 +5527,6 @@ def _validate_OpenAI_ImageGenToolInputImageMask(value: Any, path: str, errors: l
 def _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_MCPToolFilter(value, path, errors)
 
-def _validate_OpenAI_MCPTool_require_approval_object_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_OpenAI_MCPToolRequireApproval(value, path, errors)
-
 def _validate_MemorySearchOptions(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -5383,10 +5586,6 @@ def _validate_SharepointGroundingToolParameters(value: Any, path: str, errors: l
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
         return
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connections' in value:
         _validate_FabricDataAgentToolParameters_project_connections(value['project_connections'], f"{path}.project_connections", errors)
 
@@ -5439,12 +5638,8 @@ def _validate_WebSearchConfiguration(value: Any, path: str, errors: list[dict[st
         _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
     if 'instance_name' not in value:
         _append_error(errors, f"{path}.instance_name", "Required property 'instance_name' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'instance_name' in value:
         _validate_WebSearchConfiguration_instance_name(value['instance_name'], f"{path}.instance_name", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_WebSearchConfiguration_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
 
@@ -5514,15 +5709,6 @@ def _validate_OpenAI_ApproximateLocation(value: Any, path: str, errors: list[dic
         _validate_CreateResponse_instructions(value['timezone'], f"{path}.timezone", errors)
     if 'type' in value:
         _validate_OpenAI_WebSearchApproximateLocation_type(value['type'], f"{path}.type", errors)
-
-def _validate_WorkIQPreviewToolParameters(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'project_connection_id' not in value:
-        _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
-    if 'project_connection_id' in value:
-        _validate_WorkIQPreviewToolParameters_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
 
 def _validate_OpenAI_ToolCallCallerParam(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -5944,7 +6130,7 @@ def _validate_OpenAI_RealtimeMCPHTTPError(value: Any, path: str, errors: list[di
     if 'message' not in value:
         _append_error(errors, f"{path}.message", "Required property 'message' is missing")
     if 'code' in value:
-        _validate_OpenAI_RealtimeMCPHTTPError_code(value['code'], f"{path}.code", errors)
+        _validate_CreateResponse_max_output_tokens_all_of_0(value['code'], f"{path}.code", errors)
     if 'message' in value:
         _validate_OpenAI_InputParam_string(value['message'], f"{path}.message", errors)
     if 'type' in value:
@@ -5961,7 +6147,7 @@ def _validate_OpenAI_RealtimeMCPProtocolError(value: Any, path: str, errors: lis
     if 'message' not in value:
         _append_error(errors, f"{path}.message", "Required property 'message' is missing")
     if 'code' in value:
-        _validate_OpenAI_RealtimeMCPHTTPError_code(value['code'], f"{path}.code", errors)
+        _validate_CreateResponse_max_output_tokens_all_of_0(value['code'], f"{path}.code", errors)
     if 'message' in value:
         _validate_OpenAI_InputParam_string(value['message'], f"{path}.message", errors)
     if 'type' in value:
@@ -5996,15 +6182,6 @@ def _validate_OpenAI_MCPListToolsTool(value: Any, path: str, errors: list[dict[s
         _validate_OpenAI_MCPListToolsTool_input_schema(value['input_schema'], f"{path}.input_schema", errors)
     if 'name' in value:
         _validate_OpenAI_MCPListToolsTool_name(value['name'], f"{path}.name", errors)
-
-def _validate_MemorySearchItem(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'memory_item' not in value:
-        _append_error(errors, f"{path}.memory_item", "Required property 'memory_item' is missing")
-    if 'memory_item' in value:
-        _validate_MemorySearchItem_memory_item(value['memory_item'], f"{path}.memory_item", errors)
 
 def _validate_OpenAI_ItemMessage_content_array_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_MessageContent(value, path, errors)
@@ -6258,6 +6435,16 @@ def _validate_AzureAISearchToolResource_indexes(value: Any, path: str, errors: l
     for _idx, _item in enumerate(value):
         _validate_AzureAISearchToolResource_indexes_item(_item, f"{path}[{_idx}]", errors)
 
+def _validate_ToolConfig_additional_search_text(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'string'):
+        _append_type_mismatch(errors, path, 'string', value)
+        return
+
+def _validate_ToolConfig_pin(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'boolean'):
+        _append_type_mismatch(errors, path, 'boolean', value)
+        return
+
 def _validate_AzureFunctionDefinition_function(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -6390,6 +6577,15 @@ def _validate_FabricDataAgentToolParameters_project_connections(value: Any, path
     for _idx, _item in enumerate(value):
         _validate_FabricDataAgentToolParameters_project_connections_item(_item, f"{path}[{_idx}]", errors)
 
+def _validate_OpenAI_MCPToolRequireApproval(value: Any, path: str, errors: list[dict[str, str]]) -> None:
+    if not _is_type(value, 'object'):
+        _append_type_mismatch(errors, path, 'object', value)
+        return
+    if 'always' in value:
+        _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value['always'], f"{path}.always", errors)
+    if 'never' in value:
+        _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value['never'], f"{path}.never", errors)
+
 def _validate_OpenAI_ComparisonFilter(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
@@ -6427,9 +6623,7 @@ def _validate_OpenAI_RankingOptions_ranker(value: Any, path: str, errors: list[d
     _validate_OpenAI_RankingOptions_ranker_all_of_0(value, path, errors)
 
 def _validate_OpenAI_RankingOptions_score_threshold(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'number'):
-        _append_type_mismatch(errors, path, 'number', value)
-        return
+    _validate_CreateResponse_temperature_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ImageGenToolInputImageMask_image_url(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -6444,15 +6638,6 @@ def _validate_OpenAI_MCPToolFilter(value: Any, path: str, errors: list[dict[str,
         _validate_OpenAI_MCPToolFilter_read_only(value['read_only'], f"{path}.read_only", errors)
     if 'tool_names' in value:
         _validate_OpenAI_MCPToolFilter_tool_names(value['tool_names'], f"{path}.tool_names", errors)
-
-def _validate_OpenAI_MCPToolRequireApproval(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'always' in value:
-        _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value['always'], f"{path}.always", errors)
-    if 'never' in value:
-        _validate_OpenAI_MCPTool_allowed_tools_object_all_of_0(value['never'], f"{path}.never", errors)
 
 def _validate_MemorySearchOptions_max_memories(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'integer'):
@@ -6575,11 +6760,6 @@ def _validate_OpenAI_WebSearchApproximateLocation_type(value: Any, path: str, er
     _allowed_values = ('approximate',)
     if value not in _allowed_values:
         _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
-def _validate_WorkIQPreviewToolParameters_project_connection_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
@@ -6720,14 +6900,10 @@ def _validate_OpenAI_ClickParam_type(value: Any, path: str, errors: list[dict[st
         return
 
 def _validate_OpenAI_ClickParam_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ClickParam_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_DoubleClickAction_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('double_click',)
@@ -6738,14 +6914,10 @@ def _validate_OpenAI_DoubleClickAction_type(value: Any, path: str, errors: list[
         return
 
 def _validate_OpenAI_DoubleClickAction_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_DoubleClickAction_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_DragParam_path(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'array'):
@@ -6786,14 +6958,10 @@ def _validate_OpenAI_MoveParam_type(value: Any, path: str, errors: list[dict[str
         return
 
 def _validate_OpenAI_MoveParam_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_MoveParam_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ScreenshotParam_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('screenshot',)
@@ -6804,14 +6972,10 @@ def _validate_OpenAI_ScreenshotParam_type(value: Any, path: str, errors: list[di
         return
 
 def _validate_OpenAI_ScrollParam_scroll_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ScrollParam_scroll_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ScrollParam_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('scroll',)
@@ -6822,14 +6986,10 @@ def _validate_OpenAI_ScrollParam_type(value: Any, path: str, errors: list[dict[s
         return
 
 def _validate_OpenAI_ScrollParam_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ScrollParam_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_TypeParam_text(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -6989,11 +7149,6 @@ def _validate_OpenAI_RealtimeMcpErrorType(value: Any, path: str, errors: list[di
             return
         return
 
-def _validate_OpenAI_RealtimeMCPHTTPError_code(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
-
 def _validate_OpenAI_RealtimeMCPHTTPError_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('http_error',)
     if value not in _allowed_values:
@@ -7033,9 +7188,6 @@ def _validate_OpenAI_MCPListToolsTool_name(value: Any, path: str, errors: list[d
     if not _is_type(value, 'string'):
         _append_type_mismatch(errors, path, 'string', value)
         return
-
-def _validate_MemorySearchItem_memory_item(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_MemorySearchItem_memory_item_all_of_0(value, path, errors)
 
 def _validate_OpenAI_MessageContent(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -7370,7 +7522,7 @@ def _validate_OpenAI_ComparisonFilter_value(value: Any, path: str, errors: list[
             _best_branch_errors = _branch_errors_0
     if not _matched_union and _is_type(value, 'number'):
         _branch_errors_1: list[dict[str, str]] = []
-        _validate_OpenAI_ComparisonFilter_value_number(value, path, _branch_errors_1)
+        _validate_OpenAI_numeric(value, path, _branch_errors_1)
         if not _branch_errors_1:
             _matched_union = True
         elif _best_branch_errors is None or len(_branch_errors_1) < len(_best_branch_errors):
@@ -7393,7 +7545,7 @@ def _validate_OpenAI_ComparisonFilter_value(value: Any, path: str, errors: list[
         if _best_branch_errors is not None:
             errors.extend(_best_branch_errors)
             return
-        _append_error(errors, path, f"Expected one of: string, number, boolean, array; got {_type_label(value)}")
+        _append_error(errors, path, f"Expected one of: string, OpenAI.numeric, boolean, array; got {_type_label(value)}")
         return
 
 def _validate_OpenAI_CompoundFilter_filters(value: Any, path: str, errors: list[dict[str, str]]) -> None:
@@ -7739,9 +7891,6 @@ def _validate_OpenAI_MCPListToolsTool_annotations_all_of_0(value: Any, path: str
 def _validate_OpenAI_MCPListToolsTool_input_schema_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenAI_MCPListToolsToolInputSchema(value, path, errors)
 
-def _validate_MemorySearchItem_memory_item_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_MemoryItem(value, path, errors)
-
 def _validate_OpenAI_MessageContent_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = _field_literal_values('MessageContent', 'type')
     if _allowed_values is not None and value is not None:
@@ -7981,16 +8130,12 @@ def _validate_AISearchIndexResource(value: Any, path: str, errors: list[dict[str
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
         return
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'filter' in value:
         _validate_AISearchIndexResource_filter(value['filter'], f"{path}.filter", errors)
     if 'index_asset_id' in value:
         _validate_AISearchIndexResource_index_asset_id(value['index_asset_id'], f"{path}.index_asset_id", errors)
     if 'index_name' in value:
         _validate_AISearchIndexResource_index_name(value['index_name'], f"{path}.index_name", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_AISearchIndexResource_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
     if 'query_type' in value:
@@ -8021,16 +8166,12 @@ def _validate_BingCustomSearchConfiguration(value: Any, path: str, errors: list[
         _append_error(errors, f"{path}.instance_name", "Required property 'instance_name' is missing")
     if 'count' in value:
         _validate_BingCustomSearchConfiguration_count(value['count'], f"{path}.count", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'freshness' in value:
         _validate_BingCustomSearchConfiguration_freshness(value['freshness'], f"{path}.freshness", errors)
     if 'instance_name' in value:
         _validate_WebSearchConfiguration_instance_name(value['instance_name'], f"{path}.instance_name", errors)
     if 'market' in value:
         _validate_BingCustomSearchConfiguration_market(value['market'], f"{path}.market", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_BingCustomSearchConfiguration_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
     if 'set_lang' in value:
@@ -8044,14 +8185,10 @@ def _validate_BingGroundingSearchConfiguration(value: Any, path: str, errors: li
         _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
     if 'count' in value:
         _validate_BingCustomSearchConfiguration_count(value['count'], f"{path}.count", errors)
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
     if 'freshness' in value:
         _validate_BingCustomSearchConfiguration_freshness(value['freshness'], f"{path}.freshness", errors)
     if 'market' in value:
         _validate_BingCustomSearchConfiguration_market(value['market'], f"{path}.market", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_BingCustomSearchConfiguration_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
     if 'set_lang' in value:
@@ -8063,10 +8200,6 @@ def _validate_BrowserAutomationToolConnectionParameters(value: Any, path: str, e
         return
     if 'project_connection_id' not in value:
         _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_BrowserAutomationToolConnectionParameters_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
 
@@ -8120,17 +8253,8 @@ def _validate_ToolProjectConnection(value: Any, path: str, errors: list[dict[str
         return
     if 'project_connection_id' not in value:
         _append_error(errors, f"{path}.project_connection_id", "Required property 'project_connection_id' is missing")
-    if 'description' in value:
-        _validate_A2APreviewTool_description(value['description'], f"{path}.description", errors)
-    if 'name' in value:
-        _validate_A2APreviewTool_name(value['name'], f"{path}.name", errors)
     if 'project_connection_id' in value:
         _validate_ToolProjectConnection_project_connection_id(value['project_connection_id'], f"{path}.project_connection_id", errors)
-
-def _validate_OpenAI_ComparisonFilter_value_number(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'number'):
-        _append_type_mismatch(errors, path, 'number', value)
-        return
 
 def _validate_OpenAI_ComparisonFilter_value_boolean(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'boolean'):
@@ -8288,42 +8412,6 @@ def _validate_OpenAI_MCPListToolsToolInputSchema(value: Any, path: str, errors: 
     if not _is_type(value, 'object'):
         _append_type_mismatch(errors, path, 'object', value)
         return
-
-def _validate_MemoryItem(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'memory_id' not in value:
-        _append_error(errors, f"{path}.memory_id", "Required property 'memory_id' is missing")
-    if 'updated_at' not in value:
-        _append_error(errors, f"{path}.updated_at", "Required property 'updated_at' is missing")
-    if 'scope' not in value:
-        _append_error(errors, f"{path}.scope", "Required property 'scope' is missing")
-    if 'content' not in value:
-        _append_error(errors, f"{path}.content", "Required property 'content' is missing")
-    if 'kind' not in value:
-        _append_error(errors, f"{path}.kind", "Required property 'kind' is missing")
-    if 'content' in value:
-        _validate_MemoryItem_content(value['content'], f"{path}.content", errors)
-    if 'kind' in value:
-        _validate_MemoryItem_kind(value['kind'], f"{path}.kind", errors)
-    if 'memory_id' in value:
-        _validate_MemoryItem_memory_id(value['memory_id'], f"{path}.memory_id", errors)
-    if 'scope' in value:
-        _validate_MemoryItem_scope(value['scope'], f"{path}.scope", errors)
-    if 'updated_at' in value:
-        _validate_MemoryItem_updated_at(value['updated_at'], f"{path}.updated_at", errors)
-    _disc_value = value.get('kind')
-    if not isinstance(_disc_value, str):
-        _append_error(errors, f"{path}.kind", "Required discriminator 'kind' is missing or invalid")
-        return
-    if _disc_value == 'chat_summary':
-        _validate_ChatSummaryMemoryItem(value, path, errors)
-        return
-    if _disc_value == 'user_profile':
-        _validate_UserProfileMemoryItem(value, path, errors)
-        return
-    _append_error(errors, f"{path}.kind", f"Invalid discriminator '{_disc_value}'. Allowed: chat_summary, user_profile")
 
 def _validate_OpenAI_MessageContentType(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values, _literal_error = _schema_literal_values('MessageContentType')
@@ -8495,7 +8583,7 @@ def _validate_OpenAI_ComparisonFilter_value_array_item(value: Any, path: str, er
             _best_branch_errors = _branch_errors_0
     if not _matched_union and _is_type(value, 'number'):
         _branch_errors_1: list[dict[str, str]] = []
-        _validate_OpenAI_ComparisonFilter_value_number(value, path, _branch_errors_1)
+        _validate_OpenAI_numeric(value, path, _branch_errors_1)
         if not _branch_errors_1:
             _matched_union = True
         elif _best_branch_errors is None or len(_branch_errors_1) < len(_best_branch_errors):
@@ -8504,18 +8592,14 @@ def _validate_OpenAI_ComparisonFilter_value_array_item(value: Any, path: str, er
         if _best_branch_errors is not None:
             errors.extend(_best_branch_errors)
             return
-        _append_error(errors, path, f"Expected one of: string, number; got {_type_label(value)}")
+        _append_error(errors, path, f"Expected one of: string, OpenAI.numeric; got {_type_label(value)}")
         return
 
 def _validate_OpenAI_HybridSearchOptions_embedding_weight(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'number'):
-        _append_type_mismatch(errors, path, 'number', value)
-        return
+    _validate_CreateResponse_temperature_all_of_0(value, path, errors)
 
 def _validate_OpenAI_HybridSearchOptions_text_weight(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'number'):
-        _append_type_mismatch(errors, path, 'number', value)
-        return
+    _validate_CreateResponse_temperature_all_of_0(value, path, errors)
 
 def _validate_OpenApiAuthDetails_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _validate_OpenApiAuthDetails_type_all_of_0(value, path, errors)
@@ -8593,14 +8677,10 @@ def _validate_OpenAI_LocalSkillParam(value: Any, path: str, errors: list[dict[st
         _validate_OpenAI_LocalSkillParam_path(value['path'], f"{path}.path", errors)
 
 def _validate_OpenAI_CoordParam_x(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_CoordParam_y(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_VectorStoreFileAttributes_additional_property(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _matched_union = False
@@ -8614,7 +8694,7 @@ def _validate_OpenAI_VectorStoreFileAttributes_additional_property(value: Any, p
             _best_branch_errors = _branch_errors_0
     if not _matched_union and _is_type(value, 'number'):
         _branch_errors_1: list[dict[str, str]] = []
-        _validate_OpenAI_ComparisonFilter_value_number(value, path, _branch_errors_1)
+        _validate_OpenAI_numeric(value, path, _branch_errors_1)
         if not _branch_errors_1:
             _matched_union = True
         elif _best_branch_errors is None or len(_branch_errors_1) < len(_best_branch_errors):
@@ -8630,7 +8710,7 @@ def _validate_OpenAI_VectorStoreFileAttributes_additional_property(value: Any, p
         if _best_branch_errors is not None:
             errors.extend(_best_branch_errors)
             return
-        _append_error(errors, path, f"Expected one of: string, number, boolean; got {_type_label(value)}")
+        _append_error(errors, path, f"Expected one of: string, OpenAI.numeric, boolean; got {_type_label(value)}")
         return
 
 def _validate_OpenAI_PromptCacheBreakpointParam(value: Any, path: str, errors: list[dict[str, str]]) -> None:
@@ -8654,47 +8734,6 @@ def _validate_OpenAI_DetailEnum(value: Any, path: str, errors: list[dict[str, st
             _append_type_mismatch(errors, path, 'string', value)
             return
         return
-
-def _validate_MemoryItem_content(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
-def _validate_MemoryItem_kind(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _validate_MemoryItem_kind_all_of_0(value, path, errors)
-
-def _validate_MemoryItem_memory_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
-def _validate_MemoryItem_scope(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
-def _validate_MemoryItem_updated_at(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
-
-def _validate_ChatSummaryMemoryItem(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'kind' not in value:
-        _append_error(errors, f"{path}.kind", "Required property 'kind' is missing")
-    if 'kind' in value:
-        _validate_ChatSummaryMemoryItem_kind(value['kind'], f"{path}.kind", errors)
-
-def _validate_UserProfileMemoryItem(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'object'):
-        _append_type_mismatch(errors, path, 'object', value)
-        return
-    if 'kind' not in value:
-        _append_error(errors, f"{path}.kind", "Required property 'kind' is missing")
-    if 'kind' in value:
-        _validate_UserProfileMemoryItem_kind(value['kind'], f"{path}.kind", errors)
 
 def _validate_OpenAI_Annotation(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'object'):
@@ -8737,7 +8776,7 @@ def _validate_OpenAI_LogProb(value: Any, path: str, errors: list[dict[str, str]]
     if 'bytes' in value:
         _validate_OpenAI_LogProb_bytes(value['bytes'], f"{path}.bytes", errors)
     if 'logprob' in value:
-        _validate_OpenAI_ComparisonFilter_value_number(value['logprob'], f"{path}.logprob", errors)
+        _validate_CreateResponse_temperature_all_of_0(value['logprob'], f"{path}.logprob", errors)
     if 'token' in value:
         _validate_OpenAI_InputParam_string(value['token'], f"{path}.token", errors)
     if 'top_logprobs' in value:
@@ -8881,30 +8920,6 @@ def _validate_OpenAI_LocalSkillParam_path(value: Any, path: str, errors: list[di
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_MemoryItem_kind_all_of_0(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _allowed_values = _field_literal_values('MemoryItem', 'kind_all_of_0')
-    if _allowed_values is not None and value is not None:
-        if value not in _allowed_values:
-            _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-        return
-    _validate_MemoryItemKind(value, path, errors)
-
-def _validate_ChatSummaryMemoryItem_kind(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _allowed_values = ('chat_summary',)
-    if value not in _allowed_values:
-        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
-def _validate_UserProfileMemoryItem_kind(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _allowed_values = ('user_profile',)
-    if value not in _allowed_values:
-        _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-    if not _is_type(value, 'string'):
-        _append_type_mismatch(errors, path, 'string', value)
-        return
-
 def _validate_OpenAI_Annotation_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = _field_literal_values('Annotation', 'type')
     if _allowed_values is not None and value is not None:
@@ -9010,7 +9025,7 @@ def _validate_OpenAI_LogProb_bytes(value: Any, path: str, errors: list[dict[str,
         _append_type_mismatch(errors, path, 'array', value)
         return
     for _idx, _item in enumerate(value):
-        _validate_OpenAI_RealtimeMCPHTTPError_code(_item, f"{path}[{_idx}]", errors)
+        _validate_CreateResponse_max_output_tokens_all_of_0(_item, f"{path}[{_idx}]", errors)
 
 def _validate_OpenAI_LogProb_top_logprobs(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'array'):
@@ -9033,9 +9048,7 @@ def _validate_OpenAI_FunctionShellCallOutputOutcomeParamType(value: Any, path: s
         return
 
 def _validate_OpenAI_FunctionShellCallOutputExitOutcomeParam_exit_code(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_FunctionShellCallOutputExitOutcomeParam_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('exit',)
@@ -9140,19 +9153,6 @@ def _validate_OpenAI_SkillReferenceParam_version(value: Any, path: str, errors: 
         _append_type_mismatch(errors, path, 'string', value)
         return
 
-def _validate_MemoryItemKind(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    _allowed_values, _literal_error = _schema_literal_values('MemoryItemKind')
-    if _literal_error is not None:
-        _append_error(errors, path, _literal_error)
-        return
-    if _allowed_values is not None:
-        if value not in _allowed_values:
-            _append_error(errors, path, f"Invalid value '{value}'. Allowed: {', '.join(str(v) for v in _allowed_values)}")
-        if not _is_type(value, 'string'):
-            _append_type_mismatch(errors, path, 'string', value)
-            return
-        return
-
 def _validate_OpenAI_AnnotationType(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values, _literal_error = _schema_literal_values('AnnotationType')
     if _literal_error is not None:
@@ -9172,9 +9172,7 @@ def _validate_OpenAI_ContainerFileCitationBody_container_id(value: Any, path: st
         return
 
 def _validate_OpenAI_ContainerFileCitationBody_end_index(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ContainerFileCitationBody_file_id(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -9187,9 +9185,7 @@ def _validate_OpenAI_ContainerFileCitationBody_filename(value: Any, path: str, e
         return
 
 def _validate_OpenAI_ContainerFileCitationBody_start_index(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_ContainerFileCitationBody_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('container_file_citation',)
@@ -9205,9 +9201,7 @@ def _validate_OpenAI_FileCitationBody_filename(value: Any, path: str, errors: li
         return
 
 def _validate_OpenAI_FileCitationBody_index(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_FileCitationBody_type(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     _allowed_values = ('file_citation',)
@@ -9226,14 +9220,10 @@ def _validate_OpenAI_FilePath_type(value: Any, path: str, errors: list[dict[str,
         return
 
 def _validate_OpenAI_UrlCitationBody_end_index(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_UrlCitationBody_start_index(value: Any, path: str, errors: list[dict[str, str]]) -> None:
-    if not _is_type(value, 'integer'):
-        _append_type_mismatch(errors, path, 'integer', value)
-        return
+    _validate_CreateResponse_max_output_tokens_all_of_0(value, path, errors)
 
 def _validate_OpenAI_UrlCitationBody_title(value: Any, path: str, errors: list[dict[str, str]]) -> None:
     if not _is_type(value, 'string'):
@@ -9300,7 +9290,7 @@ def _validate_OpenAI_TopLogProb(value: Any, path: str, errors: list[dict[str, st
     if 'bytes' in value:
         _validate_OpenAI_LogProb_bytes(value['bytes'], f"{path}.bytes", errors)
     if 'logprob' in value:
-        _validate_OpenAI_ComparisonFilter_value_number(value['logprob'], f"{path}.logprob", errors)
+        _validate_CreateResponse_temperature_all_of_0(value['logprob'], f"{path}.logprob", errors)
     if 'token' in value:
         _validate_OpenAI_InputParam_string(value['token'], f"{path}.token", errors)
 

--- a/sdk/agentserver/azure-ai-agentserver-responses/type_spec/tsp-location.yaml
+++ b/sdk/agentserver/azure-ai-agentserver-responses/type_spec/tsp-location.yaml
@@ -1,11 +1,13 @@
 directory: specification/ai-foundry/data-plane/Foundry/src/sdk-service-agentserver-contracts
-commit: be2980b2e3b8fbf9e2034cbe441c388b2f6b54b2
+commit: 9a69dbbfe1adfc1dc7f2a0ef4fa374dadf8abf7b
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: eng/emitter-package.json
 entrypointFile: client.tsp
 additionalDirectories:
-  - specification/ai-foundry/data-plane/Foundry/src/openai-responses
-  - specification/ai-foundry/data-plane/Foundry/src/openai-conversations
+  - specification/ai-foundry/data-plane/Foundry/src/openai
+  - specification/ai-foundry/data-plane/Foundry/src/agents
+  - specification/ai-foundry/data-plane/Foundry/src/skills
   - specification/ai-foundry/data-plane/Foundry/src/tools
+  - specification/ai-foundry/data-plane/Foundry/src/toolboxes
   - specification/ai-foundry/data-plane/Foundry/src/common
   - specification/ai-foundry/data-plane/Foundry/src/memory-stores


### PR DESCRIPTION
## Summary

- advance the AgentServer TypeSpec pin to the consolidated Foundry release merge
- regenerate the complete TypedDict model surface and request validators using the SDK-pinned TypeSpec dependencies
- add memory-command, procedural-memory, model-routing, content-filter, expanded tool configuration, and shell streaming-event contracts
- refresh the API review surface and changelog for `2.2.0b2`

## Why the generated surface changed

The previous SDK pin (`be2980b2e3b8fbf9e2034cbe441c388b2f6b54b2`) predates the Foundry release consolidation. The new pin (`9a69dbbfe1adfc1dc7f2a0ef4fa374dadf8abf7b`) combines `feature/foundry-release` with the AgentServer projection, so generation now consumes the current shared OpenAI, memory, tool, toolbox, agent, skill, and common model sources.

Generation continues to use the SDK-pinned `@azure-tools/openai-typespec` 1.25.0 and `@azure-tools/typespec-python` 0.63.5. The generated differences therefore come from the updated Foundry source contracts rather than an emitter dependency update.

## Contract compatibility

- output-text `annotations` and `logprobs` remain optional
- function-call output `call_id` remains optional
- `ResponseUsageInputTokensDetails.cache_write_tokens` remains required

## Validation

- full package tests: 1,529 passed, 6 skipped
- TypeSpec model and OpenAPI generation completed successfully
- request validators regenerated from the emitted OpenAPI document
- API markdown and metadata regenerated successfully

Spec source: Azure/azure-rest-api-specs@9a69dbbfe1adfc1dc7f2a0ef4fa374dadf8abf7b