### PR TITLE
[ARH] Install deps if needed when generating artifacts

### DIFF
--- a/eng/pipelines/templates/steps/create-apireview-hub-artifacts-python.yml
+++ b/eng/pipelines/templates/steps/create-apireview-hub-artifacts-python.yml
@@ -72,7 +72,10 @@ steps:
             install -D "$tooling_dir/eng/common/scripts/Export-APIViewMarkdown.ps1" "$source_repo/eng/common/scripts/Export-APIViewMarkdown.ps1"
             install -D "$tooling_dir/eng/scripts/extract_apiview_metadata.py" "$source_repo/eng/scripts/extract_apiview_metadata.py"
             python -c "import apistub, sys; print(f'Python: {sys.executable}'); print(f'apistub: {apistub.__file__}')"
-            (cd "$source_repo" && PYTHONPATH="$common_tasks_dir${PYTHONPATH:+:$PYTHONPATH}" python -m azpysdk.main apistub --dest-dir "$package_dir" "$PACKAGE_NAME")
+            if ! (cd "$source_repo" && PYTHONPATH="$common_tasks_dir${PYTHONPATH:+:$PYTHONPATH}" python -m azpysdk.main apistub --dest-dir "$package_dir" "$PACKAGE_NAME"); then
+              echo "API review generation failed without package dependencies; retrying with --install-deps."
+              (cd "$source_repo" && PYTHONPATH="$common_tasks_dir${PYTHONPATH:+:$PYTHONPATH}" python -m azpysdk.main apistub --install-deps --dest-dir "$package_dir" "$PACKAGE_NAME")
+            fi
 
             if [ ! -f "$package_dir/api.md" ]; then
               echo "Expected api.md was not generated at $package_dir/api.md" >&2


### PR DESCRIPTION
Don't use `--install-deps` unless needed.