### PR TITLE
RLE reset(): support environment-specific kwargs, like step()

### DIFF
--- a/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_rle_async.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/aio/operations/_patch_rle_async.py
@@ -37,7 +37,6 @@ from ...models import (
     RLEnvironmentState,
     RLEnvironmentVersionBump,
     RLEPaginationOrder,
-    RLEResetRequest,
     RLEStepRequest,
     RLEStepResult,
 )
@@ -57,6 +56,7 @@ from ...operations._patch_rle import (
     _validate_poll_interval,
     _websocket_config_from_client_config,
     coerce_action,
+    coerce_reset_body,
     RLEError,
     RLEInstanceAcquireTimeoutError,
     RLEQuotaExceededError,
@@ -532,6 +532,11 @@ class AsyncOpenEnvInstance:  # pylint: disable=too-many-instance-attributes
         :type seed: int or None
         :param episode_id: Optional caller-supplied episode identifier.
         :type episode_id: str or None
+        :param kwargs: Environment-specific reset fields (for example, a task or config
+         override), forwarded to the environment as extra top-level fields alongside ``seed``/
+         ``episode_id``. Mirrors how :meth:`step` accepts environment-specific action fields as
+         keyword arguments.
+        :type kwargs: any
         :return: The initial step result for the new episode.
         :rtype: ~azure.ai.projects.models.RLEStepResult
         """
@@ -541,8 +546,7 @@ class AsyncOpenEnvInstance:  # pylint: disable=too-many-instance-attributes
             self._environment_version,
             self._instance_group_id,
             self.id,
-            RLEResetRequest(seed=seed, episode_id=episode_id),
-            **kwargs,
+            coerce_reset_body(seed, episode_id, kwargs),
         )
 
     @distributed_trace_async
@@ -1195,4 +1199,5 @@ __all__ = [
     "RLEInstanceAcquireTimeoutError",
     "RLEOperations",
     "coerce_action",
+    "coerce_reset_body",
 ]

--- a/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_rle.py
+++ b/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_patch_rle.py
@@ -399,6 +399,42 @@ def coerce_action(action: Any, action_kwargs: Mapping[str, Any]) -> dict:
     )
 
 
+def coerce_reset_body(
+    seed: Optional[int],
+    episode_id: Optional[str],
+    reset_kwargs: Mapping[str, Any],
+) -> Union["RLEResetRequest", dict]:
+    """Build the ``reset`` request body, folding in environment-specific reset kwargs.
+
+    Mirrors :func:`coerce_action` for ``step``: extra keyword arguments passed to ``reset`` are
+    environment-specific reset parameters (for example, a task or config override), not transport
+    options, so they are not forwarded as operation kwargs. When none are supplied, an
+    :class:`~azure.ai.projects.models.RLEResetRequest` is returned for the documented, strict
+    shape. When extras are present, a plain ``dict`` is returned instead: ``RLEResetRequest`` has
+    no field for arbitrary extras, but the generated ``reset`` operation also accepts a raw JSON
+    body.
+
+    :param seed: Optional deterministic seed for the next episode.
+    :type seed: int or None
+    :param episode_id: Optional caller-provided episode identifier.
+    :type episode_id: str or None
+    :param reset_kwargs: Environment-specific reset fields supplied as keyword arguments.
+    :type reset_kwargs: mapping[str, any]
+    :return: The reset request body.
+    :rtype: ~azure.ai.projects.models.RLEResetRequest or dict
+    """
+    if not reset_kwargs:
+        return RLEResetRequest(seed=seed, episode_id=episode_id)
+    reserved = sorted(reset_kwargs.keys() & {"seed", "episode_id"})
+    if reserved:
+        raise TypeError(
+            f"pass {reserved} as named parameters, not as extra keyword fields"
+        )
+    body: dict = {"seed": seed, "episodeId": episode_id}
+    body.update(reset_kwargs)
+    return body
+
+
 def _acquire_instance(
     instances: RLEInstancesOperations,
     runtime: RLEInstanceRuntimeOperations,
@@ -712,6 +748,11 @@ class OpenEnvInstance:
         :type seed: int or None
         :param episode_id: Optional caller-supplied episode identifier.
         :type episode_id: str or None
+        :param kwargs: Environment-specific reset fields (for example, a task or config
+         override), forwarded to the environment as extra top-level fields alongside ``seed``/
+         ``episode_id``. Mirrors how :meth:`step` accepts environment-specific action fields as
+         keyword arguments.
+        :type kwargs: any
         :return: The initial step result for the new episode.
         :rtype: ~azure.ai.projects.models.RLEStepResult
         """
@@ -721,8 +762,7 @@ class OpenEnvInstance:
             self._environment_version,
             self._instance_group_id,
             self.id,
-            RLEResetRequest(seed=seed, episode_id=episode_id),
-            **kwargs,
+            coerce_reset_body(seed, episode_id, kwargs),
         )
 
     @distributed_trace
@@ -1379,4 +1419,5 @@ __all__ = [
     "OpenEnvInstance",
     "RLEOperations",
     "coerce_action",
+    "coerce_reset_body",
 ]

