### PR TITLE
Appconfig test key isolation

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration-provider/assets.json
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/appconfiguration/azure-appconfiguration-provider",
-  "Tag": "python/appconfiguration/azure-appconfiguration-provider_05f22217b9"
+  "Tag": "python/appconfiguration/azure-appconfiguration-provider_293f160543"
 }

--- a/sdk/appconfiguration/azure-appconfiguration-provider/tests/aio/key_vault/test_async_secret_refresh.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/tests/aio/key_vault/test_async_secret_refresh.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 from devtools_testutils import EnvironmentVariableLoader
 from devtools_testutils.aio import recorded_by_proxy_async
 from asynctestcase import AppConfigTestCase
+from testcase import create_secret_config_setting
 from test_constants import (
     APPCONFIGURATION_ENDPOINT_STRING,
     APPCONFIGURATION_KEYVAULT_SECRET_URL,
@@ -82,35 +83,28 @@ class TestAsyncSecretRefresh(AppConfigTestCase, unittest.TestCase):
     ):
         """Test that secrets are refreshed with updated values."""
         mock_callback = Mock()
-
-        # Create client with the mock secret resolver
-        client = await self.create_client(
-            endpoint=appconfiguration_endpoint_string,
-            selects={SettingSelector(key_filter="*", label_filter="prod")},
-            keyvault_secret_url=appconfiguration_keyvault_secret_url,
-            keyvault_secret_url2=appconfiguration_keyvault_secret_url2,
-            on_refresh_success=mock_callback,
-            refresh_on=[WatchKey("secret", "prod")],
-            refresh_interval=1,
-            secret_refresh_interval=1,  # Using a short interval for testing
-        )
-
-        # Add a key vault reference to the client (this will use mock resolver)
+        secret_key = f"{self.get_resource_name('test')}-secret"
         appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-        # Get and modify a key vault reference setting
-        kv_setting = await appconfig_client.get_configuration_setting(key="secret", label="prod")
-        assert kv_setting is not None
-
-        # Verify initial value from mock resolver
-        assert client["secret"] == "Very secret value"
-        assert kv_setting is not None
-        assert isinstance(kv_setting, SecretReferenceConfigurationSetting)
-        # Update the secret_id (which is the value for SecretReferenceConfigurationSetting)
-        kv_setting.secret_id = appconfiguration_keyvault_secret_url2
+        kv_setting = create_secret_config_setting(secret_key, "prod", appconfiguration_keyvault_secret_url)
         await appconfig_client.set_configuration_setting(kv_setting)
 
         try:
+            client = await self.create_client(
+                endpoint=appconfiguration_endpoint_string,
+                selects={SettingSelector(key_filter=secret_key, label_filter="prod")},
+                keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                keyvault_secret_url2=appconfiguration_keyvault_secret_url2,
+                on_refresh_success=mock_callback,
+                refresh_on=[WatchKey(secret_key, "prod")],
+                refresh_interval=1,
+                secret_refresh_interval=1,
+            )
+
+            assert client[secret_key] == "Very secret value"
+            assert isinstance(kv_setting, SecretReferenceConfigurationSetting)
+            kv_setting.secret_id = appconfiguration_keyvault_secret_url2
+            await appconfig_client.set_configuration_setting(kv_setting)
+
             # Expire the refresh timers to simulate time passing
             client._refresh_timer._next_refresh_time = 0
             client._secret_provider.secret_refresh_timer._next_refresh_time = 0
@@ -119,11 +113,10 @@ class TestAsyncSecretRefresh(AppConfigTestCase, unittest.TestCase):
             await client.refresh()
 
             # Verify the value was updated
-            assert client["secret"] == "Very secret value 2"
+            assert client[secret_key] == "Very secret value 2"
             assert mock_callback.call_count >= 1
         finally:
-            kv_setting.secret_id = appconfiguration_keyvault_secret_url
-            await appconfig_client.set_configuration_setting(kv_setting)
+            await appconfig_client.delete_configuration_setting(key=secret_key, label="prod")
 
     @AppConfigProviderPreparer()
     @recorded_by_proxy_async

--- a/sdk/appconfiguration/azure-appconfiguration-provider/tests/aio/test_async_provider_refresh.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/tests/aio/test_async_provider_refresh.py
@@ -17,8 +17,8 @@ from test_constants import (
     APPCONFIGURATION_KEYVAULT_SECRET_URL,
     FEATURE_MANAGEMENT_KEY,
 )
