### PR TITLE
[Storage] Fix SubStream close

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -415,6 +415,8 @@ class FileChunkUploader(_ChunkUploader):
 class SubStream(IOBase):
 
     def __init__(self, wrapped_stream, stream_begin_index, length, lockObj):
+        super(SubStream, self).__init__()
+
         # Python 2.7: file-like objects created with open() typically support seek(), but are not
         # derivations of io.IOBase and thus do not implement seekable().
         # Python > 3.0: file-like objects created with open() are derived from io.IOBase.
@@ -438,13 +440,12 @@ class SubStream(IOBase):
         )
         self._current_buffer_start = 0
         self._current_buffer_size = 0
-        super(SubStream, self).__init__()
 
     def __len__(self):
         return self._length
 
     def close(self):
-        if self._buffer:
+        if hasattr(self, "_buffer"):
             self._buffer.close()
         self._wrapped_stream = None
         IOBase.close(self)

--- a/sdk/storage/azure-storage-blob/tests/test_upload_chunking.py
+++ b/sdk/storage/azure-storage-blob/tests/test_upload_chunking.py
@@ -16,6 +16,16 @@ from azure.storage.blob._shared.uploads import SubStream
 
 class StorageBlobUploadChunkingTest(unittest.TestCase):
 
+    def test_sub_stream_can_close_after_constructor_failure(self):
+        wrapped_stream = BytesIO()
+        wrapped_stream.close()
+        substream = SubStream.__new__(SubStream)
+
+        with self.assertRaisesRegex(ValueError, "Wrapped stream must support seek"):
+            substream.__init__(wrapped_stream, stream_begin_index=0, length=1, lockObj=None)
+
+        substream.close()
+
     # this is a white box test that's designed to make sure _Substream behaves properly
     # when the buffer needs to be swapped out at least once
     def test_sub_stream_with_length_larger_than_buffer(self):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -409,6 +409,8 @@ class FileChunkUploader(_ChunkUploader):
 class SubStream(IOBase):
 
     def __init__(self, wrapped_stream, stream_begin_index, length, lockObj):
+        super(SubStream, self).__init__()
+
         # Python 2.7: file-like objects created with open() typically support seek(), but are not
         # derivations of io.IOBase and thus do not implement seekable().
         # Python > 3.0: file-like objects created with open() are derived from io.IOBase.
@@ -432,13 +434,12 @@ class SubStream(IOBase):
         )
         self._current_buffer_start = 0
         self._current_buffer_size = 0
-        super(SubStream, self).__init__()
 
     def __len__(self):
         return self._length
 
     def close(self):
-        if self._buffer:
+        if hasattr(self, "_buffer"):
             self._buffer.close()
         self._wrapped_stream = None
         IOBase.close(self)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -409,6 +409,8 @@ class FileChunkUploader(_ChunkUploader):
 class SubStream(IOBase):
 
     def __init__(self, wrapped_stream, stream_begin_index, length, lockObj):
+        super(SubStream, self).__init__()
+
         # Python 2.7: file-like objects created with open() typically support seek(), but are not
         # derivations of io.IOBase and thus do not implement seekable().
         # Python > 3.0: file-like objects created with open() are derived from io.IOBase.
@@ -432,13 +434,12 @@ class SubStream(IOBase):
         )
         self._current_buffer_start = 0
         self._current_buffer_size = 0
-        super(SubStream, self).__init__()
 
     def __len__(self):
         return self._length
 
     def close(self):
-        if self._buffer:
+        if hasattr(self, "_buffer"):
             self._buffer.close()
         self._wrapped_stream = None
         IOBase.close(self)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -417,6 +417,8 @@ class FileChunkUploader(_ChunkUploader):
 class SubStream(IOBase):
 
     def __init__(self, wrapped_stream, stream_begin_index, length, lockObj):
+        super(SubStream, self).__init__()
+
         # Python 2.7: file-like objects created with open() typically support seek(), but are not
         # derivations of io.IOBase and thus do not implement seekable().
         # Python > 3.0: file-like objects created with open() are derived from io.IOBase.
@@ -440,13 +442,12 @@ class SubStream(IOBase):
         )
         self._current_buffer_start = 0
         self._current_buffer_size = 0
-        super(SubStream, self).__init__()
 
     def __len__(self):
         return self._length
 
     def close(self):
-        if self._buffer:
+        if hasattr(self, "_buffer"):
             self._buffer.close()
         self._wrapped_stream = None
         IOBase.close(self)


### PR DESCRIPTION
This was an issue I came across while testing something else. If `__init__` raised an exception (as it does when stream is not seekable) the close method would later crash if called. This fixes that and properly calls super first.