### PR TITLE
fix(storage-blob): normalize backslash to forward slash in SAS canonical resource

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -351,6 +351,10 @@ class _BlobSharedAccessHelper(_SharedAccessHelper):
         if path[0] != "/":
             path = "/" + path
 
+        # Normalize backslashes to forward slashes to match Azure Storage service behavior
+        # Go and .NET SDKs already perform this normalization
+        path = path.replace("\\", "/")
+
         canonicalized_resource = "/blob/" + account_name + path + "\n"
 
         # Form the string to sign from shared_access_policy and canonicalized

--- a/sdk/storage/azure-storage-blob/tests/test_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/tests/test_shared_access_signature.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timedelta
+
+from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+
+def test_generate_blob_sas_normalizes_backslashes_in_canonical_resource():
+    string_to_sign = []
+
+    generate_blob_sas(
+        account_name="account",
+        container_name="container",
+        blob_name="dir\\file",
+        account_key="a2V5",
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.utcnow() + timedelta(hours=1),
+        sts_hook=string_to_sign.append,
+    )
+
+    assert "/blob/account/container/dir/file\n" in string_to_sign[0]


### PR DESCRIPTION
## Fix #48690 - generate_blob_sas backslash normalization

### Description

When building the SAS string-to-sign, the SDK was inserting the blob name verbatim into the canonical resource without normalizing backslash (\) to forward slash (/).

Azure Storage service normalizes \ to / when validating SAS signatures, causing generated SAS tokens to be rejected (HTTP 403) for blob names containing backslashes.

This fix aligns Python SDK behavior with Go and .NET SDKs which already perform this normalization.

### Fix

Added path = path.replace("\\\\", "/") in add_resource_signature() method before building the canonical resource string.

### Testing

The issue reporter verified this fix against Azurite (the official Storage emulator).