### PR TITLE
Fix Python generate output package paths

### DIFF
--- a/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -246,6 +246,7 @@ def main(generate_input, generate_output):
             try:
                 package_total.add(package_name)
                 sdk_code_path = str(Path(sdk_folder, folder_name, package_name))
+                package_path = Path(folder_name, package_name).as_posix()
                 # Sanitize invalid Python escape sequences (e.g. `\W`) in
                 # generated docstrings to avoid SyntaxWarning on Python 3.12+.
                 # See https://github.com/Azure/azure-sdk-for-python/issues/47011
@@ -257,7 +258,7 @@ def main(generate_input, generate_output):
                 if package_name not in result:
                     package_entry = {}
                     package_entry["packageName"] = package_name
-                    package_entry["path"] = [folder_name]
+                    package_entry["path"] = [package_path]
                     package_entry[spec_word] = [readme_or_tsp]
                     package_entry["tagIsStable"] = (
                         sdk_release_type == "stable"
@@ -267,7 +268,7 @@ def main(generate_input, generate_output):
                     package_entry["targetReleaseDate"] = data.get("targetReleaseDate", "")
                     result[package_name] = package_entry
                 else:
-                    result[package_name]["path"].append(folder_name)
+                    result[package_name]["path"].append(package_path)
                     result[package_name][spec_word].append(readme_or_tsp)
             except Exception as e:
                 _LOGGER.error(f"Fail to process package {package_name} in {readme_or_tsp}: {str(e)}")
@@ -364,7 +365,7 @@ def main(generate_input, generate_output):
 
             # Build artifacts for package
             try:
-                create_package(result[package_name]["path"][0], package_name)
+                create_package(folder_name, package_name)
                 dist_path = Path(sdk_folder, folder_name, package_name, "dist")
                 result[package_name]["artifacts"] = [
                     str(dist_path / package_file) for package_file in os.listdir(dist_path)
@@ -383,7 +384,7 @@ def main(generate_input, generate_output):
                 "lite": f"pip install {package_name}",
             }
             result[package_name]["result"] = "succeeded"
-            result[package_name]["packageFolder"] = result[package_name]["path"][0]
+            result[package_name]["packageFolder"] = folder_name
 
     # remove duplicates
     try:

--- a/eng/tools/azure-sdk-tools/tests/test_sdk_generator.py
+++ b/eng/tools/azure-sdk-tools/tests/test_sdk_generator.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 
 MODULE = "packaging_tools.sdk_generator"
@@ -52,40 +52,50 @@ def _common_patches():
     }
 
 
+def _run_main(
+    input_path,
+    output_path,
+    input_data,
+    package_names,
+    judge_return=False,
+    expected_create_package_calls=None,
+):
+    """Helper that wires up all the mocks and calls main()."""
+    _write_input(input_path, input_data)
+
+    patches = _common_patches()
+    mocks = {name: p.start() for name, p in patches.items()}
+
+    # get_package_names returns our controlled list
+    mocks["get_package_names"].return_value = package_names
+    mocks["judge_tag_preview"].return_value = judge_return
+
+    # create_package needs a dist folder with a .whl
+    def fake_create_package(folder, pkg):
+        # Use a temporary base directory to avoid polluting the repo workspace
+        base_dir = Path(tempfile.mkdtemp())
+        dist = base_dir / folder / pkg / "dist"
+        dist.mkdir(parents=True, exist_ok=True)
+        (dist / f"{pkg}-0.0.0-py3-none-any.whl").touch()
+
+    mocks["create_package"].side_effect = fake_create_package
+
+    try:
+        from packaging_tools.sdk_generator import main
+
+        main(input_path, output_path)
+        if expected_create_package_calls is not None:
+            mocks["create_package"].assert_has_calls(expected_create_package_calls, any_order=True)
+    finally:
+        for p in patches.values():
+            p.stop()
+
+    return _read_output(output_path)
+
+
 class TestTagIsStableForTypeSpec:
     """Tests for the tagIsStable logic change: TypeSpec projects use sdkReleaseType,
     while Swagger projects still use judge_tag_preview."""
-
-    def _run_main(self, input_path, output_path, input_data, package_names, judge_return=False):
-        """Helper that wires up all the mocks and calls main()."""
-        _write_input(input_path, input_data)
-
-        patches = _common_patches()
-        mocks = {name: p.start() for name, p in patches.items()}
-
-        # get_package_names returns our controlled list
-        mocks["get_package_names"].return_value = package_names
-        mocks["judge_tag_preview"].return_value = judge_return
-
-        # create_package needs a dist folder with a .whl
-        def fake_create_package(folder, pkg):
-            # Use a temporary base directory to avoid polluting the repo workspace
-            base_dir = Path(tempfile.mkdtemp())
-            dist = base_dir / folder / pkg / "dist"
-            dist.mkdir(parents=True, exist_ok=True)
-            (dist / f"{pkg}-0.0.0-py3-none-any.whl").touch()
-
-        mocks["create_package"].side_effect = fake_create_package
-
-        try:
-            from packaging_tools.sdk_generator import main
-
-            main(input_path, output_path)
-        finally:
-            for p in patches.values():
-                p.stop()
-
-        return _read_output(output_path)
 
     # ── TypeSpec: sdkReleaseType == "stable" → tagIsStable = True ────
 
