### PR TITLE
[azure-core] Warn when an LRO poll target host differs from the client's endpoint

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `azure-deprecating` to the default allowed headers list in `HttpLoggingPolicy`, so deprecation notification headers are logged without redaction.
 
+### Other Changes
+
+- Long-running-operation polling now logs a warning when the poll target host (taken from the `Operation-Location` / `Azure-AsyncOperation` / `Location` response header) differs from the client's configured endpoint host, since the poll request carries the client's credentials to that host. Same-host and relative poll targets are unaffected.
+
 ## 1.41.0 (2026-05-07)
 
 ### Features Added

--- a/sdk/core/azure-core/azure/core/polling/async_base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/async_base_polling.py
@@ -32,6 +32,7 @@ from .base_polling import (
     OperationFailed,
     _SansIOLROBasePolling,
     _raise_if_bad_http_status_and_method,
+    _warn_on_cross_host_poll_target,
 )
 from ._async_poller import AsyncPollingMethod
 from ..pipeline._tools import is_rest
@@ -154,6 +155,7 @@ class AsyncLROBasePolling(
         """
         if self._path_format_arguments:
             status_link = self._client.format_url(status_link, **self._path_format_arguments)
+        _warn_on_cross_host_poll_target(self._initial_response.http_response.request.url, status_link)
         # Re-inject 'x-ms-client-request-id' while polling
         if "request_id" not in self._operation_config:
             self._operation_config["request_id"] = self._get_request_id()

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -26,6 +26,7 @@
 import abc
 import base64
 import json
+import logging
 from enum import Enum
 from typing import (
     Optional,
@@ -43,7 +44,7 @@ from typing import (
 
 from ..exceptions import HttpResponseError, DecodeError
 from . import PollingMethod
-from ..pipeline.policies._utils import get_retry_after
+from ..pipeline.policies._utils import get_retry_after, get_domain
 from ..pipeline._tools import is_rest
 from .._enum_meta import CaseInsensitiveEnumMeta
 from .. import PipelineClient
@@ -62,6 +63,8 @@ from ._utils import (
     _decode_continuation_token,
     _filter_sensitive_headers,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 HttpRequestType = Union[LegacyHttpRequest, HttpRequest]
@@ -223,6 +226,36 @@ def _is_empty(response: AllHttpResponseType) -> bool:
     :rtype: bool
     """
     return not bool(_get_content(response))
+
+
+def _warn_on_cross_host_poll_target(initial_request_url: str, status_link: str) -> None:
+    """Warn when the LRO poll target host differs from the client's configured endpoint.
+
+    The poll target is taken verbatim from a service response header
+    (``Operation-Location`` / ``Azure-AsyncOperation`` / ``Location``) and is then sent
+    through the client's credentialed pipeline. If the response names a host the client
+    was not configured for, that request carries the client's credentials (API key or
+    bearer token) to that host. :class:`~azure.core.pipeline.policies.SensitiveHeaderCleanupPolicy`
+    strips sensitive headers on cross-domain 3xx redirects, but the LRO poll target
+    reaches a new host without a 3xx redirect, so that policy does not cover it.
+
+    This logs a warning (it does not block the request) so it is safe for services that
+    legitimately poll a different host, while surfacing the credential-to-new-host case
+    to operators. A relative poll target (no host) resolves to the same host and is quiet.
+
+    :param str initial_request_url: URL of the client's initial (trusted) request.
+    :param str status_link: The poll URL taken from the service response.
+    """
+    initial_domain = get_domain(initial_request_url)
+    poll_domain = get_domain(status_link)
+    if initial_domain and poll_domain and poll_domain != initial_domain:
+        _LOGGER.warning(
+            "Long-running-operation poll target host '%s' differs from the client's configured "
+            "endpoint host '%s'. The poll request carries the client's credentials to that host. "
+            "Ensure the polled host is trusted.",
+            poll_domain,
+            initial_domain,
+        )
 
 
 class LongRunningOperation(ABC, Generic[HTTPRequestType_co, HTTPResponseType_co]):
@@ -1013,6 +1046,7 @@ class LROBasePolling(
         """
         if self._path_format_arguments:
             status_link = self._client.format_url(status_link, **self._path_format_arguments)
+        _warn_on_cross_host_poll_target(self._initial_response.http_response.request.url, status_link)
         # Re-inject 'x-ms-client-request-id' while polling
         if "request_id" not in self._operation_config:
             self._operation_config["request_id"] = self._get_request_id()

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -26,6 +26,7 @@
 import base64
 import datetime
 import json
+import logging
 import re
 import types
 import platform
@@ -987,3 +988,30 @@ def test_continuation_token_excludes_request_headers(port, http_request, deseria
     )
     new_polling = LROBasePolling()
     new_polling.initialize(*polling_args)
+
+
+def test_warn_on_cross_host_poll_target_warns_only_when_host_differs(caplog):
+    # The LRO poll target comes from a service response header and is sent through the
+    # client's credentialed pipeline. Warn when it names a host the client was not
+    # configured for (credentials would reach that host); stay quiet otherwise.
+    from azure.core.polling.base_polling import _warn_on_cross_host_poll_target
+
+    logger_name = "azure.core.polling.base_polling"
+    initial = "https://victim.cognitiveservices.azure.com/analyze"
+
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        _warn_on_cross_host_poll_target(initial, "https://attacker.example/poll")
+    assert any(
+        "differs from the client's configured endpoint host" in r.message for r in caplog.records
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        # Same host, same host with an explicit port, and a relative target must be quiet.
+        _warn_on_cross_host_poll_target(initial, "https://victim.cognitiveservices.azure.com/op/1")
+        _warn_on_cross_host_poll_target(
+            "https://victim.cognitiveservices.azure.com:443/analyze",
+            "https://victim.cognitiveservices.azure.com:443/op/1",
+        )
+        _warn_on_cross_host_poll_target(initial, "/operations/1")
+    assert not caplog.records


### PR DESCRIPTION
## Summary

Long-running-operation (LRO) polling reads the next poll URL from a service **response** header (`Operation-Location` / `Azure-AsyncOperation` / `Location`) and sends that GET through the client's **credentialed** pipeline (`LROBasePolling.request_status`, sync and async). There is no check that the poll target host matches the host the client was configured for, so when the response names a different host, the poll request carries the client's credentials (API key or bearer token) to that host.

`SensitiveHeaderCleanupPolicy` already strips sensitive headers on cross-domain **3xx redirects**, but the LRO poll target reaches a new host **without** a 3xx redirect, so that policy does not cover this path.

## Change

Add a defense-in-depth **warning** (it does **not** block the request) in both the sync and async `request_status` paths when the poll target host differs from the initial request host, reusing the existing `get_domain` helper for the comparison.

- Same-host poll targets and relative (no-host) targets are quiet.
- The warning names both hosts so operators can see when credentials would go to an unconfigured host.

```python
_LOGGER.warning(
    "Long-running-operation poll target host '%s' differs from the client's configured "
    "endpoint host '%s'. The poll request carries the client's credentials to that host. ...",
    poll_domain, initial_domain,
)
```

## Why a warning, not a block (question for maintainers)

I deliberately left this as a warning rather than a hard block or a credential strip. A `raise`-on-mismatch broke 16 existing `test_base_polling` tests, because several fixtures configure the client on one host (`http://example.org`) while the `Operation-Location`/`Location` header points to another (`http://dummyurl...`). That could be test-only sloppiness, or it could reflect services that legitimately poll a different host — I can't tell from outside.

**Question:** Is credentialed cross-host LRO polling ever legitimate for shipping Azure services (regional/failover endpoints, sovereign clouds, private endpoints, Traffic-Manager-fronted services)? If not, this could be escalated to strip the credential (mirroring `SensitiveHeaderCleanupPolicy`) or reject the poll. I kept it non-breaking so the decision — which needs the service inventory only Microsoft has — stays with you.

## Testing

- New `test_warn_on_cross_host_poll_target_warns_only_when_host_differs`: warns on cross-host; quiet on same-host, same-host-with-port, and relative targets.
- Existing `test_base_polling` suite unchanged (no fixtures needed rewriting, since this does not block). pylint 10.00/10 on the changed modules.

## Context

Reported privately to MSRC (assessed None severity / defense-in-depth; host-validation gap acknowledged). Filing this as a public hardening improvement per that assessment.
