### PR TITLE
Prepare azure-ai-agentserver-core 2.2.0b1 release

### DIFF
--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.2.0b1 (2026-09-01)
+## 2.2.0b1 (2026-09-03)
 
 ### Features Added
 

--- a/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
+++ b/sdk/agentserver/azure-ai-agentserver-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.2.0b1 (Unreleased)
+## 2.2.0b1 (2026-09-01)
 
 ### Features Added
 


### PR DESCRIPTION
## Description

Updates the `azure-ai-agentserver-core` 2.2.0b1 release date to 2026-09-03.

## Checklist

- [x] Version remains 2.2.0b1
- [x] CHANGELOG release date updated