### PR TITLE
[identity] pin msal to < 1.38.0

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added `RequestIdPolicy` to the default pipeline policies to ensure a unique `x-ms-client-request-id` header is sent with each request. ([#46070](https://github.com/Azure/azure-sdk-for-python/pull/46070))
 - `CertificateCredential` now passes the PEM private_key to MSAL as a str rather than bytes, matching MSAL's documented `client_credential` contract. ([#46801](https://github.com/Azure/azure-sdk-for-python/pull/46801))
+- Temporarily constrained `msal` to `<1.38.0` because MSAL 1.38 is incompatible with the Azure Core-backed transport used by synchronous Service Fabric managed identity authentication.
 
 ## 1.25.3 (2026-03-12)
 

--- a/sdk/identity/azure-identity/pyproject.toml
+++ b/sdk/identity/azure-identity/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "azure-core>=1.31.0",
     "cryptography>=2.5",
-    "msal>=1.35.1",
+    "msal>=1.35.1,<1.38.0",
     "msal-extensions>=1.2.0",
     "typing-extensions>=4.0.0",
 ]


### PR DESCRIPTION
msal 1.38.0 https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/952 breaks the Identity implementation for Service Fabric because it only accepts a Requests.Session type

temporarily pin to below 1.38 while we look into solutions