-from azure.appconfiguration import ConfigurationSetting
-from azure.appconfiguration.provider import WatchKey
+from azure.appconfiguration import ConfigurationSetting, FeatureFlagConfigurationSetting
+from azure.appconfiguration.provider import SettingSelector, WatchKey
 
 AppConfigProviderPreparer = functools.partial(
     EnvironmentVariableLoader,
@@ -39,71 +39,67 @@ try:
         @pytest.mark.asyncio
         async def test_refresh(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
             mock_callback = Mock()
-            async with await self.create_client(
-                endpoint=appconfiguration_endpoint_string,
-                keyvault_secret_url=appconfiguration_keyvault_secret_url,
-                refresh_on=[WatchKey("refresh_message")],
-                refresh_interval=1,
-                on_refresh_success=mock_callback,
-                feature_flag_enabled=True,
-                feature_flag_refresh_enabled=True,
-            ) as client:
-                assert client["refresh_message"] == "original value"
-                assert client["my_json"]["key"] == "value"
-                assert FEATURE_MANAGEMENT_KEY in client
-                assert has_feature_flag(client, "Alpha")
+            appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
+            test_prefix = self.get_resource_name("test")
+            refresh_key = f"{test_prefix}-refresh-message"
+            feature_id = f"{test_prefix}-alpha"
+            setting = ConfigurationSetting(key=refresh_key, value="original value")
+            feature_flag = FeatureFlagConfigurationSetting(feature_id=feature_id, enabled=False)
+            await appconfig_client.set_configuration_setting(setting)
+            await appconfig_client.set_configuration_setting(feature_flag)
 
-                appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
+            try:
+                async with await self.create_client(
+                    endpoint=appconfiguration_endpoint_string,
+                    keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                    selects=[SettingSelector(key_filter=refresh_key)],
+                    refresh_on=[WatchKey(refresh_key)],
+                    refresh_interval=1,
+                    on_refresh_success=mock_callback,
+                    feature_flag_enabled=True,
+                    feature_flag_refresh_enabled=True,
+                    feature_flag_selectors=[SettingSelector(key_filter=feature_id)],
+                ) as client:
+                    assert client[refresh_key] == "original value"
+                    assert FEATURE_MANAGEMENT_KEY in client
+                    assert has_feature_flag(client, feature_id)
 
-                setting = await appconfig_client.get_configuration_setting(key="refresh_message")
-                setting.value = "updated value"
-                feature_flag = await appconfig_client.get_configuration_setting(key=".appconfig.featureflag/Alpha")
-                feature_flag.enabled = True
-                await appconfig_client.set_configuration_setting(setting)
-                await appconfig_client.set_configuration_setting(feature_flag)
+                    setting.value = "updated value"
+                    feature_flag.enabled = True
+                    await appconfig_client.set_configuration_setting(setting)
+                    await appconfig_client.set_configuration_setting(feature_flag)
 
-                # Expire the refresh timers to simulate time passing
-                client._refresh_timer._next_refresh_time = 0
-                client._feature_flag_refresh_timer._next_refresh_time = 0
+                    client._refresh_timer._next_refresh_time = 0
+                    client._feature_flag_refresh_timer._next_refresh_time = 0
+                    await client.refresh()
+                    assert client[refresh_key] == "updated value"
+                    assert has_feature_flag(client, feature_id, True)
+                    assert mock_callback.call_count == 1
 
-                await client.refresh()
-                assert client["refresh_message"] == "updated value"
-                assert has_feature_flag(client, "Alpha", True)
-                assert mock_callback.call_count == 1
+                    setting.value = "original value"
+                    feature_flag.enabled = False
+                    await appconfig_client.set_configuration_setting(setting)
+                    await appconfig_client.set_configuration_setting(feature_flag)
 
-                setting.value = "original value"
-                feature_flag.enabled = False
-                await appconfig_client.set_configuration_setting(setting)
-                await appconfig_client.set_configuration_setting(feature_flag)
+                    client._refresh_timer._next_refresh_time = 0
+                    client._feature_flag_refresh_timer._next_refresh_time = 0
+                    await client.refresh()
+                    assert client[refresh_key] == "original value"
+                    assert has_feature_flag(client, feature_id, False)
+                    assert mock_callback.call_count == 2
 
-                # Expire the refresh timers to simulate time passing
-                client._refresh_timer._next_refresh_time = 0
-                client._feature_flag_refresh_timer._next_refresh_time = 0
+                    setting.value = "updated value 2"
+                    feature_flag.enabled = True
+                    await appconfig_client.set_configuration_setting(setting)
+                    await appconfig_client.set_configuration_setting(feature_flag)
 
-                await client.refresh()
-                assert client["refresh_message"] == "original value"
-                assert has_feature_flag(client, "Alpha", False)
-                assert mock_callback.call_count == 2
-
-                setting.value = "updated value 2"
-                feature_flag.enabled = True
-                await appconfig_client.set_configuration_setting(setting)
-                await appconfig_client.set_configuration_setting(feature_flag)
-
-                # Not waiting for the refresh interval to pass
-                await client.refresh()
-                assert client["refresh_message"] == "original value"
-                assert has_feature_flag(client, "Alpha", False)
-                assert mock_callback.call_count == 2
-
-                setting.value = "original value"
-                feature_flag.enabled = False
-                await appconfig_client.set_configuration_setting(setting)
-                await appconfig_client.set_configuration_setting(feature_flag)
-
-                await client.refresh()
-                assert client["refresh_message"] == "original value"
-                assert mock_callback.call_count == 2
+                    await client.refresh()
+                    assert client[refresh_key] == "original value"
+                    assert has_feature_flag(client, feature_id, False)
+                    assert mock_callback.call_count == 2
+            finally:
+                await appconfig_client.delete_configuration_setting(key=refresh_key)
+                await appconfig_client.delete_configuration_setting(key=feature_flag.key)
 
         # method: refresh
         @AppConfigProviderPreparer()
@@ -111,57 +107,43 @@ try:
         @pytest.mark.skipif(sys.version_info < (3, 8), reason="Python 3.7 does not support AsyncMock")
         @pytest.mark.asyncio
         async def test_no_refresh(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
-
             appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-            watch_key = ConfigurationSetting(key="watch key", value="0")
+            test_prefix = self.get_resource_name("test")
+            refresh_key = f"{test_prefix}-refresh-message"
+            watch_key_name = f"{test_prefix}-watch-key"
+            setting = ConfigurationSetting(key=refresh_key, value="original value")
+            watch_key = ConfigurationSetting(key=watch_key_name, value="0")
+            await appconfig_client.set_configuration_setting(setting)
             await appconfig_client.set_configuration_setting(watch_key)
 
             mock_callback = Mock()
-            async with await self.create_client(
-                endpoint=appconfiguration_endpoint_string,
-                keyvault_secret_url=appconfiguration_keyvault_secret_url,
-                refresh_on=[WatchKey("watch key")],
-                refresh_interval=1,
-                on_refresh_success=mock_callback,
-                feature_flag_enabled=True,
-                feature_flag_refresh_enabled=True,
-            ) as client:
-                assert client["refresh_message"] == "original value"
-                assert client["my_json"]["key"] == "value"
-                assert FEATURE_MANAGEMENT_KEY in client
-                assert has_feature_flag(client, "Alpha")
+            try:
+                async with await self.create_client(
+                    endpoint=appconfiguration_endpoint_string,
+                    keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                    selects=[SettingSelector(key_filter=refresh_key)],
+                    refresh_on=[WatchKey(watch_key_name)],
+                    refresh_interval=1,
+                    on_refresh_success=mock_callback,
+                ) as client:
+                    assert client[refresh_key] == "original value"
 
-                setting = await appconfig_client.get_configuration_setting(key="refresh_message")
-                setting.value = "updated value"
-                await appconfig_client.set_configuration_setting(setting)
+                    setting.value = "updated value"
+                    await appconfig_client.set_configuration_setting(setting)
+                    client._refresh_timer._next_refresh_time = 0
+                    await client.refresh()
+                    assert client[refresh_key] == "original value"
+                    assert mock_callback.call_count == 0
 
-                # Expire the refresh timers to simulate time passing
-                client._refresh_timer._next_refresh_time = 0
-                client._feature_flag_refresh_timer._next_refresh_time = 0
-
-                await client.refresh()
-                # No Change the Watch Key wasn't updated
-                assert client["refresh_message"] == "original value"
-                assert has_feature_flag(client, "Alpha", False)
-                assert mock_callback.call_count == 0
-
-                watch_key.value = "1"
-                await appconfig_client.set_configuration_setting(watch_key)
-
-                # Expire the refresh timers to simulate time passing
-                client._refresh_timer._next_refresh_time = 0
-                client._feature_flag_refresh_timer._next_refresh_time = 0
-
-                await client.refresh()
-                assert client["refresh_message"] == "updated value"
-                assert has_feature_flag(client, "Alpha", False)
-                assert mock_callback.call_count == 1
-
-                # Reset modified settings
-                setting.value = "original value"
-                await appconfig_client.set_configuration_setting(setting)
-                await appconfig_client.delete_configuration_setting(key="watch key")
+                    watch_key.value = "1"
+                    await appconfig_client.set_configuration_setting(watch_key)
+                    client._refresh_timer._next_refresh_time = 0
+                    await client.refresh()
+                    assert client[refresh_key] == "updated value"
+                    assert mock_callback.call_count == 1
+            finally:
+                await appconfig_client.delete_configuration_setting(key=refresh_key)
+                await appconfig_client.delete_configuration_setting(key=watch_key_name)
 
         @AppConfigProviderPreparer()
         @recorded_by_proxy_async
@@ -169,37 +151,31 @@ try:
         @pytest.mark.asyncio
         async def test_refresh_disabled(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
             mock_callback = AsyncMock()
-            async with await self.create_client(
-                endpoint=appconfiguration_endpoint_string,
-                keyvault_secret_url=appconfiguration_keyvault_secret_url,
-                refresh_on=[WatchKey("refresh_message")],
-                refresh_interval=1,
-                on_refresh_success=mock_callback,
-                feature_flag_enabled=True,
-                feature_flag_refresh_enabled=True,
-                refresh_enabled=False,
-            ) as client:
-                assert client["refresh_message"] == "original value"
-                assert client["my_json"]["key"] == "value"
-                assert FEATURE_MANAGEMENT_KEY in client
-                assert has_feature_flag(client, "Alpha")
+            appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
+            refresh_key = f"{self.get_resource_name('test')}-refresh-message"
+            setting = ConfigurationSetting(key=refresh_key, value="original value")
+            await appconfig_client.set_configuration_setting(setting)
 
-                appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
+            try:
+                async with await self.create_client(
+                    endpoint=appconfiguration_endpoint_string,
+                    keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                    selects=[SettingSelector(key_filter=refresh_key)],
+                    refresh_on=[WatchKey(refresh_key)],
+                    refresh_interval=1,
+                    on_refresh_success=mock_callback,
+                    refresh_enabled=False,
+                ) as client:
+                    assert client[refresh_key] == "original value"
 
-                setting = await appconfig_client.get_configuration_setting(key="refresh_message")
-                setting.value = "updated value"
-                await appconfig_client.set_configuration_setting(setting)
-
-                # Expire the refresh timers to simulate time passing
-                client._refresh_timer._next_refresh_time = 0
-
-                await client.refresh()
-                # Refresh is disabled, so the value should not change
-                assert client["refresh_message"] == "original value"
-                assert mock_callback.call_count == 0
-
-                setting.value = "original value"
-                await appconfig_client.set_configuration_setting(setting)
+                    setting.value = "updated value"
+                    await appconfig_client.set_configuration_setting(setting)
+                    client._refresh_timer._next_refresh_time = 0
+                    await client.refresh()
+                    assert client[refresh_key] == "original value"
+                    assert mock_callback.call_count == 0
+            finally:
+                await appconfig_client.delete_configuration_setting(key=refresh_key)
 
 except ImportError:
     pass

--- a/sdk/appconfiguration/azure-appconfiguration-provider/tests/key_vault/test_secret_refresh.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/tests/key_vault/test_secret_refresh.py
@@ -8,7 +8,7 @@ import time
 import unittest
 from unittest.mock import Mock, patch
 from devtools_testutils import EnvironmentVariableLoader, recorded_by_proxy
-from testcase import AppConfigTestCase
+from testcase import AppConfigTestCase, create_secret_config_setting
 from test_constants import (
     APPCONFIGURATION_ENDPOINT_STRING,
     APPCONFIGURATION_KEYVAULT_SECRET_URL,
@@ -75,35 +75,28 @@ class TestSecretRefresh(AppConfigTestCase, unittest.TestCase):
     ):
         """Test that secrets are refreshed with updated values."""
         mock_callback = Mock()
-
-        # Create client with the mock secret resolver
-        client = self.create_client(
-            endpoint=appconfiguration_endpoint_string,
-            selects={SettingSelector(key_filter="*", label_filter="prod")},
-            keyvault_secret_url=appconfiguration_keyvault_secret_url,
-            keyvault_secret_url2=appconfiguration_keyvault_secret_url2,
-            on_refresh_success=mock_callback,
-            refresh_on=[WatchKey("secret", "prod")],
-            refresh_interval=1,
-            secret_refresh_interval=1,  # Using a short interval for testing
-        )
-
-        # Add a key vault reference to the client (this will use mock resolver)
+        secret_key = f"{self.get_resource_name('test')}-secret"
         appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-        # Get and modify a key vault reference setting
-        kv_setting = appconfig_client.get_configuration_setting(key="secret", label="prod")
-        assert kv_setting is not None
-
-        # Verify initial value from mock resolver
-        assert client["secret"] == "Very secret value"
-        assert kv_setting is not None
-        assert isinstance(kv_setting, SecretReferenceConfigurationSetting)
-        # Update the secret_id (which is the value for SecretReferenceConfigurationSetting)
-        kv_setting.secret_id = appconfiguration_keyvault_secret_url2
+        kv_setting = create_secret_config_setting(secret_key, "prod", appconfiguration_keyvault_secret_url)
         appconfig_client.set_configuration_setting(kv_setting)
 
         try:
+            client = self.create_client(
+                endpoint=appconfiguration_endpoint_string,
+                selects={SettingSelector(key_filter=secret_key, label_filter="prod")},
+                keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                keyvault_secret_url2=appconfiguration_keyvault_secret_url2,
+                on_refresh_success=mock_callback,
+                refresh_on=[WatchKey(secret_key, "prod")],
+                refresh_interval=1,
+                secret_refresh_interval=1,
+            )
+
+            assert client[secret_key] == "Very secret value"
+            assert isinstance(kv_setting, SecretReferenceConfigurationSetting)
+            kv_setting.secret_id = appconfiguration_keyvault_secret_url2
+            appconfig_client.set_configuration_setting(kv_setting)
+
             # Expire the refresh timers to simulate time passing
             client._refresh_timer._next_refresh_time = 0
             client._secret_provider.secret_refresh_timer._next_refresh_time = 0
@@ -112,11 +105,10 @@ class TestSecretRefresh(AppConfigTestCase, unittest.TestCase):
             client.refresh()
 
             # Verify the value was updated
-            assert client["secret"] == "Very secret value 2"
+            assert client[secret_key] == "Very secret value 2"
             assert mock_callback.call_count >= 1
         finally:
-            kv_setting.secret_id = appconfiguration_keyvault_secret_url
-            appconfig_client.set_configuration_setting(kv_setting)
+            appconfig_client.delete_configuration_setting(key=secret_key, label="prod")
 
     @AppConfigProviderPreparer()
     @recorded_by_proxy

--- a/sdk/appconfiguration/azure-appconfiguration-provider/tests/test_provider_refresh.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/tests/test_provider_refresh.py
@@ -13,7 +13,8 @@ from test_constants import (
     APPCONFIGURATION_KEYVAULT_SECRET_URL,
     FEATURE_MANAGEMENT_KEY,
 )
-from azure.appconfiguration.provider import WatchKey
+from azure.appconfiguration import FeatureFlagConfigurationSetting
+from azure.appconfiguration.provider import SettingSelector, WatchKey
 
 AppConfigProviderPreparer = functools.partial(
     EnvironmentVariableLoader,
@@ -29,159 +30,135 @@ class TestAppConfigurationProvider(AppConfigTestCase, unittest.TestCase):
     @recorded_by_proxy
     def test_refresh(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
         mock_callback = Mock()
-        client = self.create_client(
-            endpoint=appconfiguration_endpoint_string,
-            keyvault_secret_url=appconfiguration_keyvault_secret_url,
-            refresh_on=[WatchKey("refresh_message")],
-            refresh_interval=1,
-            on_refresh_success=mock_callback,
-            feature_flag_enabled=True,
-            feature_flag_refresh_enabled=True,
-        )
-        assert client["refresh_message"] == "original value"
-        assert client["my_json"]["key"] == "value"
-        assert FEATURE_MANAGEMENT_KEY in client
-        assert has_feature_flag(client, "Alpha")
-
         appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-        setting = appconfig_client.get_configuration_setting(key="refresh_message")
-        setting.value = "updated value"
-        feature_flag = appconfig_client.get_configuration_setting(key=".appconfig.featureflag/Alpha")
-        feature_flag.enabled = True
+        test_prefix = self.get_resource_name("test")
+        refresh_key = f"{test_prefix}-refresh-message"
+        feature_id = f"{test_prefix}-alpha"
+        setting = ConfigurationSetting(key=refresh_key, value="original value")
+        feature_flag = FeatureFlagConfigurationSetting(feature_id=feature_id, enabled=False)
         appconfig_client.set_configuration_setting(setting)
         appconfig_client.set_configuration_setting(feature_flag)
 
-        # Expire the refresh timers to simulate time passing
-        client._refresh_timer._next_refresh_time = 0
-        client._feature_flag_refresh_timer._next_refresh_time = 0
+        try:
+            client = self.create_client(
+                endpoint=appconfiguration_endpoint_string,
+                keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                selects=[SettingSelector(key_filter=refresh_key)],
+                refresh_on=[WatchKey(refresh_key)],
+                refresh_interval=1,
+                on_refresh_success=mock_callback,
+                feature_flag_enabled=True,
+                feature_flag_refresh_enabled=True,
+                feature_flag_selectors=[SettingSelector(key_filter=feature_id)],
+            )
+            assert client[refresh_key] == "original value"
+            assert FEATURE_MANAGEMENT_KEY in client
+            assert has_feature_flag(client, feature_id)
 
-        client.refresh()
-        assert client["refresh_message"] == "updated value"
-        assert has_feature_flag(client, "Alpha", True)
-        assert mock_callback.call_count == 1
+            setting.value = "updated value"
+            feature_flag.enabled = True
+            appconfig_client.set_configuration_setting(setting)
+            appconfig_client.set_configuration_setting(feature_flag)
 
-        setting.value = "original value"
-        feature_flag.enabled = False
-        appconfig_client.set_configuration_setting(setting)
-        appconfig_client.set_configuration_setting(feature_flag)
+            client._refresh_timer._next_refresh_time = 0
+            client._feature_flag_refresh_timer._next_refresh_time = 0
+            client.refresh()
+            assert client[refresh_key] == "updated value"
+            assert has_feature_flag(client, feature_id, True)
+            assert mock_callback.call_count == 1
 
-        # Expire the refresh timers to simulate time passing
-        client._refresh_timer._next_refresh_time = 0
-        client._feature_flag_refresh_timer._next_refresh_time = 0
+            setting.value = "original value"
+            feature_flag.enabled = False
+            appconfig_client.set_configuration_setting(setting)
+            appconfig_client.set_configuration_setting(feature_flag)
 
-        client.refresh()
-        assert client["refresh_message"] == "original value"
-        assert has_feature_flag(client, "Alpha", False)
-        assert mock_callback.call_count == 2
+            client._refresh_timer._next_refresh_time = 0
+            client._feature_flag_refresh_timer._next_refresh_time = 0
+            client.refresh()
+            assert client[refresh_key] == "original value"
+            assert has_feature_flag(client, feature_id, False)
+            assert mock_callback.call_count == 2
 
-        setting.value = "updated value 2"
-        feature_flag.enabled = True
-        appconfig_client.set_configuration_setting(setting)
-        appconfig_client.set_configuration_setting(feature_flag)
+            setting.value = "updated value 2"
+            feature_flag.enabled = True
+            appconfig_client.set_configuration_setting(setting)
+            appconfig_client.set_configuration_setting(feature_flag)
 
-        # Not waiting for the refresh interval to pass
-        client.refresh()
-        assert client["refresh_message"] == "original value"
-        assert has_feature_flag(client, "Alpha", False)
-        assert mock_callback.call_count == 2
-
-        setting.value = "original value"
-        feature_flag.enabled = False
-        appconfig_client.set_configuration_setting(setting)
-        appconfig_client.set_configuration_setting(feature_flag)
-
-        client.refresh()
-        assert client["refresh_message"] == "original value"
-        assert mock_callback.call_count == 2
+            client.refresh()
+            assert client[refresh_key] == "original value"
+            assert has_feature_flag(client, feature_id, False)
+            assert mock_callback.call_count == 2
+        finally:
+            appconfig_client.delete_configuration_setting(key=refresh_key)
+            appconfig_client.delete_configuration_setting(key=feature_flag.key)
 
     @AppConfigProviderPreparer()
     @recorded_by_proxy
     def test_no_refresh(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
-
         appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-        watch_key = ConfigurationSetting(key="watch key", value="0")
+        test_prefix = self.get_resource_name("test")
+        refresh_key = f"{test_prefix}-refresh-message"
+        watch_key_name = f"{test_prefix}-watch-key"
+        setting = ConfigurationSetting(key=refresh_key, value="original value")
+        watch_key = ConfigurationSetting(key=watch_key_name, value="0")
+        appconfig_client.set_configuration_setting(setting)
         appconfig_client.set_configuration_setting(watch_key)
 
         mock_callback = Mock()
-        client = self.create_client(
-            endpoint=appconfiguration_endpoint_string,
-            keyvault_secret_url=appconfiguration_keyvault_secret_url,
-            refresh_on=[WatchKey("watch key")],
-            refresh_interval=1,
-            on_refresh_success=mock_callback,
-            feature_flag_enabled=True,
-            feature_flag_refresh_enabled=True,
-        )
-        assert client["refresh_message"] == "original value"
-        assert client["my_json"]["key"] == "value"
-        assert FEATURE_MANAGEMENT_KEY in client
-        assert has_feature_flag(client, "Alpha")
+        try:
+            client = self.create_client(
+                endpoint=appconfiguration_endpoint_string,
+                keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                selects=[SettingSelector(key_filter=refresh_key)],
+                refresh_on=[WatchKey(watch_key_name)],
+                refresh_interval=1,
+                on_refresh_success=mock_callback,
+            )
+            assert client[refresh_key] == "original value"
 
-        setting = appconfig_client.get_configuration_setting(key="refresh_message")
-        setting.value = "updated value"
-        appconfig_client.set_configuration_setting(setting)
+            setting.value = "updated value"
+            appconfig_client.set_configuration_setting(setting)
+            client._refresh_timer._next_refresh_time = 0
+            client.refresh()
+            assert client[refresh_key] == "original value"
+            assert mock_callback.call_count == 0
 
-        # Expire the refresh timers to simulate time passing
-        client._refresh_timer._next_refresh_time = 0
-        client._feature_flag_refresh_timer._next_refresh_time = 0
-
-        client.refresh()
-        # No Change the Watch Key wasn't updated
-        assert client["refresh_message"] == "original value"
-        assert has_feature_flag(client, "Alpha", False)
-        assert mock_callback.call_count == 0
-
-        watch_key.value = "1"
-        appconfig_client.set_configuration_setting(watch_key)
-
-        # Expire the refresh timers to simulate time passing
-        client._refresh_timer._next_refresh_time = 0
-        client._feature_flag_refresh_timer._next_refresh_time = 0
-
-        client.refresh()
-        assert client["refresh_message"] == "updated value"
-        assert has_feature_flag(client, "Alpha", False)
-        assert mock_callback.call_count == 1
-
-        # Reset modified settings
-        setting.value = "original value"
-        appconfig_client.set_configuration_setting(setting)
-        appconfig_client.delete_configuration_setting(key="watch key")
+            watch_key.value = "1"
+            appconfig_client.set_configuration_setting(watch_key)
+            client._refresh_timer._next_refresh_time = 0
+            client.refresh()
+            assert client[refresh_key] == "updated value"
+            assert mock_callback.call_count == 1
+        finally:
+            appconfig_client.delete_configuration_setting(key=refresh_key)
+            appconfig_client.delete_configuration_setting(key=watch_key_name)
 
     @AppConfigProviderPreparer()
     @recorded_by_proxy
     def test_empty_refresh(self, appconfiguration_endpoint_string, appconfiguration_keyvault_secret_url):
         mock_callback = Mock()
-        client = self.create_client(
-            endpoint=appconfiguration_endpoint_string,
-            keyvault_secret_url=appconfiguration_keyvault_secret_url,
-            refresh_on=[WatchKey("refresh_message")],
-            refresh_interval=1,
-            on_refresh_success=mock_callback,
-            feature_flag_enabled=True,
-            feature_flag_refresh_enabled=True,
-            refresh_enabled=False,
-        )
-        assert client["refresh_message"] == "original value"
-        assert client["my_json"]["key"] == "value"
-        assert FEATURE_MANAGEMENT_KEY in client
-        assert has_feature_flag(client, "Alpha")
-
         appconfig_client = self.create_appconfig_client(appconfiguration_endpoint_string)
-
-        setting = appconfig_client.get_configuration_setting(key="refresh_message")
-        setting.value = "updated value"
+        refresh_key = f"{self.get_resource_name('test')}-refresh-message"
+        setting = ConfigurationSetting(key=refresh_key, value="original value")
         appconfig_client.set_configuration_setting(setting)
 
-        # Expire the refresh timers to simulate time passing
-        client._refresh_timer._next_refresh_time = 0
+        try:
+            client = self.create_client(
+                endpoint=appconfiguration_endpoint_string,
+                keyvault_secret_url=appconfiguration_keyvault_secret_url,
+                selects=[SettingSelector(key_filter=refresh_key)],
+                refresh_on=[WatchKey(refresh_key)],
+                refresh_interval=1,
+                on_refresh_success=mock_callback,
+                refresh_enabled=False,
+            )
+            assert client[refresh_key] == "original value"
 
-        client.refresh()
-        # Refresh is disabled, so the value should not change
-        assert client["refresh_message"] == "original value"
-        assert mock_callback.call_count == 0
-
-        setting.value = "original value"
-        appconfig_client.set_configuration_setting(setting)
+            setting.value = "updated value"
+            appconfig_client.set_configuration_setting(setting)
+            client._refresh_timer._next_refresh_time = 0
+            client.refresh()
+            assert client[refresh_key] == "original value"
+            assert mock_callback.call_count == 0
+        finally:
+            appconfig_client.delete_configuration_setting(key=refresh_key)

--- a/sdk/appconfiguration/azure-mgmt-appconfiguration/samples/sample_get_key_value_with_send_request.py
+++ b/sdk/appconfiguration/azure-mgmt-appconfiguration/samples/sample_get_key_value_with_send_request.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""
+FILE: sample_get_key_value_with_send_request.py
+
+DESCRIPTION:
+    This sample creates or updates the App Configuration feature flag named "Alpha" by using
+    AppConfigurationManagementClient.send_request.
+
+USAGE:
+    python sample_get_key_value_with_send_request.py
+
+    Set these environment variables before running the sample:
+    1) AZURE_SUBSCRIPTION_ID
+    2) RESOURCE_GROUP_NAME
+    3) APPCONFIGURATION_STORE_NAME
+"""
+
+from azure.core.rest import HttpRequest
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.appconfiguration import AppConfigurationManagementClient
+
+
+AZURE_ARM_ENDPOINT = "https://centraluseuap.management.azure.com"
+
+
+def main() -> None:
+    subscription_id = "160a734f-944d-4dd1-a36a-ebf7acd0958a"
+    resource_group_name = "mametcal"
+    config_store_name = "mgmt-wus2"
+
+    credential = DefaultAzureCredential()
+    with AppConfigurationManagementClient(
+        credential,
+        subscription_id,
+        base_url=AZURE_ARM_ENDPOINT,
+    ) as client:
+        request = HttpRequest(
+            method="PUT",
+            url=(
+                f"/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}"
+                "/providers/Microsoft.AppConfiguration/configurationStores/"
+                f"{config_store_name}/featureFlags/Alpha"
+            ),
+            params={"api-version": "2026-09-01-preview"},
+            headers={"Content-Type": "application/json"},
+            json={"properties": {"enabled": True}},
+        )
+        response = client.send_request(request)
+        if response.status_code >= 400:
+            print(f"Request URL: {response.request.url}")
+            print(f"Response headers: {dict(response.headers)}")
+            print(f"Response body: {response.text()}")
+        response.raise_for_status()
+
+        feature_flag = response.json()
+        print(feature_flag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request improves the reliability and maintainability of the App Configuration Provider test suite by making the test data more robust and reducing hard-coded values. The changes focus on dynamically generating resource names for test keys, cleaning up test data after execution, and updating test logic to use these dynamic keys. This helps prevent test conflicts and ensures a cleaner test environment.

**Test improvements and reliability:**

* Updated tests to generate unique resource names for configuration keys and feature flags using `get_resource_name`, reducing the risk of key collisions during parallel test runs. [[1]](diffhunk://#diff-b8b2a290028e46c9e0cbea7f78f8ea4fe86bdc0aad847d6620eb3f82a73a5b2eR42-R178) [[2]](diffhunk://#diff-9fbecda12112aeb757846dbed0fff3b2c518e6b403ad28bb908a46bf7534b8b7R86-L113) [[3]](diffhunk://#diff-27deeda57d3108ceb7a0a2562a05b954bf2b92254e74bb5af3f631a66ac6e7a9R78-L106)
* Modified tests to clean up configuration settings and feature flags after each test by deleting them in `finally` blocks, ensuring no leftover data affects other tests. [[1]](diffhunk://#diff-b8b2a290028e46c9e0cbea7f78f8ea4fe86bdc0aad847d6620eb3f82a73a5b2eR42-R178) [[2]](diffhunk://#diff-9fbecda12112aeb757846dbed0fff3b2c518e6b403ad28bb908a46bf7534b8b7L122-R119) [[3]](diffhunk://#diff-27deeda57d3108ceb7a0a2562a05b954bf2b92254e74bb5af3f631a66ac6e7a9L115-R111)

**Test logic and import adjustments:**

* Adjusted test logic to use dynamically generated keys in assertions and refresh logic, replacing hard-coded key names throughout the async and sync test suites. [[1]](diffhunk://#diff-b8b2a290028e46c9e0cbea7f78f8ea4fe86bdc0aad847d6620eb3f82a73a5b2eR42-R178) [[2]](diffhunk://#diff-9fbecda12112aeb757846dbed0fff3b2c518e6b403ad28bb908a46bf7534b8b7R86-L113) [[3]](diffhunk://#diff-27deeda57d3108ceb7a0a2562a05b954bf2b92254e74bb5af3f631a66ac6e7a9R78-L106)
* Added or updated imports to include new or needed test utilities and types, such as `SettingSelector` and `FeatureFlagConfigurationSetting`. [[1]](diffhunk://#diff-b8b2a290028e46c9e0cbea7f78f8ea4fe86bdc0aad847d6620eb3f82a73a5b2eL20-R21) [[2]](diffhunk://#diff-9fbecda12112aeb757846dbed0fff3b2c518e6b403ad28bb908a46bf7534b8b7R13) [[3]](diffhunk://#diff-329b837c32f035d3ea8af7d7b2c338907e3a522f9a79f226f910adcedc187bfdL16-R17) [[4]](diffhunk://#diff-27deeda57d3108ceb7a0a2562a05b954bf2b92254e74bb5af3f631a66ac6e7a9L11-R11)

**Test asset tracking:**

* Updated the asset tag in `assets.json` to reflect the new state of the test assets.# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new API spec, a link to the pull request containing these API spec changes should be included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
