### PR TITLE
Fix issue with filtering

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -255,11 +255,37 @@ stages:
                     ConfigFileDir: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo'
                     PackageArtifactName: ${{artifact.name}}
 
-                - template: /eng/common/pipelines/templates/steps/mark-package-released.yml
-                  parameters:
-                    PackageInfoFiles:
-                      - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{ artifact.name }}.json
-                    RepoOwner: Azure
+                # Management-plane-only workaround: skip marking packages that do not generate an APIView revision.
+                - pwsh: |
+                    $packageInfoPath = '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{ artifact.name }}.json'
+                    $packageInfo = Get-Content -Raw -Path $packageInfoPath | ConvertFrom-Json
+                    $isManagementPackage = $packageInfo.SdkType -eq 'mgmt'
+                    Write-Host "##vso[task.setvariable variable=IsManagementPackage]$isManagementPackage"
+                  displayName: Check package SDK type
+
+                - task: AzureCLI@2
+                  displayName: Mark Package Released
+                  condition: >-
+                    and(
+                      succeeded(),
+                      ne(variables['IsManagementPackage'], 'true'),
+                      not(
+                        and(
+                          eq(variables['Skip.MarkPackageReleased'], 'true'),
+                          eq(variables['IsRequesterAuthorizedToSkipApiReview'], 'true')
+                        )
+                      )
+                    )
+                  inputs:
+                    azureSubscription: "ADO to ARH Service Connection"
+                    scriptType: pscore
+                    scriptLocation: scriptPath
+                    scriptPath: $(Build.SourcesDirectory)/eng/common/scripts/Mark-PackageReleased.ps1
+                    arguments: >
+                      -PackageInfoFiles @('$(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{ artifact.name }}.json')
+                      -RepoOwner 'Azure'
+                      -AzSdkExePath '$(AZSDK)'
+                    workingDirectory: $(Pipeline.Workspace)
 
             - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
                 - job: PublishGitHubIODocs

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -176,10 +176,12 @@ extends:
                   - pwsh: |
                       & '$(Build.SourcesDirectory)/eng/scripts/Filter-PackageInfoForPackageApproval.ps1' `
                         -PackageInfoDirectory '$(Pipeline.Workspace)/packages_extended/PackageInfo' `
-                        -ArtifactsJson '${{ convertToJson(parameters.Artifacts) }}' `
+                        -ArtifactsJson $env:ARTIFACTS_JSON `
                         -PackageInfoPathPrefix 'packages_extended/PackageInfo'
                     name: filterPackageInfo
                     displayName: Filter management plane packages from package approval
+                    env:
+                      ARTIFACTS_JSON: ${{ convertToJson(parameters.Artifacts) }}
 
               - job: CheckPackageApproval
                 displayName: Check Package Approval Status

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -176,6 +176,7 @@ extends:
                   - pwsh: |
                       & '$(Build.SourcesDirectory)/eng/scripts/Filter-PackageInfoForPackageApproval.ps1' `
                         -PackageInfoDirectory '$(Pipeline.Workspace)/packages_extended/PackageInfo' `
+                        -ArtifactsJson '${{ convertToJson(parameters.Artifacts) }}' `
                         -PackageInfoPathPrefix 'packages_extended/PackageInfo'
                     name: filterPackageInfo
                     displayName: Filter management plane packages from package approval

--- a/eng/scripts/Filter-PackageInfoForPackageApproval.ps1
+++ b/eng/scripts/Filter-PackageInfoForPackageApproval.ps1
@@ -4,27 +4,29 @@ param (
     [string] $PackageInfoDirectory,
 
     [Parameter(Mandatory = $true)]
+    [string] $ArtifactsJson,
+
+    [Parameter(Mandatory = $true)]
     [string] $PackageInfoPathPrefix
 )
 
+$artifacts = $ArtifactsJson | ConvertFrom-Json
 $packageInfoFiles = @()
 
-$availablePackageInfoFiles = @(Get-ChildItem -Path $PackageInfoDirectory -Filter '*.json' -File -ErrorAction SilentlyContinue)
-if ($availablePackageInfoFiles.Count -eq 0) {
-    Write-Host "No packages require a package approval check."
-    Write-Host "##vso[task.setvariable variable=PackageApprovalInfoFiles;isOutput=true]"
-    Write-Host "##vso[task.setvariable variable=HasPackageApprovalPackages;isOutput=true]False"
-    exit 0
-}
+foreach ($artifact in $artifacts) {
+    $packageInfoPath = Join-Path $PackageInfoDirectory "$($artifact.name).json"
+    if (!(Test-Path -Path $packageInfoPath -PathType Leaf)) {
+        Write-Host "PackageInfo file was not found; skipping: $packageInfoPath"
+        continue
+    }
 
-foreach ($packageInfoFile in $availablePackageInfoFiles) {
-    $packageInfo = Get-Content -Raw -Path $packageInfoFile.FullName | ConvertFrom-Json
+    $packageInfo = Get-Content -Raw -Path $packageInfoPath | ConvertFrom-Json
     if ($packageInfo.SdkType -eq 'mgmt') {
         Write-Host "Package approval is not required for management plane SDKs: $($packageInfo.Name)"
         continue
     }
 
-    $packageInfoFiles += "$PackageInfoPathPrefix/$($packageInfoFile.Name)"
+    $packageInfoFiles += "$PackageInfoPathPrefix/$($artifact.name).json"
 }
 
 $hasPackageApprovalPackages = $packageInfoFiles.Count -gt 0


### PR DESCRIPTION
If you set the `BuildTargetingString` variable, there's a step in the pipeline where we forcibly delete any PackageInfo files except the one in the variable. When it gets to the step to filter management plane packages, the CI can fail because an expected PackageInfo file is missing. This corrects that. 

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6785204&view=results

This also introduces a check in the APIView/ARH "mark package released" stage that skips this for management plane. Since APIView token files aren't generated for mgmt plane, ApiHash cannot be calculated and thus ARH cannot be called. APIView does not succeed either because it does not create automatic revisions for mgmt plane. This change ensures this stage doesn't fail. 