@@ -98,7 +108,7 @@ class TestTagIsStableForTypeSpec:
             "relatedTypeSpecProjectFolder": ["Microsoft.Test/stable"],
             "sdkReleaseType": "stable",
         }
-        result = self._run_main(
+        result = _run_main(
             input_path,
             output_path,
             input_data,
@@ -118,7 +128,7 @@ class TestTagIsStableForTypeSpec:
             "relatedTypeSpecProjectFolder": ["Microsoft.Test/preview"],
             "sdkReleaseType": "preview",
         }
-        result = self._run_main(
+        result = _run_main(
             input_path,
             output_path,
             input_data,
@@ -138,7 +148,7 @@ class TestTagIsStableForTypeSpec:
             "relatedTypeSpecProjectFolder": ["Microsoft.Test/preview"],
             # no sdkReleaseType key
         }
-        result = self._run_main(
+        result = _run_main(
             input_path,
             output_path,
             input_data,
@@ -158,7 +168,7 @@ class TestTagIsStableForTypeSpec:
             "relatedReadmeMdFiles": ["specification/test/resource-manager/readme.md"],
             "sdkReleaseType": "stable",
         }
-        result = self._run_main(
+        result = _run_main(
             input_path,
             output_path,
             input_data,
@@ -175,7 +185,7 @@ class TestTagIsStableForTypeSpec:
             "relatedReadmeMdFiles": ["specification/test/resource-manager/readme.md"],
             "sdkReleaseType": "stable",
         }
-        result = self._run_main(
+        result = _run_main(
             input_path,
             output_path,
             input_data,
@@ -184,6 +194,52 @@ class TestTagIsStableForTypeSpec:
         )
         pkg = result["packages"][0]
         assert pkg["tagIsStable"] is True
+
+
+class TestPackagePaths:
+    def test_reports_package_source_root(self, io_paths):
+        input_path, output_path = io_paths
+        result = _run_main(
+            input_path,
+            output_path,
+            {
+                "specFolder": "spec",
+                "headSha": "abc123",
+                "repoHttpsUrl": "https://github.com/test/repo",
+                "relatedTypeSpecProjectFolder": ["Microsoft.DevTestLab/DevTestLab.Management"],
+            },
+            package_names=[("sdk/devtestlabs", "azure-mgmt-devtestlabs")],
+            expected_create_package_calls=[call("sdk/devtestlabs", "azure-mgmt-devtestlabs")],
+        )
+
+        assert result["packages"][0]["path"] == ["sdk/devtestlabs/azure-mgmt-devtestlabs"]
+
+    def test_reports_distinct_roots_for_packages_in_same_service(self, io_paths):
+        input_path, output_path = io_paths
+        result = _run_main(
+            input_path,
+            output_path,
+            {
+                "specFolder": "spec",
+                "headSha": "abc123",
+                "repoHttpsUrl": "https://github.com/test/repo",
+                "relatedTypeSpecProjectFolder": ["Microsoft.ServiceFabric/ServiceFabric.Management"],
+            },
+            package_names=[
+                ("sdk/servicefabric", "azure-servicefabric"),
+                ("sdk/servicefabric", "azure-mgmt-servicefabric"),
+            ],
+            expected_create_package_calls=[
+                call("sdk/servicefabric", "azure-servicefabric"),
+                call("sdk/servicefabric", "azure-mgmt-servicefabric"),
+            ],
+        )
+
+        package_paths = {package["packageName"]: package["path"] for package in result["packages"]}
+        assert package_paths == {
+            "azure-servicefabric": ["sdk/servicefabric/azure-servicefabric"],
+            "azure-mgmt-servicefabric": ["sdk/servicefabric/azure-mgmt-servicefabric"],
+        }
 
 
 class TestExtractSdkFolder:


### PR DESCRIPTION
## Summary

- report each generated Python package's source root in `generateOutput.json`
- keep the service folder as the internal input to `create_package`
- cover the expected devtestlabs path and multiple packages in one service

This allows `spec-gen-sdk` and SDK validation tools to receive the actual package root instead of the containing service directory.

Related to Azure/azure-sdk-tools#16947.

## Testing

- `python -m pytest tests/test_sdk_generator.py -q` (`11 passed`)
- `python -m black --check packaging_tools/sdk_generator.py tests/test_sdk_generator.py`
- `git diff --check`