### PR TITLE
Fix device provisioning release validation

### DIFF
--- a/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py
@@ -78,15 +78,15 @@ class DeviceProvisioningClient(
         try:
             if not endpoint.lower().startswith("http"):
                 endpoint = "https://" + endpoint
-        except AttributeError:
-            raise ValueError("Endpoint URL must be a string.")
+        except AttributeError as exc:
+            raise ValueError("Endpoint URL must be a string.") from exc
         endpoint = endpoint.rstrip("/")
 
         # Validate api-version
         try:
             api_version = ApiVersion(api_version).value
-        except ValueError:
-            raise ValueError(f"Invalid api-version {api_version} specified")
+        except ValueError as exc:
+            raise ValueError(f"Invalid api-version {api_version} specified") from exc
 
         # Generate base client
         super().__init__(

--- a/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_serialization.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_serialization.py
@@ -561,7 +561,7 @@ class Serializer(object):
             "[]": self.serialize_iter,
             "{}": self.serialize_dict,
         }
-        self.dependencies: Dict[str, Type[ModelType]] = dict(classes) if classes else {}
+        self.dependencies: Dict[str, Type[ModelType]] = dict(classes) if classes else {}  # type: ignore
         self.key_transformer = full_restapi_key_transformer
         self.client_side_validation = True
 
@@ -814,7 +814,7 @@ class Serializer(object):
             # If dependencies is empty, try with current data class
             # It has to be a subclass of Enum anyway
             enum_type = self.dependencies.get(data_type, data.__class__)
-            if issubclass(enum_type, Enum):
+            if issubclass(enum_type, Enum):  # type: ignore
                 return Serializer.serialize_enum(data, enum_obj=enum_type)
 
             iter_type = data_type[0] + data_type[-1]
@@ -1381,7 +1381,7 @@ class Deserializer(object):
             "duration": (isodate.Duration, datetime.timedelta),
             "iso-8601": (datetime.datetime),
         }
-        self.dependencies: Dict[str, Type[ModelType]] = dict(classes) if classes else {}
+        self.dependencies: Dict[str, Type[ModelType]] = dict(classes) if classes else {}  # type: ignore
         self.key_extractors = [rest_key_extractor, xml_key_extractor]
         # Additional properties only works if the "rest_key_extractor" is used to
         # extract the keys. Making it to work whatever the key extractor is too much
@@ -1581,14 +1581,14 @@ class Deserializer(object):
         if callable(response):
             subtype = getattr(response, "_subtype_map", {})
             try:
-                readonly = [k for k, v in response._validation.items() if v.get("readonly")]
-                const = [k for k, v in response._validation.items() if v.get("constant")]
+                readonly = [k for k, v in response._validation.items() if v.get("readonly")]  # type: ignore
+                const = [k for k, v in response._validation.items() if v.get("constant")]  # type: ignore
                 kwargs = {k: v for k, v in attrs.items() if k not in subtype and k not in readonly + const}
                 response_obj = response(**kwargs)
                 for attr in readonly:
                     setattr(response_obj, attr, attrs.get(attr))
                 if additional_properties:
-                    response_obj.additional_properties = additional_properties
+                    response_obj.additional_properties = additional_properties  # type: ignore
                 return response_obj
             except TypeError as err:
                 msg = "Unable to deserialize {} into model {}. ".format(kwargs, response)  # type: ignore
@@ -1900,7 +1900,7 @@ class Deserializer(object):
         if re.search(r"[^\W\d_]", attr, re.I + re.U):  # type: ignore
             raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
-        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
+        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)  # type: ignore
 
     @staticmethod
     def deserialize_time(attr):

--- a/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py
@@ -80,15 +80,15 @@ class DeviceProvisioningClient(
         try:
             if not endpoint.lower().startswith("http"):
                 endpoint = "https://" + endpoint
-        except AttributeError:
-            raise ValueError("Endpoint URL must be a string.")
+        except AttributeError as exc:
+            raise ValueError("Endpoint URL must be a string.") from exc
         endpoint = endpoint.rstrip("/")
 
         # Validate api-version
         try:
             api_version = ApiVersion(api_version).value
-        except ValueError:
-            raise ValueError(f"Invalid api-version {api_version} specified")
+        except ValueError as exc:
+            raise ValueError(f"Invalid api-version {api_version} specified") from exc
 
         # Generate protocol client
         super().__init__(
@@ -175,10 +175,10 @@ class DeviceProvisioningClient(
         if not transport:
             try:
                 from azure.core.pipeline.transport import AioHttpTransport
-            except ImportError:
+            except ImportError as exc:
                 raise ImportError(
                     "Unable to create async transport. Please check aiohttp is installed."
-                )
+                ) from exc
             transport = AioHttpTransport(**kwargs)
 
         policies = [

--- a/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/device_registration_state/test_device_registration_state_unit.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/device_registration_state/test_device_registration_state_unit.py
@@ -51,9 +51,8 @@ class TestDeviceRegistrationStateDelete(object):
     def service_client_delete(self, mocked_response):
         mocked_response.delete(
             url=registrations_url,
-            body="{}",
+            body="",
             status=204,
-            content_type="application/json",
             match_querystring=False,
         )
 

--- a/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/enrollments/test_enrollment_groups_unit.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/enrollments/test_enrollment_groups_unit.py
@@ -232,9 +232,8 @@ class TestGroupEnrollmentDelete(object):
     def service_client(self, mocked_response):
         mocked_response.delete(
             url=enrollment_group_url,
-            body="{}",
+            body="",
             status=204,
-            content_type="application/json",
             match_querystring=False,
         )
         yield mocked_response

--- a/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/enrollments/test_individual_enrollments_unit.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/tests/unit/enrollments/test_individual_enrollments_unit.py
@@ -242,9 +242,8 @@ class TestIndividualEnrollmentDelete(object):
     def service_client(self, mocked_response):
         mocked_response.delete(
             url=enrollment_url,
-            body="{}",
+            body="",
             status=204,
-            content_type="application/json",
             match_querystring=False,
         )
         yield mocked_response


### PR DESCRIPTION
## Summary
- return truly empty mocked bodies for successful 204 DELETE responses
- add scoped typing suppressions for dynamic behavior in the legacy serializer
- preserve exception context in sync and async client validation

## Context
Fixes the service-wide validation failures blocking the `azure-mgmt-iothubprovisioningservices` release in Azure DevOps build 6806262.

## Validation
- Azure SDK package playback tests: 166 passed
- Targeted DELETE failures no longer reproduce
- Local current-linter validation still reports pre-existing legacy generated-code findings outside this change