### PR TITLE
Update azure-mgmt-iothubprovisioningservices 2.0.0 release date

### DIFF
--- a/sdk/iothub/azure-mgmt-iothubprovisioningservices/CHANGELOG.md
+++ b/sdk/iothub/azure-mgmt-iothubprovisioningservices/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2026-09-10)
+## 2.0.0 (2026-09-11)
 
 ### Features Added
 

--- a/sdk/iothub/azure-mgmt-iothubprovisioningservices/CHANGELOG.md
+++ b/sdk/iothub/azure-mgmt-iothubprovisioningservices/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2026-08-26)
+## 2.0.0 (2026-09-10)
 
 ### Features Added
 


### PR DESCRIPTION
Closing because further investigation showed the release readiness gate reads the planned date from the Azure DevOps package work item (`Custom.PlannedPackages`), not from this changelog date. This change would not resolve the blocker.