### PR TITLE
[Evaluation] Prepare azure-ai-evaluation 1.18.5 release

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
+++ b/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.18.5 (Unreleased)
+## 1.18.5 (2026-09-02)
 
 ### Bugs Fixed
 
 - Made Application Insights export failures best-effort for evaluations using project managed identity authentication.
-
-## 1.18.4 (2026-08-27)
-
-### Bugs Fixed
 
 - Fixed keyword argument routing so bare `messages=[...]` input, with optional top-level `context`, `ground_truth`,
   and `tool_definitions`, is normalized into the already-supported conversation path for `RelevanceEvaluator`,


### PR DESCRIPTION
## Summary

- stamp `azure-ai-evaluation` 1.18.5 for release on 2026-09-02
- fold the unpublished 1.18.4 change note into 1.18.5
- make the release notes describe the cumulative update from the latest PyPI version, 1.18.3

PyPI has no 1.18.4 artifact. This PR intentionally supersedes that prior release-preparation attempt rather than leaving a changelog section that implies 1.18.4 was published.

## Validation

- official `Verify-ChangeLog.ps1` release validation passed for 1.18.5
- Black 24.4.0: 407 files unchanged
- targeted regression tests: 60 passed
- built wheel and sdist both report version 1.18.5
- local wheel import smoke test reports 1.18.5

Artifact SHA-256:
- wheel: `B3DB99DA43FE91D0739B561EED99F292D3B6C77F740A865D71C40047C0BBBD25`
- sdist: `73B47141FE0BD8A2AE0F5CC2221C8544FA1FE9C52ABC4CECE64DCCFD4FBBC29A`