### PR TITLE
[ApiStub] Reuse staged wheels and fail on input prompts

### DIFF
--- a/eng/pipelines/templates/jobs/apireview-hub-job-python.yml
+++ b/eng/pipelines/templates/jobs/apireview-hub-job-python.yml
@@ -30,6 +30,9 @@ jobs:
     imageOverride: ${{ parameters.imageOverride }}
     sourceRepositoryFullName: ${{ format('{0}/azure-sdk-for-python', parameters.repositoryOwner) }}
     sourceCheckoutDir: $(Pipeline.Workspace)/apireview/source
+    variables:
+      - name: PIP_NO_INPUT
+        value: '1'
     setupSteps:
       - task: UsePythonVersion@0
         displayName: 'Use Python ${{ parameters.pythonVersion }}'

--- a/eng/tools/azure-sdk-tools/azpysdk/apistub.py
+++ b/eng/tools/azure-sdk-tools/azpysdk/apistub.py
@@ -17,7 +17,7 @@ AZURE_SDK_INDEX_URL = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/az
 PYPI_INDEX_URL = "https://pypi.org/simple/"
 
 
-def get_package_wheel_path(pkg_root: str) -> str:
+def get_package_wheel_path(pkg_root: str, staging_dir: Optional[str] = None) -> str:
     # parse setup.py to get package name and version
     pkg_details = ParsedSetup.from_path(pkg_root)
 
@@ -34,7 +34,11 @@ def get_package_wheel_path(pkg_root: str) -> str:
                 )
             )
         return pkg_path
-    # Otherwise, use wheel created in staging directory, or fall back on source directory
+    if staging_dir:
+        found_whl = find_whl(staging_dir, pkg_details.name, pkg_details.version)
+        if found_whl:
+            return os.path.join(staging_dir, found_whl)
+    # Otherwise, use a wheel in the source directory, or fall back on the source directory
     pkg_path = find_whl(pkg_root, pkg_details.name, pkg_details.version) or pkg_root
     return pkg_path
 
@@ -197,7 +201,7 @@ class apistub(Check):
                         pre_download_disabled=False,
                         python_executable=executable,
                     )
-                pkg_path = get_package_wheel_path(package_dir)
+                pkg_path = get_package_wheel_path(package_dir, staging_directory)
 
             if install_deps:
                 self.pip_freeze(executable)

--- a/eng/tools/azure-sdk-tools/tests/test_apistub.py
+++ b/eng/tools/azure-sdk-tools/tests/test_apistub.py
@@ -101,6 +101,19 @@ class TestGetPackageWheelPath:
 
     @patch("azpysdk.apistub.ParsedSetup")
     @patch("azpysdk.apistub.find_whl")
+    def test_no_prebuilt_dir_returns_staging_whl(self, mock_find_whl, mock_parsed, monkeypatch):
+        monkeypatch.delenv("PREBUILT_WHEEL_DIR", raising=False)
+        mock_parsed.from_path.return_value.name = "azure-core"
+        mock_parsed.from_path.return_value.version = "1.0.0"
+        mock_find_whl.return_value = "azure_core-1.0.0-py3-none-any.whl"
+
+        result = get_package_wheel_path("/my/pkg", "/staging")
+
+        assert result == os.path.join("/staging", "azure_core-1.0.0-py3-none-any.whl")
+        mock_find_whl.assert_called_once_with("/staging", "azure-core", "1.0.0")
+
+    @patch("azpysdk.apistub.ParsedSetup")
+    @patch("azpysdk.apistub.find_whl")
     def test_no_prebuilt_dir_falls_back_to_pkg_root(self, mock_find_whl, mock_parsed, monkeypatch):
         """Without PREBUILT_WHEEL_DIR and no wheel found, fall back to pkg_root path."""
         monkeypatch.delenv("PREBUILT_WHEEL_DIR", raising=False)


### PR DESCRIPTION
This does 2 things:

1) Makes the CI fail if pip install requires interactive prompts
2) Allows `azpysk apistub` to reuse staged wheels instead of always recompiling them