### PR TITLE
[Storage] Reject CRLF in batch request headers

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed an issue with the new generation where listing page ranges for an empty page blob could raise a `ValueError` instead of returning
   an empty list.
 - Fixed an issue where a SAS generated for a blob name containing a backslash (`\`) was invalid because the backslash was not normalized to a forward slash when building the signed resource.
+- Fixed an issue where a header name or value containing a `\r` or `\n` was written directly into a batch request body. Such headers are now rejected with a `ValueError`.
 
 ### Other Changes
 - Added public `SignedIdentifier` model and updated `ContainerClient.get_container_access_policy`

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -262,6 +262,11 @@ def _make_body_from_sub_request(sub_request):
     # append remaining headers (this will set the Content-Length, as it was set on `sub-request`)
     for header_name, header_value in headers.items():
         if header_value is not None:
+            if "\r" in header_name or "\n" in header_name or "\r" in header_value or "\n" in header_value:
+                raise ValueError(
+                    f"Invalid header {header_name!r} in batch sub-request: the header name or its value "
+                    r"contains a '\r' or '\n' character, which is not permitted."
+                )
             sub_request_body.append(header_name)
             sub_request_body.append(": ")
             sub_request_body.append(header_value)

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1583,6 +1583,15 @@ class TestStorageContainer(StorageRecordedTestCase):
         blob_list = []
         container_client.delete_blobs(*blob_list)
 
+    @pytest.mark.parametrize("value", ["\r", "\n", "\r\n"])
+    def test_batch_delete_blobs_rejects_crlf_in_header(self, value):
+        container_client = ContainerClient("https://mystorageaccount.blob.core.windows.net", "container")
+
+        with pytest.raises(ValueError):
+            container_client.delete_blobs(
+                "blob1", if_tags_match_condition=f"\"tag1\"='first{value}x-ms-lease-id: injected'"
+            )
+
     @pytest.mark.live_test_only
     @BlobPreparer()
     def test_delete_blobs_simple(self, **kwargs):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -262,6 +262,11 @@ def _make_body_from_sub_request(sub_request):
     # append remaining headers (this will set the Content-Length, as it was set on `sub-request`)
     for header_name, header_value in headers.items():
         if header_value is not None:
+            if "\r" in header_name or "\n" in header_name or "\r" in header_value or "\n" in header_value:
+                raise ValueError(
+                    f"Invalid header {header_name!r} in batch sub-request: the header name or its value "
+                    r"contains a '\r' or '\n' character, which is not permitted."
+                )
             sub_request_body.append(header_name)
             sub_request_body.append(": ")
             sub_request_body.append(header_value)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -262,6 +262,11 @@ def _make_body_from_sub_request(sub_request):
     # append remaining headers (this will set the Content-Length, as it was set on `sub-request`)
     for header_name, header_value in headers.items():
         if header_value is not None:
+            if "\r" in header_name or "\n" in header_name or "\r" in header_value or "\n" in header_value:
+                raise ValueError(
+                    f"Invalid header {header_name!r} in batch sub-request: the header name or its value "
+                    r"contains a '\r' or '\n' character, which is not permitted."
+                )
             sub_request_body.append(header_name)
             sub_request_body.append(": ")
             sub_request_body.append(header_value)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -262,6 +262,11 @@ def _make_body_from_sub_request(sub_request):
     # append remaining headers (this will set the Content-Length, as it was set on `sub-request`)
     for header_name, header_value in headers.items():
         if header_value is not None:
+            if "\r" in header_name or "\n" in header_name or "\r" in header_value or "\n" in header_value:
+                raise ValueError(
+                    f"Invalid header {header_name!r} in batch sub-request: the header name or its value "
+                    r"contains a '\r' or '\n' character, which is not permitted."
+                )
             sub_request_body.append(header_name)
             sub_request_body.append(": ")
             sub_request_body.append(header_value)


### PR DESCRIPTION
Previously, `_make_body_from_sub_request` serializes headers into the `multipart/mixed` batch body by string concatenation with `\r\n` separators, with no validation. A header name or value containing a `\r` or `\n` could therefore inject additional headers into the sub-request. Now a `ValueError` is raised before anything is sent. 
