### PR TITLE
[Cosmos] Harden diagnostics logging redaction (Set-Cookie/auth-challenge headers + error-path URL)

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bugs Fixed
 * Fixed regression with handling of v1 legacy containers when passing `{}` as a partition key. `{}` and `NonePartitionKeyValue` now both resolve to the `Undefined` effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
 * Fixed the same `TypeError` on system key (migrated) containers, where a missing partition key value resolves to `_Empty` instead of `Undefined`. It now maps to the minimum effective partition key. See [PR 48422](https://github.com/Azure/azure-sdk-for-python/pull/48422)
+* Hardened diagnostics logging redaction: `Set-Cookie`, `Proxy-Authenticate`, and `WWW-Authenticate` headers are no longer logged in the clear, and the request URL is now redacted on the error and exception logging paths (matching the success path), so query-parameter values are not logged.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_http_logging_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_http_logging_policy.py
@@ -58,6 +58,30 @@ HTTPResponseType = Union["LegacyHttpResponse", "HttpResponse", "LegacyAsyncHttpR
 "AsyncHttpResponse", "SansIOHttpResponse", "LegacySansIOHttpResponse"]
 
 
+def _redact_url(url: Optional[str]) -> Optional[str]:
+    """Redact all query-parameter values from a URL so it can be logged safely.
+
+    The success path (``on_request``) already logs a redacted URL; the error and exception
+    paths must apply the same redaction so query-parameter values are never logged in the clear.
+
+    :param url: The request URL to redact.
+    :type url: Optional[str]
+    :return: The URL with every query-parameter value replaced by the redaction placeholder.
+    :rtype: Optional[str]
+    """
+    if not url:
+        return url
+    try:
+        parsed = list(urllib.parse.urlparse(url))
+        query_pairs = urllib.parse.parse_qsl(parsed[4], keep_blank_values=True)
+        parsed[4] = "&".join(
+            f"{key}={HttpLoggingPolicy.REDACTED_PLACEHOLDER}" for key, _ in query_pairs
+        )
+        return urllib.parse.urlunparse(parsed)
+    except Exception:  # pylint: disable=broad-except
+        return HttpLoggingPolicy.REDACTED_PLACEHOLDER
+
+
 # These Helper functions are used to Log Diagnostics for the SDK outside on_request and on_response
 def _populate_logger_attributes(  # type: ignore[attr-defined, union-attr]
                             logger_attributes: Optional[dict[str, Any]] = None,
@@ -85,7 +109,7 @@ def _populate_logger_attributes(  # type: ignore[attr-defined, union-attr]
     if http_request:
         logger_attributes["activity_id"] = http_request.headers.get(HttpHeaders.ActivityId, "")
         logger_attributes["verb"] = http_request.method
-        logger_attributes["url"] = http_request.url
+        logger_attributes["url"] = _redact_url(http_request.url)
         logger_attributes["operation_type"] = http_request.headers.get(
             'x-ms-thinclient-proxy-operation-type')
         logger_attributes["resource_type"] = http_request.headers.get(
@@ -144,7 +168,7 @@ def _log_diagnostics_error(  # type: ignore[attr-defined, union-attr]
         log_string += _get_database_account_settings(global_endpoint_manager)
         http_request = request.http_request if request else None
         if http_request:
-            log_string += f"\nRequest URL: {http_request.url}"
+            log_string += f"\nRequest URL: {_redact_url(http_request.url)}"
             log_string += f"\nRequest method: {http_request.method}"
             log_string += "\nRequest Activity ID: {}".format(http_request.headers.get(HttpHeaders.ActivityId))
             log_string += "\nRequest headers:"
@@ -542,7 +566,7 @@ class CosmosHttpLoggingPolicy(HttpLoggingPolicy):
                 logger_attributes["duration"] = duration
                 logger_attributes["activity_id"] = request.http_request.headers.get(HttpHeaders.ActivityId, "")
                 logger_attributes["verb"] = request.http_request.method
-                logger_attributes["url"] = request.http_request.url
+                logger_attributes["url"] = _redact_url(request.http_request.url)
                 logger_attributes["operation_type"] = request.http_request.headers.get(
                     'x-ms-thinclient-proxy-operation-type')
                 logger_attributes["resource_type"] = request.http_request.headers.get(

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
@@ -495,8 +495,19 @@ class ResourceType:
             ResourceType.PartitionKey,
         )
 
-# The list of headers we do not want to log, it needs to be updated if any new headers should not be logged
-_cosmos_disallow_list = ["Authorization", "ProxyAuthorization", "TransferEncoding"]
+# Security-sensitive headers that must never be logged, even when diagnostics logging is enabled.
+# This includes credential/authorization headers and headers that can carry session material
+# (cookies, authentication challenges), matching the headers azure-core's HttpLoggingPolicy
+# redacts by default. Redaction here is deny-by-list, so any newly added sensitive header must be
+# added below to avoid being logged in the clear.
+_cosmos_disallow_list = [
+    "Authorization",
+    "ProxyAuthorization",
+    "TransferEncoding",
+    "SetCookie",
+    "ProxyAuthenticate",
+    "WwwAuthenticate",
+]
 _cosmos_allow_list = set(
     v.lower()
     for k, v in HttpHeaders.__dict__.items()

--- a/sdk/cosmos/azure-cosmos/tests/test_cosmos_log_redaction.py
+++ b/sdk/cosmos/azure-cosmos/tests/test_cosmos_log_redaction.py
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+"""Regression tests for CosmosHttpLoggingPolicy redaction.
+
+Asserts the PROPERTY (sensitive headers and query-parameter values are never
+logged), not a single input. Place under sdk/cosmos/azure-cosmos/tests/.
+"""
+import logging
+
+from azure.cosmos._cosmos_http_logging_policy import _redact_url
+from azure.cosmos.http_constants import _cosmos_allow_list
+
+
+def test_sensitive_headers_are_not_in_allow_list():
+    # These are redacted by azure-core's HttpLoggingPolicy by default and must
+    # not be logged by the Cosmos policy either.
+    for header in ("authorization", "proxy-authorization", "set-cookie",
+                   "proxy-authenticate", "www-authenticate"):
+        assert header not in _cosmos_allow_list, f"{header} must be redacted, not logged"
+
+
+def test_redact_url_strips_query_values_keeps_path():
+    url = "https://acct.documents.azure.com/dbs/d/colls/c/docs/x?sig=SECRET&%24filter=foo"
+    redacted = _redact_url(url)
+    assert "SECRET" not in redacted
+    assert "foo" not in redacted
+    # Path (database/collection/document identifiers) is preserved for diagnostics.
+    assert "/dbs/d/colls/c/docs/x" in redacted
+
+
+def test_redact_url_handles_no_query_and_none():
+    plain = "https://acct.documents.azure.com/dbs/d/colls/c"
+    assert _redact_url(plain) == plain
+    assert _redact_url(None) is None
+    assert _redact_url("") == ""
+
+
+def test_error_path_logs_redacted_url(caplog):
+    """The error path must log a URL with no query-parameter values."""
+    from unittest.mock import MagicMock
+    from azure.cosmos._cosmos_http_logging_policy import _log_diagnostics_error
+
+    request = MagicMock()
+    request.http_request.url = "https://acct.documents.azure.com/dbs/d/colls/c?sig=SECRET"
+    request.http_request.method = "GET"
+    request.http_request.headers = {}
+
+    with caplog.at_level(logging.INFO, logger="azure.cosmos._cosmos_http_logging_policy"):
+        _log_diagnostics_error(diagnostics_enabled=True, request=request,
+                               response_headers={}, error=Exception("boom"))
+    assert "SECRET" not in caplog.text


### PR DESCRIPTION
**What**

`CosmosHttpLoggingPolicy` redacted only a 3-entry denylist (`Authorization`, `ProxyAuthorization`, `TransferEncoding`), logging every other header in the clear when diagnostics logging (`enable_diagnostics_logging=True`) is on. That re-exposes headers azure-core's `HttpLoggingPolicy` redacts by default — notably `Set-Cookie`, `Proxy-Authenticate`, and `WWW-Authenticate`, which can carry session material.

Separately, the success path (`on_request`) logged a query-redacted URL, but the error/exception paths (`_log_diagnostics_error`, `on_exception`, `_populate_logger_attributes`) logged the **raw** URL, so query-parameter values could be logged.

**Changes**

- Add `SetCookie`, `ProxyAuthenticate`, `WwwAuthenticate` to `_cosmos_disallow_list` (`http_constants.py`), and note in the comment that deny-by-list is fail-open, so any new sensitive header must be added there.
- Add a `_redact_url` helper (`_cosmos_http_logging_policy.py`) and apply it on the error/exception logging paths, so the URL is redacted consistently with `on_request`.
- CHANGELOG entry under Unreleased > Bugs Fixed.
- Tests covering the header redaction and the error-path URL redaction.

**Scope / severity (stated honestly)**

Defense-in-depth for diagnostics logging. Credential headers (`Authorization` for both the master-key HMAC signature and AAD bearer, `ProxyAuthorization`) were already redacted and remain so; this closes the leakage of cookies / auth-challenge headers and query-parameter values that azure-core redacts by default. Requires opt-in diagnostics logging plus access to the logs; not remotely exploitable.

The deny-by-list design is fail-open by nature (a newly introduced sensitive header would be logged until added to the list). This PR keeps the existing intent (the SDK deliberately logs `x-ms-*` diagnostics headers) and makes the minimal, mergeable change; a maintainer wanting a stronger posture could switch to an allowlist, which the added comment flags.