--- a/sdk/ai/azure-ai-projects/tests/rle/test_rle_models.py
+++ b/sdk/ai/azure-ai-projects/tests/rle/test_rle_models.py
@@ -35,6 +35,7 @@ from azure.ai.projects.operations._patch_rle import (
     _OpenEnvWebSocketConfig,
     _build_openenv_websocket_url,
     coerce_action,
+    coerce_reset_body,
     OpenEnvClient,
     OpenEnvInstance,
     OpenEnvWebSocket,
@@ -192,6 +193,7 @@ def test_rle_sync_and_async_modules_export_common_helpers():
         "RLEQuotaExceededError",
         "RLEInstanceAcquireTimeoutError",
         "coerce_action",
+        "coerce_reset_body",
     }.issubset(async_rle_patch.__all__)
 
 
@@ -289,6 +291,32 @@ def test_coerce_action_rejects_ambiguous_or_invalid_actions():
 
     with pytest.raises(TypeError):
         coerce_action(42, {})
+
+
+def test_coerce_reset_body_with_no_extras_returns_strict_model():
+    from azure.ai.projects.models import RLEResetRequest
+
+    body = coerce_reset_body(42, "ep-1", {})
+    assert isinstance(body, RLEResetRequest)
+    assert body.seed == 42
+    assert body.episode_id == "ep-1"
+
+
+def test_coerce_reset_body_folds_environment_specific_kwargs_into_a_dict():
+    body = coerce_reset_body(42, None, {"task_id": "duke_energy", "difficulty": "hard"})
+    assert body == {
+        "seed": 42,
+        "episodeId": None,
+        "task_id": "duke_energy",
+        "difficulty": "hard",
+    }
+
+
+def test_coerce_reset_body_rejects_seed_or_episode_id_as_extra_kwargs():
+    with pytest.raises(TypeError):
+        coerce_reset_body(None, None, {"seed": 7})
+    with pytest.raises(TypeError):
+        coerce_reset_body(None, None, {"episode_id": "ep-2"})
 
 
 # ---------------------------------------------------------------------------
@@ -882,6 +910,22 @@ def test_openenv_instance_runtime_uses_resolved_environment_route():
     )
     reset_call = instances.calls[2]
     assert reset_call[5].get("seed") == 42
+
+
+def test_openenv_instance_reset_forwards_environment_specific_kwargs():
+    client, _groups, instances = _make_openenv_client(max_active_instances=1)
+    with client:
+        with client.get_instance() as instance:
+            assert isinstance(
+                instance.reset(seed=7, episode_id="ep-9", task_id="duke_energy"),
+                RLEStepResult,
+            )
+
+    reset_call = next(call for call in instances.calls if call[0] == "reset")
+    body = reset_call[5]
+    assert body["seed"] == 7
+    assert body["episodeId"] == "ep-9"
+    assert body["task_id"] == "duke_energy"
 
 
 def test_openenv_runtime_calls_use_runtime_operations_group():
@@ -1624,6 +1668,27 @@ def test_async_openenv_client_creates_group_and_runs():
             call[1:5] == ("env-1", "resolved-latest", "grp-1", "inst-0")
             for call in instances.calls
         )
+
+    asyncio.run(run())
+
+
+def test_async_openenv_instance_reset_forwards_environment_specific_kwargs():
+    async def run():
+        client, _groups, instances = _make_async_openenv_client(max_active_instances=1)
+        async with client:
+            async with client.get_instance() as instance:
+                assert isinstance(
+                    await instance.reset(
+                        seed=7, episode_id="ep-9", task_id="duke_energy"
+                    ),
+                    RLEStepResult,
+                )
+
+        reset_call = next(call for call in instances.calls if call[0] == "reset")
+        body = reset_call[5]
+        assert body["seed"] == 7
+        assert body["episodeId"] == "ep-9"
+        assert body["task_id"] == "duke_energy"
 
     asyncio.run(run())
 


### PR DESCRIPTION
Stacks on #48833 (targets its branch `farhannawaz/rle-websocket` directly since I don't have push access to that branch).

## What
`OpenEnvInstance.reset()` / `AsyncOpenEnvInstance.reset()` already accepted `**kwargs` on their signature, but those kwargs were forwarded as transport/operation options to the generated `runtime.reset(...)` call and never reached the environment. `step()`, by contrast, treats its `**action_kwargs` as environment-specific action fields via `coerce_action()`. This PR aligns `reset()` with that same pattern.

## Changes
- `operations/_patch_rle.py` / `aio/operations/_patch_rle_async.py`: add `coerce_reset_body(seed, episode_id, kwargs)`, mirroring `coerce_action`.
  - No extra kwargs -> still returns the strict `RLEResetRequest` model (unchanged wire shape, fully backward compatible).
  - Extra kwargs present -> returns a plain `dict` merging `seed`/`episodeId` with the environment-specific fields. `RLEResetRequest` has no field for arbitrary extras, but the generated `reset` operation already accepts a raw JSON body (`Union[RLEResetRequest, JSON, IO[bytes]]`), so no service-spec change is needed.
  - `reset()` no longer forwards `**kwargs` to the runtime operation call; it builds the body via `coerce_reset_body` instead (matching how `step()` never forwards `action_kwargs` to the operation call either).
  - Passing `seed`/`episode_id` as extra kwargs raises `TypeError` (use the named parameters).
- Tests: unit tests for `coerce_reset_body`, plus end-to-end sync/async tests confirming extra reset kwargs (e.g. `task_id=`) reach the wire body.

## Testing
`pytest tests/rle/` — 106 passed (101 existing + 5 new).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>